### PR TITLE
pom.xml: Version 2.12-1.1-SNAPSHOT => 2.12-0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.kframework.k</groupId>
   <artifactId>kore_2.12</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
- Downgrade to version 0.1, depicting a BETA release.
- Used in the current version of UIUC-K.
- See kframework/k#2396 for related PR in K.

Do not merge.