### PR TITLE
Bring the Haskell Kore code in sync with the docs.

### DIFF
--- a/src/main/haskell/language-kore/src/Data/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTPrettyPrint.hs
@@ -325,14 +325,14 @@ instance (IsMeta a) => PrettyPrint (Implies a) where
             , writeFieldNewLine "impliesSecond" impliesSecond p
             ]
 
-instance (IsMeta a) => PrettyPrint (Mem a) where
-    prettyPrint _ p@(Mem _ _ _ _) =
+instance (IsMeta a) => PrettyPrint (In a) where
+    prettyPrint _ p@(In _ _ _ _) =
         writeStructure
-            "Mem"
-            [ writeFieldNewLine "memOperandSort" memOperandSort p
-            , writeFieldNewLine "memResultSort" memResultSort p
-            , writeFieldNewLine "memVariable" memVariable p
-            , writeFieldNewLine "memPattern" memPattern p
+            "In"
+            [ writeFieldNewLine "inOperandSort" inOperandSort p
+            , writeFieldNewLine "inResultSort" inResultSort p
+            , writeFieldNewLine "inContainedPattern" inContainedPattern p
+            , writeFieldNewLine "inContainingPattern" inContainingPattern p
             ]
 
 instance (IsMeta a) => PrettyPrint (Not a) where
@@ -377,8 +377,8 @@ instance (IsMeta a) => PrettyPrint (Pattern a) where
         writeOneFieldStruct flags "IffPattern" p
     prettyPrint flags (ImpliesPattern p)       =
         writeOneFieldStruct flags "ImpliesPattern" p
-    prettyPrint flags (MemPattern p)           =
-        writeOneFieldStruct flags "MemPattern" p
+    prettyPrint flags (InPattern p)           =
+        writeOneFieldStruct flags "InPattern" p
     prettyPrint flags (NotPattern p)           =
         writeOneFieldStruct flags "NotPattern" p
     prettyPrint flags (OrPattern p)            =

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
@@ -614,7 +614,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ pattern ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
 
@@ -629,7 +629,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ pattern ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
 @
@@ -710,7 +710,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ pattern ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
 
@@ -728,7 +728,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ pattern ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
 @

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
@@ -386,31 +386,31 @@ ceilFloorRemainderParser x constructor = do
     cfPattern <- inParenthesesParser patternParser
     return (constructor sort1 sort2 cfPattern)
 
-{-|'memRemainderParser' parses the part after a mem
+{-|'inRemainderParser' parses the part after a in
 operator's name and the first open curly brace and constructs it.
 
 BNF fragments:
 
 @
-... ::= ... ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
-... ::= ... ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+... ::= ... ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
+... ::= ... ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
 @
 
 The @meta-@ version always starts with @#@, while the @object-@ one does not.
 -}
-memRemainderParser
+inRemainderParser
     :: IsMeta a
     => a  -- ^ Distinguishes between the meta and non-meta elements.
-    -> Parser (Mem a)
-memRemainderParser x = do
+    -> Parser (In a)
+inRemainderParser x = do
     (sort1, sort2) <- curlyPairRemainderParser (sortParser x)
-    (variable, mPattern) <-
-        parenPairParser unifiedVariableParser patternParser
-    return Mem
-           { memOperandSort = sort1
-           , memResultSort = sort2
-           , memVariable = variable
-           , memPattern = mPattern
+    (cdPattern, cgPattern) <-
+        parenPairParser patternParser patternParser
+    return In
+           { inOperandSort = sort1
+           , inResultSort = sort2
+           , inContainedPattern = cdPattern
+           , inContainingPattern = cgPattern
            }
 
 {-|'equalsLikeRemainderParser' parses the part after an equals
@@ -614,7 +614,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\mem’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
 
@@ -629,7 +629,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\mem’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
 @
@@ -651,7 +651,7 @@ mlConstructorParser = do
         , ("forall", mlConstructorRemainderParser ForallPatternType)
         , ("iff", mlConstructorRemainderParser IffPatternType)
         , ("implies", mlConstructorRemainderParser ImpliesPatternType)
-        , ("mem", mlConstructorRemainderParser MemPatternType)
+        , ("in", mlConstructorRemainderParser InPatternType)
         , ("not", mlConstructorRemainderParser NotPatternType)
         , ("or", mlConstructorRemainderParser OrPatternType)
         , ("top", mlConstructorRemainderParser TopPatternType)
@@ -683,8 +683,8 @@ mlConstructorParser = do
                 binaryOperatorRemainderParser x Iff
             ImpliesPatternType -> ImpliesPattern <$>
                 binaryOperatorRemainderParser x Implies
-            MemPatternType -> MemPattern <$>
-                memRemainderParser x
+            InPatternType -> InPattern <$>
+                inRemainderParser x
             NotPatternType -> NotPattern <$>
                 unaryOperatorRemainderParser x Not
             OrPatternType -> OrPattern <$>
@@ -710,7 +710,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\mem’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨object-sort⟩ ‘,’ ⟨object-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨object-sort⟩ ‘}’ ‘(’ ‘)’
 
@@ -728,7 +728,7 @@ BNF definitions:
     | ‘\ceil’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\floor’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘)’
     | ‘\equals’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨pattern⟩ ‘,’ ⟨pattern⟩ ‘)’
-    | ‘\mem’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
+    | ‘\in’ ‘{’ ⟨meta-sort⟩ ‘,’ ⟨meta-sort⟩ ‘}’ ‘(’ ⟨variable⟩ ‘,’ ⟨pattern⟩ ‘)’
     | ‘\top’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
     | ‘\bottom’ ‘{’ ⟨meta-sort⟩ ‘}’ ‘(’ ‘)’
 @

--- a/src/main/haskell/language-kore/src/Data/Kore/Unparser/Unparse.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unparser/Unparse.hs
@@ -120,7 +120,7 @@ instance Unparse MLPatternType where
     unparse ForallPatternType  = write "\\forall"
     unparse IffPatternType     = write "\\iff"
     unparse ImpliesPatternType = write "\\implies"
-    unparse MemPatternType     = write "\\mem"
+    unparse InPatternType      = write "\\in"
     unparse NotPatternType     = write "\\not"
     unparse OrPatternType      = write "\\or"
     unparse TopPatternType     = write "\\top"
@@ -174,12 +174,8 @@ instance Unparse (Iff a) where
 instance Unparse (Implies a) where
     unparse = unparseMLPattern
 
-instance Unparse (Mem a) where
-    unparse m = do
-        unparse MemPatternType
-        inCurlyBraces (unparse [memOperandSort m, memResultSort m])
-        inParens
-            (unparse (memVariable m) >> write ", " >> unparse (memPattern m))
+instance Unparse (In a) where
+    unparse = unparseMLPattern
 
 instance Unparse (Not a) where
     unparse = unparseMLPattern
@@ -201,7 +197,7 @@ instance Unparse (Pattern a) where
     unparse (ForallPattern p)        = unparse p
     unparse (IffPattern p)           = unparse p
     unparse (ImpliesPattern p)       = unparse p
-    unparse (MemPattern p)           = unparse p
+    unparse (InPattern p)            = unparse p
     unparse (NotPattern p)           = unparse p
     unparse (OrPattern p)            = unparse p
     unparse (StringLiteralPattern p) = unparse p

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/ASTGen.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/ASTGen.hs
@@ -179,11 +179,11 @@ iffGen x = binaryOperatorGen x Iff
 impliesGen :: IsMeta a => a -> Gen (Implies a)
 impliesGen x = binaryOperatorGen x Implies
 
-memGen :: IsMeta a => a -> Gen (Mem a)
-memGen x = pure Mem
+inGen :: IsMeta a => a -> Gen (In a)
+inGen x = pure In
     <*> scale (`div` 2) (sortGen x)
     <*> scale (`div` 2) (sortGen x)
-    <*> scale (`div` 2) unifiedVariableGen
+    <*> scale (`div` 2) unifiedPatternGen
     <*> scale (`div` 2) unifiedPatternGen
 
 notGen :: IsMeta a => a -> Gen (Not a)
@@ -210,7 +210,7 @@ patternGen x =
         , ForallPattern <$> forallGen x
         , IffPattern <$> iffGen x
         , ImpliesPattern <$> impliesGen x
-        , MemPattern <$> memGen x
+        , InPattern <$> inGen x
         , NotPattern <$> notGen x
         , OrPattern <$> orGen x
         , StringLiteralPattern <$> stringLiteralGen

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTest.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTest.hs
@@ -592,32 +592,42 @@ impliesPatternParserTests =
 memPatternParserTests :: [TestTree]
 memPatternParserTests =
     parseTree patternParser
-        [ success "\\mem{s1,s2}(v:s3, \"b\")"
-            ( ObjectPattern $ MemPattern Mem
-                    { memOperandSort = sortVariableSort "s1"
-                    , memResultSort = sortVariableSort "s2"
-                    , memVariable = ObjectVariable
-                        Variable
+        [ success "\\in{s1,s2}(v:s3, \"b\")"
+            ( ObjectPattern $ InPattern In
+                    { inOperandSort = sortVariableSort "s1"
+                    , inResultSort = sortVariableSort "s2"
+                    , inContainedPattern = ObjectPattern $
+                        VariablePattern Variable
                             { variableName = Id "v"
                             , variableSort = sortVariableSort "s3"
                             }
-                    , memPattern =
+                    , inContainingPattern =
+                        MetaPattern $ StringLiteralPattern (StringLiteral "b")
+                    }
+            )
+        , success "\\in{s1,s2}(\"a\", \"b\")"
+            ( ObjectPattern $ InPattern In
+                    { inOperandSort = sortVariableSort "s1"
+                    , inResultSort = sortVariableSort "s2"
+                    , inContainedPattern =
+                        MetaPattern $ StringLiteralPattern (StringLiteral "a")
+                    , inContainingPattern =
                         MetaPattern $ StringLiteralPattern (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
             [ ""
-            , "\\mem{s}(v:s1, \"b\")"
-            , "\\mem{s,s,s}(v:s1, \"b\")"
-            , "\\mem{s,s}(\"b\", \"b\")"
-            , "\\mem{s,s}(, \"b\")"
-            , "\\mem{s,s}(\"b\")"
-            , "\\mem{s,s}(v:s1, )"
-            , "\\mem{s,s}(v:s1)"
-            , "\\mem{s,s}()"
-            , "\\mem{s,s}"
-            , "\\mem"
-            , "\\mem(v:s1, \"b\")"
+            , "\\mem{s1,s2}(v:s3, \"b\")"
+            , "\\in{s}(v:s1, \"b\")"
+            , "\\in{s,s,s}(v:s1, \"b\")"
+            , "\\in{s,s}(, \"b\")"
+            , "\\in{s,s}(\"b\")"
+            , "\\in{s,s}(v:s1, )"
+            , "\\in{s,s}(v:s1)"
+            , "\\in{s,s}()"
+            , "\\in{s,s}"
+            , "\\in"
+            , "\\in(v:s1, \"b\")"
             ]
         ]
 notPatternParserTests :: [TestTree]

--- a/src/test/resources/expected/test-pattern-11.kore.golden
+++ b/src/test/resources/expected/test-pattern-11.kore.golden
@@ -9,18 +9,18 @@ Definition
                         [ ObjectSortVariable (SortVariable (Id Object "S"))
                         ]
                     , sentenceAxiomPattern =
-                        ObjectPattern (MemPattern Mem
-                            { memOperandSort =
+                        ObjectPattern (InPattern In
+                            { inOperandSort =
                                 SortVariableSort (SortVariable (Id Object "S"))
-                            , memResultSort =
+                            , inResultSort =
                                 SortVariableSort (SortVariable (Id Object "S"))
-                            , memVariable =
-                                ObjectVariable Variable
+                            , inContainedPattern =
+                                ObjectPattern (VariablePattern Variable
                                     { variableName = Id Object "X"
                                     , variableSort =
                                         SortVariableSort (SortVariable (Id Object "S"))
-                                    }
-                            , memPattern =
+                                    })
+                            , inContainingPattern =
                                 ObjectPattern (VariablePattern Variable
                                     { variableName = Id Object "X"
                                     , variableSort =

--- a/src/test/resources/test-exception-20.kore
+++ b/src/test/resources/test-exception-20.kore
@@ -3,6 +3,6 @@
 module TEST-EXCEPTION-20
 
   axiom{}
-    \mem{#S,S}(X:S,X:S) []
+    \in{#S,S}(X:S,X:S) []
 
 endmodule []


### PR DESCRIPTION
* \mem -> \in rename
* Changed \in to accept generic patterns on the first position instead of only variables.