### PR TITLE
Nicer parsing

### DIFF
--- a/src/main/haskell/language-kore/app/parser/Main.hs
+++ b/src/main/haskell/language-kore/app/parser/Main.hs
@@ -3,14 +3,13 @@ module Main where
 import           Data.Kore.ASTVerifier.DefinitionVerifier
 import           Data.Kore.Parser.Parser
 
-import qualified Data.ByteString                          as ByteString
 import           System.Environment                       (getArgs)
 
 main :: IO ()
 main = do
     (fileName:_) <- getArgs
-    contents <- ByteString.readFile fileName
-    case fromKore contents of
+    contents <- readFile fileName
+    case fromKore fileName contents of
         Left err -> print err
         Right definition ->
             case verifyDefinition definition of

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
@@ -13,6 +13,7 @@ This is a parser for the Kore language. Sample usage:
 import Data.Kore.Parser.KoreParser
 
 import           Text.Parsec (parse)
+import           Data.Kore.Parser.ParserUtils (parseOnly)
 import           System.Environment (getArgs)
 
 main :: IO ()
@@ -22,6 +23,8 @@ main = do
     print (fromKore contents)
     -- or --
     print (parse koreParser fileName contents)
+    -- or --
+    print (parseOnly koreParser fileName contents)
 @
 
 -}

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
@@ -12,17 +12,16 @@ This is a parser for the Kore language. Sample usage:
 @
 import Data.Kore.Parser.KoreParser
 
-import           Data.Attoparsec.ByteString.Char8 (parseOnly)
-import qualified Data.ByteString as ByteString
+import           Text.Parsec (parse)
 import           System.Environment (getArgs)
 
 main :: IO ()
 main = do
     (fileName:_) <- getArgs
-    contents <- ByteString.readFile fileName
+    contents <- readFile fileName
     print (fromKore contents)
     -- or --
-    print (parseOnly koreParser contents)
+    print (parse koreParser fileName contents)
 @
 
 -}
@@ -31,13 +30,12 @@ module Data.Kore.Parser.Parser ( Definition
                                , koreParser
                                ) where
 
-import           Data.Kore.AST.Kore               (Definition)
-import           Data.Kore.Parser.Lexeme          (skipWhitespace)
-import           Data.Kore.Parser.ParserImpl      (definitionParser)
+import           Data.Kore.AST.Kore           (Definition)
+import           Data.Kore.Parser.Lexeme      (skipWhitespace)
+import           Data.Kore.Parser.ParserImpl  (definitionParser)
+import           Data.Kore.Parser.ParserUtils
 
-import           Data.Attoparsec.ByteString.Char8 (Parser, endOfInput,
-                                                   parseOnly)
-import qualified Data.ByteString                  as ByteString
+import           Text.Parsec.String           (Parser)
 
 {-|'koreParser' is a parser for Kore.
 
@@ -51,5 +49,5 @@ a 'Definition' or a parse error.
 
 The input must contain a full valid Kore defininition and nothing else.
 -}
-fromKore :: ByteString.ByteString -> Either String Definition
+fromKore :: FilePath -> String -> Either String Definition
 fromKore = parseOnly koreParser

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
@@ -40,17 +40,16 @@ module Data.Kore.Parser.ParserImpl where
 import           Data.Kore.AST.Common
 import           Data.Kore.AST.Kore
 import           Data.Kore.Parser.Lexeme
-import qualified Data.Kore.Parser.ParserUtils     as ParserUtils
+import qualified Data.Kore.Parser.ParserUtils as ParserUtils
 import           Data.Kore.Unparser.Unparse
 
-import           Control.Arrow                    ((&&&))
-import           Control.Monad                    (unless, void, when)
+import           Control.Arrow                ((&&&))
+import           Control.Monad                (unless, void, when)
 
-import           Data.Attoparsec.ByteString.Char8 (Parser)
-import qualified Data.Attoparsec.ByteString.Char8 as Parser (char, peekChar,
-                                                             peekChar')
-import           Data.Attoparsec.Combinator       (many1)
-import           Data.Maybe                       (isJust)
+import           Data.Maybe                   (isJust)
+import qualified Text.Parsec.Char             as Parser (char)
+import           Text.Parsec.Combinator       (many1)
+import           Text.Parsec.String           (Parser)
 
 {-|'sortVariableParser' parses either an @object-sort-variable@, or a
 @meta-sort-variable@.
@@ -101,7 +100,7 @@ inCurlyBracesSortVariableListParser x =
 {-|'unifiedSortVariableParser' parses a sort variable.-}
 unifiedSortVariableParser :: Parser UnifiedSortVariable
 unifiedSortVariableParser = do
-    c <- Parser.peekChar'
+    c <- ParserUtils.peekChar'
     if c == '#'
         then MetaSortVariable <$> sortVariableParser Meta
         else ObjectSortVariable <$> sortVariableParser Object
@@ -152,7 +151,7 @@ sortParser
     -> Parser (Sort level)
 sortParser x = do
     identifier <- idParser x
-    c <- Parser.peekChar
+    c <- ParserUtils.peekChar
     case c of
         Just '{' -> actualSortParser identifier
         _        -> return (SortVariableSort $ SortVariable identifier)
@@ -547,7 +546,7 @@ BNF definitions:
 -}
 unifiedVariableParser :: Parser (UnifiedVariable Variable)
 unifiedVariableParser = do
-    c <- Parser.peekChar'
+    c <- ParserUtils.peekChar'
     if c == '#'
         then MetaVariable <$> variableParser Meta
         else ObjectVariable <$> variableParser Object
@@ -581,7 +580,7 @@ variableOrTermPatternParser
     -> Parser (Pattern level Variable UnifiedPattern)
 variableOrTermPatternParser x = do
     identifier <- idParser x
-    c <- Parser.peekChar'
+    c <- ParserUtils.peekChar'
     if c == ':'
         then VariablePattern <$> variableRemainderParser x identifier
         else symbolOrAliasPatternRemainderParser x identifier
@@ -602,7 +601,7 @@ BNF definitions:
 -}
 unifiedVariableOrTermPatternParser :: Parser UnifiedPattern
 unifiedVariableOrTermPatternParser = do
-    c <- Parser.peekChar'
+    c <- ParserUtils.peekChar'
     if c == '#'
         then MetaPattern <$> variableOrTermPatternParser Meta
         else ObjectPattern <$> variableOrTermPatternParser Object
@@ -656,7 +655,7 @@ mlConstructorParser = do
         (map (patternString &&& mlConstructorRemainderParser) allPatternTypes)
     mlConstructorRemainderParser patternType = do
         openCurlyBraceParser
-        c <- Parser.peekChar'
+        c <- ParserUtils.peekChar'
         if c == '#'
             then MetaPattern <$>
                 mlConstructorRemainderParser'
@@ -757,7 +756,7 @@ can't.
 -}
 patternParser :: Parser UnifiedPattern
 patternParser = do
-    c <- Parser.peekChar'
+    c <- ParserUtils.peekChar'
     case c of
         '\\' -> mlConstructorParser
         '"'  -> MetaPattern . StringLiteralPattern <$> stringLiteralParser
@@ -880,7 +879,7 @@ sentenceParser = keywordBasedParsers
     ]
   where
     sentenceConstructorRemainderParser sentenceType = do
-        c <- Parser.peekChar'
+        c <- ParserUtils.peekChar'
         case (c, sentenceType) of
             ('#', AliasSentenceType) -> MetaSentenceAliasSentence <$>
                 aliasSymbolSentenceRemainderParser Meta (aliasParser Meta)

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserUtils.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserUtils.hs
@@ -19,17 +19,34 @@ import qualified Text.Parsec.Char       as Parser
 import           Text.Parsec.Combinator (eof, lookAhead)
 import           Text.Parsec.String     (Parser)
 
+{-|'peekChar' is similar to Attoparsec's 'peekChar'. It returns the next
+available character in the input, without consuming it. Returns 'Nothing'
+if the input does not have any available characters.
+-}
 peekChar :: Parser (Maybe Char)
 peekChar =
     Just <$> peekChar' <|> return Nothing
 
+{-|'peekChar'' is similar to Attoparsec's 'peekChar''. It returns the next
+available character in the input, without consuming it. Fails if the input
+does not have any available characters.
+-}
 peekChar' :: Parser Char
 peekChar' =
     lookAhead Parser.anyChar
 
+{-|'scan' is similar to Attoparsec's 'scan'. It does the same thing as
+'runScanner', but without returning the last state.
+-}
 scan :: a -> (a -> Char -> Maybe a) -> Parser String
 scan state delta = fst <$> runScanner state delta
 
+{-|'runScanner' is similar to Attoparsec's 'runScanner'. It parses a string
+with the given state machine, stopping when the state function returns
+'Nothing' or at the end of the input (without producing an error).
+
+Returns a pair of the parsed string and the last state.
+-}
 runScanner :: a -> (a -> Char -> Maybe a) -> Parser (String, a)
 runScanner state delta = do
     maybeC <- peekChar
@@ -40,15 +57,29 @@ runScanner state delta = do
             (reminder, finalState) <- runScanner s delta
             return (c:reminder, finalState)
 
+{-|'skipSpace' is similar to Attoparsec's 'skipSpace'. It consumes all
+characters until the first non-space one.
+-}
 skipSpace :: Parser ()
 skipSpace = Parser.spaces
 
+{-|'takeWhile' is similar to Attoparsec's 'takeWhile'. It consumes all
+the input characters that satisfy the given predicate and returns them
+as a string.
+-}
 takeWhile :: (Char -> Bool) -> Parser String
 takeWhile = many . Parser.satisfy
 
+{-|'endOfInput' is similar to Attoparsec's 'endOfInput'. It matches only the
+end-of-input position.
+-}
 endOfInput :: Parser ()
 endOfInput = eof
 
+{-|'parseOnly' is similar to Attoparsec's 'parseOnly'. It takes a parser,
+a FilePath that is used for generating error messages and an input string
+and produces either a parsed object, or an error message.
+-}
 parseOnly :: Parser a -> FilePath -> String -> Either String a
 parseOnly parser filePathForErrors input =
     case parse parser filePathForErrors input of

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/LexemeTest.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/LexemeTest.hs
@@ -67,13 +67,15 @@ idParserTests =
         , Failure FailureTest
             { failureInput = "["
             , failureExpected =
-                "Failed reading: genericIdRawParser: " ++
-                "Invalid first character '['."
+                "\"<test-string>\" (line 1, column 1):\n"
+                ++ "genericIdRawParser: Invalid first character '['."
             }
         , Failure FailureTest
             { failureInput = "module"
             , failureExpected =
-                "Failed reading: Identifiers should not be keywords: 'module'."
+                "\"<test-string>\" (line 1, column 7):\n"
+                ++ "unexpected end of input\n"
+                ++ "Identifiers should not be keywords: 'module'."
             }
         , FailureWithoutMessage
             [   "",   "'",   "'a",   "2",   "2a", "`", "`a"
@@ -160,12 +162,14 @@ keywordBasedParsersTests =
         , Failure FailureTest
             { failureInput = "dg(a)"
             , failureExpected =
-                "Failed reading: Keyword Based Parsers - unexpected character."
+                "\"<test-string>\" (line 1, column 2):\n"
+                ++ "Keyword Based Parsers - unexpected character."
             }
         , Failure FailureTest
             { failureInput = "dda"
             , failureExpected =
-                "Failed reading: Expecting keyword to end."
+                "\"<test-string>\" (line 1, column 3):\n"
+                ++ "Expecting keyword to end."
             }
         , FailureWithoutMessage
             [ "abc(a)", "abc[a]", "de{a}", "de[a]", "df{a}", "dfa)"
@@ -216,7 +220,10 @@ skipWhitespaceTests =
             , "\t//hello\n /* world\n //*/  //!\n"]
         , Failure FailureTest
             { failureInput = "/*/"
-            , failureExpected = "Failed reading: Unfinished comment."
+            , failureExpected =
+                "\"<test-string>\" (line 1, column 4):\n"
+                ++ "unexpected end of input\n"
+                ++ "Unfinished comment."
             }
         , FailureWithoutMessage
             [ "a", "/*", "/**", "/***", "/*hello", "/*//", "*/"
@@ -253,8 +260,10 @@ stringLiteralParserTests =
         , success "\"\\U000120ff\"" (StringLiteral "\73983")
         , Failure FailureTest
             { failureInput = "\"\\UFFFFFFFF\""
-            , failureExpected = "Failed reading: Character code 4294967295"
-                ++ " outside of the representable codes."
+            , failureExpected =
+                "\"<test-string>\" (line 1, column 13):\n"
+                ++ "Character code 4294967295 outside of the representable "
+                ++ "codes."
             }
         , FailureWithoutMessage
             [ "", "'a'", "\"\\z\"", "\"\\xzf\"", "\"\\u123\"", "\"\\U1234567\""
@@ -292,13 +301,16 @@ charLiteralParserTests =
         , success "'\\U000120ff'" (CharLiteral '\73983')
         , Failure FailureTest
             { failureInput = "'\\UFFFFFFFF'"
-            , failureExpected = "Failed reading: Character code 4294967295"
-                ++ " outside of the representable codes."
+            , failureExpected =
+                "\"<test-string>\" (line 1, column 13):\n"
+                ++ "Character code 4294967295 outside of the representable "
+                ++ "codes."
             }
         , Failure FailureTest
             { failureInput = "''"
             , failureExpected =
-                "Failed reading: '' is not a valid character literal."
+                "\"<test-string>\" (line 1, column 3):\n"
+                ++ "'' is not a valid character literal."
             }
         , FailureWithoutMessage
             [ "", "'\\z'", "'\\xzf'", "'\\u123'", "'\\U1234567'"

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTest.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTest.hs
@@ -115,13 +115,16 @@ metaSortConverterTests =
         , Failure FailureTest
             { failureInput = "#Chart{}"
             , failureExpected =
-                "Failed reading: metaSortConverter: " ++
-                "Invalid constructor: '#Chart'."
+                "\"<test-string>\" (line 1, column 9):\n"
+                ++ "unexpected end of input\n"
+                ++ "metaSortConverter: Invalid constructor: '#Chart'."
             }
         , Failure FailureTest
             { failureInput = "#Char{#Char}"
             , failureExpected =
-                "Failed reading: metaSortConverter: Non empty parameter sorts."
+                "\"<test-string>\" (line 1, column 13):\n"
+                ++ "unexpected end of input\n"
+                ++ "metaSortConverter: Non empty parameter sorts."
             }
         , FailureWithoutMessage
             [ "var1, var2", "var1{var1 var2}"
@@ -668,7 +671,8 @@ nextPatternParserTests =
         , Failure FailureTest
             { failureInput = "\\next{#s}(\"a\")"
             , failureExpected =
-                "Failed reading: Cannot have a \\next meta pattern."
+                "\"<test-string>\" (line 1, column 7):\n"
+                ++"Cannot have a \\next meta pattern."
             }
         , FailureWithoutMessage
             [ ""
@@ -715,7 +719,8 @@ rewritesPatternParserTests =
         , Failure FailureTest
             { failureInput = "\\rewrites{#s}(\"a\", \"b\")"
             , failureExpected =
-                "Failed reading: Cannot have a \\rewrites meta pattern."
+                "\"<test-string>\" (line 1, column 11):\n"
+                ++ "Cannot have a \\rewrites meta pattern."
             }
         , FailureWithoutMessage
             [ ""

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTestUtils.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/ParserTestUtils.hs
@@ -1,12 +1,13 @@
 module Data.Kore.Parser.ParserTestUtils where
 
-import           Test.Tasty                       (TestTree, testGroup)
-import           Test.Tasty.HUnit                 (Assertion, assertBool,
-                                                   assertEqual, testCase)
+import           Test.Tasty                   (TestTree, testGroup)
+import           Test.Tasty.HUnit             (Assertion, assertBool,
+                                               assertEqual, testCase)
 
-import qualified Data.Attoparsec.ByteString.Char8 as Parser
-import qualified Data.ByteString.Char8            as Char8
-import           Data.Either                      (isLeft)
+import           Data.Kore.Parser.ParserUtils
+
+import           Data.Either                  (isLeft)
+import qualified Text.Parsec.String           as Parser
 
 data SuccessfulTest a = SuccessfulTest
     { successInput    :: String
@@ -88,23 +89,22 @@ parseSuccess expected parser input =
     assertEqual
         "Expecting parse success!"
         (Right expected)
-        (Parser.parseOnly (parser <* Parser.endOfInput) (Char8.pack input))
+        (parseOnly (parser <* endOfInput) "<test-string>" input)
 
 parseSkip :: Parser.Parser () -> String -> Assertion
 parseSkip parser input =
     assertEqual
         "Expecting skip success!"
         (Right ())
-        (Parser.parseOnly (parser <* Parser.endOfInput) (Char8.pack input))
+        (parseOnly (parser <* endOfInput) "<test-string>" input)
 
 parseFailureWithoutMessage :: Parser.Parser a -> String -> Assertion
 parseFailureWithoutMessage parser input =
     assertBool
         "Expecting parse failure!"
         (isLeft
-            (Parser.parseOnly
-                (parser <* Parser.endOfInput)
-                (Char8.pack input)))
+            (parseOnly (parser <* endOfInput) "<test-string>" input)
+        )
 
 parseFailureWithMessage
     :: (Show a, Eq a)
@@ -113,4 +113,4 @@ parseFailureWithMessage expected parser input =
     assertEqual
         "Expecting parse failure!"
         (Left expected)
-        (Parser.parseOnly (parser <* Parser.endOfInput) (Char8.pack input))
+        (parseOnly (parser <* endOfInput) "<test-string>" input)

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/RegressionTest.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Parser/RegressionTest.hs
@@ -10,7 +10,6 @@ import           Test.Tasty.Golden          (findByExtension, goldenVsString)
 import           Data.Kore.ASTPrettyPrint
 import           Data.Kore.Parser.Parser
 
-import qualified Data.ByteString            as ByteString
 import qualified Data.ByteString.Lazy       as LazyByteString
 import qualified Data.ByteString.Lazy.Char8 as LazyChar8
 import           System.FilePath            (addExtension, splitFileName, (</>))
@@ -53,5 +52,5 @@ toByteString (Right definition) =
 
 runParser :: String -> IO LazyByteString.ByteString
 runParser inputFileName = do
-    fileContent <- ByteString.readFile inputFileName
-    return (toByteString (fromKore fileContent))
+    fileContent <- readFile inputFileName
+    return (toByteString (fromKore inputFileName fileContent))

--- a/src/main/haskell/language-kore/test/parser/Data/Kore/Unparser/UnparseTest.hs
+++ b/src/main/haskell/language-kore/test/parser/Data/Kore/Unparser/UnparseTest.hs
@@ -7,13 +7,13 @@ import           Data.Kore.AST.Kore
 import           Data.Kore.ASTGen
 import           Data.Kore.Parser.LexemeImpl
 import           Data.Kore.Parser.ParserImpl
+import           Data.Kore.Parser.ParserUtils
 import           Data.Kore.Unparser.Unparse
 
-import qualified Data.Attoparsec.ByteString.Char8 as Parser
-import qualified Data.ByteString.Char8            as Char8
-import           Test.Tasty                       (TestTree, testGroup)
-import           Test.Tasty.HUnit                 (assertEqual, testCase)
-import           Test.Tasty.QuickCheck            (forAll, testProperty)
+import           Test.Tasty                   (TestTree, testGroup)
+import           Test.Tasty.HUnit             (assertEqual, testCase)
+import           Test.Tasty.QuickCheck        (forAll, testProperty)
+import qualified Text.Parsec.String           as Parser
 
 unparseUnitTests :: TestTree
 unparseUnitTests =
@@ -195,8 +195,8 @@ unparseParseTests =
         ]
 
 parse :: Parser.Parser a -> String -> Either String a
-parse parser input =
-    Parser.parseOnly (parser <* Parser.endOfInput) (Char8.pack input)
+parse parser =
+    parseOnly (parser <* endOfInput) "<test-string>"
 
 unparseParseProp :: (Unparse a, Eq a) => Parser.Parser a -> a -> Bool
 unparseParseProp p a = parse p (unparseToString a) == Right a

--- a/src/test/resources/expected/test-exception-1.kore.golden
+++ b/src/test/resources/expected/test-exception-1.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-1.kore" (line 5, column 8):
+unexpected "#"
+expecting white space
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-10.kore.golden
+++ b/src/test/resources/expected/test-exception-10.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: metaSortConverter: Non empty parameter sorts..
+Parse error: "../../../test/resources//test-exception-10.kore" (line 6, column 15):
+unexpected "["
+expecting white space
+metaSortConverter: Non empty parameter sorts..

--- a/src/test/resources/expected/test-exception-11.kore.golden
+++ b/src/test/resources/expected/test-exception-11.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: metaSortConverter: Non empty parameter sorts..
+Parse error: "../../../test/resources//test-exception-11.kore" (line 6, column 21):
+unexpected "["
+expecting white space
+metaSortConverter: Non empty parameter sorts..

--- a/src/test/resources/expected/test-exception-12.kore.golden
+++ b/src/test/resources/expected/test-exception-12.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-12.kore" (line 6, column 9):
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-13.kore.golden
+++ b/src/test/resources/expected/test-exception-13.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-13.kore" (line 5, column 12):
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-14.kore.golden
+++ b/src/test/resources/expected/test-exception-14.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: metaSortConverter: Invalid constructor: '#S'..
+Parse error: "../../../test/resources//test-exception-14.kore" (line 6, column 12):
+metaSortConverter: Invalid constructor: '#S'..

--- a/src/test/resources/expected/test-exception-15.kore.golden
+++ b/src/test/resources/expected/test-exception-15.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-15.kore" (line 6, column 8):
+unexpected "S"
+expecting "#".

--- a/src/test/resources/expected/test-exception-16.kore.golden
+++ b/src/test/resources/expected/test-exception-16.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-16.kore" (line 6, column 8):
+unexpected "S"
+expecting "#".

--- a/src/test/resources/expected/test-exception-17.kore.golden
+++ b/src/test/resources/expected/test-exception-17.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-17.kore" (line 6, column 7):
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-18.kore.golden
+++ b/src/test/resources/expected/test-exception-18.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-18.kore" (line 6, column 14):
+unexpected "S"
+expecting "#".

--- a/src/test/resources/expected/test-exception-19.kore.golden
+++ b/src/test/resources/expected/test-exception-19.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-19.kore" (line 6, column 16):
+unexpected "S"
+expecting "#".

--- a/src/test/resources/expected/test-exception-2.kore.golden
+++ b/src/test/resources/expected/test-exception-2.kore.golden
@@ -1,1 +1,3 @@
-Parse error: Failed reading: Identifiers should not be keywords: 'sort'..
+Parse error: "../../../test/resources//test-exception-2.kore" (line 6, column 9):
+unexpected ":"
+Identifiers should not be keywords: 'sort'..

--- a/src/test/resources/expected/test-exception-20.kore.golden
+++ b/src/test/resources/expected/test-exception-20.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-20.kore" (line 6, column 12):
+unexpected "S"
+expecting "#".

--- a/src/test/resources/expected/test-exception-21.kore.golden
+++ b/src/test/resources/expected/test-exception-21.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-21.kore" (line 5, column 8):
+unexpected "#"
+expecting white space
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-22.kore.golden
+++ b/src/test/resources/expected/test-exception-22.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-22.kore" (line 5, column 8):
+unexpected "#"
+expecting white space
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-23.kore.golden
+++ b/src/test/resources/expected/test-exception-23.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-23.kore" (line 5, column 12):
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-24.kore.golden
+++ b/src/test/resources/expected/test-exception-24.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-24.kore" (line 5, column 19):
+unexpected "#"
+expecting white space
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-25.kore.golden
+++ b/src/test/resources/expected/test-exception-25.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-25.kore" (line 5, column 17):
+unexpected "m"
+expecting "#".

--- a/src/test/resources/expected/test-exception-26.kore.golden
+++ b/src/test/resources/expected/test-exception-26.kore.golden
@@ -1,1 +1,3 @@
-Parse error: #: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-26.kore" (line 5, column 23):
+unexpected "n"
+expecting white space or "#".

--- a/src/test/resources/expected/test-exception-27.kore.golden
+++ b/src/test/resources/expected/test-exception-27.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: Keyword Based Parsers - unexpected character..
+Parse error: "../../../test/resources//test-exception-27.kore" (line 5, column 4):
+Keyword Based Parsers - unexpected character..

--- a/src/test/resources/expected/test-exception-3.kore.golden
+++ b/src/test/resources/expected/test-exception-3.kore.golden
@@ -1,1 +1,3 @@
-Parse error: ': Failed reading: satisfyWith.
+Parse error: "../../../test/resources//test-exception-3.kore" (line 6, column 7):
+unexpected ":"
+expecting "'".

--- a/src/test/resources/expected/test-exception-4.kore.golden
+++ b/src/test/resources/expected/test-exception-4.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '2'..
+Parse error: "../../../test/resources//test-exception-4.kore" (line 6, column 5):
+unexpected "2"
+expecting space
+genericIdRawParser: Invalid first character '2'..

--- a/src/test/resources/expected/test-exception-5.kore.golden
+++ b/src/test/resources/expected/test-exception-5.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '-'..
+Parse error: "../../../test/resources//test-exception-5.kore" (line 6, column 5):
+unexpected "-"
+expecting space
+genericIdRawParser: Invalid first character '-'..

--- a/src/test/resources/expected/test-exception-6.kore.golden
+++ b/src/test/resources/expected/test-exception-6.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '2'..
+Parse error: "../../../test/resources//test-exception-6.kore" (line 6, column 6):
+genericIdRawParser: Invalid first character '2'..

--- a/src/test/resources/expected/test-exception-7.kore.golden
+++ b/src/test/resources/expected/test-exception-7.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '2'..
+Parse error: "../../../test/resources//test-exception-7.kore" (line 6, column 7):
+genericIdRawParser: Invalid first character '2'..

--- a/src/test/resources/expected/test-exception-8.kore.golden
+++ b/src/test/resources/expected/test-exception-8.kore.golden
@@ -1,1 +1,2 @@
-Parse error: Failed reading: genericIdRawParser: Invalid first character '#'..
+Parse error: "../../../test/resources//test-exception-8.kore" (line 6, column 9):
+genericIdRawParser: Invalid first character '#'..

--- a/src/test/resources/expected/test-exception-9.kore.golden
+++ b/src/test/resources/expected/test-exception-9.kore.golden
@@ -1,1 +1,4 @@
-Parse error: Failed reading: metaSortConverter: Invalid constructor: '#S'..
+Parse error: "../../../test/resources//test-exception-9.kore" (line 6, column 13):
+unexpected "["
+expecting white space
+metaSortConverter: Invalid constructor: '#S'..

--- a/src/test/resources/outdated/expected/imp-lesson-4.kore.golden
+++ b/src/test/resources/outdated/expected/imp-lesson-4.kore.golden
@@ -1,1 +1,3 @@
-Parse error: {: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//outdated/imp-lesson-4.kore" (line 1, column 13):
+unexpected "("
+expecting "{".

--- a/src/test/resources/outdated/expected/kool-typed-dynamic.kore.golden
+++ b/src/test/resources/outdated/expected/kool-typed-dynamic.kore.golden
@@ -1,1 +1,3 @@
-Parse error: {: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//outdated/kool-typed-dynamic.kore" (line 1, column 13):
+unexpected "("
+expecting "{".

--- a/src/test/resources/outdated/expected/p4.kore.golden
+++ b/src/test/resources/outdated/expected/p4.kore.golden
@@ -1,1 +1,3 @@
-Parse error: {: Failed reading: satisfyWith.
+Parse error: "../../../test/resources//outdated/p4.kore" (line 1, column 13):
+unexpected "("
+expecting "{".


### PR DESCRIPTION
This solves the problem of having line numbers for parse errors, but does not provide line numbers for verification errors and does not always provide nice error messages.

Sorry, @mattoxb, it seems that people started to need this and were nagging us, so I implemented this myself.