### PR TITLE
New alias syntax

### DIFF
--- a/src/main/haskell/language-kore/app/parser/Main.hs
+++ b/src/main/haskell/language-kore/app/parser/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import           Data.Kore.ASTVerifier.DefinitionVerifier
 import           Data.Kore.Error
 import           Data.Kore.Parser.Parser
+import           Data.Kore.ASTPrettyPrint                 (prettyPrintToString)
 
 import           Control.Exception                        (evaluate)
 import           Control.Monad                            (when)
@@ -99,5 +100,4 @@ main = do
                         return unverifiedDefinition
             when
                 (commandLineFlagsPrint commandLineFlags)
-                (print verifiedDefinition)
-
+                (putStrLn (prettyPrintToString verifiedDefinition))

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Builders.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Builders.hs
@@ -15,6 +15,7 @@ import           Data.Kore.AST.MetaOrObject
 import           Data.Kore.AST.PureML
 import           Data.Kore.ASTHelpers
 import           Data.Kore.Error
+import           Data.Fix
 
 {-|'sortParameter' defines a sort parameter that can be used in declarations.
 -}
@@ -148,6 +149,10 @@ alias_
     -> AstLocation
     -> [Sort level]
     -> Sort level
+    -- -> Pattern level variable (Fix (pat variable))
+    -- -> Pattern level variable (Fix (pat variable))
+    -> Pattern level Variable (Fix (Pattern level Variable))
+    -> Pattern level Variable (Fix (Pattern level Variable))
     -> PureSentenceAlias level
 alias_ name location = parameterizedAlias_ name location []
 
@@ -159,8 +164,12 @@ parameterizedAlias_
     -> [SortVariable level]
     -> [Sort level]
     -> Sort level
+    -- -> Pattern level variable (Fix (pat variable))
+    -- -> Pattern level variable (Fix (pat variable))
+    -> Pattern level Variable (Fix (Pattern level Variable))
+    -> Pattern level Variable (Fix (Pattern level Variable))
     -> PureSentenceAlias level
-parameterizedAlias_ name location parameters operandSorts resultSort =
+parameterizedAlias_ name location parameters operandSorts resultSort leftPat rightPat =
     SentenceAlias
         { sentenceAliasAlias = Alias
             { aliasConstructor = Id
@@ -171,6 +180,8 @@ parameterizedAlias_ name location parameters operandSorts resultSort =
             }
         , sentenceAliasSorts = operandSorts
         , sentenceAliasResultSort = resultSort
+        , leftPattern = leftPat
+        , rightPattern = rightPat
         , sentenceAliasAttributes = Attributes []
         }
 

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Common.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Common.hs
@@ -731,10 +731,13 @@ Section 9.1.6 (Declaration and Definitions).
 The 'level' type parameter is used to distiguish between the meta- and object-
 versions of symbol declarations. It should verify 'MetaOrObject level'.
 -}
-data SentenceAlias level pat variable = SentenceAlias
+
+{- data SentenceAlias level pat variable = SentenceAlias
     { sentenceAliasAlias      :: !(Alias level)
     , sentenceAliasSorts      :: ![Sort level]
     , sentenceAliasResultSort :: !(Sort level)
+    --, leftPattern             :: !(Pattern level variable (Fix (pat variable)))
+    --, rightPattern            :: !(Pattern level variable (Fix (pat variable)))
     , sentenceAliasAttributes :: !(Attributes pat variable)
     }
 
@@ -744,6 +747,25 @@ deriving instance
 
 deriving instance
     (Show (pat variable (Fix (pat variable))))
+     => Show (SentenceAlias level pat variable) -}
+
+
+data SentenceAlias level pat variable = SentenceAlias
+    { sentenceAliasAlias      :: !(Alias level)
+    , sentenceAliasSorts      :: ![Sort level]
+    , sentenceAliasResultSort :: !(Sort level)
+    , leftPattern             :: !(Pattern level variable (Fix (pat variable)))
+    , rightPattern            :: !(Pattern level variable (Fix (pat variable)))
+    , sentenceAliasAttributes :: !(Attributes pat variable)
+    }
+deriving instance
+     (Eq (pat variable (Fix (pat variable)))
+     ,Eq (variable level))
+      => Eq (SentenceAlias level pat variable)
+ 
+deriving instance
+     (Show (pat variable (Fix (pat variable)))
+     ,Show (variable level))
      => Show (SentenceAlias level pat variable)
 
 {-|'SentenceSymbol' corresponds to the @object-symbol-declaration@ and
@@ -876,11 +898,13 @@ data Sentence level sortParam pat variable where
 deriving instance
     ( Eq (pat variable (Fix (pat variable)))
     , Eq sortParam
+    , Eq (variable level)
     ) => Eq (Sentence level sortParam pat variable)
 
 deriving instance
     ( Show (pat variable (Fix (pat variable)))
     , Show sortParam
+    , Show (variable level)
     ) => Show (Sentence level sortParam pat variable)
 
 {-|A 'Module' consists of a 'ModuleName' a list of 'Sentence's and some

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Kore.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Kore.hs
@@ -182,11 +182,15 @@ newtype UnifiedSentence sortParam pat variable = UnifiedSentence
 deriving instance
     ( Eq (pat variable (Fix (pat variable)))
     , Eq sortParam
+    , Eq (variable Meta)
+    , Eq (variable Object)
     ) => Eq (UnifiedSentence sortParam pat variable)
 
 deriving instance
     ( Show (pat variable (Fix (pat variable)))
     , Show sortParam
+    , Show (variable Meta)
+    , Show (variable Object)
     ) => Show (UnifiedSentence sortParam pat variable)
 
 type UnifiedSortVariable = Unified SortVariable


### PR DESCRIPTION
This is still a work in progress (and currently broken!!) 

* make use of the pretty printer 
* change the `alias` construct to reflect the Semantics of K paper