### PR TITLE
Common module for Main modules

### DIFF
--- a/src/main/haskell/language-kore/app/parser/GlobalMain.hs
+++ b/src/main/haskell/language-kore/app/parser/GlobalMain.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP             #-}
+
+module GlobalMain
+    ( MainOptions(..)
+    , GlobalOptions(..)
+    , mainGlobal
+    , enableDisableFlag
+    , clockSomething
+    , clockSomethingIO
+    ) where
+
+import           Control.Monad                          ( when )
+import           Control.Exception                      ( evaluate )
+import           Data.Semigroup                         ( (<>) )
+import           Development.GitRev                     ( gitBranch
+                                                        , gitHash
+                                                        , gitCommitDate )
+import           System.Clock                           ( Clock (Monotonic)
+                                                        , diffTimeSpec
+                                                        , getTime )
+import           Options.Applicative                    ( Parser
+                                                        , InfoMod
+                                                        , (<|>)
+                                                        , (<**>)
+                                                        , flag
+                                                        , flag'
+                                                        , long
+                                                        , hidden
+                                                        , internal
+                                                        , help
+                                                        , helper
+                                                        , info
+                                                        , execParser )
+
+
+{- | Record Type containing common command-line arguments to each executable in 
+the project -}
+data GlobalOptions = GlobalOptions
+    { willVersion    :: Bool -- ^ Version flag [default=false]
+    }
+
+-- | Record type to store all state and options for the subMain operations
+data MainOptions a = MainOptions
+    { globalOptions :: GlobalOptions
+    , localOptions :: Maybe a
+    }
+
+{- |
+Global main function parses command line arguments, handles global flags
+and returns the parsed options
+-}
+mainGlobal
+    :: Parser options                -- ^ local options parser
+    -> InfoMod (MainOptions options) -- ^ option parser information
+    -> IO      (MainOptions options)
+mainGlobal localOptionsParser modifiers = do
+  options@MainOptions
+            { globalOptions = GlobalOptions{..}
+            , localOptions = _
+            } <- commandLineParse localOptionsParser modifiers
+  when willVersion mainVersion
+  return options
+
+
+-- | main function to print version information
+mainVersion :: IO ()
+mainVersion = mapM_ putStrLn
+              [ "K framework version " ++ packageVersion
+              , "Git:"
+              , "  revision:\t"    ++ $gitHash
+              , "  branch:\t"      ++ $gitBranch
+              , "  last commit:\t" ++  gitTime
+              , "Build date:\t"    ++  exeTime
+              ]
+    where
+      packageVersion = "UNKNOWN" -- for now, TODO: reify package.yaml or some other source
+      formatGit (_:mm:dd:tt:yy:tz:_) = [yy,mm,dd,tt,tz]
+      formatGit time                 = time
+      formatExe (mm:dd:yy:tt:_)      = [yy,mm,dd,tt,"LOCAL"]
+      formatExe time                 = time
+      gitTime = (unwords . formatGit . words) $gitCommitDate
+      exeTime = (unwords . formatExe . words) (__DATE__++" "++ __TIME__)
+
+--------------------
+-- Option Parsers --
+
+-- | Global Main argument parser for common options
+globalCommandLineParser :: Parser GlobalOptions
+globalCommandLineParser =
+    GlobalOptions
+    <$> flag False True
+        (  long "version"
+        <> help "Print version information" )
+
+
+-- | Run argument parser for local executable
+commandLineParse
+    :: Parser a                -- ^ local options parser
+    -> InfoMod (MainOptions a) -- ^ local parser info modifiers
+    -> IO (MainOptions a)
+commandLineParse localCommandLineParser modifiers =
+    execParser
+    $ info
+      ( MainOptions
+        <$> globalCommandLineParser
+        <*> (   Just <$> localCommandLineParser
+            <|> pure Nothing )
+      <**> helper )
+    modifiers
+
+
+----------------------
+-- Helper Functions --
+
+{-|
+Parser builder to create an optional boolean flag,
+with an enabled, disabled and default value.
+Based on `enableDisableFlagNoDefault`
+from commercialhaskell/stack:
+https://github.com/commercialhaskell/stack/blob/master/src/Options/Applicative/Builder/Extra.hs
+-}
+enableDisableFlag
+    :: String -- ^ flag name
+    -> option -- ^ enabled value
+    -> option -- ^ disabled value
+    -> option -- ^ default value
+    -> String -- ^ Help text suffix; appended to "Enable/disable "
+    -> Parser option
+enableDisableFlag name enabledVal disabledVal defaultVal helpSuffix =
+    flag' enabledVal
+        (  hidden
+        <> internal
+        <> long name
+        <> help helpSuffix)
+    <|> flag' disabledVal
+        (  hidden
+        <> internal
+        <> long ("no-" ++ name)
+        <> help helpSuffix )
+    <|> flag' disabledVal
+        (  long ( "[no-]" ++ name )
+        <> help ( "Enable/disable " ++ helpSuffix ) )
+    <|> pure defaultVal
+
+
+-- | Time a pure computation and print results.
+clockSomething :: String -> a -> IO a
+clockSomething description something =
+    clockSomethingIO description (evaluate something)
+
+
+-- | Time an IO computation and print results.
+clockSomethingIO :: String -> IO a -> IO a
+clockSomethingIO description something = do
+    start <- getTime Monotonic
+    x <- something
+    end <- getTime Monotonic
+    putStrLn $ description ++" "++ show (diffTimeSpec end start)
+    return x

--- a/src/main/haskell/language-kore/app/parser/Main.hs
+++ b/src/main/haskell/language-kore/app/parser/Main.hs
@@ -1,20 +1,33 @@
-{-# LANGUAGE  NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 
-module Main where
+module Main
+  ( main
+  ) where
 
-import           Data.Kore.ASTVerifier.DefinitionVerifier
-import           Data.Kore.Error
-import           Data.Kore.Parser.Parser                    (fromKore)
-import           Data.Kore.AST.Sentence                     (KoreDefinition)
+import           Data.Semigroup                             ( (<>) )
+import           Control.Monad                              ( when )
+import           Options.Applicative                        ( Parser
+                                                            , InfoMod
+                                                            , str
+                                                            , help
+                                                            , metavar
+                                                            , fullDesc
+                                                            , progDesc
+                                                            , header
+                                                            , argument )
 
-import           Control.Exception                          (evaluate)
-import           Control.Monad                              (when)
-import           System.Clock                               (Clock (Monotonic)
-                                                            ,diffTimeSpec
-                                                            ,getTime)
+import           Data.Kore.Error                            ( printError )
+import           Data.Kore.Parser.Parser                    ( fromKore )
+import           Data.Kore.AST.Sentence                     ( KoreDefinition )
+import           Data.Kore.ASTVerifier.DefinitionVerifier   ( defaultAttributesVerification
+                                                            , AttributesVerification(DoNotVerifyAttributes)
+                                                            , verifyDefinition )
 
-import           Options.Applicative
-import           Data.Semigroup                             ((<>))
+import           GlobalMain                                 ( MainOptions(..)
+                                                            , mainGlobal
+                                                            , enableDisableFlag
+                                                            , clockSomething
+                                                            , clockSomethingIO )
 
 {-
 Main module to run kore-parser
@@ -36,107 +49,68 @@ commandLineParser =
     <$> argument str
         (  metavar "FILE"
         <> help "Kore source file to parse [and verify]" )
-    <*> switch3 "print"
-        "Print parsed definition to stdout [default]"
-        "Do not print parsed definition to stdout"
-    <*> switch3 "verify"
-            "Verify well-formedness of parsed definition [default]"
-            "Do not verify well-formedness of parsed definition"
-    <*> switch3 "chkattr"
-            "Check attributes during verification [default]"
-            "Ignore attributes during verification"
-
--- | Run argument parser for kore-parser
-commandLineParse :: IO KoreParserOptions
-commandLineParse = execParser opts
-    where
-      opts = info
-             ( commandLineParser <**> helper )
-             (  fullDesc
-             <> progDesc "Parses Kore definition in FILE; optionally, \
-                         \Verifies well-formedness"
-             <> header "kore-parser - a parser for Kore definitions" )
+    <*> enableDisableFlag "print"
+        True False True
+        "printing parsed definition to stdout [default enabled]"
+    <*> enableDisableFlag "verify"
+        True False True
+        "Verify well-formedness of parsed definition [default enabled]"
+    <*> enableDisableFlag "chkattr"
+        True False True
+            "attributes checking during verification [default enabled]"
 
 
+-- | modifiers for the Command line parser description
+parserInfoModifiers :: InfoMod options
+parserInfoModifiers =
+    (  fullDesc
+    <> progDesc "Parses Kore definition in FILE; optionally, \
+                \Verifies well-formedness"
+    <> header "kore-parser - a parser for Kore definitions" )
+
+
+-- | Parses a kore file and Check wellformedness
 main :: IO ()
-main =
-    do {
-    ; KoreParserOptions
-      { fileName    = fileName
-      , willPrint   = willPrint
-      , willVerify  = willVerify
-      , willChkAttr = willChkAttr
-      } <- commandLineParse
-    ; contents <-
-        clockSomethingIO "Reading the input file" (readFile fileName)
-    ; parseResult <-
-        clockSomething "Parsing the file" (fromKore fileName contents)
-    ; let parsedDefinition =
-            case parseResult of
-                Left err         -> error err
-                Right definition -> definition
-    ; when (willVerify) (verifyMain willChkAttr parsedDefinition)
-    ; when (willPrint) (print parsedDefinition)
-    }
+main = do
+  MainOptions{..} <- mainGlobal commandLineParser parserInfoModifiers
+  case localOptions of
+    Nothing -> return () -- global options parsed, but local failed; exit gracefully
+    Just KoreParserOptions{..} -> do
+            parsedDefinition <- mainParse fileName
+            when willVerify $ mainVerify willChkAttr parsedDefinition
+            when willPrint  $ print parsedDefinition
 
-{-|
-IO subprocess to verify well-formedness of Kore definition
-Bool argument determines if attributes are checked (True), or ignored.
--}
-verifyMain :: Bool -> KoreDefinition -> IO ()
-verifyMain willChkAttr definition =
+
+-- | IO action that parses a kore definition from a filename and prints timing information.
+mainParse :: String -> IO KoreDefinition
+mainParse fileName = do
+    contents <-
+        clockSomethingIO "Reading the input file" (readFile fileName)
+    parseResult <-
+        clockSomething "Parsing the file" (fromKore fileName contents)
+    case parseResult of
+        Left err         -> error err
+        Right definition -> return definition
+
+
+-- | IO action verifies well-formedness of Kore definition and prints timing information.
+mainVerify
+    :: Bool -- ^ whether to check (True) or ignore attributes during verification
+    -> KoreDefinition -- ^ Parsed definition to check well-formedness
+    -> IO ()
+mainVerify willChkAttr definition =
     let attributesVerification =
             if willChkAttr
             then case defaultAttributesVerification of
-                    Left err           -> error (printError err)
-                    Right verification -> verification
+                   Left err           -> error (printError err)
+                   Right verification -> verification
             else DoNotVerifyAttributes
-    in do {
-       ; verifyResult <-
-            clockSomething
-              "Verifying the definition"
-              ( verifyDefinition
-                attributesVerification
-                definition )
-      ; case verifyResult of
-            Left err1 -> error (printError err1)
-            Right _   -> return ()
-      }
-
-
-----------------------
--- Helper Functions --
-
-{-|
-Parser builder to create a boolean argument,
-with a positive and negative 'flag'
-and default value (True)
--}
-switch3 
-    :: String -- ^ flag name
-    -> String -- ^ Positive help text
-    -> String -- ^ Negative help text
-    -> Parser Bool
-switch3 longName posHelpText negHelpText =
-    flag' False
-        (  long ("no"++longName)
-        <> help negHelpText )
-    <|> flag True True  -- first argument to 'flag' is the default
-        (  long longName
-        <> help posHelpText )
-
-
--- | Time a pure computation and print results.
-clockSomething :: String -> a -> IO a
-clockSomething description something =
-    clockSomethingIO description (evaluate something)
-
-
--- | Time an IO computation and print results.
-clockSomethingIO :: String -> IO a -> IO a
-clockSomethingIO description something = do
-    start <- getTime Monotonic
-    x <- something
-    end <- getTime Monotonic
-    putStrLn (description ++" "++ show (diffTimeSpec end start))
-    return x
+    in do
+      verifyResult <- clockSomething
+                      "Verifying the definition"
+                      ( verifyDefinition
+                        attributesVerification
+                        definition )
+      case verifyResult of
+        Left err1 -> error (printError err1)
+        Right _   -> return ()

--- a/src/main/haskell/language-kore/package.yaml
+++ b/src/main/haskell/language-kore/package.yaml
@@ -35,10 +35,11 @@ dependencies:
 - data-fix
 - clock
 - optparse-applicative
-
+- gitrev
+  
 library:
   source-dirs: src
-
+  
 executables:
   kore-parser:
     main:                Main.hs


### PR DESCRIPTION
I added a `--version` flag to kore-parser and moved the common elements of the kore-parser main module to a new module `GlobalMain`.  GlobalMain exports a function `mainGlobal` that takes an arbitrary command line parser and combines it with it's predefined parser, handles its global flags and returns all of the parsed options.

I wasn't sure how to expand the project directory structure, but I'm guessing `GlobalMain.hs`  is not in the right place.

In order to print the version information in the `package.yaml` I would need to add some options to that file that would require setting a minimum version of stack (v1.7) so I have held off on that for now.