### PR TITLE
Automatic code style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 - [ ] Test coverage: `stack test --coverage`
 - [ ] Public API documentation: `stack haddock`
-- [ ] Style conformance
+- [ ] Style conformance: `stylish-haskell`
 
 ---
 

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,244 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: group
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: new_line
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: false
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: new_line
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: right_after
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: module_name
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: true
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+#
+# Please keep this up-to-date with default_extensions in package.yaml
+language_extensions:
+  - DataKinds
+  - DeriveFoldable
+  - DeriveFunctor
+  - DeriveTraversable
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - LambdaCase
+  - MultiParamTypeClasses
+  - RankNTypes
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TypeSynonymInstances
+  - UndecidableInstances
+

--- a/src/main/haskell/language-kore/app/format/Main.hs
+++ b/src/main/haskell/language-kore/app/format/Main.hs
@@ -2,19 +2,23 @@
 
 module Main where
 
-import           Data.Semigroup                        ((<>))
-import           Data.Text.Prettyprint.Doc             (LayoutOptions (..),
-                                                        PageWidth (..),
-                                                        defaultLayoutOptions,
-                                                        layoutPretty, pretty)
-import           Data.Text.Prettyprint.Doc.Render.Text (renderIO)
-import           Options.Applicative
-import           System.IO                             (stdout)
+import Data.Semigroup
+       ( (<>) )
+import Data.Text.Prettyprint.Doc
+       ( LayoutOptions (..), PageWidth (..), defaultLayoutOptions,
+       layoutPretty, pretty )
+import Data.Text.Prettyprint.Doc.Render.Text
+       ( renderIO )
+import Options.Applicative
+import System.IO
+       ( stdout )
 
-import           Data.Kore.AST.Sentence                (KoreDefinition)
-import           Data.Kore.Parser.Parser               (fromKore)
+import Data.Kore.AST.Sentence
+       ( KoreDefinition )
+import Data.Kore.Parser.Parser
+       ( fromKore )
 
-import           GlobalMain
+import GlobalMain
 
 
 data KoreFormatOptions =

--- a/src/main/haskell/language-kore/app/parser/Main.hs
+++ b/src/main/haskell/language-kore/app/parser/Main.hs
@@ -4,34 +4,36 @@ module Main
   ( main
   ) where
 
-import           Control.Monad                            (when)
-import qualified Data.Map                                 as Map
-import           Data.Semigroup                           ((<>))
-import           Options.Applicative                      (InfoMod, Parser,
-                                                           argument, fullDesc,
-                                                           header, help, long,
-                                                           metavar, progDesc,
-                                                           str, strOption,
-                                                           value)
+import           Control.Monad
+                 ( when )
+import qualified Data.Map as Map
+import           Data.Semigroup
+                 ( (<>) )
+import           Options.Applicative
+                 ( InfoMod, Parser, argument, fullDesc, header, help, long,
+                 metavar, progDesc, str, strOption, value )
 
-import           Data.Kore.AST.Kore                       (CommonKorePattern)
-import           Data.Kore.AST.Sentence                   (KoreDefinition,
-                                                           ModuleName (..))
-import           Data.Kore.ASTPrettyPrint                 (prettyPrintToString)
-import           Data.Kore.ASTVerifier.DefinitionVerifier (AttributesVerification (DoNotVerifyAttributes),
-                                                           defaultAttributesVerification,
-                                                           verifyAndIndexDefinition)
-import           Data.Kore.ASTVerifier.PatternVerifier    (verifyStandalonePattern)
-import           Data.Kore.Error                          (printError)
-import           Data.Kore.IndexedModule.IndexedModule    (KoreIndexedModule)
-import           Data.Kore.Parser.Parser                  (fromKore,
-                                                           fromKorePattern)
+import Data.Kore.AST.Kore
+       ( CommonKorePattern )
+import Data.Kore.AST.Sentence
+       ( KoreDefinition, ModuleName (..) )
+import Data.Kore.ASTPrettyPrint
+       ( prettyPrintToString )
+import Data.Kore.ASTVerifier.DefinitionVerifier
+       ( AttributesVerification (DoNotVerifyAttributes),
+       defaultAttributesVerification, verifyAndIndexDefinition )
+import Data.Kore.ASTVerifier.PatternVerifier
+       ( verifyStandalonePattern )
+import Data.Kore.Error
+       ( printError )
+import Data.Kore.IndexedModule.IndexedModule
+       ( KoreIndexedModule )
+import Data.Kore.Parser.Parser
+       ( fromKore, fromKorePattern )
 
-import           GlobalMain                               (MainOptions (..),
-                                                           clockSomething,
-                                                           clockSomethingIO,
-                                                           enableDisableFlag,
-                                                           mainGlobal)
+import GlobalMain
+       ( MainOptions (..), clockSomething, clockSomethingIO, enableDisableFlag,
+       mainGlobal )
 
 {-
 Main module to run kore-parser

--- a/src/main/haskell/language-kore/app/share/GlobalMain.hs
+++ b/src/main/haskell/language-kore/app/share/GlobalMain.hs
@@ -9,35 +9,30 @@ module GlobalMain
     , clockSomethingIO
     ) where
 
-import           Control.Monad                          ( when )
-import           Control.Exception                      ( evaluate )
-import           Data.Semigroup                         ( (<>) )
-import           Development.GitRev                     ( gitBranch
-                                                        , gitHash
-                                                        , gitCommitDate )
-import           Data.Time.LocalTime                    (ZonedTime, getZonedTime)
-import           Data.Time.Format                       (formatTime, defaultTimeLocale)
-import           Data.Version                           (showVersion)
-import qualified Paths_language_kore                    as MetaData (version)
-import           System.Clock                           ( Clock (Monotonic)
-                                                        , diffTimeSpec
-                                                        , getTime )
-import           Options.Applicative                    ( Parser
-                                                        , InfoMod
-                                                        , (<|>)
-                                                        , (<**>)
-                                                        , flag
-                                                        , flag'
-                                                        , long
-                                                        , hidden
-                                                        , internal
-                                                        , help
-                                                        , helper
-                                                        , info
-                                                        , execParser )
+import           Control.Exception
+                 ( evaluate )
+import           Control.Monad
+                 ( when )
+import           Data.Semigroup
+                 ( (<>) )
+import           Data.Time.Format
+                 ( defaultTimeLocale, formatTime )
+import           Data.Time.LocalTime
+                 ( ZonedTime, getZonedTime )
+import           Data.Version
+                 ( showVersion )
+import           Development.GitRev
+                 ( gitBranch, gitCommitDate, gitHash )
+import           Options.Applicative
+                 ( InfoMod, Parser, execParser, flag, flag', help, helper,
+                 hidden, info, internal, long, (<**>), (<|>) )
+import qualified Paths_language_kore as MetaData
+                 ( version )
+import           System.Clock
+                 ( Clock (Monotonic), diffTimeSpec, getTime )
 
 
-{- | Record Type containing common command-line arguments for each executable in 
+{- | Record Type containing common command-line arguments for each executable in
 the project -}
 data GlobalOptions = GlobalOptions
     { willVersion    :: !Bool -- ^ Version flag [default=false]

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/AstWithLocation.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/AstWithLocation.hs
@@ -14,9 +14,9 @@ module Data.Kore.AST.AstWithLocation
     , prettyPrintLocationFromAst
     ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
 
 {-| 'AstWithLocation' should be implemented by all AST terms that have
 an 'AstLocation'.

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Builders.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Builders.hs
@@ -43,16 +43,18 @@ module Data.Kore.AST.Builders
     , unparameterizedVariable_
     ) where
 
-import           Data.Fix                   (Fix (..))
-import           Data.Proxy                 (Proxy (..))
+import Data.Fix
+       ( Fix (..) )
+import Data.Proxy
+       ( Proxy (..) )
 
-import           Data.Kore.AST.BuildersImpl
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTHelpers
-import           Data.Kore.Error
+import Data.Kore.AST.BuildersImpl
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTHelpers
+import Data.Kore.Error
 
 {-|'sortParameter' defines a sort parameter that can be used in declarations.
 -}

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/BuildersImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/BuildersImpl.hs
@@ -9,12 +9,12 @@ Portability : POSIX
 -}
 module Data.Kore.AST.BuildersImpl where
 
-import           Data.Fix
-import           Data.Proxy
+import Data.Fix
+import Data.Proxy
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
 
 
 newtype ChildSort level = ChildSort (Sort level)

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Common.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Common.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFoldable        #-}
 {-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DeriveTraversable     #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
@@ -10,8 +12,6 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE UndecidableInstances  #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE LambdaCase            #-}
 {-|
 Module      : Data.Kore.AST.Common
 Description : Data Structures for representing the Kore language AST that do not
@@ -36,16 +36,20 @@ Please refer to Section 9 (The Kore Language) of the
 -}
 module Data.Kore.AST.Common where
 
-import           Data.Proxy
-import           Data.String (fromString)
+import Data.Proxy
+import Data.String
+       ( fromString )
 
 import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Pretty (Pretty(..), (<>))
+import           Data.Kore.AST.Pretty
+                 ( Pretty (..), (<>) )
 import qualified Data.Kore.AST.Pretty as Pretty
-import           Data.Kore.Parser.CString (escapeCString)
+import           Data.Kore.Parser.CString
+                 ( escapeCString )
 
-import           GHC.Generics (Generic)
-import           Data.Hashable
+import Data.Hashable
+import GHC.Generics
+       ( Generic )
 
 {-| 'FileLocation' represents a position in a source file.
 -}
@@ -277,7 +281,7 @@ instance Hashable (Sort level)
 
 instance Pretty (Sort level) where
     pretty (SortVariableSort sortVariable) = pretty sortVariable
-    pretty (SortActualSort sortActual) = pretty sortActual
+    pretty (SortActualSort sortActual)     = pretty sortActual
 
 {-|'MetaSortType' corresponds to the @meta-sort-constructor@ syntactic category
 from the Semantics of K, Section 9.1.2 (Sorts).
@@ -885,7 +889,7 @@ be members only of 'Pattern Meta'.
 -}
 -- NOTE: If you are adding a case to Pattern, you should add cases in:
 -- ASTUtils/SmartConstructors.hs
--- as well as a ton of other places, probably. 
+-- as well as a ton of other places, probably.
 data Pattern level variable child where
     AndPattern
         :: !(And level child) -> Pattern level variable child
@@ -931,11 +935,11 @@ data Pattern level variable child where
 -- instance Generic child => Generic (Pattern level variable child)
 
 -- instance (Hashable child, Generic child, Hashable (variable level))
--- => Hashable (Pattern level variable child) 
+-- => Hashable (Pattern level variable child)
 
 instance (Hashable (child), Hashable (variable level))
- => Hashable (Pattern level variable child) where 
-  hashWithSalt s = \case 
+ => Hashable (Pattern level variable child) where
+  hashWithSalt s = \case
     AndPattern           p -> hashWithSalt s p
     ApplicationPattern   p -> hashWithSalt s p
     BottomPattern        p -> hashWithSalt s p
@@ -1013,7 +1017,7 @@ data PatternStub level variable child
     | UnsortedPatternStub (Sort level -> Pattern level variable child)
     deriving(Generic)
 
--- cannot hash. 
+-- cannot hash.
 
 {-|'withSort' transforms an 'UnsortedPatternStub' in a 'SortedPatternStub'.
 -}

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Error.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Error.hs
@@ -14,10 +14,11 @@ module Data.Kore.AST.Error
     , withLocationsContext
     ) where
 
-import           Data.Kore.AST.AstWithLocation
-import           Data.Kore.Error
+import Data.Kore.AST.AstWithLocation
+import Data.Kore.Error
 
-import           Data.List                     (intercalate)
+import Data.List
+       ( intercalate )
 
 {-|'koreFailWithLocations' produces an error result with a context containing
 the provided locations. -}

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Kore.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Kore.hs
@@ -41,12 +41,14 @@ module Data.Kore.AST.Kore
     , transformUnifiedPattern
     ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Pretty (Pretty(..))
-import           Data.Kore.HaskellExtensions (Rotate31 (..))
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Pretty
+       ( Pretty (..) )
+import Data.Kore.HaskellExtensions
+       ( Rotate31 (..) )
 
-import           Data.Fix
+import Data.Fix
 
 
 

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/MLPatterns.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/MLPatterns.hs
@@ -21,10 +21,10 @@ module Data.Kore.AST.MLPatterns (MLPatternClass(..),
                                  getPatternResultSort,
                                  undefinedHeadSort) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Implicit.ImplicitSorts
 
 {-|'MLPatternClass' offers a common interface to ML patterns
   (those starting with '\', except for 'Exists' and 'Forall')

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/MetaOrObject.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/MetaOrObject.hs
@@ -33,9 +33,11 @@ module Data.Kore.AST.MetaOrObject
     , IsMetaOrObject (..)
     ) where
 
-import           Data.Proxy (Proxy (Proxy))
+import Data.Proxy
+       ( Proxy (Proxy) )
 
-import           Data.Kore.AST.Pretty (Pretty(..))
+import Data.Kore.AST.Pretty
+       ( Pretty (..) )
 
 toProxy :: a -> Proxy a
 toProxy _ = Proxy

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Pretty.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Pretty.hs
@@ -22,9 +22,11 @@ module Data.Kore.AST.Pretty
     , layoutPrettyUnbounded
     ) where
 
-import           Data.Fix
-import           Data.String (fromString)
-import           Data.Text.Prettyprint.Doc hiding (list)
+import Data.Fix
+import Data.String
+       ( fromString )
+import Data.Text.Prettyprint.Doc hiding
+       ( list )
 
 -- TODO: Refer to semantics document for syntactic rules.
 

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/PureML.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/PureML.hs
@@ -18,9 +18,9 @@ Portability : portable
 -}
 module Data.Kore.AST.PureML where
 
-import           Data.Fix
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
+import Data.Fix
+import Data.Kore.AST.Common
+import Data.Kore.AST.Sentence
 
 {-|'PureMLPattern' corresponds to "fixed point" representations
 of the 'Pattern' class where the level is fixed to a given @level@.

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/PureToKore.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/PureToKore.hs
@@ -25,16 +25,17 @@ module Data.Kore.AST.PureToKore
     , patternKoreToPure
     ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTTraversals
-import           Data.Kore.Error
-import           Data.Kore.HaskellExtensions (Rotate31 (..))
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTTraversals
+import Data.Kore.Error
+import Data.Kore.HaskellExtensions
+       ( Rotate31 (..) )
 
-import           Data.Fix
+import Data.Fix
 
 patternPureToKore
     :: MetaOrObject level => CommonPurePattern level -> CommonKorePattern

--- a/src/main/haskell/language-kore/src/Data/Kore/AST/Sentence.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/AST/Sentence.hs
@@ -34,15 +34,18 @@ Please refer to Section 9 (The Kore Language) of the
 -}
 module Data.Kore.AST.Sentence where
 
-import           Data.Fix
-import           Data.Maybe (catMaybes)
+import Data.Fix
+import Data.Maybe
+       ( catMaybes )
 
 import           Data.Kore.AST.Common
 import           Data.Kore.AST.Kore
 import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Pretty (Pretty(..), (<>), (<+>))
+import           Data.Kore.AST.Pretty
+                 ( Pretty (..), (<+>), (<>) )
 import qualified Data.Kore.AST.Pretty as Pretty
-import           Data.Kore.HaskellExtensions (Rotate41 (..))
+import           Data.Kore.HaskellExtensions
+                 ( Rotate41 (..) )
 
 
 {-|'Attributes' corresponds to the @attributes@ Kore syntactic declaration.
@@ -256,7 +259,7 @@ instance
     Pretty (Fix (pat variable) )
     => Pretty (SentenceHook level pat variable)
   where
-    pretty (SentenceHookedSort a) = "hooked-" <> pretty a
+    pretty (SentenceHookedSort a)   = "hooked-" <> pretty a
     pretty (SentenceHookedSymbol a) = "hooked-" <> pretty a
 
 {-|The 'Sentence' type corresponds to the @declaration@ syntactic category

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTHelpers.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTHelpers.hs
@@ -17,18 +17,21 @@ module Data.Kore.ASTHelpers ( ApplicationSorts (..)
                             , quantifyFreeVariables
                             ) where
 
-import           Data.Fix                   (Fix (..))
-import           Data.Foldable              (foldl')
-import qualified Data.Map                   as Map
-import           Data.Proxy                 (Proxy (..))
-import qualified Data.Set                   as Set
+import           Data.Fix
+                 ( Fix (..) )
+import           Data.Foldable
+                 ( foldl' )
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+import qualified Data.Set as Set
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Variables.Free
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Variables.Free
 
 
 data ApplicationSorts level = ApplicationSorts

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTPrettyPrint.hs
@@ -7,20 +7,22 @@ module Data.Kore.ASTPrettyPrint ( prettyPrintToString
                                 , PrettyPrint
                                 ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.HaskellExtensions
-import           Data.Kore.IndentingPrinter    (PrinterOutput, StringPrinter,
-                                                betweenLines, printToString,
-                                                withIndent, write)
-import           Data.Kore.Parser.CString      (escapeCString)
-import           Data.Kore.Unification.Unifier
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.HaskellExtensions
+import Data.Kore.IndentingPrinter
+       ( PrinterOutput, StringPrinter, betweenLines, printToString, withIndent,
+       write )
+import Data.Kore.Parser.CString
+       ( escapeCString )
+import Data.Kore.Unification.Unifier
 
-import           Data.Fix
-import           Data.List                     (intersperse)
+import Data.Fix
+import Data.List
+       ( intersperse )
 
 {-# ANN module ("HLint: ignore Use record patterns" :: String) #-}
 {-
@@ -643,7 +645,7 @@ instance
     ( MetaOrObject level
     , PrettyPrint sortParam
     , PrettyPrint (Fix (pat variable))
-    , PrettyPrint (variable level)    
+    , PrettyPrint (variable level)
     ) => PrettyPrint (Sentence level sortParam pat variable)
   where
     prettyPrint flags (SentenceAliasSentence s)    =

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTTraversals.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTTraversals.hs
@@ -27,11 +27,12 @@ module Data.Kore.ASTTraversals ( patternBottomUpVisitor
                                ) where
 
 
-import           Control.Monad              ((>=>))
-import           Data.Fix
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.FixTraversals
+import Control.Monad
+       ( (>=>) )
+import Data.Fix
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.FixTraversals
 
 {-|'patternTopDownVisitorM' is a generalized monadic visitor for Kore patterns.
 It takes as arguments a preprocess function and a postprocess function and

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTUtils/SmartConstructors.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTUtils/SmartConstructors.hs
@@ -85,19 +85,20 @@ module Data.Kore.ASTUtils.SmartConstructors
 where
 
 
-import           Control.Lens
-import           Control.Monad.State
+import Control.Lens
+import Control.Monad.State
 
-import           Data.Fix
-import           Data.Foldable
-import           Data.Reflection
+import Data.Fix
+import Data.Foldable
+import Data.Reflection
 
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.PureML                  (PureMLPattern)
-import           Data.Kore.IndexedModule.MetadataTools
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.PureML
+       ( PureMLPattern )
+import Data.Kore.IndexedModule.MetadataTools
 
 
 -- | Gets the sort of of a pattern, taking the Metadatatools implicitly

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTUtils/Substitution.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTUtils/Substitution.hs
@@ -10,117 +10,116 @@ Stability   : experimental
 Portability : portable
 -}
 
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE Rank2Types             #-}
 {-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE BangPatterns           #-}
-{-# LANGUAGE LambdaCase             #-}
-{-# LANGUAGE DeriveFunctor          #-}
 {-# LANGUAGE DeriveFoldable         #-}
+{-# LANGUAGE DeriveFunctor          #-}
 {-# LANGUAGE DeriveTraversable      #-}
-{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE PatternSynonyms        #-}
+{-# LANGUAGE Rank2Types             #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeFamilies           #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Data.Kore.ASTUtils.Substitution
-( subst 
+( subst
 , localSubst
 )
 where
 
 
-import           Control.Lens
+import Control.Lens
 
-import qualified Data.Set as S
 import           Data.Fix
+import qualified Data.Set as S
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
 
-import           Data.Kore.ASTUtils.SmartConstructors
+import Data.Kore.ASTUtils.SmartConstructors
 
 -- | subst phi_1 phi_2 phi = phi[phi_2/phi_1]
 -- Note that different papers use different conventions.
 -- Here `phi_1` is the old pattern that disappears
--- and `phi_2` is the new pattern that replaces it. 
+-- and `phi_2` is the new pattern that replaces it.
 subst
-    :: MetaOrObject level 
-    => CommonPurePattern level 
-    -> CommonPurePattern level 
-    -> CommonPurePattern level 
+    :: MetaOrObject level
+    => CommonPurePattern level
     -> CommonPurePattern level
-subst old new = \case 
-    Forall_ s1 v p -> handleBinder old new Forall_ s1 v p 
-    Exists_ s1 v p -> handleBinder old new Exists_ s1 v p 
-    pat 
+    -> CommonPurePattern level
+    -> CommonPurePattern level
+subst old new = \case
+    Forall_ s1 v p -> handleBinder old new Forall_ s1 v p
+    Exists_ s1 v p -> handleBinder old new Exists_ s1 v p
+    pat
      | pat == old -> new
-     | otherwise  -> Fix $ fmap (subst old new) $ unFix pat 
+     | otherwise  -> Fix $ fmap (subst old new) $ unFix pat
 
 -- subst2 a b = cata (\pat -> if Fix pat == a then b else Fix pat)
 
 -- handleBinder
---     :: MetaOrObject level 
---     => CommonPurePattern level 
---     -> CommonPurePattern level 
---     -> ( Sort level 
---       -> Variable level 
---       -> CommonPurePattern level 
+--     :: MetaOrObject level
+--     => CommonPurePattern level
+--     -> CommonPurePattern level
+--     -> ( Sort level
+--       -> Variable level
+--       -> CommonPurePattern level
 --       -> CommonPurePattern level
 --       )
---     -> Sort level 
---     -> Variable level 
---     -> CommonPurePattern level 
---     -> CommonPurePattern level 
--- handleBinder old new binder s1 v p = 
---     let fa = freeVars old 
+--     -> Sort level
+--     -> Variable level
+--     -> CommonPurePattern level
+--     -> CommonPurePattern level
+-- handleBinder old new binder s1 v p =
+--     let fa = freeVars old
 --         fb = freeVars new
---     in if S.member v fa 
---         then binder s1 v p 
+--     in if S.member v fa
+--         then binder s1 v p
 --     else if S.member v fb
---         then subst old new $ alphaRename $ binder s1 v p 
+--         then subst old new $ alphaRename $ binder s1 v p
 --         else binder s1 v $ subst old new p
 
-handleBinder old new binder s1 v p 
-  | S.member v (freeVars old) = binder s1 v p  
+handleBinder old new binder s1 v p
+  | S.member v (freeVars old) = binder s1 v p
   | S.member v (freeVars new) = subst old new $ alphaRename binder s1 v p
-  | otherwise = binder s1 v $ subst old new p  
-  where 
-    alphaRename binder s1 v p = 
+  | otherwise = binder s1 v $ subst old new p
+  where
+    alphaRename binder s1 v p =
         binder s1 (replacementVar v p)
         (subst (Var_ v) (Var_ $ replacementVar v p) p)
-    replacementVar v p = 
+    replacementVar v p =
         head $ filter (not . flip S.member freeVarsP) $ alternatives v
-    freeVarsP = freeVars p 
-    alternatives (Variable (Id name loc) sort) = 
+    freeVarsP = freeVars p
+    alternatives (Variable (Id name loc) sort) =
         [Variable (Id (name ++ show n) loc) sort | n <- [(0::Integer)..] ]
 
 freeVars
-    :: MetaOrObject level 
+    :: MetaOrObject level
     => CommonPurePattern level
     -> S.Set (Variable level)
-freeVars = \case 
-    Forall_ s1 v p -> S.delete v $ freeVars p 
-    Exists_ s1 v p -> S.delete v $ freeVars p 
+freeVars = \case
+    Forall_ s1 v p -> S.delete v $ freeVars p
+    Exists_ s1 v p -> S.delete v $ freeVars p
     Var_ v -> S.singleton v
     p -> S.unions $ map freeVars $ p ^. partsOf allChildren
 
 -- | Apply a substitution at every eligible position below the specified path.
 -- This is technically less general than axiom 7, which allows for
 -- substituting at an arbitrary set of eligible positions,
--- but it doesn't matter in practice. 
+-- but it doesn't matter in practice.
 localSubst
-    :: MetaOrObject level 
-    => CommonPurePattern level 
-    -> CommonPurePattern level 
+    :: MetaOrObject level
+    => CommonPurePattern level
+    -> CommonPurePattern level
     -> [Int]
-    -> CommonPurePattern level 
+    -> CommonPurePattern level
     -> CommonPurePattern level
 localSubst a b path pat = localInPattern path (subst a b) pat
 

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/AttributesVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/AttributesVerifier.hs
@@ -12,14 +12,16 @@ module Data.Kore.ASTVerifier.AttributesVerifier (verifyAttributes,
   where
 
 import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject            (asUnified)
+import           Data.Kore.AST.MetaOrObject
+                 ( asUnified )
 import           Data.Kore.AST.Sentence
 import           Data.Kore.ASTVerifier.Error
 import           Data.Kore.ASTVerifier.PatternVerifier
 import           Data.Kore.Error
-import           Data.Kore.Implicit.Attributes         (attributeObjectSort)
+import           Data.Kore.Implicit.Attributes
+                 ( attributeObjectSort )
 import           Data.Kore.IndexedModule.IndexedModule
-import qualified Data.Set                              as Set
+import qualified Data.Set as Set
 
 {--| Whether we should verify attributes and, when verifying, the module with
 declarations visible in these atributes. --}

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -16,18 +16,19 @@ module Data.Kore.ASTVerifier.DefinitionVerifier
     , AttributesVerification (..)
     ) where
 
-import           Control.Monad                            (foldM, foldM_)
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTVerifier.AttributesVerifier
-import           Data.Kore.ASTVerifier.Error
-import           Data.Kore.ASTVerifier.ModuleVerifier
-import           Data.Kore.Error
-import           Data.Kore.Implicit.Definitions           (uncheckedAttributesDefinition,
-                                                           uncheckedKoreModules)
-import           Data.Kore.IndexedModule.IndexedModule
+import Control.Monad
+       ( foldM, foldM_ )
+import Data.Kore.AST.Common
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTVerifier.AttributesVerifier
+import Data.Kore.ASTVerifier.Error
+import Data.Kore.ASTVerifier.ModuleVerifier
+import Data.Kore.Error
+import Data.Kore.Implicit.Definitions
+       ( uncheckedAttributesDefinition, uncheckedKoreModules )
+import Data.Kore.IndexedModule.IndexedModule
 
-import qualified Data.Map                                 as Map
+import qualified Data.Map as Map
 
 {-|'verifyDefinition' verifies the welformedness of a Kore 'Definition'.
 

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/Error.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/Error.hs
@@ -9,7 +9,7 @@ Portability : POSIX
 -}
 module Data.Kore.ASTVerifier.Error where
 
-import           Data.Kore.Error
+import Data.Kore.Error
 
 {-| 'VerifyError' is a tag for verification errors. -}
 newtype VerifyError = VerifyError ()

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/ModuleVerifier.hs
@@ -15,11 +15,11 @@ import           Data.Kore.AST.Common
 import           Data.Kore.AST.Sentence
 import           Data.Kore.ASTVerifier.AttributesVerifier
 import           Data.Kore.ASTVerifier.Error
-import qualified Data.Kore.ASTVerifier.SentenceVerifier   as SentenceVerifier
+import qualified Data.Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Data.Kore.Error
 import           Data.Kore.IndexedModule.IndexedModule
 
-import qualified Data.Map                                 as Map
+import qualified Data.Map as Map
 
 {-|'verifyUniqueNames' verifies that names defined in a module are unique both
 within the module and outside, using the provided name set. -}

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/PatternVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/PatternVerifier.hs
@@ -20,7 +20,8 @@ import           Data.Kore.AST.Error
 import           Data.Kore.AST.Kore
 import           Data.Kore.AST.MetaOrObject
 import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.Pretty (Pretty(..), (<>), (<+>))
+import           Data.Kore.AST.Pretty
+                 ( Pretty (..), (<+>), (<>) )
 import qualified Data.Kore.AST.Pretty as Pretty
 import           Data.Kore.AST.Sentence
 import           Data.Kore.ASTHelpers
@@ -30,12 +31,15 @@ import           Data.Kore.Error
 import           Data.Kore.Implicit.ImplicitSorts
 import           Data.Kore.IndexedModule.IndexedModule
 import           Data.Kore.IndexedModule.Resolvers
-import           Data.Kore.Variables.Free              (freeVariables)
+import           Data.Kore.Variables.Free
+                 ( freeVariables )
 
-import           Control.Monad                         (foldM, zipWithM_)
-import qualified Data.Map                              as Map
-import qualified Data.Set                              as Set
-import           Data.Text.Prettyprint.Doc.Render.String (renderString)
+import           Control.Monad
+                 ( foldM, zipWithM_ )
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import           Data.Text.Prettyprint.Doc.Render.String
+                 ( renderString )
 
 data DeclaredVariables = DeclaredVariables
     { objectDeclaredVariables :: !(Map.Map (Id Object) (Variable Object))

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/SentenceVerifier.hs
@@ -13,24 +13,25 @@ module Data.Kore.ASTVerifier.SentenceVerifier ( verifyUniqueNames
                                               , verifySentences
                                               ) where
 
-import           Control.Monad                            (foldM)
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.Error
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.ASTVerifier.AttributesVerifier
-import           Data.Kore.ASTVerifier.Error
-import           Data.Kore.ASTVerifier.PatternVerifier
-import           Data.Kore.ASTVerifier.SortVerifier
-import           Data.Kore.ASTHelpers
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.IndexedModule
-import           Data.Kore.IndexedModule.Resolvers
+import Control.Monad
+       ( foldM )
+import Data.Kore.AST.Common
+import Data.Kore.AST.Error
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTHelpers
+import Data.Kore.ASTVerifier.AttributesVerifier
+import Data.Kore.ASTVerifier.Error
+import Data.Kore.ASTVerifier.PatternVerifier
+import Data.Kore.ASTVerifier.SortVerifier
+import Data.Kore.Error
+import Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.IndexedModule.Resolvers
 
-import qualified Data.Map                                 as Map
-import qualified Data.Set                                 as Set
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 {-|'verifyUniqueNames' verifies that names defined in a list of sentences are
 unique both within the list and outside, using the provided name set.
@@ -274,10 +275,10 @@ verifyAliasSentence
                 findSortDeclaration
                 variables
                 (sentenceAliasResultSort sentence)
-            if leftPatternSort == rightPatternSort 
+            if leftPatternSort == rightPatternSort
                 then
                     verifySuccess
-                else 
+                else
                     koreFail "Left and Right sorts do not match"
             verifyAliasLeftPattern
                 (asKorePattern $ sentenceAliasLeftPattern sentence)
@@ -298,7 +299,7 @@ verifyAliasSentence
     leftPatternSort  = patternSort leftPattern
     rightPatternSort = patternSort rightPattern
     headSort         = applicationSortsResult . getHeadApplicationSorts indexedModule
-    patternSort      = getPatternResultSort headSort 
+    patternSort      = getPatternResultSort headSort
     leftPattern      = sentenceAliasLeftPattern sentence
     rightPattern     = sentenceAliasRightPattern sentence
 

--- a/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/SortVerifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/ASTVerifier/SortVerifier.hs
@@ -10,14 +10,14 @@ Portability : POSIX
 module Data.Kore.ASTVerifier.SortVerifier (verifySort) where
 
 import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
 import           Data.Kore.AST.Error
 import           Data.Kore.AST.Kore
 import           Data.Kore.AST.MetaOrObject
+import           Data.Kore.AST.Sentence
 import           Data.Kore.ASTVerifier.Error
 import           Data.Kore.Error
 import           Data.Kore.IndexedModule.IndexedModule
-import qualified Data.Set                              as Set
+import qualified Data.Set as Set
 
 {-|'verifySort' verifies the welformedness of a Kore 'Sort'. -}
 verifySort

--- a/src/main/haskell/language-kore/src/Data/Kore/Algorithm/TopologicalSort.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Algorithm/TopologicalSort.hs
@@ -12,8 +12,9 @@ module Data.Kore.Algorithm.TopologicalSort
     (topologicalSort, ToplogicalSortCycles(..))
   where
 
-import           Data.Graph (SCC (..), stronglyConnComp)
-import qualified Data.Map   as Map
+import           Data.Graph
+                 ( SCC (..), stronglyConnComp )
+import qualified Data.Map as Map
 
 newtype ToplogicalSortCycles node = ToplogicalSortCycles [node]
     deriving (Show, Eq)

--- a/src/main/haskell/language-kore/src/Data/Kore/Building/Implicit.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Building/Implicit.hs
@@ -12,12 +12,13 @@ Portability : POSIX
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Data.Kore.Building.Implicit where
 
-import           Data.Kore.AST.Common        (Application (..),
-                                              AstLocation (..), Id (..),
-                                              Pattern (..), SymbolOrAlias (..))
-import           Data.Kore.AST.MetaOrObject  (Meta)
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..), Pattern (..),
+       SymbolOrAlias (..) )
+import Data.Kore.AST.MetaOrObject
+       ( Meta )
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
 
 data MetaNilSortList = MetaNilSortList
 instance ProperPattern Meta SortListSort MetaNilSortList where

--- a/src/main/haskell/language-kore/src/Data/Kore/Building/Patterns.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Building/Patterns.hs
@@ -17,21 +17,20 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Data.Kore.Building.Patterns where
-import           Data.Proxy                 (Proxy (Proxy))
+import Data.Proxy
+       ( Proxy (Proxy) )
 
-import           Data.Kore.AST.Common       (And (..), AstLocation, Bottom (..),
-                                             Ceil (..), CharLiteral (..),
-                                             DomainValue (..), Equals (..),
-                                             Exists (..), Floor (..),
-                                             Forall (..), Id (..), Iff (..),
-                                             Implies (..), In (..), Next (..),
-                                             Not (..), Or (..), Pattern (..),
-                                             Rewrites (..), StringLiteral (..),
-                                             Top (..), Variable (..))
-import           Data.Kore.AST.Kore         (CommonKorePattern, asKorePattern)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Sorts
+import Data.Kore.AST.Common
+       ( And (..), AstLocation, Bottom (..), Ceil (..), CharLiteral (..),
+       DomainValue (..), Equals (..), Exists (..), Floor (..), Forall (..),
+       Id (..), Iff (..), Implies (..), In (..), Next (..), Not (..), Or (..),
+       Pattern (..), Rewrites (..), StringLiteral (..), Top (..),
+       Variable (..) )
+import Data.Kore.AST.Kore
+       ( CommonKorePattern, asKorePattern )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Sorts
 
 {-| When defining new patterns (e.g. for new symbols and aliases),
 users are expected to instantiate either

--- a/src/main/haskell/language-kore/src/Data/Kore/Building/Sorts.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Building/Sorts.hs
@@ -31,10 +31,10 @@ module Data.Kore.Building.Sorts
   , ObjectSortVariable1 (ObjectSortVariable1)
   ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Building.AsAst
+import Data.Kore.Implicit.ImplicitSorts
 
 type AsSort level = AsAst (Sort level)
 type MetaSort = AsSort Meta

--- a/src/main/haskell/language-kore/src/Data/Kore/Error.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Error.hs
@@ -9,8 +9,10 @@ Portability : POSIX
 -}
 module Data.Kore.Error where
 
-import           Control.Monad (when)
-import           Data.List     (intercalate)
+import Control.Monad
+       ( when )
+import Data.List
+       ( intercalate )
 
 {-|'Error' represents a Kore error with a stacktrace-like context.
 

--- a/src/main/haskell/language-kore/src/Data/Kore/FixTraversals.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/FixTraversals.hs
@@ -28,8 +28,8 @@ module Data.Kore.FixTraversals ( fixBottomUpVisitor
                                ) where
 
 
-import           Control.Monad.Identity
-import           Data.Fix
+import Control.Monad.Identity
+import Data.Fix
 
 {-|'fixTopDownVisitorM' is a generalized monadic visitor.
 It takes as arguments a preprocess function and a postprocess function and

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/Attributes.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/Attributes.hs
@@ -18,10 +18,10 @@ module Data.Kore.Implicit.Attributes
     , uncheckedAttributesModule
     ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
 
 noParameterObjectSortAndSentence
     :: String -> (AstLocation -> Sort Object, KoreSentence)
@@ -87,7 +87,7 @@ attributeObjectSymbolSentence
   :: String                       -- ^ attribute symbol
   -> (AstLocation -> Sort Object) -- ^ argument sort constructor
   -> KoreSentence
-attributeObjectSymbolSentence name sort = 
+attributeObjectSymbolSentence name sort =
     asSentence
         ( SentenceSymbol
             { sentenceSymbolSymbol  = Symbol
@@ -143,7 +143,7 @@ constructorAttribute = simpleAttribute "constructor"
 constructorSymbolSentence :: KoreSentence
 constructorSymbolSentence  = simpleAttributeSentence "constructor"
 
-{-| Creates a Pattern for an attribute 
+{-| Creates a Pattern for an attribute
 consisting of a single keyword with no arguments.
 -}
 simpleAttribute :: String -> CommonKorePattern

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/Definitions.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/Definitions.hs
@@ -15,11 +15,14 @@ module Data.Kore.Implicit.Definitions
     , uncheckedMetaDefinition
     ) where
 
-import           Data.Kore.AST.PureToKore        (modulePureToKore)
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Implicit.Attributes   (uncheckedAttributesModule)
-import           Data.Kore.Implicit.ImplicitKore (uncheckedKoreModule)
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.PureToKore
+       ( modulePureToKore )
+import Data.Kore.AST.Sentence
+import Data.Kore.Implicit.Attributes
+       ( uncheckedAttributesModule )
+import Data.Kore.Implicit.ImplicitKore
+       ( uncheckedKoreModule )
+import Data.Kore.MetaML.AST
 
 metaModules :: [MetaModule]
 metaModules = [uncheckedKoreModule]

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitKore.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitKore.hs
@@ -26,14 +26,15 @@ module Data.Kore.Implicit.ImplicitKore ( uncheckedKoreModule
                                        , symbolDeclaredA
                                        ) where
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML                    (PureSentenceSymbol)
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.Implicit.ImplicitVarsInternal
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+       ( PureSentenceSymbol )
+import Data.Kore.AST.Sentence
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.Implicit.ImplicitVarsInternal
+import Data.Kore.MetaML.AST
 
 {-
 Conventions used:

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitSorts.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitSorts.hs
@@ -11,8 +11,8 @@ Portability : POSIX
 
 module Data.Kore.Implicit.ImplicitSorts where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.Implicit.ImplicitSortsImpl
+import Data.Kore.AST.Common
+import Data.Kore.Implicit.ImplicitSortsImpl
 
 -- TODO(virgil-serbanuta): Add tests for "defined but not used" symbols
 ( charMetaSort, charListMetaSort

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitSortsImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitSortsImpl.hs
@@ -9,11 +9,11 @@ Portability : POSIX
 -}
 module Data.Kore.Implicit.ImplicitSortsImpl where
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Implicit.ImplicitVarsInternal
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Implicit.ImplicitVarsInternal
+import Data.Kore.MetaML.AST
 
 parameterizedEqualsAxiom
     :: [SortVariable Meta]

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitVarsInternal.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/ImplicitVarsInternal.hs
@@ -10,11 +10,12 @@ Portability : POSIX
 -}
 module Data.Kore.Implicit.ImplicitVarsInternal where
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML       (CommonPurePatternStub)
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+       ( CommonPurePatternStub )
+import Data.Kore.MetaML.AST
 
 vf, vL, vphi, vphi1, vphi2, vphi3, vphii, vpsi, vR, vS, vS', vs, vs1, vs2, vs3
     , vs', vsigma, vu, v1, v2, vx, vx' :: MetaPatternStub

--- a/src/main/haskell/language-kore/src/Data/Kore/Implicit/Verified.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Implicit/Verified.hs
@@ -15,17 +15,19 @@ module Data.Kore.Implicit.Verified
     )
     where
 
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTVerifier.DefinitionVerifier (defaultAttributesVerification,
-                                                           verifyImplicitKoreDefinition,
-                                                           verifyNormalKoreDefinition)
-import           Data.Kore.ASTVerifier.Error              (VerifyError)
-import           Data.Kore.Error                          (Error, printError)
-import           Data.Kore.Implicit.Definitions           (uncheckedAttributesDefinition,
-                                                           uncheckedKoreDefinition,
-                                                           uncheckedMetaDefinition)
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTVerifier.DefinitionVerifier
+       ( defaultAttributesVerification, verifyImplicitKoreDefinition,
+       verifyNormalKoreDefinition )
+import Data.Kore.ASTVerifier.Error
+       ( VerifyError )
+import Data.Kore.Error
+       ( Error, printError )
+import Data.Kore.Implicit.Definitions
+       ( uncheckedAttributesDefinition, uncheckedKoreDefinition,
+       uncheckedMetaDefinition )
+import Data.Kore.MetaML.AST
 
 checkedMetaDefinition :: Either (Error VerifyError) MetaDefinition
 checkedMetaDefinition = do

--- a/src/main/haskell/language-kore/src/Data/Kore/IndentingPrinter.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/IndentingPrinter.hs
@@ -10,8 +10,8 @@ module Data.Kore.IndentingPrinter ( betweenLines
                                   , write
                                   ) where
 
-import           Control.Monad.Reader
-import           Control.Monad.Writer
+import Control.Monad.Reader
+import Control.Monad.Writer
 
 class FromString a where
     fromString :: String -> a

--- a/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/IndexedModule.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/IndexedModule.hs
@@ -34,19 +34,22 @@ module Data.Kore.IndexedModule.IndexedModule
     , SortDescription
     ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
-import           Control.Arrow                    ((&&&))
-import           Control.Monad                    (foldM)
-import qualified Data.Map                         as Map
-import qualified Data.Set                         as Set
+import           Control.Arrow
+                 ( (&&&) )
+import           Control.Monad
+                 ( foldM )
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
-import           Data.Fix                         (Fix)
+import Data.Fix
+       ( Fix )
 
 type SortDescription level = SentenceSort level UnifiedPattern Variable
 

--- a/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/MetadataTools.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/MetadataTools.hs
@@ -14,13 +14,13 @@ module Data.Kore.IndexedModule.MetadataTools
     )
   where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.ASTHelpers
-import           Data.Kore.Implicit.Attributes
-import           Data.Kore.IndexedModule.IndexedModule
-import           Data.Kore.IndexedModule.Resolvers
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.ASTHelpers
+import Data.Kore.Implicit.Attributes
+import Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.IndexedModule.Resolvers
 
 -- |'MetadataTools' defines a dictionary of functions which can be used to
 -- access the metadata needed during the unification process.

--- a/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/Resolvers.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/IndexedModule/Resolvers.hs
@@ -17,23 +17,24 @@ module Data.Kore.IndexedModule.Resolvers
     ) where
 
 import           Data.Fix
-import qualified Data.Map                              as Map
-import           Data.Proxy                            (Proxy (..))
-import qualified Data.Set                              as Set
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+import qualified Data.Set as Set
 
-import           Data.Kore.AST.Common                  
-import           Data.Kore.AST.Error                   (koreFailWithLocations)
-import           Data.Kore.AST.Kore                    
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.MetaOrObject            (IsMetaOrObject (..),
-                                                        MetaOrObject,
-                                                        isMetaOrObject)
-import           Data.Kore.ASTHelpers                  (ApplicationSorts,
-                                                        symbolOrAliasSorts)
-import           Data.Kore.Error                       (Error, printError)
-import           Data.Kore.IndexedModule.IndexedModule (IndexedModule (..),
-                                                        KoreIndexedModule,
-                                                        SortDescription)
+import Data.Kore.AST.Common
+import Data.Kore.AST.Error
+       ( koreFailWithLocations )
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+       ( IsMetaOrObject (..), MetaOrObject, isMetaOrObject )
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTHelpers
+       ( ApplicationSorts, symbolOrAliasSorts )
+import Data.Kore.Error
+       ( Error, printError )
+import Data.Kore.IndexedModule.IndexedModule
+       ( IndexedModule (..), KoreIndexedModule, SortDescription )
 
 
 
@@ -109,8 +110,8 @@ getAttributeList
     :: MetaOrObject level
     => KoreIndexedModule   -- ^module representing a verified definition
     -> SymbolOrAlias level -- ^the head we want to find sorts for
-    -> [Fix (UnifiedPattern Variable)] 
-getAttributeList m patternHead = 
+    -> [Fix (UnifiedPattern Variable)]
+getAttributeList m patternHead =
     case resolveSymbol m headName of
         Right sentence -> getAttributes $ sentenceSymbolAttributes sentence
         Left _ ->

--- a/src/main/haskell/language-kore/src/Data/Kore/MetaML/AST.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/MetaML/AST.hs
@@ -22,13 +22,15 @@ Please refer to Section 9 (The Kore Language) of the
 -}
 module Data.Kore.MetaML.AST where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Variables.Free   (pureFreeVariables)
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.Variables.Free
+       ( pureFreeVariables )
 
-import           Data.Set                   (Set)
+import Data.Set
+       ( Set )
 
 {-|'MetaMLPattern' corresponds to "fixed point" representations
 of the 'Pattern' class where the level is fixed to 'Meta'.

--- a/src/main/haskell/language-kore/src/Data/Kore/MetaML/Lift.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/MetaML/Lift.hs
@@ -18,18 +18,19 @@ module Data.Kore.MetaML.Lift ( liftDefinition
                              , LiftableToMetaML(liftToMeta)
                              ) where
 
-import           Data.Fix
+import Data.Fix
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.PureML
-import           Data.Kore.FixTraversals
-import           Data.Kore.HaskellExtensions      (Rotate31 (..))
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.FixTraversals
+import Data.Kore.HaskellExtensions
+       ( Rotate31 (..) )
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.MetaML.AST
 
 {-|'LiftableToMetaML' describes functionality to lift mixed Kore
 'Object' and 'Meta' constructs to pure 'Meta' constructs.
@@ -346,19 +347,19 @@ symbolOrAliasLiftedDeclaration sa = symbolDeclaration
         }
 
 -- Section 9.2.7 Lift Object Alias Declarations
-liftAliasDeclaration 
-    :: KoreSentenceAlias Object 
+liftAliasDeclaration
+    :: KoreSentenceAlias Object
     -> (MetaSentenceSymbol, MetaSentenceAxiom)
-liftAliasDeclaration as = (symbolOrAliasLiftedDeclaration as, axiom) 
+liftAliasDeclaration as = (symbolOrAliasLiftedDeclaration as, axiom)
   where
     axiom = SentenceAxiom
         { sentenceAxiomAttributes = Attributes []
         , sentenceAxiomParameters = [ sortParam ]
-        , sentenceAxiomPattern    = pat 
+        , sentenceAxiomPattern    = pat
         }
-    pat = Fix . EqualsPattern $ 
-        Equals 
-            { equalsOperandSort = patternMetaSort 
+    pat = Fix . EqualsPattern $
+        Equals
+            { equalsOperandSort = patternMetaSort
             , equalsResultSort  = SortVariableSort sortParam
             , equalsFirst       = left
             , equalsSecond      = right
@@ -436,7 +437,7 @@ liftObjectSentence
     :: Sentence Object UnifiedSortVariable UnifiedPattern Variable
     -> [MetaSentence]
 liftObjectSentence (SentenceAliasSentence osa) =
-    let (mas, axiom) = liftAliasDeclaration osa in 
+    let (mas, axiom) = liftAliasDeclaration osa in
         [ SentenceSymbolSentence mas
         , SentenceAxiomSentence axiom
         ]

--- a/src/main/haskell/language-kore/src/Data/Kore/MetaML/Unlift.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/MetaML/Unlift.hs
@@ -16,19 +16,21 @@ for all MetaML constructs up to patterns.
 module Data.Kore.MetaML.Unlift ( UnliftableFromMetaML (..)
                                ) where
 
-import           Control.Applicative
-import           Data.Fix
-import           Data.Maybe
+import Control.Applicative
+import Data.Fix
+import Data.Maybe
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence           (SentenceSymbolOrAlias (..))
-import           Data.Kore.Implicit.ImplicitKore  (mlPatternP, variable)
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.MetaML.AST
-import           Data.Kore.Parser.LexemeImpl
-import           Data.Kore.Parser.ParserUtils     as Parser
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+       ( SentenceSymbolOrAlias (..) )
+import Data.Kore.Implicit.ImplicitKore
+       ( mlPatternP, variable )
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.MetaML.AST
+import Data.Kore.Parser.LexemeImpl
+import Data.Kore.Parser.ParserUtils as Parser
 
 -- |'UnliftableFromMetaML' specifies common functionality for constructs
 -- which can be "unlifted" from 'Meta'-only to full 'Kore' representations.

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/CString.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/CString.hs
@@ -14,11 +14,12 @@ module Data.Kore.Parser.CString
        , oneCharEscapeDict
        ) where
 
-import           Data.Kore.Parser.CharSet as CharSet
+import Data.Kore.Parser.CharSet as CharSet
 
-import           Data.Char                (chr, digitToInt, isHexDigit,
-                                           isOctDigit, ord, toUpper)
-import           Numeric                  (showHex, showOct)
+import Data.Char
+       ( chr, digitToInt, isHexDigit, isOctDigit, ord, toUpper )
+import Numeric
+       ( showHex, showOct )
 
 {-# ANN oneCharEscapes ("HLint: ignore Use String" :: String) #-}
 oneCharEscapes :: [Char]

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/CharDict.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/CharDict.hs
@@ -17,7 +17,8 @@ module Data.Kore.Parser.CharDict
   where
 
 import qualified Data.Array as Array
-import           Data.Maybe (fromMaybe)
+import           Data.Maybe
+                 ( fromMaybe )
 
 newtype CharDict a = CharDict { getCharDict :: Array.Array Char a }
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/CharSet.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/CharSet.hs
@@ -15,8 +15,9 @@ module Data.Kore.Parser.CharSet
        , elem
        ) where
 
-import           Data.Kore.Parser.CharDict as CharDict
-import           Prelude                   hiding (elem)
+import Data.Kore.Parser.CharDict as CharDict
+import Prelude hiding
+       ( elem )
 
 newtype CharSet = CharSet { getCharSet :: CharDict.CharDict Bool }
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/Lexeme.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/Lexeme.hs
@@ -41,4 +41,4 @@ module Data.Kore.Parser.Lexeme
        , charLiteralParser
        ) where
 
-import           Data.Kore.Parser.LexemeImpl
+import Data.Kore.Parser.LexemeImpl

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/LexemeImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/LexemeImpl.hs
@@ -29,26 +29,31 @@ Conventions used:
 module Data.Kore.Parser.LexemeImpl where
 
 import           Data.Kore.AST.Common
+import           Data.Kore.AST.MetaOrObject
+                 ( IsMetaOrObject (..), MetaOrObject (..), toProxy )
 import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.MetaOrObject   (IsMetaOrObject (..),
-                                               MetaOrObject (..), toProxy)
-import qualified Data.Kore.Parser.CharDict    as CharDict
-import           Data.Kore.Parser.CharSet     as CharSet
+import qualified Data.Kore.Parser.CharDict as CharDict
+import           Data.Kore.Parser.CharSet as CharSet
 import           Data.Kore.Parser.CString
 import           Data.Kore.Parser.ParserUtils as ParserUtils
 
-import           Control.Arrow                ((&&&))
-import           Control.Monad                (void, when)
-import           Control.Monad.Combinators    (manyTill, (<|>))
-import qualified Data.ByteString.Char8        as Char8
-import           Data.Char                    (isHexDigit, isOctDigit)
-import           Data.Maybe                   (isJust)
-import qualified Data.Trie                    as Trie
-import           Text.Megaparsec              (SourcePos (..), eof, getPosition,
-                                               unPos)
-import qualified Text.Megaparsec.Char         as Parser (anyChar, char, space1,
-                                                         string)
-import qualified Text.Megaparsec.Char.Lexer   as L
+import           Control.Arrow
+                 ( (&&&) )
+import           Control.Monad
+                 ( void, when )
+import           Control.Monad.Combinators
+                 ( manyTill, (<|>) )
+import qualified Data.ByteString.Char8 as Char8
+import           Data.Char
+                 ( isHexDigit, isOctDigit )
+import           Data.Maybe
+                 ( isJust )
+import qualified Data.Trie as Trie
+import           Text.Megaparsec
+                 ( SourcePos (..), eof, getPosition, unPos )
+import qualified Text.Megaparsec.Char as Parser
+                 ( anyChar, char, space1, string )
+import qualified Text.Megaparsec.Char.Lexer as L
 
 sourcePosToFileLocation :: SourcePos -> FileLocation
 sourcePosToFileLocation

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/Parser.hs
@@ -34,11 +34,13 @@ module Data.Kore.Parser.Parser
     , korePatternParser
     ) where
 
-import           Data.Kore.AST.Kore           (CommonKorePattern)
+import           Data.Kore.AST.Kore
+                 ( CommonKorePattern )
 import           Data.Kore.AST.Sentence
-import           Data.Kore.Parser.Lexeme      (skipWhitespace)
-import qualified Data.Kore.Parser.ParserImpl  as KoreParser (koreDefinitionParser,
-                                                             korePatternParser)
+import           Data.Kore.Parser.Lexeme
+                 ( skipWhitespace )
+import qualified Data.Kore.Parser.ParserImpl as KoreParser
+                 ( koreDefinitionParser, korePatternParser )
 import           Data.Kore.Parser.ParserUtils
 
 {-|'koreParser' is a parser for Kore.

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserImpl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE GADTs #-}
 
 {-|
 Module      : Data.Kore.Parser.ParserImpl
@@ -39,24 +39,32 @@ Conventions used:
 -}
 module Data.Kore.Parser.ParserImpl where
 
-import           Data.Kore.AST.PureML                            (CommonPurePattern)
 import           Data.Kore.AST.Common
 import           Data.Kore.AST.Kore
 import           Data.Kore.AST.MetaOrObject
+import           Data.Kore.AST.PureML
+                 ( CommonPurePattern )
 import           Data.Kore.AST.Sentence
-import           Data.Kore.HaskellExtensions  (Rotate31 (..), (<....>))
+import           Data.Kore.HaskellExtensions
+                 ( Rotate31 (..), (<....>) )
 import           Data.Kore.MetaML.AST
 import           Data.Kore.Parser.Lexeme
-import           Data.Kore.Parser.ParserUtils (Parser)
+import           Data.Kore.Parser.ParserUtils
+                 ( Parser )
 import qualified Data.Kore.Parser.ParserUtils as ParserUtils
 import           Data.Kore.Unparser.Unparse
 
-import           Control.Arrow                ((&&&))
-import           Control.Monad                (unless, void, when)
+import           Control.Arrow
+                 ( (&&&) )
+import           Control.Monad
+                 ( unless, void, when )
 import           Data.Fix
-import           Data.Maybe                   (isJust)
-import           Text.Megaparsec              (some)
-import qualified Text.Megaparsec.Char         as Parser (char)
+import           Data.Maybe
+                 ( isJust )
+import           Text.Megaparsec
+                 ( some )
+import qualified Text.Megaparsec.Char as Parser
+                 ( char )
 
 {-|'sortVariableParser' parses either an @object-sort-variable@, or a
 @meta-sort-variable@.
@@ -934,7 +942,7 @@ symbolSentenceRemainderParser  x aliasSymbolParser constructor
 
 
 {-|'aliasSentenceRemainderParser' parses the part after the starting
-keyword of an alias declaration. 
+keyword of an alias declaration.
 
 BNF fragment example:
 
@@ -957,11 +965,11 @@ aliasSentenceRemainderParser x
     resultSort <- sortParser x
     mlLexemeParser "where"
     -- Note: constraints for left pattern checked in verifySentence
-    leftPattern <- leveledPatternParser korePatternParser x 
-    mlLexemeParser ":="    
-    rightPattern <- leveledPatternParser korePatternParser x 
+    leftPattern <- leveledPatternParser korePatternParser x
+    mlLexemeParser ":="
+    rightPattern <- leveledPatternParser korePatternParser x
     attributes <- attributesParser
-    return (Rotate31 (SentenceAlias aliasSymbol sorts resultSort leftPattern rightPattern attributes)) 
+    return (Rotate31 (SentenceAlias aliasSymbol sorts resultSort leftPattern rightPattern attributes))
 
 {-|'importSentenceRemainderParser' parses the part after the starting
 'import' keyword of an import-declaration and constructs it.

--- a/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserUtils.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Parser/ParserUtils.hs
@@ -14,14 +14,17 @@ Helper tools for parsing Kore. Meant for internal use only.
 -}
 module Data.Kore.Parser.ParserUtils where
 
-import           Control.Applicative   ((<|>))
-import           Control.Monad         (void)
-import           Data.Functor          (($>))
-import           Text.Megaparsec       (Parsec, eof, lookAhead, parse,
-                                        takeWhileP)
-import qualified Text.Megaparsec.Char  as Parser
-import           Text.Megaparsec.Error (ShowErrorComponent (..),
-                                        parseErrorPretty)
+import           Control.Applicative
+                 ( (<|>) )
+import           Control.Monad
+                 ( void )
+import           Data.Functor
+                 ( ($>) )
+import           Text.Megaparsec
+                 ( Parsec, eof, lookAhead, parse, takeWhileP )
+import qualified Text.Megaparsec.Char as Parser
+import           Text.Megaparsec.Error
+                 ( ShowErrorComponent (..), parseErrorPretty )
 
 type Parser = Parsec String String
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/AxiomPatterns.hs
@@ -7,17 +7,19 @@ module Data.Kore.Step.AxiomPatterns
     )
   where
 
-import           Data.Either                           (rights)
-import           Data.Fix
+import Data.Either
+       ( rights )
+import Data.Fix
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore              (patternKoreToPure)
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.IndexedModule.IndexedModule
 
 newtype AxiomPatternError = AxiomPatternError ()
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/BaseStep.hs
@@ -20,33 +20,42 @@ module Data.Kore.Step.BaseStep
 
 import qualified Control.Arrow
 import           Data.Fix
-import qualified Data.Map                                        as Map
-import           Data.Monoid                                     ((<>))
-import qualified Data.Set                                        as Set
+import qualified Data.Map as Map
+import           Data.Monoid
+                 ( (<>) )
+import qualified Data.Set as Set
 
 import           Data.Kore.AST.Common
 import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML                            (CommonPurePattern,
-                                                                  PureMLPattern,
-                                                                  asPurePattern,
-                                                                  mapPatternVariables)
-import           Data.Kore.FixTraversals                         (fixBottomUpVisitor)
-import           Data.Kore.IndexedModule.MetadataTools           (MetadataTools)
+import           Data.Kore.AST.PureML
+                 ( CommonPurePattern, PureMLPattern, asPurePattern,
+                 mapPatternVariables )
+import           Data.Kore.FixTraversals
+                 ( fixBottomUpVisitor )
+import           Data.Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
 import           Data.Kore.Step.AxiomPatterns
-import           Data.Kore.Step.Condition.Condition              (ConditionSort (..))
+import           Data.Kore.Step.Condition.Condition
+                 ( ConditionSort (..) )
 import           Data.Kore.Step.Error
-import           Data.Kore.Substitution.Class                    (Hashable (..), PatternSubstitutionClass (..))
-import qualified Data.Kore.Substitution.List                     as ListSubstitution
-import           Data.Kore.Unification.SubstitutionNormalization (normalizeSubstitution)
-import           Data.Kore.Unification.Unifier                   (FunctionalProof (..),
-                                                                  UnificationProof (..),
-                                                                  UnificationSubstitution,
-                                                                  unificationProcedure)
-import           Data.Kore.Variables.Free                        (pureAllVariables)
-import           Data.Kore.Variables.Fresh.Class                 (FreshVariablesClass (freshVariableSuchThat))
-import           Data.Kore.Variables.Fresh.IntCounter            (IntCounter)
-import           Data.Kore.Variables.Int                         (IntVariable (..))
-import           Data.Maybe                                      (fromMaybe)
+import           Data.Kore.Substitution.Class
+                 ( Hashable (..), PatternSubstitutionClass (..) )
+import qualified Data.Kore.Substitution.List as ListSubstitution
+import           Data.Kore.Unification.SubstitutionNormalization
+                 ( normalizeSubstitution )
+import           Data.Kore.Unification.Unifier
+                 ( FunctionalProof (..), UnificationProof (..),
+                 UnificationSubstitution, unificationProcedure )
+import           Data.Kore.Variables.Free
+                 ( pureAllVariables )
+import           Data.Kore.Variables.Fresh.Class
+                 ( FreshVariablesClass (freshVariableSuchThat) )
+import           Data.Kore.Variables.Fresh.IntCounter
+                 ( IntCounter )
+import           Data.Kore.Variables.Int
+                 ( IntVariable (..) )
+import           Data.Maybe
+                 ( fromMaybe )
 
 {--| 'StepperConfiguration' represents the configuration to which a rewriting
 axiom is applied.

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Condition/Condition.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Condition/Condition.hs
@@ -19,10 +19,11 @@ module Data.Kore.Step.Condition.Condition
     , makeEvaluatedOr
     ) where
 
-import           Data.Kore.AST.Common (And (..), Iff (..), Implies (..),
-                                       Not (..), Or (..), Pattern (..),
-                                       Sort (..))
-import           Data.Kore.AST.PureML (CommonPurePattern, asPurePattern)
+import Data.Kore.AST.Common
+       ( And (..), Iff (..), Implies (..), Not (..), Or (..), Pattern (..),
+       Sort (..) )
+import Data.Kore.AST.PureML
+       ( CommonPurePattern, asPurePattern )
 
 {--| 'ConditionProof' is a placeholder for a proof showing that a condition
 evaluation was correct.

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Condition/Evaluator.hs
@@ -12,25 +12,19 @@ module Data.Kore.Step.Condition.Evaluator
     ( evaluateFunctionCondition
     ) where
 
-import           Data.Kore.AST.Common                 (And (..), Equals (..),
-                                                       Iff (..), Implies (..),
-                                                       Not (..), Or (..),
-                                                       Pattern (..), Variable)
-import           Data.Kore.AST.PureML                 (CommonPurePattern,
-                                                       asPurePattern,
-                                                       fromPurePattern)
-import           Data.Kore.Step.Condition.Condition   (ConditionProof (..),
-                                                       ConditionSort (..),
-                                                       EvaluatedCondition (..),
-                                                       UnevaluatedCondition (..),
-                                                       makeEvaluatedAnd,
-                                                       makeEvaluatedIff,
-                                                       makeEvaluatedImplies,
-                                                       makeEvaluatedNot,
-                                                       makeEvaluatedOr)
-import           Data.Kore.Step.Function.Data         (CommonPurePatternFunctionEvaluator (..),
-                                                       FunctionResult (..))
-import           Data.Kore.Variables.Fresh.IntCounter (IntCounter)
+import Data.Kore.AST.Common
+       ( And (..), Equals (..), Iff (..), Implies (..), Not (..), Or (..),
+       Pattern (..), Variable )
+import Data.Kore.AST.PureML
+       ( CommonPurePattern, asPurePattern, fromPurePattern )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionProof (..), ConditionSort (..), EvaluatedCondition (..),
+       UnevaluatedCondition (..), makeEvaluatedAnd, makeEvaluatedIff,
+       makeEvaluatedImplies, makeEvaluatedNot, makeEvaluatedOr )
+import Data.Kore.Step.Function.Data
+       ( CommonPurePatternFunctionEvaluator (..), FunctionResult (..) )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter )
 
 {--| 'evaluateFunctionCondition' attempts to evaluate a Kore condition.
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Error.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Error.hs
@@ -7,9 +7,9 @@ module Data.Kore.Step.Error
     )
   where
 
-import qualified Data.Set                    as Set
+import qualified Data.Set as Set
 
-import           Data.Kore.Unification.Error
+import Data.Kore.Unification.Error
 
 {--| 'StepError' represents the various error cases encountered while executing
 a single step.

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Function/Data.hs
@@ -16,12 +16,14 @@ module Data.Kore.Step.Function.Data
     , AttemptedFunctionResult (..)
     ) where
 
-import           Data.Kore.AST.Common                 (Application)
-import           Data.Kore.AST.PureML                 (CommonPurePattern)
-import           Data.Kore.Step.Condition.Condition   (ConditionProof,
-                                                       EvaluatedCondition,
-                                                       UnevaluatedCondition)
-import           Data.Kore.Variables.Fresh.IntCounter (IntCounter)
+import Data.Kore.AST.Common
+       ( Application )
+import Data.Kore.AST.PureML
+       ( CommonPurePattern )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionProof, EvaluatedCondition, UnevaluatedCondition )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter )
 
 {--| 'FunctionResultProof' is a placeholder for proofs showing that a Kore
 function evaluation was correct.

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Function/Evaluator.hs
@@ -13,34 +13,33 @@ module Data.Kore.Step.Function.Evaluator
     ( evaluateFunctions
     ) where
 
-import           Data.List                             (nub)
-import qualified Data.Map                              as Map
+import           Data.List
+                 ( nub )
+import qualified Data.Map as Map
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        Id (..), Pattern (..),
-                                                        SymbolOrAlias (..),
-                                                        Variable)
-import           Data.Kore.AST.MLPatterns              (MLBinderPatternClass (..),
-                                                        MLPatternClass (..),
-                                                        PatternLeveledFunction (..),
-                                                        applyPatternLeveledFunction)
-import           Data.Kore.AST.PureML                  (CommonPurePattern,
-                                                        UnFixedPureMLPattern,
-                                                        asPurePattern)
-import           Data.Kore.FixTraversals               (fixTopDownVisitor)
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import           Data.Kore.Step.Condition.Condition    (ConditionProof (..),
-                                                        ConditionSort (..),
-                                                        EvaluatedCondition (..),
-                                                        makeEvaluatedAnd)
-import           Data.Kore.Step.Condition.Evaluator    (evaluateFunctionCondition)
-import           Data.Kore.Step.Function.Data          (ApplicationFunctionEvaluator (..),
-                                                        AttemptedFunctionResult (..),
-                                                        CommonPurePatternFunctionEvaluator (..),
-                                                        ConditionEvaluator (..),
-                                                        FunctionResult (..),
-                                                        FunctionResultProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter  (IntCounter)
+import Data.Kore.AST.Common
+       ( Application (..), Id (..), Pattern (..), SymbolOrAlias (..),
+       Variable )
+import Data.Kore.AST.MLPatterns
+       ( MLBinderPatternClass (..), MLPatternClass (..),
+       PatternLeveledFunction (..), applyPatternLeveledFunction )
+import Data.Kore.AST.PureML
+       ( CommonPurePattern, UnFixedPureMLPattern, asPurePattern )
+import Data.Kore.FixTraversals
+       ( fixTopDownVisitor )
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools (..) )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionProof (..), ConditionSort (..), EvaluatedCondition (..),
+       makeEvaluatedAnd )
+import Data.Kore.Step.Condition.Evaluator
+       ( evaluateFunctionCondition )
+import Data.Kore.Step.Function.Data
+       ( ApplicationFunctionEvaluator (..), AttemptedFunctionResult (..),
+       CommonPurePatternFunctionEvaluator (..), ConditionEvaluator (..),
+       FunctionResult (..), FunctionResultProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter )
 
 {-|'evaluateFunctions' evaluates Kore functions (in a bottom-up manner).
 

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Function/UserDefined.hs
@@ -13,24 +13,24 @@ module Data.Kore.Step.Function.UserDefined
     , axiomFunctionEvaluator
     ) where
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        Pattern (..), Top (..))
-import           Data.Kore.AST.MetaOrObject            (MetaOrObject)
-import           Data.Kore.AST.PureML                  (CommonPurePattern,
-                                                        asPurePattern)
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import           Data.Kore.Step.BaseStep               (AxiomPattern, StepperConfiguration (..),
-                                                        stepWithAxiom)
-import           Data.Kore.Step.Condition.Condition    (ConditionSort (..),
-                                                        EvaluatedCondition (..),
-                                                        UnevaluatedCondition (..),
-                                                        makeEvaluatedAnd)
-import           Data.Kore.Step.Function.Data          (AttemptedFunctionResult (..),
-                                                        CommonPurePatternFunctionEvaluator (..),
-                                                        ConditionEvaluator (..),
-                                                        FunctionResult (..),
-                                                        FunctionResultProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter  (IntCounter)
+import Data.Kore.AST.Common
+       ( Application (..), Pattern (..), Top (..) )
+import Data.Kore.AST.MetaOrObject
+       ( MetaOrObject )
+import Data.Kore.AST.PureML
+       ( CommonPurePattern, asPurePattern )
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools (..) )
+import Data.Kore.Step.BaseStep
+       ( AxiomPattern, StepperConfiguration (..), stepWithAxiom )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionSort (..), EvaluatedCondition (..),
+       UnevaluatedCondition (..), makeEvaluatedAnd )
+import Data.Kore.Step.Function.Data
+       ( AttemptedFunctionResult (..), CommonPurePatternFunctionEvaluator (..),
+       ConditionEvaluator (..), FunctionResult (..), FunctionResultProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter )
 
 {--| 'axiomFunctionEvaluator' evaluates a user-defined function. After
 evaluating the function, it tries to re-evaluate all functions on the result.

--- a/src/main/haskell/language-kore/src/Data/Kore/Step/Step.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Step/Step.hs
@@ -13,15 +13,17 @@ module Data.Kore.Step.Step
     , MaxStepCount(..)
     ) where
 
-import           Data.Either                           (rights)
+import Data.Either
+       ( rights )
 
-import           Data.Kore.AST.MetaOrObject            (MetaOrObject)
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools)
-import           Data.Kore.Step.BaseStep               (AxiomPattern,
-                                                        StepProof (..),
-                                                        StepperConfiguration,
-                                                        stepWithAxiom)
-import           Data.Kore.Variables.Fresh.IntCounter  (IntCounter)
+import Data.Kore.AST.MetaOrObject
+       ( MetaOrObject )
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools )
+import Data.Kore.Step.BaseStep
+       ( AxiomPattern, StepProof (..), StepperConfiguration, stepWithAxiom )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter )
 
 data MaxStepCount
     = MaxStepCount Integer

--- a/src/main/haskell/language-kore/src/Data/Kore/Substitution/Class.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Substitution/Class.hs
@@ -17,21 +17,25 @@ module Data.Kore.Substitution.Class ( SubstitutionClass (..)
                                     , Hashable (..)
                                     ) where
 
-import           Control.Monad.Reader              (ReaderT, ask, asks, local,
-                                                    runReaderT)
+import           Control.Monad.Reader
+                 ( ReaderT, ask, asks, local, runReaderT )
 import           Data.Fix
-import           Data.Hashable                     (hash)
-import           Data.Maybe                        (isJust)
-import qualified Data.Set                          as Set
-import           Prelude                           hiding (lookup)
+import           Data.Hashable
+                 ( hash )
+import           Data.Maybe
+                 ( isJust )
+import qualified Data.Set as Set
+import           Prelude hiding
+                 ( lookup )
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.ASTTraversals           (patternTopDownVisitorM)
-import           Data.Kore.Datastructures.MapClass
-import           Data.Kore.Variables.Free
-import           Data.Kore.Variables.Fresh.Class
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.ASTTraversals
+       ( patternTopDownVisitorM )
+import Data.Kore.Datastructures.MapClass
+import Data.Kore.Variables.Free
+import Data.Kore.Variables.Fresh.Class
 
 {-|'SubstitutionClass' represents a substitution type @s@ mapping variables
 of type @v@ to terms of type @t@.

--- a/src/main/haskell/language-kore/src/Data/Kore/Substitution/List.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Substitution/List.hs
@@ -19,14 +19,15 @@ module Data.Kore.Substitution.List ( Substitution
                                    , toList
                                    ) where
 
-import           Data.Fix
-import           Data.List                         (nubBy)
+import Data.Fix
+import Data.List
+       ( nubBy )
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Datastructures.MapClass
-import           Data.Kore.Substitution.Class
-import           Data.Kore.Variables.Free
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Datastructures.MapClass
+import Data.Kore.Substitution.Class
+import Data.Kore.Variables.Free
 
 -- |A very simple substitution represented as a list of pairs
 newtype Substitution var pat = Substitution { getSubstitution :: [(var, pat)] }

--- a/src/main/haskell/language-kore/src/Data/Kore/Unification/Error.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unification/Error.hs
@@ -14,9 +14,9 @@ module Data.Kore.Unification.Error
     , substitutionErrorVariables
     ) where
 
-import qualified Data.Set             as Set
+import qualified Data.Set as Set
 
-import           Data.Kore.AST.Common
+import Data.Kore.AST.Common
 
 -- |'UnificationError' specifies various error cases encountered during
 -- unification

--- a/src/main/haskell/language-kore/src/Data/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unification/SubstitutionNormalization.hs
@@ -21,17 +21,22 @@ import           Data.Kore.AST.Common
 import           Data.Kore.AST.MetaOrObject
 import           Data.Kore.AST.PureML
 import           Data.Kore.Substitution.Class
-import qualified Data.Kore.Substitution.List          as ListSubstitution
-import           Data.Kore.Unification.Error          (SubstitutionError (..))
-import           Data.Kore.Unification.UnifierImpl    (UnificationSubstitution)
+import qualified Data.Kore.Substitution.List as ListSubstitution
+import           Data.Kore.Unification.Error
+                 ( SubstitutionError (..) )
+import           Data.Kore.Unification.UnifierImpl
+                 ( UnificationSubstitution )
 import           Data.Kore.Variables.Free
-import           Data.Kore.Variables.Fresh.IntCounter (IntCounter)
-import           Data.Kore.Variables.Int              (IntVariable)
+import           Data.Kore.Variables.Fresh.IntCounter
+                 ( IntCounter )
+import           Data.Kore.Variables.Int
+                 ( IntVariable )
 
 
-import qualified Data.Map                             as Map
-import           Data.Maybe                           (mapMaybe)
-import qualified Data.Set                             as Set
+import qualified Data.Map as Map
+import           Data.Maybe
+                 ( mapMaybe )
+import qualified Data.Set as Set
 
 instance
     ( MetaOrObject level

--- a/src/main/haskell/language-kore/src/Data/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unification/Unifier.hs
@@ -13,9 +13,8 @@ module Data.Kore.Unification.Unifier
     , module Error
     ) where
 
-import           Data.Kore.Unification.Error       as Error (UnificationError (..))
-import           Data.Kore.Unification.UnifierImpl as UnifierImpl (FunctionalProof (..),
-                                                                   UnificationProof (..),
-                                                                   UnificationSolution (..),
-                                                                   UnificationSubstitution,
-                                                                   unificationProcedure)
+import Data.Kore.Unification.Error as Error
+       ( UnificationError (..) )
+import Data.Kore.Unification.UnifierImpl as UnifierImpl
+       ( FunctionalProof (..), UnificationProof (..), UnificationSolution (..),
+       UnificationSubstitution, unificationProcedure )

--- a/src/main/haskell/language-kore/src/Data/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unification/UnifierImpl.hs
@@ -10,18 +10,20 @@ Portability : portable
 -}
 module Data.Kore.Unification.UnifierImpl where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.PureML
-import           Data.Kore.FixTraversals
-import           Data.Kore.IndexedModule.MetadataTools
-import           Data.Kore.Unification.Error
+import Data.Kore.AST.Common
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.PureML
+import Data.Kore.FixTraversals
+import Data.Kore.IndexedModule.MetadataTools
+import Data.Kore.Unification.Error
 
-import           Control.Monad                         (foldM)
-import           Data.Fix
-import           Data.Function                         (on)
-import           Data.List                             (groupBy, partition,
-                                                        sortBy)
+import Control.Monad
+       ( foldM )
+import Data.Fix
+import Data.Function
+       ( on )
+import Data.List
+       ( groupBy, partition, sortBy )
 
 type UnificationSubstitution level variable
     = [(variable level, PureMLPattern level variable)]

--- a/src/main/haskell/language-kore/src/Data/Kore/Unparser/Unparse.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Unparser/Unparse.hs
@@ -15,10 +15,12 @@ Portability : portable
 -}
 module Data.Kore.Unparser.Unparse (Unparse(..), unparseToString) where
 
-import           Data.Text.Prettyprint.Doc (defaultLayoutOptions, layoutPretty)
-import           Data.Text.Prettyprint.Doc.Render.String (renderString)
+import Data.Text.Prettyprint.Doc
+       ( defaultLayoutOptions, layoutPretty )
+import Data.Text.Prettyprint.Doc.Render.String
+       ( renderString )
 
-import           Data.Kore.AST.Pretty
+import Data.Kore.AST.Pretty
 
 -- |'Unparse' class offers functionality to reverse the parsing process.
 class Pretty a => Unparse a where

--- a/src/main/haskell/language-kore/src/Data/Kore/Variables/Free.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Variables/Free.hs
@@ -20,13 +20,15 @@ module Data.Kore.Variables.Free ( freeVariables
                                 , pureAllVariables
                                 ) where
 
-import           Data.Fix                   (Fix)
-import           Data.Foldable              (fold)
-import qualified Data.Set                   as Set
+import           Data.Fix
+                 ( Fix )
+import           Data.Foldable
+                 ( fold )
+import qualified Data.Set as Set
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.ASTTraversals
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.ASTTraversals
 
 {-| 'freeVariables' extracts the set of free variables of a pattern. -}
 freeVariables

--- a/src/main/haskell/language-kore/src/Data/Kore/Variables/Fresh/Class.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Variables/Fresh/Class.hs
@@ -14,11 +14,11 @@ Portability : portable
 -}
 module Data.Kore.Variables.Fresh.Class where
 
-import qualified Control.Monad.State                  as State
+import qualified Control.Monad.State as State
 
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Variables.Fresh.IntCounter
-import           Data.Kore.Variables.Int
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.Variables.Int
 
 {-|'FreshVariablesClass' links @var@ representing a type of variables
 with a 'Monad' @m@ containing state needed to generate fresh

--- a/src/main/haskell/language-kore/src/Data/Kore/Variables/Fresh/IntCounter.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Variables/Fresh/IntCounter.hs
@@ -14,7 +14,8 @@ module Data.Kore.Variables.Fresh.IntCounter ( IntCounter
                                             , runIntCounter
                                             ) where
 
-import           Control.Monad.State (MonadState (get, put), State, runState)
+import Control.Monad.State
+       ( MonadState (get, put), State, runState )
 
 -- |'IntCounter' is a monad encapsulating an integer counter
 newtype IntCounter a = IntCounter { intCounterState :: State Int a }

--- a/src/main/haskell/language-kore/src/Data/Kore/Variables/Int.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Variables/Int.hs
@@ -14,8 +14,8 @@ Portability : portable
 module Data.Kore.Variables.Int ( IntVariable(..)
                                      ) where
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
 
 class IntVariable var where
     {-|Given an existing variable @v@ and an integer index @n@, 'intVariable'

--- a/src/main/haskell/language-kore/src/Data/Kore/Variables/Sort.hs
+++ b/src/main/haskell/language-kore/src/Data/Kore/Variables/Sort.hs
@@ -16,17 +16,20 @@ Portability : portable
 module Data.Kore.Variables.Sort ( TermWithSortVariablesClass(sortVariables)
                                 ) where
 
-import           Data.Fix                   (cata)
-import           Data.Foldable              (fold)
-import           Data.List                  (foldl')
-import qualified Data.Set                   as Set
+import           Data.Fix
+                 ( cata )
+import           Data.Foldable
+                 ( fold )
+import           Data.List
+                 ( foldl' )
+import qualified Data.Set as Set
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.ASTTraversals
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.ASTTraversals
+import Data.Kore.MetaML.AST
 
 
 {-| 'TermWithSortVariableClass' links a @term@ type with a @var@ type and

--- a/src/main/haskell/language-kore/test/Paths.hs
+++ b/src/main/haskell/language-kore/test/Paths.hs
@@ -3,8 +3,10 @@
 module Paths where
 
 import qualified Language.Haskell.TH as TH
-import           System.Directory    (doesFileExist, makeAbsolute)
-import           System.FilePath     (takeDirectory, (</>))
+import           System.Directory
+                 ( doesFileExist, makeAbsolute )
+import           System.FilePath
+                 ( takeDirectory, (</>) )
 
 
 {-| Resolve the file name of a test resource relative to the package root.

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE GADTs             #-}
 module Test.Data.Kore where
 
-import           Test.QuickCheck.Gen         (Gen, choose, chooseAny, elements,
-                                              frequency, getSize, listOf, oneof,
-                                              scale, sized, suchThat, vectorOf)
+import Test.QuickCheck.Gen
+       ( Gen, choose, chooseAny, elements, frequency, getSize, listOf, oneof,
+       scale, sized, suchThat, vectorOf )
 
-import           Data.Fix
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Parser.LexemeImpl
+import Data.Fix
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Parser.LexemeImpl
 
 couple :: Gen a -> Gen [a]
 couple gen = do

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/Common.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/Common.hs
@@ -1,14 +1,15 @@
 module Test.Data.Kore.AST.Common (test_withSort, test_id, test_prettyPrintAstLocation) where
 
-import           Test.Tasty                       (TestTree, testGroup)
-import           Test.Tasty.HUnit                 (assertBool, assertEqual,
-                                                   assertFailure, testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( assertBool, assertEqual, assertFailure, testCase )
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Implicit.ImplicitSorts
-import           Test.Tasty.HUnit.Extensions
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Implicit.ImplicitSorts
+import Test.Tasty.HUnit.Extensions
 
 test_withSort :: TestTree
 test_withSort =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/MLPatterns.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/MLPatterns.hs
@@ -6,24 +6,27 @@ module Test.Data.Kore.AST.MLPatterns
     , extractPurePattern
     ) where
 
-import           Test.Tasty                       (TestTree, testGroup)
-import           Test.Tasty.HUnit                 (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.Kore               (CommonKorePattern)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.PureML
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts         as Sorts
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+       ( CommonKorePattern )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts as Sorts
+import Data.Kore.Implicit.ImplicitSorts
 
-import           Data.Fix
+import Data.Fix
 
 extractPurePattern
     :: MetaOrObject level

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/PureToKore.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/AST/PureToKore.hs
@@ -1,19 +1,22 @@
 module Test.Data.Kore.AST.PureToKore (test_pureToKore) where
 
-import           Test.Tasty                 (TestTree)
-import           Test.Tasty.HUnit           (assertEqual, testCase)
-import           Test.Tasty.QuickCheck      (forAll, testProperty)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
+import Test.Tasty.QuickCheck
+       ( forAll, testProperty )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.MetaML.AST
+import Test.Data.Kore
+import Test.Data.Kore.MetaML.AST
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.MetaML.AST
 
 
 pureToKoreToPureProp :: CommonMetaPattern -> Bool

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTHelpers.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTHelpers.hs
@@ -1,14 +1,16 @@
 module Test.Data.Kore.ASTHelpers (test_symbolOrAliasSorts) where
 
-import           Test.Tasty             (TestTree)
-import           Test.Tasty.HUnit       (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTHelpers
-import           Data.Kore.Error
+import Data.Kore.AST.Common
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTHelpers
+import Data.Kore.Error
 
 test_symbolOrAliasSorts :: [TestTree]
 test_symbolOrAliasSorts =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTPrettyPrint.hs
@@ -1,18 +1,22 @@
 module Test.Data.Kore.ASTPrettyPrint (test_astPrettyPrint) where
 
-import           Test.Tasty                       (TestTree)
-import           Test.Tasty.HUnit                 (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.ASTPrettyPrint
-import           Data.Kore.Implicit.ImplicitSorts (charMetaSort)
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.ASTPrettyPrint
+import Data.Kore.Implicit.ImplicitSorts
+       ( charMetaSort )
+import Data.Kore.MetaML.AST
 
-import           Data.Fix                         (Fix (..))
+import Data.Fix
+       ( Fix (..) )
 
 test_astPrettyPrint :: [TestTree]
 test_astPrettyPrint =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTTraversals.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTTraversals.hs
@@ -1,16 +1,18 @@
 module Test.Data.Kore.ASTTraversals (test_astTraversals) where
 
-import           Test.Tasty                 (TestTree)
-import           Test.Tasty.HUnit           (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.ASTTraversals
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.ASTTraversals
 
-import           Control.Monad.Identity
+import Control.Monad.Identity
 
 
 lhs :: CommonKorePattern -> CommonKorePattern

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTUtils.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTUtils.hs
@@ -1,147 +1,147 @@
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE Rank2Types             #-}
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE BangPatterns           #-}
-{-# LANGUAGE LambdaCase             #-}
-{-# LANGUAGE DeriveFunctor          #-}
-{-# LANGUAGE DeriveFoldable         #-}
-{-# LANGUAGE DeriveTraversable      #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE PatternSynonyms        #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
-{-# LANGUAGE TypeApplications       #-}
-{-# LANGUAGE StandaloneDeriving     #-}
-{-# LANGUAGE TypeSynonymInstances   #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE AllowAmbiguousTypes        #-}
+{-# LANGUAGE DeriveFoldable             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# OPTIONS_GHC -Wno-missing-pattern-synonym-signatures #-}
 
 module Test.Data.Kore.ASTUtils (test_substitutions, test_sortAgreement) where
 
-import           Test.Tasty                                          (TestTree,
-                                                                      testGroup)
+import Test.Tasty
+       ( TestTree, testGroup )
 
-import           Test.Tasty.HUnit                 (assertEqual, testCase)
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
 
-import           Control.Lens
-import           Data.Reflection
+import Control.Lens
+import Data.Reflection
 
-import           Data.Kore.IndexedModule.MetadataTools
-import           Data.Kore.AST.Common 
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.ASTUtils.SmartConstructors
-import           Data.Kore.ASTUtils.Substitution
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.ASTUtils.SmartConstructors
+import Data.Kore.ASTUtils.Substitution
+import Data.Kore.IndexedModule.MetadataTools
 
 test_substitutions :: TestTree
-test_substitutions = testGroup "Substitutions" 
+test_substitutions = testGroup "Substitutions"
     [ testCase "subTrivial" $ assertEqual "" subTrivial subTrivialSolution
     , testCase "subShadow"  $ assertEqual "" subShadow subShadowSolution
-    , testCase "subAlphaRename1" $ 
-          assertEqual "" 
+    , testCase "subAlphaRename1" $
+          assertEqual ""
               subAlphaRename1
               subAlphaRename1Solution
-    , testCase "subAlphaRename2" $ 
-          assertEqual "" 
-              (subAlphaRename2 ^? inPath [0]) 
+    , testCase "subAlphaRename2" $
+          assertEqual ""
+              (subAlphaRename2 ^? inPath [0])
               (Just $ Var_ $ var "b")
-    , testCase "subTermForTerm" $ 
-          assertEqual "" 
+    , testCase "subTermForTerm" $
+          assertEqual ""
               subTermForTerm
               subTermForTermSolution
     ]
 
 test_sortAgreement :: TestTree
 test_sortAgreement = testGroup "Sort agreement"
-    [ testCase "sortAgreement1" $ 
-          assertEqual "" 
+    [ testCase "sortAgreement1" $
+          assertEqual ""
               (sortAgreement1 ^? inPath [1])
               (Just $ Bottom_ (testSort "X"))
-    , testCase "sortAgreement2.1" $ 
-          assertEqual "" 
+    , testCase "sortAgreement2.1" $
+          assertEqual ""
               (sortAgreement2 ^? inPath [0])
               (Just $ Bottom_ (testSort "Y"))
-    , testCase "sortAgreement2.2" $ 
-          assertEqual "" 
+    , testCase "sortAgreement2.2" $
+          assertEqual ""
               (sortAgreement2 ^? (inPath [1] . resultSort ))
               (Just $ testSort "Y")
-    , testCase "flexibleSort.1" $ 
+    , testCase "flexibleSort.1" $
           assertEqual ""
               (dummyEnvironment mkBottom ^? resultSort)
               (Just (flexibleSort :: Sort Object))
-    , testCase "flexibleSort.2" $ 
+    , testCase "flexibleSort.2" $
           assertEqual ""
               (dummyEnvironment mkTop ^? resultSort)
               (Just (flexibleSort :: Sort Object))
-    , testCase "flexibleSort.3" $ 
+    , testCase "flexibleSort.3" $
           assertEqual ""
               (dummyEnvironment (mkExists (var_ "a" "A") mkBottom) ^? resultSort)
               (Just (flexibleSort :: Sort Object))
-    , testGroup "sortAgreementManySimplePatterns" $ 
+    , testGroup "sortAgreementManySimplePatterns" $
           dummyEnvironment sortAgreementManySimplePatterns
     , testGetSetIdentity 5
     ]
 
 
-subTrivial :: CommonPurePattern Object 
-subTrivial = dummyEnvironment $ 
-    subst (Var_ $ var "a") (Var_ $ var "b") $ 
+subTrivial :: CommonPurePattern Object
+subTrivial = dummyEnvironment $
+    subst (Var_ $ var "a") (Var_ $ var "b") $
     mkExists (var "p") (Var_ $ var "a")
 
-subTrivialSolution :: CommonPurePattern Object 
-subTrivialSolution = dummyEnvironment $ 
+subTrivialSolution :: CommonPurePattern Object
+subTrivialSolution = dummyEnvironment $
     mkExists (var "p") (Var_ $ var "b")
 
-subShadow :: CommonPurePattern Object 
-subShadow = dummyEnvironment $ 
-    subst (Var_ $ var "a") (Var_ $ var "b") $ 
+subShadow :: CommonPurePattern Object
+subShadow = dummyEnvironment $
+    subst (Var_ $ var "a") (Var_ $ var "b") $
     mkExists (var "a") (Var_ $ var "q")
 
-subShadowSolution :: CommonPurePattern Object 
-subShadowSolution = dummyEnvironment $ 
+subShadowSolution :: CommonPurePattern Object
+subShadowSolution = dummyEnvironment $
     mkExists (var "a") (Var_ $ var "q")
 
-subAlphaRename1 :: CommonPurePattern Object 
-subAlphaRename1 = dummyEnvironment $ 
-    subst (Var_ $ var "a") (Var_ $ var "b") $ 
+subAlphaRename1 :: CommonPurePattern Object
+subAlphaRename1 = dummyEnvironment $
+    subst (Var_ $ var "a") (Var_ $ var "b") $
     mkExists (var "b") (Var_ $ var "q")
 
-subAlphaRename1Solution :: CommonPurePattern Object 
-subAlphaRename1Solution = dummyEnvironment $ 
-    mkExists (var "b0") (Var_ $ var "q") 
+subAlphaRename1Solution :: CommonPurePattern Object
+subAlphaRename1Solution = dummyEnvironment $
+    mkExists (var "b0") (Var_ $ var "q")
 
-subAlphaRename2 :: CommonPurePattern Object 
-subAlphaRename2 = dummyEnvironment $ 
-    subst (Var_ $ var "a") (Var_ $ var "b") $ 
+subAlphaRename2 :: CommonPurePattern Object
+subAlphaRename2 = dummyEnvironment $
+    subst (Var_ $ var "a") (Var_ $ var "b") $
     mkExists (var "b") (Var_ $ var "a")
 
-subTermForTerm :: CommonPurePattern Object 
-subTermForTerm = dummyEnvironment $ 
-    subst (mkOr mkTop mkBottom) (mkAnd mkTop mkBottom) $ 
-    mkImplies (mkOr mkTop mkBottom) mkTop 
+subTermForTerm :: CommonPurePattern Object
+subTermForTerm = dummyEnvironment $
+    subst (mkOr mkTop mkBottom) (mkAnd mkTop mkBottom) $
+    mkImplies (mkOr mkTop mkBottom) mkTop
 
-subTermForTermSolution :: CommonPurePattern Object 
-subTermForTermSolution = dummyEnvironment $ 
-    mkImplies (mkAnd mkTop mkBottom) mkTop 
+subTermForTermSolution :: CommonPurePattern Object
+subTermForTermSolution = dummyEnvironment $
+    mkImplies (mkAnd mkTop mkBottom) mkTop
 
--- subAlphaRename2Solution :: CommonPurePattern Object 
--- subAlphaRename2Solution = dummyEnvironment @Object $ 
---   subst (Var_ $ var "a") (Var_ $ var "b") $ 
+-- subAlphaRename2Solution :: CommonPurePattern Object
+-- subAlphaRename2Solution = dummyEnvironment @Object $
+--   subst (Var_ $ var "a") (Var_ $ var "b") $
 --   mkExists (var "b0") (Var_ $ var "b")
 
 -- the a : X forces bottom : X
 sortAgreement1 :: CommonPurePattern Object
-sortAgreement1 = dummyEnvironment $ 
+sortAgreement1 = dummyEnvironment $
     mkOr (Var_ $ var_ "a" "X") mkBottom
 
 -- the y : Y should force everything else to be Y
 sortAgreement2 :: CommonPurePattern Object
-sortAgreement2 = dummyEnvironment $ 
+sortAgreement2 = dummyEnvironment $
     mkImplies mkBottom $
     mkIff
         (mkEquals (Var_ $ var_ "foo" "X") (Var_ $ var_ "bar" "X"))
@@ -150,116 +150,116 @@ sortAgreement2 = dummyEnvironment $
 varX :: (Given (MetadataTools Object)) => CommonPurePattern Object
 varX = mkVar $ var_ "x" "X"
 
-sortAgreementManySimplePatterns 
+sortAgreementManySimplePatterns
   :: (Given (MetadataTools Object))
   => [TestTree]
-sortAgreementManySimplePatterns = do 
+sortAgreementManySimplePatterns = do
     flexibleZeroArg <- [mkBottom, mkTop]
     (a,b) <- [(varX, flexibleZeroArg), (flexibleZeroArg, varX), (varX, varX)]
-    shouldHaveSortXOneArg <- 
+    shouldHaveSortXOneArg <-
         [ mkForall (var "a") varX
         , mkExists (var "a") varX
         , mkNot varX
-        , mkNext varX 
+        , mkNext varX
         ]
-    shouldHaveSortXTwoArgs <- 
+    shouldHaveSortXTwoArgs <-
         [ mkAnd a b
         , mkOr a b
         , mkImplies a b
         , mkIff a b
         , mkRewrites a b
         ]
-    shouldHaveFlexibleSortTwoArgs <- 
+    shouldHaveFlexibleSortTwoArgs <-
         [ mkEquals a b
         , mkIn a b
         ]
-    shoudlHaveFlexibleSortOneArg <- 
+    shoudlHaveFlexibleSortOneArg <-
         [ mkCeil a
         , mkFloor a
         ]
-    let assert1 = return $ testCase "" $ assertEqual "" 
-            (getSort shouldHaveSortXOneArg) 
+    let assert1 = return $ testCase "" $ assertEqual ""
+            (getSort shouldHaveSortXOneArg)
             (testSort "X")
     let assert2 = return $ testCase "" $ assertEqual ""
             (getSort shouldHaveSortXTwoArgs)
             (testSort "X")
-    let assert3 = return $ testCase "" $ assertEqual "" 
+    let assert3 = return $ testCase "" $ assertEqual ""
             (getSort shoudlHaveFlexibleSortOneArg)
             flexibleSort
-    let assert4 = return $ testCase "" $ assertEqual "" 
+    let assert4 = return $ testCase "" $ assertEqual ""
             (getSort shouldHaveFlexibleSortTwoArgs)
             flexibleSort
-    assert1 ++ assert2 ++ assert3 ++ assert4 
+    assert1 ++ assert2 ++ assert3 ++ assert4
 
 substitutionGetSetIdentity a b pat =
-  assertEqual "" 
+  assertEqual ""
   (subst b a pat)
   (subst b a $ subst a b pat)
 
-generatePatterns 
+generatePatterns
   :: Given (MetadataTools Object)
-  => Int 
+  => Int
   -> [CommonPurePattern Object]
 generatePatterns size = genBinaryPatterns size ++ genUnaryPatterns size
 genBinaryPatterns
   :: Given (MetadataTools Object)
-  => Int 
+  => Int
   -> [CommonPurePattern Object]
 genBinaryPatterns 0 = []
 genBinaryPatterns size = do
   sa <- [1..size-1]
-  let sb = size - sa 
-  a <- generatePatterns sa 
-  b <- generatePatterns sb 
+  let sb = size - sa
+  a <- generatePatterns sa
+  b <- generatePatterns sb
   [mkAnd a b, mkOr a b, mkImplies a b, mkIff a b, mkRewrites a b]
 genUnaryPatterns
   :: Given (MetadataTools Object)
-  => Int 
+  => Int
   -> [CommonPurePattern Object]
 genUnaryPatterns 0 = []
 genUnaryPatterns 1 = [Var_ $ var_ "x" "X"]
-genUnaryPatterns size = do 
+genUnaryPatterns size = do
   a <- generatePatterns (size - 1)
   [mkNot a, mkNext a, mkForall (var $ show size) a]
 
---FIXME: Make a proper Tasty generator instead 
+--FIXME: Make a proper Tasty generator instead
 testGetSetIdentity
-  :: Int 
+  :: Int
   -> TestTree
-testGetSetIdentity size = dummyEnvironment $ testGroup "getSetIdent" $ do 
-  a <- generatePatterns (size `div` 3) 
+testGetSetIdentity size = dummyEnvironment $ testGroup "getSetIdent" $ do
+  a <- generatePatterns (size `div` 3)
   b <- generatePatterns (size `div` 3)
-  pat <- generatePatterns size 
-  return $ testCase "" $ substitutionGetSetIdentity a b pat 
+  pat <- generatePatterns size
+  return $ testCase "" $ substitutionGetSetIdentity a b pat
 
 var :: MetaOrObject level => String -> Variable level
-var x = 
-  Variable (noLocationId x) (testSort "S")  
+var x =
+  Variable (noLocationId x) (testSort "S")
 
 
 var_ :: MetaOrObject level => String -> String -> Variable level
-var_ x s = 
-  Variable (noLocationId x) (testSort s) 
+var_ x s =
+  Variable (noLocationId x) (testSort s)
 
 dummyEnvironment
-  :: forall r . MetaOrObject Object 
-  => (Given (MetadataTools Object) => r) 
+  :: forall r . MetaOrObject Object
+  => (Given (MetadataTools Object) => r)
   -> r
 dummyEnvironment = give (dummyMetadataTools @Object)
 
-dummyMetadataTools 
-  :: MetaOrObject level 
+dummyMetadataTools
+  :: MetaOrObject level
   => MetadataTools level
 dummyMetadataTools = MetadataTools
-    { isConstructor    = const True 
-    , isFunctional     = const True 
+    { isConstructor    = const True
+    , isFunctional     = const True
     , isFunction       = const True
-    , getArgumentSorts = const [] 
+    , getArgumentSorts = const []
     , getResultSort    = const $ testSort "S"
     }
 
-testSort 
-  :: MetaOrObject level 
+testSort
+  :: MetaOrObject level
   => String
   -> Sort level
 testSort name =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -1,25 +1,24 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier where
 
-import           Test.Tasty                               (TestTree, testGroup)
-import           Test.Tasty.HUnit                         (HasCallStack,
-                                                           assertEqual,
-                                                           assertFailure,
-                                                           testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( HasCallStack, assertEqual, assertFailure, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Fix
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTPrettyPrint
-import           Data.Kore.ASTVerifier.DefinitionVerifier
-import           Data.Kore.ASTVerifier.Error
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.Unparser.Unparse
+import Data.Fix
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTPrettyPrint
+import Data.Kore.ASTVerifier.DefinitionVerifier
+import Data.Kore.ASTVerifier.Error
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.Unparser.Unparse
 
 newtype ExpectedErrorMessage = ExpectedErrorMessage String
 newtype ErrorStack = ErrorStack [String]
@@ -492,11 +491,11 @@ symbolSentenceWithArguments
 
 objectAliasSentenceWithArguments
     :: AliasName -> Sort Object -> [Sort Object] -> KoreSentence
-objectAliasSentenceWithArguments a b c = 
-    aliasSentenceWithArguments 
-        a 
-        b 
-        c 
+objectAliasSentenceWithArguments a b c =
+    aliasSentenceWithArguments
+        a
+        b
+        c
         (TopPattern $ Top { topSort = b })
         (TopPattern $ Top { topSort = b })
 

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/Attributes.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/Attributes.hs
@@ -1,16 +1,18 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.Attributes (test_attributes) where
 
-import           Test.Tasty                                          (TestTree)
+import Test.Tasty
+       ( TestTree )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.Attributes                       (attributeObjectSort)
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.Attributes
+       ( attributeObjectSort )
 
 test_attributes :: [TestTree]
 test_attributes =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/Imports.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/Imports.hs
@@ -1,18 +1,18 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.Imports
     (test_imports) where
 
-import           Test.Tasty                                          (TestTree,
-                                                                      testGroup)
+import Test.Tasty
+       ( TestTree, testGroup )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
 test_imports :: [TestTree]
 test_imports =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/MetaObject.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/MetaObject.hs
@@ -1,17 +1,18 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.MetaObject
     (test_metaObject) where
 
-import           Test.Tasty                                          (TestTree)
+import Test.Tasty
+       ( TestTree )
 
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.AstWithLocation
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.AstWithLocation
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
 test_metaObject :: [TestTree]
 test_metaObject =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -3,24 +3,27 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.PatternVerifier
     (test_patternVerifier) where
 
-import           Test.Tasty                                          (TestTree)
-import           Test.Tasty.HUnit                                    (HasCallStack)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( HasCallStack )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier as Helpers
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier as Helpers
 
-import           Data.Kore.AST.AstWithLocation
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Building.Implicit
-import           Data.Kore.Building.Patterns                         as Patterns
-import           Data.Kore.Error
-import           Data.Kore.Implicit.Attributes                       (attributeObjectSort)
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.AstWithLocation
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Building.Implicit
+import Data.Kore.Building.Patterns as Patterns
+import Data.Kore.Error
+import Data.Kore.Implicit.Attributes
+       ( attributeObjectSort )
+import Data.Kore.Implicit.ImplicitSorts
 
-import qualified Data.List                                           as List
+import qualified Data.List as List
 
 data PatternRestrict
     = NeedsInternalDefinitions

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/SortUsage.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/SortUsage.hs
@@ -2,21 +2,23 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.SortUsage
     (test_sortUsage) where
 
-import           Test.Tasty                                          (TestTree,
-                                                                      testGroup)
-import           Test.Tasty.HUnit                                    (HasCallStack)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( HasCallStack )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
-import qualified Data.List                                           as List
-import           Data.Maybe                                          (mapMaybe)
+import qualified Data.List as List
+import           Data.Maybe
+                 ( mapMaybe )
 
 data TestFlag
     = CannotSeeSortVariables
@@ -539,8 +541,8 @@ unfilteredTestExamplesForSort
                     (ModuleName "MODULE")
                     (sentenceAliasSentence
                         (sentenceAliasWithResultSort
-                            aliasName 
-                            sort 
+                            aliasName
+                            sort
                             sortVariables
                             (TopPattern $ Top sort)
                             (TopPattern $ Top sort) )
@@ -563,11 +565,11 @@ unfilteredTestExamplesForSort
                     (ModuleName "MODULE")
                     (sentenceAliasSentence
                         (sentenceAliasWithSortArgument
-                            aliasName 
-                            sort 
-                            additionalSort 
+                            aliasName
+                            sort
+                            additionalSort
                             sortVariables
-                            (TopPattern $ Top sort) 
+                            (TopPattern $ Top sort)
                             (TopPattern $ Top sort) )
                     : additionalSentences
                     )

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/UniqueNames.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/UniqueNames.hs
@@ -1,15 +1,16 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.UniqueNames
     (test_uniqueNames) where
 
-import           Test.Tasty                                          (TestTree)
+import Test.Tasty
+       ( TestTree )
 
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
 test_uniqueNames :: [TestTree]
 test_uniqueNames =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/UniqueSortVariables.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/ASTVerifier/DefinitionVerifier/UniqueSortVariables.hs
@@ -1,15 +1,16 @@
 module Test.Data.Kore.ASTVerifier.DefinitionVerifier.UniqueSortVariables
     (test_uniqueSortVariables) where
 
-import           Test.Tasty                                          (TestTree)
+import Test.Tasty
+       ( TestTree )
 
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.AST.Common
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
 
 test_uniqueSortVariables :: [TestTree]
 test_uniqueSortVariables =
@@ -90,10 +91,10 @@ test_uniqueSortVariables =
         ( simpleDefinitionFromSentences (ModuleName "MODULE")
             [ asSentence
                 (aliasSentenceWithSortParameters
-                    (AliasName "a") 
-                    (SortName "s") 
-                    [] 
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s") }) 
+                    (AliasName "a")
+                    (SortName "s")
+                    []
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                 :: KoreSentenceAlias Object
                 )
@@ -107,7 +108,7 @@ test_uniqueSortVariables =
                     (AliasName "a")
                     (SortName "s")
                     [ sortVariable Object (SortVariableName "sv") ]
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s") }) 
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s") }))
             , simpleSortSentence (SortName "s")
             ]
@@ -119,7 +120,7 @@ test_uniqueSortVariables =
                     (AliasName "a")
                     (SortName "s")
                     [ sortVariable Object (SortVariableName "a") ]
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s") }) 
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s") }))
             , simpleSortSentence (SortName "s")
             ]
@@ -132,7 +133,7 @@ test_uniqueSortVariables =
                     (AliasName "a")
                     (SortName "s")
                     [ sortVariable Object (SortVariableName "s") ]
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s") }) 
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s") }))
             , simpleSortSentence (SortName "s")
             ]
@@ -146,7 +147,7 @@ test_uniqueSortVariables =
                     [ sortVariable Object (SortVariableName "sv1")
                     , sortVariable Object (SortVariableName "sv2")
                     ]
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s") }) 
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s") }))
             , simpleSortSentence (SortName "s")
             ]
@@ -353,7 +354,7 @@ test_uniqueSortVariables =
                     [ sortVariable Object (SortVariableName "sv")
                     , sortVariable Object (SortVariableName "sv")
                     ]
-                    (TopPattern $ Top { topSort = simpleSort (SortName "s1") }) 
+                    (TopPattern $ Top { topSort = simpleSort (SortName "s1") })
                     (TopPattern $ Top { topSort = simpleSort (SortName "s1") }))
             , simpleSortSentence (SortName "s")
             ]

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Algorithm/TopologicalSort.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Algorithm/TopologicalSort.hs
@@ -1,13 +1,15 @@
 module Test.Data.Kore.Algorithm.TopologicalSort
     (test_topologicalSort) where
 
-import           Test.Tasty                          (TestTree)
-import           Test.Tasty.HUnit                    (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import qualified Data.Map                            as Map
+import qualified Data.Map as Map
 
-import           Data.Kore.Algorithm.TopologicalSort
-import           Test.Tasty.HUnit.Extensions
+import Data.Kore.Algorithm.TopologicalSort
+import Test.Tasty.HUnit.Extensions
 
 test_topologicalSort :: [TestTree]
 test_topologicalSort =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Comparators.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Comparators.hs
@@ -14,15 +14,15 @@ Portability : portable
 -}
 module Test.Data.Kore.Comparators where
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
-import           Data.Kore.AST.Common
-import           Data.Kore.Step.BaseStep
-import           Data.Kore.Step.Condition.Condition
-import           Data.Kore.Step.Error
-import           Data.Kore.Step.Function.Data
-import           Data.Kore.Unification.Error
-import           Data.Kore.Unification.Unifier
+import Data.Kore.AST.Common
+import Data.Kore.Step.BaseStep
+import Data.Kore.Step.Condition.Condition
+import Data.Kore.Step.Error
+import Data.Kore.Step.Function.Data
+import Data.Kore.Unification.Error
+import Data.Kore.Unification.Unifier
 
 {-# ANN module "HLint: ignore Use record patterns" #-}
 

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Implicit/ImplicitKore.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Implicit/ImplicitKore.hs
@@ -1,19 +1,21 @@
 module Test.Data.Kore.Implicit.ImplicitKore (test_implicitKore, test_implicitAttributes) where
 
-import           Test.Tasty                      (TestTree, testGroup)
-import           Test.Tasty.Golden               (goldenVsString)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.Golden
+       ( goldenVsString )
 
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Implicit.Verified                         (implicitAttributesDefinition,
-                                                                      implicitKoreDefinition)
-import           Test.Data.Kore.Parser.Regression (GoldenFileName (..),
-                                                    InputFileName (..),
-                                                    VerifyRequest (..),
-                                                    regressionTest)
-import           Data.Kore.Unparser.Unparse      (unparseToString)
+import Data.Kore.AST.Sentence
+import Data.Kore.Implicit.Verified
+       ( implicitAttributesDefinition, implicitKoreDefinition )
+import Data.Kore.Unparser.Unparse
+       ( unparseToString )
+import Test.Data.Kore.Parser.Regression
+       ( GoldenFileName (..), InputFileName (..), VerifyRequest (..),
+       regressionTest )
 
-import qualified Data.ByteString.Lazy            as LazyByteString
-import qualified Data.ByteString.Lazy.Char8      as LazyChar8
+import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Data.ByteString.Lazy.Char8 as LazyChar8
 
 import qualified Paths
 

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndentingPrinter.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndentingPrinter.hs
@@ -1,10 +1,13 @@
 module Test.Data.Kore.IndentingPrinter (test_indentingPrinter) where
 
-import           Data.Kore.IndentingPrinter
-import           Data.List                  (intersperse)
+import Data.Kore.IndentingPrinter
+import Data.List
+       ( intersperse )
 
-import           Test.Tasty                 (TestTree)
-import           Test.Tasty.HUnit           (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
 class TestPrinter a where
     testPrint :: PrinterOutput w m => a -> m ()

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndexedModule/MetadataTools.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndexedModule/MetadataTools.hs
@@ -1,26 +1,28 @@
 module Test.Data.Kore.IndexedModule.MetadataTools (test_metadataTools) where
 
-import qualified Data.Map                                            as Map
-import           Data.Maybe                                          (fromMaybe)
-import           Test.Tasty                                          (TestTree)
-import           Test.Tasty.HUnit                                    (assertEqual,
-                                                                      testCase)
+import qualified Data.Map as Map
+import           Data.Maybe
+                 ( fromMaybe )
+import           Test.Tasty
+                 ( TestTree )
+import           Test.Tasty.HUnit
+                 ( assertEqual, testCase )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTVerifier.DefinitionVerifier
-import           Data.Kore.Error
-import           Data.Kore.Implicit.Attributes
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.IndexedModule.IndexedModule
-import           Data.Kore.IndexedModule.MetadataTools
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTVerifier.DefinitionVerifier
+import Data.Kore.Error
+import Data.Kore.Implicit.Attributes
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.IndexedModule.MetadataTools
 
 objectS1 :: Sort Object
 objectS1 = simpleSort (SortName "s1")

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndexedModule/Resolvers.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/IndexedModule/Resolvers.hs
@@ -1,28 +1,30 @@
 module Test.Data.Kore.IndexedModule.Resolvers (test_resolvers) where
 
-import           Test.Tasty                                          (TestTree)
-import           Test.Tasty.HUnit                                    (assertEqual,
-                                                                      testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import qualified Data.Map                                            as Map
-import           Data.Maybe                                          (fromMaybe)
 import           Data.Fix
+import qualified Data.Map as Map
+import           Data.Maybe
+                 ( fromMaybe )
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTHelpers
-import           Data.Kore.ASTVerifier.DefinitionVerifier
-import           Data.Kore.Error
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.IndexedModule.IndexedModule
-import           Data.Kore.IndexedModule.Resolvers
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTHelpers
+import Data.Kore.ASTVerifier.DefinitionVerifier
+import Data.Kore.Error
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.IndexedModule.Resolvers
 
 objectS1 :: Sort Object
 objectS1 = simpleSort (SortName "s1")

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/AST.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/AST.hs
@@ -1,15 +1,16 @@
 module Test.Data.Kore.MetaML.AST where
 
-import           Test.QuickCheck.Gen        (Gen, frequency, oneof, sized)
+import Test.QuickCheck.Gen
+       ( Gen, frequency, oneof, sized )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Fix
+import Data.Fix
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.MetaML.AST
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.MetaML.AST
 
 metaMLPatternGen :: Gen (MetaMLPattern Variable)
 metaMLPatternGen = Fix <$> sized (\n ->

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/Lift.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/Lift.hs
@@ -4,27 +4,29 @@ module Test.Data.Kore.MetaML.Lift
     , test_lift
     ) where
 
-import           Test.Tasty                       (TestTree, testGroup)
-import           Test.Tasty.HUnit                 (testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore
-import           Test.Tasty.HUnit.Extensions
+import Test.Data.Kore
+import Test.Tasty.HUnit.Extensions
 
-import           Data.CallStack
-import           Data.Fix
+import Data.CallStack
+import Data.Fix
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.BuildersImpl
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.ASTPrettyPrint
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.MetaML.AST
-import           Data.Kore.MetaML.Lift
-import           Data.Kore.MetaML.Unlift
+import Data.Kore.AST.Builders
+import Data.Kore.AST.BuildersImpl
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTPrettyPrint
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.MetaML.AST
+import Data.Kore.MetaML.Lift
+import Data.Kore.MetaML.Unlift
 
 variablePattern :: String -> Sort Meta -> CommonMetaPattern
 variablePattern name sort =
@@ -524,9 +526,9 @@ test_lift =
             [ SentenceSymbolSentence
                 (symbol_ "#`alias" AstLocationTest [] patternMetaSort)
             , SentenceAxiomSentence SentenceAxiom
-                { sentenceAxiomParameters = 
+                { sentenceAxiomParameters =
                     [ sortParameter Meta "#s" AstLocationTest ]
-                , sentenceAxiomPattern = Fix 
+                , sentenceAxiomPattern = Fix
                     (EqualsPattern Equals
                         { equalsOperandSort =
                             SortActualSort SortActual
@@ -534,9 +536,9 @@ test_lift =
                                 , sortActualSorts = []
                                 }
                         , equalsResultSort =
-                            SortVariableSort 
+                            SortVariableSort
                                 (sortParameter Meta "#s" AstLocationTest)
-                        , equalsFirst = Fix 
+                        , equalsFirst = Fix
                             (apply (groundHead "#\\top" AstLocationImplicit)
                                 [ Fix (apply (groundHead "#`s3" AstLocationImplicit) []) ]
                             )

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/Unlift.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/MetaML/Unlift.hs
@@ -1,20 +1,23 @@
 -- TODO(traiansf): add more negative tests
 module Test.Data.Kore.MetaML.Unlift (test_unlift) where
 
-import           Test.Tasty                       (TestTree)
-import           Test.Tasty.HUnit                 (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.MetaML.Lift       (prettyAssertEqual, variablePattern)
+import Test.Data.Kore.MetaML.Lift
+       ( prettyAssertEqual, variablePattern )
 
-import           Data.Fix
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.MetaML.AST
-import           Data.Kore.MetaML.Unlift
+import Data.Fix
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.MetaML.AST
+import Data.Kore.MetaML.Unlift
 
 test_unlift :: [TestTree]
 test_unlift =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser.hs
@@ -1,12 +1,14 @@
 module Test.Data.Kore.Parser where
 
-import           Test.Tasty                   (TestTree, testGroup)
-import           Test.Tasty.HUnit             (Assertion, assertBool,
-                                               assertEqual, testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( Assertion, assertBool, assertEqual, testCase )
 
-import           Data.Kore.Parser.ParserUtils
+import Data.Kore.Parser.ParserUtils
 
-import           Data.Either                  (isLeft)
+import Data.Either
+       ( isLeft )
 
 data SuccessfulTest a = SuccessfulTest
     { successInput    :: String

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CString.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CString.hs
@@ -1,10 +1,13 @@
 module Test.Data.Kore.Parser.CString (test_cString) where
 
-import           Test.Tasty               (TestTree)
-import           Test.Tasty.HUnit         (assertEqual, testCase)
-import           Test.Tasty.QuickCheck    (testProperty)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
+import Test.Tasty.QuickCheck
+       ( testProperty )
 
-import           Data.Kore.Parser.CString
+import Data.Kore.Parser.CString
 
 test_cString :: [TestTree]
 test_cString =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CharDict.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CharDict.hs
@@ -1,9 +1,11 @@
 module Test.Data.Kore.Parser.CharDict (test_charDict) where
 
-import           Test.Tasty                (TestTree)
-import           Test.Tasty.HUnit          (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Data.Kore.Parser.CharDict
+import Data.Kore.Parser.CharDict
 
 test_charDict :: [TestTree]
 test_charDict =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CharSet.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/CharSet.hs
@@ -1,9 +1,11 @@
 module Test.Data.Kore.Parser.CharSet (test_charSet) where
 
-import           Test.Tasty               (TestTree)
-import           Test.Tasty.HUnit         (assertBool, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertBool, testCase )
 
-import           Data.Kore.Parser.CharSet as CharSet
+import Data.Kore.Parser.CharSet as CharSet
 
 test_charSet :: [TestTree]
 test_charSet =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Lexeme.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Lexeme.hs
@@ -1,14 +1,15 @@
 module Test.Data.Kore.Parser.Lexeme (test_koreLexeme) where
 
-import           Test.Tasty                       (TestTree, testGroup)
+import Test.Tasty
+       ( TestTree, testGroup )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.Parser
+import Test.Data.Kore
+import Test.Data.Kore.Parser
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Sentence
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Parser.Lexeme
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Parser.Lexeme
 
 test_koreLexeme :: [TestTree]
 test_koreLexeme =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Parser.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Parser.hs
@@ -1,16 +1,17 @@
 module Test.Data.Kore.Parser.Parser (test_koreParser) where
 
-import           Test.Tasty                       (TestTree, testGroup)
+import Test.Tasty
+       ( TestTree, testGroup )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.Parser
+import Test.Data.Kore
+import Test.Data.Kore.Parser
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Implicit.ImplicitSorts
-import           Data.Kore.Parser.ParserImpl
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Sentence
+import Data.Kore.Implicit.ImplicitSorts
+import Data.Kore.Parser.ParserImpl
 
 test_koreParser :: [TestTree]
 test_koreParser =
@@ -797,7 +798,7 @@ variablePatternParserTests =
 sentenceAliasParserTests :: [TestTree]
 sentenceAliasParserTests =
     parseTree koreSentenceParser
-        [ 
+        [
           success "alias a{s1}(s2) : s3 where a{s1}(X:s2) := g{}() [\"a\"]"
             ( constructUnifiedSentence SentenceAliasSentence $
                 (SentenceAlias
@@ -854,8 +855,8 @@ sentenceAliasParserTests =
                         { applicationSymbolOrAlias =
                             SymbolOrAlias
                                 { symbolOrAliasConstructor = testId "a" :: Id Object
-                                , symbolOrAliasParams = 
-                                    [ 
+                                , symbolOrAliasParams =
+                                    [
                                           sortVariableSort "s1"
                                         , sortVariableSort "s2"
                                     ]

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Regression.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Parser/Regression.hs
@@ -5,23 +5,26 @@ module Test.Data.Kore.Parser.Regression
     , regressionTest, test_regression
     ) where
 
-import           Test.Tasty                               (TestTree)
-import           Test.Tasty.Golden                        (findByExtension,
-                                                           goldenVsString)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.Golden
+       ( findByExtension, goldenVsString )
 
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTPrettyPrint
-import           Data.Kore.ASTVerifier.DefinitionVerifier
-import           Data.Kore.Error
-import           Data.Kore.Parser.Parser
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTPrettyPrint
+import Data.Kore.ASTVerifier.DefinitionVerifier
+import Data.Kore.Error
+import Data.Kore.Parser.Parser
 
 
-import Control.Exception (bracket)
-import qualified Data.ByteString.Lazy                     as LazyByteString
-import qualified Data.ByteString.Lazy.Char8               as LazyChar8
-import System.Directory (getCurrentDirectory, setCurrentDirectory)
-import           System.FilePath                          (addExtension,
-                                                           splitFileName, (</>))
+import           Control.Exception
+                 ( bracket )
+import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Data.ByteString.Lazy.Char8 as LazyChar8
+import           System.Directory
+                 ( getCurrentDirectory, setCurrentDirectory )
+import           System.FilePath
+                 ( addExtension, splitFileName, (</>) )
 
 import qualified Paths
 

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/AxiomPatterns.hs
@@ -1,31 +1,36 @@
 module Test.Data.Kore.Step.AxiomPatterns (test_axiomPatterns) where
 
-import           Test.Tasty                                          (TestTree,
-                                                                      testGroup)
-import           Test.Tasty.HUnit                                    (assertEqual,
-                                                                      testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore                                      (testId)
-import           Test.Data.Kore.AST.MLPatterns                       (extractPurePattern)
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore
+       ( testId )
+import Test.Data.Kore.AST.MLPatterns
+       ( extractPurePattern )
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
 
-import qualified Data.Map                                            as Map
-import           Data.Maybe                                          (fromMaybe)
+import qualified Data.Map as Map
+import           Data.Maybe
+                 ( fromMaybe )
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore                                  (asKorePattern)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTVerifier.DefinitionVerifier            (AttributesVerification (..),
-                                                                      verifyAndIndexDefinition)
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.IndexedModule               (KoreIndexedModule)
-import           Data.Kore.Parser.ParserImpl
-import           Data.Kore.Parser.ParserUtils
-import           Data.Kore.Step.AxiomPatterns
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+       ( asKorePattern )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTVerifier.DefinitionVerifier
+       ( AttributesVerification (..), verifyAndIndexDefinition )
+import Data.Kore.Error
+import Data.Kore.IndexedModule.IndexedModule
+       ( KoreIndexedModule )
+import Data.Kore.Parser.ParserImpl
+import Data.Kore.Parser.ParserUtils
+import Data.Kore.Step.AxiomPatterns
 
 test_axiomPatterns :: [TestTree]
 test_axiomPatterns =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/BaseStep.hs
@@ -3,35 +3,37 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Step.BaseStep (test_baseStep) where
 
-import           Test.Tasty                            (TestTree)
-import           Test.Tasty.HUnit                      (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators            ()
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        AstLocation (..),
-                                                        Id (..),
-                                                        Pattern (ApplicationPattern),
-                                                        Sort,
-                                                        SymbolOrAlias (..),
-                                                        Variable)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureToKore              (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import           Data.Kore.MetaML.AST                  (CommonMetaPattern)
-import           Data.Kore.Step.BaseStep
-import           Data.Kore.Step.Condition.Condition    (ConditionSort (..))
-import           Data.Kore.Step.Error
-import           Data.Kore.Unification.Error
-import           Data.Kore.Unification.Unifier         (FunctionalProof (..),
-                                                        UnificationProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..),
+       Pattern (ApplicationPattern), Sort, SymbolOrAlias (..), Variable )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools (..) )
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Step.BaseStep
+import Data.Kore.Step.Condition.Condition
+       ( ConditionSort (..) )
+import Data.Kore.Step.Error
+import Data.Kore.Unification.Error
+import Data.Kore.Unification.Unifier
+       ( FunctionalProof (..), UnificationProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 test_baseStep :: [TestTree]
 test_baseStep =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition.hs
@@ -1,10 +1,11 @@
 module Test.Data.Kore.Step.Condition (mockConditionEvaluator) where
 
-import           Data.Kore.Step.Condition.Condition   (ConditionProof (..),
-                                                       EvaluatedCondition (..),
-                                                       UnevaluatedCondition (..))
-import           Data.Kore.Step.Function.Data         (ConditionEvaluator (..))
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.Step.Condition.Condition
+       ( ConditionProof (..), EvaluatedCondition (..),
+       UnevaluatedCondition (..) )
+import Data.Kore.Step.Function.Data
+       ( ConditionEvaluator (..) )
+import Data.Kore.Variables.Fresh.IntCounter
 
 mockConditionEvaluator
     ::  [   ( UnevaluatedCondition level

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition/Condition.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition/Condition.hs
@@ -1,16 +1,18 @@
 module Test.Data.Kore.Step.Condition.Condition (test_condition) where
 
-import           Test.Tasty                         (TestTree)
-import           Test.Tasty.HUnit                   (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators         ()
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Step.Condition.Condition
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Sorts
+import Data.Kore.Step.Condition.Condition
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 test_condition :: [TestTree]
 test_condition =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Condition/Evaluator.hs
@@ -3,31 +3,36 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Step.Condition.Evaluator (test_conditionEvaluator) where
 
-import           Test.Tasty                           (TestTree)
-import           Test.Tasty.HUnit                     (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators           ()
-import           Test.Data.Kore.Step.Function         (mockFunctionEvaluator)
+import Test.Data.Kore.Comparators ()
+import Test.Data.Kore.Step.Function
+       ( mockFunctionEvaluator )
 
-import           Data.Kore.AST.Common                 (Application (..),
-                                                       AstLocation (..),
-                                                       Id (..), Pattern (..),
-                                                       Sort, SymbolOrAlias (..))
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureToKore             (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.MetaML.AST                 (CommonMetaPattern)
-import           Data.Kore.Step.Condition.Condition
-import           Data.Kore.Step.Condition.Evaluator   (evaluateFunctionCondition)
-import           Data.Kore.Step.Function.Data         (CommonPurePatternFunctionEvaluator (..),
-                                                       FunctionResult (..),
-                                                       FunctionResultProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..), Pattern (..), Sort,
+       SymbolOrAlias (..) )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Step.Condition.Condition
+import Data.Kore.Step.Condition.Evaluator
+       ( evaluateFunctionCondition )
+import Data.Kore.Step.Function.Data
+       ( CommonPurePatternFunctionEvaluator (..), FunctionResult (..),
+       FunctionResultProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 test_conditionEvaluator :: [TestTree]
 test_conditionEvaluator =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function.hs
@@ -1,13 +1,14 @@
 module Test.Data.Kore.Step.Function (mockFunctionEvaluator) where
 
-import           Test.Data.Kore.Comparators           ()
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.PureML                 (CommonPurePattern)
-import           Data.Kore.Step.Condition.Condition
-import           Data.Kore.Step.Function.Data         (CommonPurePatternFunctionEvaluator (..),
-                                                       FunctionResult (..),
-                                                       FunctionResultProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.PureML
+       ( CommonPurePattern )
+import Data.Kore.Step.Condition.Condition
+import Data.Kore.Step.Function.Data
+       ( CommonPurePatternFunctionEvaluator (..), FunctionResult (..),
+       FunctionResultProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
 
 mockFunctionEvaluator
     ::  [   ( CommonPurePattern level

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function/Integration.hs
@@ -3,43 +3,49 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Step.Function.Integration (test_functionIntegration) where
 
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import qualified Data.Map                              as Map
+import           Data.Kore.IndexedModule.MetadataTools
+                 ( MetadataTools (..) )
+import qualified Data.Map as Map
 
 
-import           Test.Tasty                            (TestTree)
-import           Test.Tasty.HUnit                      (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators            ()
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        AstLocation (..),
-                                                        Id (..), Pattern (..),
-                                                        Sort,
-                                                        SymbolOrAlias (..))
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML                  (CommonPurePattern)
-import           Data.Kore.AST.PureToKore              (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error                       (printError)
-import           Data.Kore.MetaML.AST                  (CommonMetaPattern)
-import           Data.Kore.Step.BaseStep               (AxiomPattern (..))
-import           Data.Kore.Step.Condition.Condition    (ConditionSort (..),
-                                                        EvaluatedCondition (..))
-import           Data.Kore.Step.Function.Data          (ApplicationFunctionEvaluator (..),
-                                                        AttemptedFunctionResult (..),
-                                                        CommonPurePatternFunctionEvaluator,
-                                                        ConditionEvaluator,
-                                                        FunctionResult (..),
-                                                        FunctionResultProof (..))
-import           Data.Kore.Step.Function.Evaluator     (evaluateFunctions)
-import           Data.Kore.Step.Function.UserDefined   (axiomFunctionEvaluator)
-import           Data.Kore.Variables.Fresh.IntCounter  (IntCounter,
-                                                        runIntCounter)
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..), Pattern (..), Sort,
+       SymbolOrAlias (..) )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+       ( CommonPurePattern )
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+       ( printError )
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Step.BaseStep
+       ( AxiomPattern (..) )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionSort (..), EvaluatedCondition (..) )
+import Data.Kore.Step.Function.Data
+       ( ApplicationFunctionEvaluator (..), AttemptedFunctionResult (..),
+       CommonPurePatternFunctionEvaluator, ConditionEvaluator,
+       FunctionResult (..), FunctionResultProof (..) )
+import Data.Kore.Step.Function.Evaluator
+       ( evaluateFunctions )
+import Data.Kore.Step.Function.UserDefined
+       ( axiomFunctionEvaluator )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( IntCounter, runIntCounter )
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 test_functionIntegration :: [TestTree]
 test_functionIntegration =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Function/UserDefined.hs
@@ -3,42 +3,46 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Step.Function.UserDefined (test_userDefinedFunction) where
 
-import           Test.Tasty                            (TestTree)
-import           Test.Tasty.HUnit                      (testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators            ()
-import           Test.Data.Kore.Step.Condition         (mockConditionEvaluator)
-import           Test.Data.Kore.Step.Function          (mockFunctionEvaluator)
+import Test.Data.Kore.Comparators ()
+import Test.Data.Kore.Step.Condition
+       ( mockConditionEvaluator )
+import Test.Data.Kore.Step.Function
+       ( mockFunctionEvaluator )
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        AstLocation (..),
-                                                        Id (..), Pattern (..),
-                                                        Sort (..),
-                                                        SymbolOrAlias (..))
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML                  (CommonPurePattern,
-                                                        fromPurePattern)
-import           Data.Kore.AST.PureToKore              (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import           Data.Kore.MetaML.AST                  (CommonMetaPattern)
-import           Data.Kore.Step.BaseStep               (AxiomPattern (..))
-import           Data.Kore.Step.Condition.Condition    (ConditionProof (..),
-                                                        ConditionSort (..),
-                                                        EvaluatedCondition (..),
-                                                        UnevaluatedCondition (..))
-import           Data.Kore.Step.Function.Data          (AttemptedFunctionResult (..),
-                                                        CommonPurePatternFunctionEvaluator (..),
-                                                        ConditionEvaluator (..),
-                                                        FunctionResult (..),
-                                                        FunctionResultProof (..))
-import           Data.Kore.Step.Function.UserDefined   (axiomFunctionEvaluator)
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..), Pattern (..), Sort (..),
+       SymbolOrAlias (..) )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+       ( CommonPurePattern, fromPurePattern )
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools (..) )
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Step.BaseStep
+       ( AxiomPattern (..) )
+import Data.Kore.Step.Condition.Condition
+       ( ConditionProof (..), ConditionSort (..), EvaluatedCondition (..),
+       UnevaluatedCondition (..) )
+import Data.Kore.Step.Function.Data
+       ( AttemptedFunctionResult (..), CommonPurePatternFunctionEvaluator (..),
+       ConditionEvaluator (..), FunctionResult (..), FunctionResultProof (..) )
+import Data.Kore.Step.Function.UserDefined
+       ( axiomFunctionEvaluator )
+import Data.Kore.Variables.Fresh.IntCounter
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 test_userDefinedFunction :: [TestTree]
 test_userDefinedFunction =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Step.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Step/Step.hs
@@ -3,34 +3,36 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Step.Step (test_multiple, test_single) where
 
-import           Test.Tasty                            (TestTree, testGroup)
-import           Test.Tasty.HUnit                      (testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( testCase )
 
-import           Test.Data.Kore.Comparators            ()
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.Common                  (Application (..),
-                                                        AstLocation (..),
-                                                        Id (..),
-                                                        Pattern (ApplicationPattern),
-                                                        Sort,
-                                                        SymbolOrAlias (..),
-                                                        Variable)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureToKore              (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.MetadataTools (MetadataTools (..))
-import           Data.Kore.MetaML.AST                  (CommonMetaPattern)
-import           Data.Kore.Step.BaseStep
-import           Data.Kore.Step.Condition.Condition    (ConditionSort (..))
-import           Data.Kore.Step.Step
-import           Data.Kore.Unification.Unifier         (FunctionalProof (..),
-                                                        UnificationProof (..))
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..),
+       Pattern (ApplicationPattern), Sort, SymbolOrAlias (..), Variable )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.IndexedModule.MetadataTools
+       ( MetadataTools (..) )
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Step.BaseStep
+import Data.Kore.Step.Condition.Condition
+       ( ConditionSort (..) )
+import Data.Kore.Step.Step
+import Data.Kore.Unification.Unifier
+       ( FunctionalProof (..), UnificationProof (..) )
+import Data.Kore.Variables.Fresh.IntCounter
 
-import           Test.Tasty.HUnit.Extensions
+import Test.Tasty.HUnit.Extensions
 
 v1 :: MetaSort sort => sort -> MetaVariable sort
 v1 = metaVariable "#v1" AstLocationTest

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.Data.Kore.Substitution where
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
 
 objectSort :: Sort Object
 objectSort = SortVariableSort (SortVariable (testId "s"))

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution/Class.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution/Class.hs
@@ -4,17 +4,19 @@
 {-# LANGUAGE TypeSynonymInstances  #-}
 module Test.Data.Kore.Substitution.Class (test_class) where
 
-import           Test.Tasty                           (TestTree)
-import           Test.Tasty.HUnit                     (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
-import           Test.Data.Kore.Substitution
+import Test.Data.Kore
+import Test.Data.Kore.Substitution
 
 import           Data.Kore.AST.Common
 import           Data.Kore.AST.Kore
 import           Data.Kore.AST.MetaOrObject
 import           Data.Kore.Substitution.Class
-import qualified Data.Kore.Substitution.List          as S
+import qualified Data.Kore.Substitution.List as S
 import           Data.Kore.Variables.Fresh.IntCounter
 import           Data.Kore.Variables.Int
 

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution/List.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Substitution/List.hs
@@ -1,14 +1,16 @@
 module Test.Data.Kore.Substitution.List (test_list) where
 
-import           Test.Tasty                        (TestTree)
-import           Test.Tasty.HUnit                  (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore.Substitution
+import Test.Data.Kore.Substitution
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Substitution.List
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Substitution.List
 
 type UnifiedPatternSubstitution =
     Substitution (Unified Variable) CommonKorePattern

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unification/SubstitutionNormalization.hs
@@ -3,24 +3,31 @@
 module Test.Data.Kore.Unification.SubstitutionNormalization
     (test_substitutionNormalization) where
 
-import           Test.Tasty                                      (TestTree)
-import           Test.Tasty.HUnit                                (assertEqual,
-                                                                  testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Data.Kore.AST.Common                            (AstLocation (..),
-                                                                  Variable)
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.PureML                            (CommonPurePattern)
-import           Data.Kore.AST.PureToKore                        (patternKoreToPure)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.MetaML.AST                            (CommonMetaPattern)
-import           Data.Kore.Unification.Error                     (SubstitutionError (..))
-import           Data.Kore.Unification.SubstitutionNormalization
-import           Data.Kore.Unification.UnifierImpl               (UnificationSubstitution)
-import           Data.Kore.Variables.Fresh.IntCounter            (runIntCounter)
+import Data.Kore.AST.Common
+       ( AstLocation (..), Variable )
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.PureML
+       ( CommonPurePattern )
+import Data.Kore.AST.PureToKore
+       ( patternKoreToPure )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Data.Kore.Unification.Error
+       ( SubstitutionError (..) )
+import Data.Kore.Unification.SubstitutionNormalization
+import Data.Kore.Unification.UnifierImpl
+       ( UnificationSubstitution )
+import Data.Kore.Variables.Fresh.IntCounter
+       ( runIntCounter )
 
 test_substitutionNormalization :: [TestTree]
 test_substitutionNormalization =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unification/Unifier.hs
@@ -1,30 +1,35 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Test.Data.Kore.Unification.Unifier (test_unification) where
 
-import           Data.CallStack
-import           Test.Tasty                                          (TestTree)
-import           Test.Tasty.HUnit                                    (testCase)
-import           Test.Tasty.HUnit.Extensions
+import Data.CallStack
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( testCase )
+import Test.Tasty.HUnit.Extensions
 
-import           Test.Data.Kore
-import           Test.Data.Kore.AST.MLPatterns                       (extractPurePattern)
-import           Test.Data.Kore.ASTVerifier.DefinitionVerifier
-import           Test.Data.Kore.Comparators                          ()
+import Test.Data.Kore
+import Test.Data.Kore.AST.MLPatterns
+       ( extractPurePattern )
+import Test.Data.Kore.ASTVerifier.DefinitionVerifier
+import Test.Data.Kore.Comparators ()
 
-import           Data.Kore.AST.Builders
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.MLPatterns
-import           Data.Kore.AST.PureML
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTPrettyPrint
-import           Data.Kore.IndexedModule.MetadataTools
-import           Data.Kore.Unification.Error
-import           Data.Kore.Unification.UnifierImpl
+import Data.Kore.AST.Builders
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.MLPatterns
+import Data.Kore.AST.PureML
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTPrettyPrint
+import Data.Kore.IndexedModule.MetadataTools
+import Data.Kore.Unification.Error
+import Data.Kore.Unification.UnifierImpl
 
-import           Data.Fix
-import           Data.Function                                       (on)
-import           Data.List                                           (sortBy)
+import Data.Fix
+import Data.Function
+       ( on )
+import Data.List
+       ( sortBy )
 
 s1, s2, s3 :: Sort Object
 s1 = simpleSort (SortName "s1")

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unparser/Unparse.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Unparser/Unparse.hs
@@ -1,22 +1,26 @@
 module Test.Data.Kore.Unparser.Unparse
     ( test_parse, test_unparse ) where
 
-import           Test.Tasty                   (TestTree, testGroup)
-import           Test.Tasty.HUnit             (assertEqual, testCase)
-import           Test.Tasty.QuickCheck        (forAll, testProperty)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
+import Test.Tasty.QuickCheck
+       ( forAll, testProperty )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.AST.Pretty (Pretty(..))
-import           Data.Kore.AST.Sentence
-import           Data.Kore.Parser.LexemeImpl
-import           Data.Kore.Parser.ParserImpl
-import           Data.Kore.Parser.ParserUtils
-import           Data.Kore.Unparser.Unparse
-import           Data.Kore.HaskellExtensions
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.AST.Pretty
+       ( Pretty (..) )
+import Data.Kore.AST.Sentence
+import Data.Kore.HaskellExtensions
+import Data.Kore.Parser.LexemeImpl
+import Data.Kore.Parser.ParserImpl
+import Data.Kore.Parser.ParserUtils
+import Data.Kore.Unparser.Unparse
 
 test_unparse :: TestTree
 test_unparse =
@@ -33,23 +37,23 @@ test_unparse =
             )
             "sort x{} []"
         , unparseTest
-            (UnifiedSentence 
-                { getUnifiedSentence = UnifiedObject (Rotate41 
-                    { unRotate41 = SentenceAliasSentence (SentenceAlias 
-                        { sentenceAliasAlias = Alias 
+            (UnifiedSentence
+                { getUnifiedSentence = UnifiedObject (Rotate41
+                    { unRotate41 = SentenceAliasSentence (SentenceAlias
+                        { sentenceAliasAlias = Alias
                             { aliasConstructor = Id {getId = "i", idLocation = AstLocationTest} :: Id Object
                             , aliasParams = []
                             }
                         , sentenceAliasSorts = []
-                        , sentenceAliasResultSort = SortVariableSort (SortVariable 
+                        , sentenceAliasResultSort = SortVariableSort (SortVariable
                             { getSortVariable = Id {getId = "z", idLocation = AstLocationTest} :: Id Object})
-                        , sentenceAliasLeftPattern = TopPattern (Top 
-                            { topSort = SortActualSort (SortActual 
+                        , sentenceAliasLeftPattern = TopPattern (Top
+                            { topSort = SortActualSort (SortActual
                                 { sortActualName = Id {getId = "i", idLocation = AstLocationTest} :: Id Object
                                 , sortActualSorts = []
                                 })})
-                        , sentenceAliasRightPattern = TopPattern (Top 
-                            { topSort = SortVariableSort (SortVariable 
+                        , sentenceAliasRightPattern = TopPattern (Top
+                            { topSort = SortVariableSort (SortVariable
                                 { getSortVariable = Id {getId = "q", idLocation = AstLocationTest} :: Id Object})
                             })
                         , sentenceAliasAttributes = Attributes {getAttributes = []}

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Fresh/IntCounter.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Fresh/IntCounter.hs
@@ -1,18 +1,19 @@
 module Test.Data.Kore.Variables.Fresh.IntCounter (test_intCounter) where
 
-import           Test.Tasty                           (TestTree)
-import           Test.Tasty.HUnit                     (assertEqual,
-                                                       assertFailure, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, assertFailure, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Control.Exception                    (ErrorCall (ErrorCall),
-                                                       catch, evaluate)
+import Control.Exception
+       ( ErrorCall (ErrorCall), catch, evaluate )
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Variables.Fresh.Class
-import           Data.Kore.Variables.Fresh.IntCounter
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Variables.Fresh.Class
+import Data.Kore.Variables.Fresh.IntCounter
 
 objectVariable :: Variable Object
 objectVariable = Variable

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Int.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Int.hs
@@ -1,13 +1,15 @@
 module Test.Data.Kore.Variables.Int (test_int) where
 
-import           Test.Tasty                 (TestTree)
-import           Test.Tasty.HUnit           (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Test.Data.Kore
+import Test.Data.Kore
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Variables.Int
+import Data.Kore.AST.Common
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Variables.Int
 
 test_int :: [TestTree]
 test_int =

--- a/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Sort.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Data/Kore/Variables/Sort.hs
@@ -1,17 +1,19 @@
 module Test.Data.Kore.Variables.Sort (test_freeSortVariables) where
 
-import           Test.Tasty                  (TestTree)
-import           Test.Tasty.HUnit            (assertEqual, testCase)
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
-import           Data.Kore.AST.Common
-import           Data.Kore.AST.Kore
-import           Data.Kore.AST.MetaOrObject
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts    as Sorts
-import           Data.Kore.Variables.Sort
+import Data.Kore.AST.Common
+import Data.Kore.AST.Kore
+import Data.Kore.AST.MetaOrObject
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts as Sorts
+import Data.Kore.Variables.Sort
 
-import qualified Data.Set                    as Set
+import qualified Data.Set as Set
 
 test_freeSortVariables :: [TestTree]
 test_freeSortVariables =

--- a/src/main/haskell/language-kore/test/parser/Test/Tasty/HUnit/Extensions.hs
+++ b/src/main/haskell/language-kore/test/parser/Test/Tasty/HUnit/Extensions.hs
@@ -6,12 +6,15 @@
 {-# LANGUAGE TypeSynonymInstances      #-}
 {-# LANGUAGE UndecidableInstances      #-}
 module Test.Tasty.HUnit.Extensions where
-import           Control.Exception (SomeException, catch, evaluate)
-import           Control.Monad
-import           Data.CallStack
-import           Data.Fix
-import           Data.List         (intercalate, isInfixOf)
-import           Test.Tasty.HUnit  (assertBool, assertFailure)
+import Control.Exception
+       ( SomeException, catch, evaluate )
+import Control.Monad
+import Data.CallStack
+import Data.Fix
+import Data.List
+       ( intercalate, isInfixOf )
+import Test.Tasty.HUnit
+       ( assertBool, assertFailure )
 
 assertEqualWithPrinter
     :: (Eq a, HasCallStack)

--- a/src/main/haskell/matching-logic/Setup.hs
+++ b/src/main/haskell/matching-logic/Setup.hs
@@ -1,2 +1,2 @@
-import           Distribution.Simple
+import Distribution.Simple
 main = defaultMain

--- a/src/main/haskell/matching-logic/app/Main.hs
+++ b/src/main/haskell/matching-logic/app/Main.hs
@@ -1,21 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
-import           Data.Char                                     (isAlphaNum)
-import qualified Data.Map.Strict                               as Map
-import qualified Data.Set                                      as Set
+import           Data.Char
+                 ( isAlphaNum )
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import           Data.Text
 
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Text.Megaparsec
+import Text.Megaparsec.Char
 
-import           Data.Reflection
+import Data.Reflection
 
-import           Kore.MatchingLogic.AST
-import           Kore.MatchingLogic.AST.Syntax
-import           Kore.MatchingLogic.HilbertProof
-import           Kore.MatchingLogic.ProofSystem.Minimal
-import           Kore.MatchingLogic.ProofSystem.Minimal.Syntax (parseMLRuleSig)
-import           Kore.MatchingLogic.ProverRepl
-import           Kore.MatchingLogic.Signature.Simple
+import Kore.MatchingLogic.AST
+import Kore.MatchingLogic.AST.Syntax
+import Kore.MatchingLogic.HilbertProof
+import Kore.MatchingLogic.ProofSystem.Minimal
+import Kore.MatchingLogic.ProofSystem.Minimal.Syntax
+       ( parseMLRuleSig )
+import Kore.MatchingLogic.ProverRepl
+import Kore.MatchingLogic.Signature.Simple
 
 -- Todo: Parsing Formula as Text. Hook to Kore Parser
 parseName :: Parser Text

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/AST.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/AST.hs
@@ -55,14 +55,15 @@ module Kore.MatchingLogic.AST
   , andP' , notP', orP', impliesP', iffP', forallP', existsP'
   ) where
 
-import           Control.Monad
-import           Data.Coerce
+import Control.Monad
+import Data.Coerce
 
-import           Data.Deriving                (deriveEq1, deriveShow1)
-import           Data.Functor.Foldable
-import           Data.Text.Prettyprint.Doc
+import Data.Deriving
+       ( deriveEq1, deriveShow1 )
+import Data.Functor.Foldable
+import Data.Text.Prettyprint.Doc
 
-import           Kore.MatchingLogic.Signature
+import Kore.MatchingLogic.Signature
 
 -- | The base functor of patterns
 --

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/AST/Syntax.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/AST/Syntax.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- |
 Description: Parser and printer for matching logic patterns, using a subset of Kore syntax.
@@ -16,22 +16,27 @@ module Kore.MatchingLogic.AST.Syntax
   , simpleSigLabel
   , simpleSigSort
   ) where
-import           Control.Applicative
-import           Control.Monad                       (void)
-import           Data.Text                           (Text)
-import           Data.Void
+import Control.Applicative
+import Control.Monad
+       ( void )
+import Data.Text
+       ( Text )
+import Data.Void
 
-import           Data.Functor.Foldable               (Fix (Fix))
-import           Data.Reflection
+import Data.Functor.Foldable
+       ( Fix (Fix) )
+import Data.Reflection
 
-import           Data.Text.Prettyprint.Doc           (Doc, Pretty (..), (<>))
-import qualified Data.Text.Prettyprint.Doc           as Doc
+import           Data.Text.Prettyprint.Doc
+                 ( Doc, Pretty (..), (<>) )
+import qualified Data.Text.Prettyprint.Doc as Doc
 
-import           Text.Megaparsec                     hiding (some)
-import           Text.Megaparsec.Char
+import Text.Megaparsec hiding
+       ( some )
+import Text.Megaparsec.Char
 
-import           Kore.MatchingLogic.AST
-import           Kore.MatchingLogic.Signature.Simple
+import Kore.MatchingLogic.AST
+import Kore.MatchingLogic.Signature.Simple
 
 type Parser = Parsec Void Text
 

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Error.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Error.hs
@@ -9,9 +9,9 @@ Portability : POSIX
 -}
 module Kore.MatchingLogic.Error where
 
-import           Data.Kore.Error
+import Data.Kore.Error
 
-import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc
 
 {-| 'MLError' is a tag for errors related to matching logic. -}
 newtype MLError = MLError ()

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/HilbertProof.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/HilbertProof.hs
@@ -21,15 +21,17 @@ module Kore.MatchingLogic.HilbertProof
   ,renderProof
   ) where
 import           Data.Foldable
-import           Data.Map.Strict           (Map)
-import qualified Data.Map.Strict           as Map
-import           Data.Sequence             (Seq, (|>))
-import qualified Data.Sequence             as Seq
+import           Data.Map.Strict
+                 ( Map )
+import qualified Data.Map.Strict as Map
+import           Data.Sequence
+                 ( Seq, (|>) )
+import qualified Data.Sequence as Seq
 
-import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc
 
-import           Data.Kore.Error
-import           Kore.MatchingLogic.Error
+import Data.Kore.Error
+import Kore.MatchingLogic.Error
 
 data Proof ix rule formula =
   Proof

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Dummy.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Dummy.hs
@@ -11,9 +11,9 @@ module Kore.MatchingLogic.ProofSystem.Dummy
   (DummyRule(DummyRule)
   ,DummyError(DummyError)
   ) where
-import           Data.Text
+import Data.Text
 
-import           Kore.MatchingLogic.HilbertProof
+import Kore.MatchingLogic.HilbertProof
 
 {-| A dummy rule contains an arbitrary string
   which is printed in the 'Show' instance but

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/MLProofSystem.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/MLProofSystem.hs
@@ -1,41 +1,47 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE MonoLocalBinds        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Kore.MatchingLogic.ProofSystem.MLProofSystem where
 
-import           Data.Kore.AST.Common                   (And (..),
-                                                         Application (..),
-                                                         Exists (..),
-                                                         Implies (..), Not (..),
-                                                         Or (..), Pattern (..),
-                                                         SymbolOrAlias (..),
-                                                         Variable)
-import qualified Data.Kore.AST.Common                   as Common (Forall (..))
-import           Data.Kore.AST.Kore                     (CommonKorePattern)
-import           Data.Kore.AST.MetaOrObject             (Meta (..),
-                                                         Unified (..))
-import           Data.Kore.AST.PureToKore               (patternPureToKore)
-import           Data.Kore.ASTVerifier.PatternVerifier  (verifyPattern)
-import           Data.Kore.Error                        (Error, castError,
-                                                         koreFail, koreFailWhen,
-                                                         withContext)
-import           Data.Kore.IndexedModule.IndexedModule  (KoreIndexedModule)
-import           Data.Kore.MetaML.AST                   (CommonMetaPattern,
-                                                         metaFreeVariables)
-import           Data.Kore.Substitution.Class           (PatternSubstitutionClass (..))
-import qualified Data.Kore.Substitution.List            as Substitution
-import           Data.Kore.Unparser.Unparse             (Unparse,
-                                                         unparseToString)
-import           Data.Kore.Variables.Fresh.Class        (FreshVariablesClass (..))
-import           Data.Kore.Variables.Sort               (TermWithSortVariablesClass (sortVariables))
+import           Data.Kore.AST.Common
+                 ( And (..), Application (..), Exists (..), Implies (..),
+                 Not (..), Or (..), Pattern (..), SymbolOrAlias (..),
+                 Variable )
+import qualified Data.Kore.AST.Common as Common
+                 ( Forall (..) )
+import           Data.Kore.AST.Kore
+                 ( CommonKorePattern )
+import           Data.Kore.AST.MetaOrObject
+                 ( Meta (..), Unified (..) )
+import           Data.Kore.AST.PureToKore
+                 ( patternPureToKore )
+import           Data.Kore.ASTVerifier.PatternVerifier
+                 ( verifyPattern )
+import           Data.Kore.Error
+                 ( Error, castError, koreFail, koreFailWhen, withContext )
+import           Data.Kore.IndexedModule.IndexedModule
+                 ( KoreIndexedModule )
+import           Data.Kore.MetaML.AST
+                 ( CommonMetaPattern, metaFreeVariables )
+import           Data.Kore.Substitution.Class
+                 ( PatternSubstitutionClass (..) )
+import qualified Data.Kore.Substitution.List as Substitution
+import           Data.Kore.Unparser.Unparse
+                 ( Unparse, unparseToString )
+import           Data.Kore.Variables.Fresh.Class
+                 ( FreshVariablesClass (..) )
+import           Data.Kore.Variables.Sort
+                 ( TermWithSortVariablesClass (sortVariables) )
 
-import           Kore.MatchingLogic.Error               (MLError)
-import           Kore.MatchingLogic.HilbertProof        (ProofSystem (..))
-import           Kore.MatchingLogic.ProofSystem.Minimal (MLRule (..), SubstitutedVariable (..),
-                                                         SubstitutingVariable (..))
+import Kore.MatchingLogic.Error
+       ( MLError )
+import Kore.MatchingLogic.HilbertProof
+       ( ProofSystem (..) )
+import Kore.MatchingLogic.ProofSystem.Minimal
+       ( MLRule (..), SubstitutedVariable (..), SubstitutingVariable (..) )
 
 import           Data.Fix
-import qualified Data.Set                               as Set
+import qualified Data.Set as Set
 
 type Var = Variable Meta
 type Symbol = SymbolOrAlias Meta

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Minimal.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Minimal.hs
@@ -8,14 +8,15 @@ which does not assume the existence of a definedness symbol.
  -}
 module Kore.MatchingLogic.ProofSystem.Minimal where
 
-import           Control.Lens
-import           Data.Functor.Foldable           (Fix (..))
+import Control.Lens
+import Data.Functor.Foldable
+       ( Fix (..) )
 
-import           Kore.MatchingLogic.AST          as AST
-import           Kore.MatchingLogic.Error
-import           Kore.MatchingLogic.HilbertProof
+import Kore.MatchingLogic.AST as AST
+import Kore.MatchingLogic.Error
+import Kore.MatchingLogic.HilbertProof
 
-import           Data.Kore.Error
+import Data.Kore.Error
 
 newtype SubstitutedVariable var = SubstitutedVariable var
     deriving (Eq, Show)

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Minimal/Syntax.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProofSystem/Minimal/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-| Description: Parser and pretty-printer for the minimal proof system
 
@@ -9,19 +9,25 @@ module Kore.MatchingLogic.ProofSystem.Minimal.Syntax
   , parseMLRule
   , parseMLRuleSig)
   where
-import           Control.Applicative                    (some)
-import           Control.Monad                          (void)
-import           Data.Char                              (isAlphaNum)
-import           Data.Text                              (Text)
-import           Data.Void
+import Control.Applicative
+       ( some )
+import Control.Monad
+       ( void )
+import Data.Char
+       ( isAlphaNum )
+import Data.Text
+       ( Text )
+import Data.Void
 
-import           Data.Text.Prettyprint.Doc              (Doc, Pretty (pretty),
-                                                         sep, tupled, (<>))
-import           Text.Megaparsec                        hiding (some)
-import           Text.Megaparsec.Char
+import Data.Text.Prettyprint.Doc
+       ( Doc, Pretty (pretty), sep, tupled, (<>) )
+import Text.Megaparsec hiding
+       ( some )
+import Text.Megaparsec.Char
 
-import qualified Kore.MatchingLogic.AST                 as AST
-import           Kore.MatchingLogic.AST.Syntax          (mlPattern)
+import qualified Kore.MatchingLogic.AST as AST
+import           Kore.MatchingLogic.AST.Syntax
+                 ( mlPattern )
 import           Kore.MatchingLogic.ProofSystem.Minimal
 import           Kore.MatchingLogic.Signature
 

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProverRepl.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/ProverRepl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
 Description: A simple textual interface for building a proof
 
@@ -8,20 +8,24 @@ Parsers must be provided for the formulas, rules, and labels of
 a particular instance of 'HilbertProof'.
 -}
 module Kore.MatchingLogic.ProverRepl where
-import           Control.Monad.State.Strict      (MonadState (get,put), execStateT)
-import           Control.Monad.Trans             (MonadTrans (lift))
-import           Data.Text                       (Text, pack)
+import           Control.Monad.State.Strict
+                 ( MonadState (get, put), execStateT )
+import           Control.Monad.Trans
+                 ( MonadTrans (lift) )
+import qualified Data.Map.Strict as Map
+import           Data.Text
+                 ( Text, pack )
 import           Data.Void
-import qualified Data.Map.Strict                 as Map
 
-import           Data.Text.Prettyprint.Doc       (Pretty (pretty), colon, (<+>))
-import           System.Console.Haskeline
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Data.Text.Prettyprint.Doc
+       ( Pretty (pretty), colon, (<+>) )
+import System.Console.Haskeline
+import Text.Megaparsec
+import Text.Megaparsec.Char
 
-import           Kore.MatchingLogic.HilbertProof
-import           Data.Kore.Error
-import           Kore.MatchingLogic.Error
+import Data.Kore.Error
+import Kore.MatchingLogic.Error
+import Kore.MatchingLogic.HilbertProof
 
 newtype ProverState ix rule formula =
   ProverState (Proof ix rule formula)
@@ -37,10 +41,10 @@ applyAddAndProve :: (Ord ix, Pretty ix, ProofSystem error rule formula)
                  -> Proof ix rule formula
                  -> ix -> formula -> (rule ix)
                  -> Either (Error error) (Proof ix rule formula)
-applyAddAndProve formulaVerifier proof ix f rule = 
-  do 
+applyAddAndProve formulaVerifier proof ix f rule =
+  do
     proof' <- add formulaVerifier proof ix f
-    derive proof' ix f rule 
+    derive proof' ix f rule
 
 applyProve :: (Ord ix, Pretty ix, ProofSystem error rule formula)
            => Proof ix rule formula
@@ -50,7 +54,7 @@ applyProve proof ix rule = do
   f' <- case Map.lookup ix (index proof) of
           Nothing    ->   mlFail ["Formula with ID ", pretty ix, "not found"]
           Just (_,f) -> return f
-  derive proof ix f' rule 
+  derive proof ix f' rule
 
 applyAdd :: (Ord ix, Pretty ix, ProofSystem error rule formula)
          => (formula -> Either (Error error) ())
@@ -95,7 +99,7 @@ parseProve pIx _ pDerivation = do
   return (Prove ix rule)
 
 parseCommand :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
-parseCommand pIx pFormula pDerivation 
+parseCommand pIx pFormula pDerivation
   =  parseProve pIx pFormula pDerivation
  <|> parseAdd pIx pFormula pDerivation
 

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Signature/Poly.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Signature/Poly.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies     #-}
-{-# LANGUAGE ConstraintKinds      #-}
 {-|
 Description: A generic signature for parameterized sorts and labels
 
@@ -23,19 +23,22 @@ module Kore.MatchingLogic.Signature.Poly
   ,reifySignature
   ,prettyPolyTerm) where
   -- ,ValidatedSignature,fromValidated,findLabel) where
-import           Data.Char                 (isAlpha, isAlphaNum)
+import           Data.Char
+                 ( isAlpha, isAlphaNum )
 import           Data.Coerce
-import           Data.Map.Strict           (Map)
-import qualified Data.Map.Strict           as Map
+import           Data.Map.Strict
+                 ( Map )
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
-import           Data.Text                 (Text)
-import qualified Data.Text                 as Text
+import           Data.Text
+                 ( Text )
+import qualified Data.Text as Text
 
-import           Data.Reflection
-import           Data.Text.Prettyprint.Doc
+import Data.Reflection
+import Data.Text.Prettyprint.Doc
 
-import           Kore.MatchingLogic.AST
-import           Kore.MatchingLogic.Signature
+import Kore.MatchingLogic.AST
+import Kore.MatchingLogic.Signature
 
 -- | A tree of applied sort constructors,
 -- which also allows for sort variables.

--- a/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Signature/Simple.hs
+++ b/src/main/haskell/matching-logic/src/Kore/MatchingLogic/Signature/Simple.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies     #-}
 {-|
 Description: A generic signature for finite sets of simply-sorted labels
 
@@ -20,18 +20,21 @@ module Kore.MatchingLogic.Signature.Simple
   ,reifySignature) where
 import           Data.Char
 import           Data.Coerce
-import           Data.Map.Strict           (Map)
-import qualified Data.Map.Strict           as Map
+import           Data.Map.Strict
+                 ( Map )
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
-import           Data.Set                  (Set)
-import qualified Data.Set                  as Set
-import           Data.Text                 (Text)
-import qualified Data.Text                 as Text
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
+import           Data.Text
+                 ( Text )
+import qualified Data.Text as Text
 
-import           Data.Text.Prettyprint.Doc
-import           Data.Reflection
+import Data.Reflection
+import Data.Text.Prettyprint.Doc
 
-import           Kore.MatchingLogic.Signature
+import Kore.MatchingLogic.Signature
 
 -- | A finite signatures of sorts and labels written as text
 data SignatureInfo = SignatureInfo
@@ -109,7 +112,7 @@ instance (Reifies s ValidatedSignature) => CheckableSignature (SimpleSignature s
            to avoid keeping multiple Text values with identical contents -}
         case Set.lookupGE sortName (sorts sig) of
             Just sort' | sort' == sortName -> Just (SimpleSort sort')
-            _          -> Nothing
+            _                              -> Nothing
       where sig = fromValidated (reflect @s Proxy)
 
     resolveLabel labelName =
@@ -117,5 +120,5 @@ instance (Reifies s ValidatedSignature) => CheckableSignature (SimpleSignature s
            to avoid keeping multiple Text values with identical contents -}
         case Map.lookupGE labelName (labels sig) of
             Just (label',_) | label' == labelName -> Just (SimpleLabel label')
-            _               -> Nothing
+            _                                     -> Nothing
       where sig = fromValidated (reflect @s Proxy)

--- a/src/main/haskell/matching-logic/test/Paths.hs
+++ b/src/main/haskell/matching-logic/test/Paths.hs
@@ -3,8 +3,10 @@
 module Paths where
 
 import qualified Language.Haskell.TH as TH
-import           System.Directory    (doesFileExist, makeAbsolute)
-import           System.FilePath     (takeDirectory, (</>))
+import           System.Directory
+                 ( doesFileExist, makeAbsolute )
+import           System.FilePath
+                 ( takeDirectory, (</>) )
 
 
 -- | Resolve the file name of a test resource relative to the package root.

--- a/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/Minimal.hs
+++ b/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/Minimal.hs
@@ -1,19 +1,22 @@
 module Test.Kore.MatchingLogic.ProofSystem.Minimal where
 
-import           Test.Tasty                                    (TestTree,
-                                                                testGroup)
-import           Test.Tasty.HUnit
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
 
-import           Control.Applicative                           (some)
-import           Data.Text                                     (Text)
-import qualified Data.Text                                     as T
+import           Control.Applicative
+                 ( some )
+import           Data.Text
+                 ( Text )
+import qualified Data.Text as T
 import           Data.Text.Prettyprint.Doc
 import           Data.Void
-import           Text.Megaparsec                               hiding (some)
+import           Text.Megaparsec hiding
+                 ( some )
 import           Text.Megaparsec.Char
 
-import           Kore.MatchingLogic.ProofSystem.Minimal
-import           Kore.MatchingLogic.ProofSystem.Minimal.Syntax
+import Kore.MatchingLogic.ProofSystem.Minimal
+import Kore.MatchingLogic.ProofSystem.Minimal.Syntax
 
 test :: String -> DummyRule -> String -> TestTree
 test name ast str =
@@ -140,4 +143,4 @@ parseTestRule :: String -> DummyRule
 parseTestRule ruleStr =
     case parse mlRuleTestParser "" (T.pack ruleStr) of
         Right parsedRule -> parsedRule
-        Left err -> error (parseErrorPretty err)
+        Left err         -> error (parseErrorPretty err)

--- a/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne.hs
+++ b/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE PartialTypeSignatures      #-}
+{-# LANGUAGE RecordWildCards            #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
@@ -20,47 +20,45 @@ AST because the proof was done assuming the forall quantifier is primitive.
 -}
 module Test.Kore.MatchingLogic.ProofSystem.OnePlusOne where
 
-import           Prelude                                hiding (all, and, not,
-                                                         succ, lines, pred)
+import Prelude hiding
+       ( all, and, lines, not, pred, succ )
 
-import           Control.Applicative
-import           Control.Monad                          (foldM)
-import           Control.Monad.State.Strict
+import Control.Applicative
+import Control.Monad
+       ( foldM )
+import Control.Monad.State.Strict
 
-import qualified Data.ByteString.Lazy                   as L
-import qualified Data.Map.Strict                        as Map
-import qualified Data.Set                               as Set
-import           Data.Text                              (Text)
-import qualified Data.Tree                              as Tree
+import qualified Data.ByteString.Lazy as L
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           Data.Text
+                 ( Text )
+import qualified Data.Tree as Tree
 import           Data.Word
 
-import           GHC.Generics
-import           Data.Data
+import Data.Data
+import GHC.Generics
 
-import           Data.Functor.Foldable                  (Fix (Fix))
-import           Data.Void                              (Void)
+import Data.Functor.Foldable
+       ( Fix (Fix) )
+import Data.Void
+       ( Void )
 
-import           Text.Megaparsec                        (Parsec
-                                                        ,parse
-                                                        ,eof
-                                                        ,parseErrorPretty)
+import           Text.Megaparsec
+                 ( Parsec, eof, parse, parseErrorPretty )
 import           Text.Megaparsec.Byte
 import qualified Text.Megaparsec.Byte.Lexer as Lexer
 
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
-import qualified Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST as AST
-import           Kore.MatchingLogic.HilbertProof        as HilbertProof (Proof(..)
-                                                                        ,add
-                                                                        ,derive
-                                                                        ,emptyProof)
-import           Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ProofSystem ( MLRule (..)
-                                                        , MLRuleSig
-                                                        , transformRule
-                                                        , SubstitutedVariable (..)
-                                                        , SubstitutingVariable (..))
+import           Kore.MatchingLogic.HilbertProof as HilbertProof
+                 ( Proof (..), add, derive, emptyProof )
 import           Kore.MatchingLogic.Signature.Simple
+import qualified Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST as AST
+import           Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ProofSystem
+                 ( MLRule (..), MLRuleSig, SubstitutedVariable (..),
+                 SubstitutingVariable (..), transformRule )
 
 import qualified Paths
 
@@ -315,7 +313,7 @@ convert :: Simple_proof -> ConvM Int
 convert (Conclusion formula rule) = convertRule convert rule >>= \case
     Right rule' -> emit (convertFormula formula) rule'
     Left ix -> return ix
-               
+
 useHyp :: (Applicative f) => (Nat -> f Nat) -> (Simple_proof -> f Simple_proof)
 useHyp f (Conclusion pat (Rule_use_hyp v)) = Conclusion pat . Rule_use_hyp <$> f v
 useHyp _ proof = pure proof
@@ -324,7 +322,7 @@ loadCoqOutput :: IO Simple_proof
 loadCoqOutput = do
     text <- L.readFile (Paths.dataFileName "test/resources/proof_tree.txt")
     case parse (space1 *> pSimple_proof' <* eof) "proof_tree.txt" text of
-        Left err -> error (parseErrorPretty err)
+        Left err    -> error (parseErrorPretty err)
         Right proof -> return proof
 
 {- ^ runConversion takes the number of indices to leave free at the beginning,
@@ -386,7 +384,7 @@ chomp str' = go 0 str'
     go 1     (')':_)   = ")"
     go depth (')':str) = ')':go (depth-1) str
     go depth (c  :str) = c:go depth str
-    go _     ""        = error "chomp on the empty string is undefined" 
+    go _     ""        = error "chomp on the empty string is undefined"
 
 findBadThings :: ReifiesSignature s
               => proxy (SimpleSignature s)

--- a/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne/ForallAST.hs
+++ b/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne/ForallAST.hs
@@ -48,14 +48,15 @@ module Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST
   , andP' , notP', orP', impliesP', iffP', forallP', existsP'
   ) where
 
-import           Control.Monad
-import           Data.Coerce
+import Control.Monad
+import Data.Coerce
 
-import           Data.Deriving                (deriveEq1, deriveShow1)
-import           Data.Functor.Foldable
-import           Data.Text.Prettyprint.Doc
+import Data.Deriving
+       ( deriveEq1, deriveShow1 )
+import Data.Functor.Foldable
+import Data.Text.Prettyprint.Doc
 
-import           Kore.MatchingLogic.Signature
+import Kore.MatchingLogic.Signature
 
 -- | The base functor of patterns
 data PatternF sort -- ^ The type of sorts
@@ -80,11 +81,11 @@ visitPatternF :: (Applicative f)
               -> (PatternF sort label var pat
                    -> f (PatternF sort' label' var' pat'))
 visitPatternF sort label var pat term = case term of
-  Variable s v -> Variable <$> sort s <*> var v
+  Variable s v       -> Variable <$> sort s <*> var v
   Application l args -> Application <$> label l <*> traverse pat args
-  And s p1 p2 -> And <$> sort s <*> pat p1 <*> pat p2
-  Not s p -> Not <$> sort s <*> pat p
-  Forall s sVar v p -> Forall <$> sort s <*> sort sVar <*> var v <*> pat p
+  And s p1 p2        -> And <$> sort s <*> pat p1 <*> pat p2
+  Not s p            -> Not <$> sort s <*> pat p
+  Forall s sVar v p  -> Forall <$> sort s <*> sort sVar <*> var v <*> pat p
 
 -- | Specializing 'PatternF' to use the sort and label from a signature 'sig'.
 type SigPatternF sig = PatternF (Sort sig) (Label sig)

--- a/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne/ProofSystem.hs
+++ b/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/OnePlusOne/ProofSystem.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-|
 Description: The minimal matching logic proof system of
 Kore.MatchingLogic.ProofSystem.Minimal, with added
@@ -7,20 +7,23 @@ connectives, which were needed to complete the 1+1=2 proof.
  -}
 module Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ProofSystem where
 
-import           Data.Functor.Foldable           (Fix (..))
-import           Control.Lens                    ((&),(%~))
+import Control.Lens
+       ( (%~), (&) )
+import Data.Functor.Foldable
+       ( Fix (..) )
 
-import qualified          Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST          as AST
-import Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST
-  (Sort,Label,Pattern,WFPattern
-  ,pattern ApplicationP,pattern OrP, pattern ImpliesP, pattern AndP, pattern NotP
-  ,pattern VariableP,pattern ExistsP,pattern ForallP
-  ,notP',impliesP')
+import           Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST
+                 ( pattern AndP, pattern ApplicationP, pattern ExistsP,
+                 pattern ForallP, pattern ImpliesP, Label, pattern NotP,
+                 pattern OrP, Pattern, Sort, pattern VariableP, WFPattern,
+                 impliesP', notP' )
+import qualified Test.Kore.MatchingLogic.ProofSystem.OnePlusOne.ForallAST as AST
 
-import           Kore.MatchingLogic.HilbertProof
-import           Kore.MatchingLogic.Error(MLError)
-import           Kore.MatchingLogic.Signature
-import           Data.Kore.Error
+import Data.Kore.Error
+import Kore.MatchingLogic.Error
+       ( MLError )
+import Kore.MatchingLogic.HilbertProof
+import Kore.MatchingLogic.Signature
 
 newtype SubstitutedVariable var = SubstitutedVariable var
     deriving (Eq, Show)

--- a/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/ProofAssistant.hs
+++ b/src/main/haskell/matching-logic/test/Test/Kore/MatchingLogic/ProofSystem/ProofAssistant.hs
@@ -3,43 +3,42 @@
 
 module Test.Kore.MatchingLogic.ProofSystem.ProofAssistant where
 
-import           Test.Tasty                                   (TestTree,
-                                                               testGroup)
-import           Test.Tasty.HUnit                             (assertFailure,
-                                                               testCase)
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+       ( assertFailure, testCase )
 
-import           Data.Kore.AST.Common                         (Application (..),
-                                                               AstLocation (..),
-                                                               Id (..),
-                                                               Pattern (..),
-                                                               Symbol (..),
-                                                               SymbolOrAlias (..),
-                                                               Variable)
-import           Data.Kore.AST.Kore                           (CommonKorePattern)
-import           Data.Kore.AST.MetaOrObject                   (Meta (..))
-import           Data.Kore.AST.PureToKore
-import           Data.Kore.AST.Sentence
-import           Data.Kore.ASTVerifier.DefinitionVerifier     (AttributesVerification (..),
-                                                               verifyAndIndexDefinition)
-import           Data.Kore.Building.AsAst
-import           Data.Kore.Building.Patterns
-import           Data.Kore.Building.Sorts
-import           Data.Kore.Error
-import           Data.Kore.IndexedModule.IndexedModule
-import           Data.Kore.MetaML.AST                         (MetaMLPattern)
+import Data.Kore.AST.Common
+       ( Application (..), AstLocation (..), Id (..), Pattern (..),
+       Symbol (..), SymbolOrAlias (..), Variable )
+import Data.Kore.AST.Kore
+       ( CommonKorePattern )
+import Data.Kore.AST.MetaOrObject
+       ( Meta (..) )
+import Data.Kore.AST.PureToKore
+import Data.Kore.AST.Sentence
+import Data.Kore.ASTVerifier.DefinitionVerifier
+       ( AttributesVerification (..), verifyAndIndexDefinition )
+import Data.Kore.Building.AsAst
+import Data.Kore.Building.Patterns
+import Data.Kore.Building.Sorts
+import Data.Kore.Error
+import Data.Kore.IndexedModule.IndexedModule
+import Data.Kore.MetaML.AST
+       ( MetaMLPattern )
 
-import           Kore.MatchingLogic.Error
-import           Kore.MatchingLogic.HilbertProof              as HilbertProof (Proof (..),
-                                                                               add,
-                                                                               derive,
-                                                                               emptyProof)
-import           Kore.MatchingLogic.ProofSystem.Minimal       (MLRule (..), SubstitutedVariable (..),
-                                                               SubstitutingVariable (..))
-import           Kore.MatchingLogic.ProofSystem.MLProofSystem as MLProofSystem
+import Kore.MatchingLogic.Error
+import Kore.MatchingLogic.HilbertProof as HilbertProof
+       ( Proof (..), add, derive, emptyProof )
+import Kore.MatchingLogic.ProofSystem.Minimal
+       ( MLRule (..), SubstitutedVariable (..), SubstitutingVariable (..) )
+import Kore.MatchingLogic.ProofSystem.MLProofSystem as MLProofSystem
 
-import           Control.Monad                                (foldM)
-import           Data.List                                    (foldl')
-import qualified Data.Map.Strict                              as Map
+import           Control.Monad
+                 ( foldM )
+import           Data.List
+                 ( foldl' )
+import qualified Data.Map.Strict as Map
 import           Data.Text.Prettyprint.Doc
 
 test_proofAssistant :: TestTree


### PR DESCRIPTION
Our style guide is currently silent on some formatting issues around import statements. This pull request adds a configuration for stylish-haskell which applies some simple alignment rules to import statements and alphabetizes them within their groups. A few other simple formatting rules are applied, such as removing trailing whitespace and aligning LANGUAGE pragmas. I would like to suggest that the style guide recommend running stylish-haskell for the issues it can handle; the formatting is fairly good, but most importantly: it is _automatic_.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance

---

