### PR TITLE
Fix argument order to tasty-discover

### DIFF
--- a/src/main/haskell/language-kore/test/parser/Driver.hs
+++ b/src/main/haskell/language-kore/test/parser/Driver.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC
     -F -pgmF tasty-discover
     -optF --tree-display
-    -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner
-    -optF --ingredient=Test.Tasty.Runners.listingTests
     -optF --ingredient=Test.Tasty.Runners.consoleTestReporter
+    -optF --ingredient=Test.Tasty.Runners.listingTests
+    -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner
 #-}

--- a/src/main/haskell/matching-logic/test/Driver.hs
+++ b/src/main/haskell/matching-logic/test/Driver.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC
     -F -pgmF tasty-discover
     -optF --tree-display
-    -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner
-    -optF --ingredient=Test.Tasty.Runners.listingTests
     -optF --ingredient=Test.Tasty.Runners.consoleTestReporter
+    -optF --ingredient=Test.Tasty.Runners.listingTests
+    -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner
 #-}


### PR DESCRIPTION
`antXMLRunner` must come first in the list of `tasty` ingredients so that it has
the opportunity to grab the `--xml=` option; therefore it must come _last_ on
the command line.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance

---

