### PR TITLE
LTS Haskell 12.2

### DIFF
--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -1,7 +1,7 @@
 name:                kore
 version:             0.0.1.0
 github:              "kframework/kore"
-license:             OtherLicense
+license:             NCSA
 license-file:        LICENSE
 author:              "Virgil Serbanuta"
 maintainer:          "virgil.serbanuta@runtimeverification.com"

--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -25,7 +25,6 @@ dependencies:
   - base >= 4.7
   - array
   - bytestring >= 0.10
-  - bytestring-trie
   - containers
   - clock
   - data-default
@@ -46,6 +45,7 @@ dependencies:
   - reflection
   - text
   - time
+  - unordered-containers
 
 build-tools:
   - tasty-discover

--- a/src/main/haskell/kore/src/Data/Function/Compose.hs
+++ b/src/main/haskell/kore/src/Data/Function/Compose.hs
@@ -2,7 +2,7 @@
 Module      : Data.Function.Compose
 Description : Short-hand notation for function composition with many arguments
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
+++ b/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
@@ -2,7 +2,7 @@
 Module      : Data.Functor.Impredicative
 Description : Wrappers to work around the absence of impredicative types
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Data/Graph/TopologicalSort.hs
+++ b/src/main/haskell/kore/src/Data/Graph/TopologicalSort.hs
@@ -2,7 +2,7 @@
 Module      : Data.Graph.TopologicalSort
 Description : Topological sorting algorithm.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Data/Map/Class.hs
+++ b/src/main/haskell/kore/src/Data/Map/Class.hs
@@ -2,7 +2,7 @@
 Module      : Data.Map.Class
 Description : Class for representing a @key@ |-> @value@ map functionality.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/AstWithLocation.hs
+++ b/src/main/haskell/kore/src/Kore/AST/AstWithLocation.hs
@@ -2,7 +2,7 @@
 Module      : Kore.AST.AstWithLocation
 Description : Class for extracting locations from AST terms.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/AST/Builders.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Builders.hs
@@ -2,7 +2,7 @@
 Module      : Kore.MetaML.Builders
 Description : Safe way to build larger 'level' patterns from components.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
+++ b/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
@@ -2,7 +2,7 @@
 Module      : Kore.MetaML.BuildersImpl
 Description : Helper functions for "Data.Kore.MetaML.Builder"
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -6,7 +6,7 @@ Description : Data Structures for representing the Kore language AST that do not
               need unified constructs (see "Kore.AST.Kore" for the unified
               ones).
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/Error.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Error.hs
@@ -2,7 +2,7 @@
 Module      : Kore.AST.Error
 Description : Extensions for errors related to the AST.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/AST/Kore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Kore.hs
@@ -3,7 +3,7 @@ Module      : Kore.AST.Kore
 Description : Data Structures for representing the Kore language AST with
               unified constructs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
@@ -2,7 +2,7 @@
 Module      : Kore.MLPatterns
 Description : Data structures and functions for handling patterns uniformly.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/MetaOrObject.hs
+++ b/src/main/haskell/kore/src/Kore/AST/MetaOrObject.hs
@@ -3,7 +3,7 @@ Module      : Kore.AST.MetaOrObject
 Description : Specifies the 'Meta', 'Object', and 'Unified' types, and common
               functionality for them
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/PureML.hs
+++ b/src/main/haskell/kore/src/Kore/AST/PureML.hs
@@ -5,7 +5,7 @@ Description : Specifies the "pure" version of patterns, sentences, modules, and
               definition, which can be specialized to 'Object'-only and
               'Meta'-only objects.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/PureToKore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/PureToKore.hs
@@ -2,7 +2,7 @@
 Module      : Kore.AST.PureToKore
 Description : Functionality for viewing "Pure"-only as unified Kore constructs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/AST/Sentence.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Sentence.hs
@@ -4,7 +4,7 @@ Description : Data Structures for representing the Kore language AST that do not
               need unified constructs (see Kore.AST.Kore for the unified
               ones).
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/ASTHelpers.hs
+++ b/src/main/haskell/kore/src/Kore/ASTHelpers.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTHelpers
 Description : Utilities for handling ASTs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/ASTTraversals.hs
+++ b/src/main/haskell/kore/src/Kore/ASTTraversals.hs
@@ -3,7 +3,7 @@ Module      : Kore.ASTTraversals
 Description : Defines traversals functions for patterns of
               `UnifiedPatternInterface` class.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
@@ -3,7 +3,7 @@ Module      : Kore.ASTUtils.SmartConstructors
 Description : Tree-based proof system, which can be
               hash-consed into a list-based one.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : phillip.harris@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/ASTUtils/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/Substitution.hs
@@ -4,7 +4,7 @@ Description : Substitute phi_1 for phi_2, avoiding capture
               In particular this implements axiom 7 in
               the "large" axiom set (Rosu 2017).
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : phillip.harris@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.AttributesVerifier
 Description : Tools for verifying the wellformedness of Kore 'Attributes'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.DefinitionVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Definiton'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/Error.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/Error.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.Error
 Description : Helpers for verification errors.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.ModuleVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Module'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.PatternVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Pattern'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -2,7 +2,7 @@
 Module      : Kore.ASTVerifier.SentenceVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Sentence'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/SortVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/SortVerifier.hs
@@ -3,7 +3,7 @@
 Module      : Kore.ASTVerifier.SortVerifier
 Description : Tools for verifying the wellformedness of a Kore 'Sort'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Building/AsAst.hs
+++ b/src/main/haskell/kore/src/Kore/Building/AsAst.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Building.AsAst
 Description : Class for things that can be transformed into AST terms.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Building/Implicit.hs
+++ b/src/main/haskell/kore/src/Kore/Building/Implicit.hs
@@ -3,7 +3,7 @@ Module      : Kore.Building.Implicit
 Description : Builders for symbols and aliases that are implicitly defined in
               Kore.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Building/Patterns.hs
+++ b/src/main/haskell/kore/src/Kore/Building/Patterns.hs
@@ -3,7 +3,7 @@
 Module      : Kore.Building.Patterns
 Description : Builders for the standard Kore patterns, without 'Application'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Building/Sorts.hs
+++ b/src/main/haskell/kore/src/Kore/Building/Sorts.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Building.Sorts
 Description : Builders for meta sorts and sort variables.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Error.hs
+++ b/src/main/haskell/kore/src/Kore/Error.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Error
 Description : Kore error handling.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/Attributes.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/Attributes.hs
@@ -5,7 +5,7 @@ Module      : Kore.Implicit.Attributes
 Description : Haskell definitions for the implicit constructs for attributes.
               uncheckedAttributesModule gathers all of them in a Kore morule
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/Definitions.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/Definitions.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Implicit.Definitions
 Description : Builds the implicit kore Definitions.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/ImplicitKore.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/ImplicitKore.hs
@@ -3,7 +3,7 @@
 Module      : Kore.Implicit.ImplicitKore
 Description : Builds the implicit kore definitions.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/ImplicitSorts.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/ImplicitSorts.hs
@@ -3,7 +3,7 @@
 Module      : Kore.Implicit.ImplicitSorts
 Description : Haskell definitions for the implicit Kore 'Meta' sorts.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/ImplicitSortsImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/ImplicitSortsImpl.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Implicit.ImplicitSortsImpl
 Description : Infrastructure for defining the implicit Kore 'Meta' sorts.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/ImplicitVarsInternal.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/ImplicitVarsInternal.hs
@@ -3,7 +3,7 @@
 Module      : Kore.Implicit.ImplicitVarsInternal
 Description : Variable defimitions shared by modules defining kore.kore
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Implicit/Verified.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/Verified.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Implicit.Verified
 Description : Builds and verifies the implicit kore definitions.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -2,7 +2,7 @@
 Module      : Kore.IndexedModule.IndexedModule
 Description : Indexed representation for a module.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/IndexedModule/MetadataTools.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/MetadataTools.hs
@@ -3,7 +3,7 @@ Module      : Kore.IndexedModule.MetadataTools
 Description : Datastructures and functionality for retrieving metadata
               information from patterns
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/IndexedModule/Resolvers.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/Resolvers.hs
@@ -2,7 +2,7 @@
 Module      : Kore.IndexedModule.Resolvers
 Description : Tools for resolving IDs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/MetaML/AST.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/AST.hs
@@ -4,7 +4,7 @@ Module      : Kore.MetaML.AST
 Description : Data Structures for representing a Meta-only version of the
               Kore language AST
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/MetaML/Lift.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/Lift.hs
@@ -2,7 +2,7 @@
 Module      : Kore.MetaML.Lift
 Description : Lifts mixed 'Object' and 'Meta' constructs into pure 'Meta' ones.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/MetaML/Unlift.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/Unlift.hs
@@ -2,7 +2,7 @@
 Module      : Kore.MetaML.Unlift
 Description : Reverses the effects of 'Kore.MetaML.Lift.liftToMeta'
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/CString.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/CString.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Parser.CString
 Description : Unescaping for C-style strings. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/CharDict.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/CharDict.hs
@@ -3,7 +3,7 @@ Module      : Kore.Parser.CharSet
 Description : Efficient representation for a dictionary having extended ASCII
               characters as keys. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/CharSet.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/CharSet.hs
@@ -3,7 +3,7 @@ Module      : Kore.Parser.CharSet
 Description : Efficient representation for a set of extended ASCII characters.
               Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/Lexeme.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/Lexeme.hs
@@ -3,7 +3,7 @@ Module      : Kore.Parser.Lexeme
 Description : Lexical unit definitions for Kore and simple ways of composing
               parsers. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/LexemeImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/LexemeImpl.hs
@@ -3,7 +3,7 @@ Module      : Kore.Parser.LexemeImpl
 Description : Lexical unit definitions for Kore and simple ways of composing
               parsers. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/LexemeImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/LexemeImpl.hs
@@ -34,9 +34,12 @@ import           Control.Monad.Combinators
 import qualified Data.ByteString.Char8 as Char8
 import           Data.Char
                  ( isHexDigit, isOctDigit )
-import           Data.Maybe
-                 ( isJust )
-import qualified Data.Trie as Trie
+import           Data.HashMap.Strict
+                 ( HashMap )
+import qualified Data.HashMap.Strict as HashMap
+import           Data.HashSet
+                 ( HashSet )
+import qualified Data.HashSet as HashSet
 import           Text.Megaparsec
                  ( SourcePos (..), eof, getPosition, unPos )
 import qualified Text.Megaparsec.Char as Parser
@@ -121,9 +124,10 @@ skipWhitespace = L.space Parser.space1 (L.skipLineComment "//") blockComment
     blockComment = Parser.string "/*" >> void (manyTill commentBody (Parser.string "*/"))
     commentBody = Parser.anyChar <|> (eof >> fail "Unfinished comment.")
 
-koreKeywordsSet :: Trie.Trie ()
-koreKeywordsSet = Trie.fromList $ map (\s -> (Char8.pack s, ()))
-    ["module", "endmodule", "sort", "symbol", "alias", "axiom"]
+koreKeywordsSet :: HashSet Char8.ByteString
+koreKeywordsSet = HashSet.fromList (Char8.pack <$> keywords)
+  where
+    keywords = ["module", "endmodule", "sort", "symbol", "alias", "axiom"]
 
 data IdKeywordParsing
     = KeywordsPermitted
@@ -145,7 +149,7 @@ genericIdRawParser firstCharSet bodyCharSet idKeywordParsing = do
         else ParserUtils.takeWhile (`CharSet.elem` bodyCharSet)
     when
         (  (idKeywordParsing == KeywordsForbidden)
-        && isJust (Trie.lookup (Char8.pack idChar) koreKeywordsSet)
+        && HashSet.member (Char8.pack idChar) koreKeywordsSet
         )
         (fail
             (  "Identifiers should not be keywords: '"
@@ -451,9 +455,9 @@ prefixBasedParsersWithDefault prefixParser defaultParser stringParsers = do
             else defaultParser
 
 {-|'metaSortTrie' is a trie containing all the possible metasorts.-}
-metaSortTrie :: Trie.Trie MetaSortType
+metaSortTrie :: HashMap Char8.ByteString MetaSortType
 metaSortTrie =
-    Trie.fromList $
+    HashMap.fromList $
         map (\s -> (Char8.pack (show s), s)) metaSortsListWithString
 
 {-|'metaSortConverter' converts a string representation of a metasort name
@@ -462,4 +466,4 @@ metaSortTrie =
 metaSortConverter :: String -> Maybe MetaSortType
 -- TODO(virgil): Does the pack call matter for performance? Should we try to
 -- improve it?
-metaSortConverter identifier = Trie.lookup (Char8.pack identifier) metaSortTrie
+metaSortConverter identifier = HashMap.lookup (Char8.pack identifier) metaSortTrie

--- a/src/main/haskell/kore/src/Kore/Parser/Parser.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/Parser.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Parser.Parser
 Description : Parser for the Kore language
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Parser.ParserImpl
 Description : Parser definition for Kore. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Parser/ParserUtils.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/ParserUtils.hs
@@ -3,7 +3,7 @@
 Module      : Kore.Parser.ParserUtils
 Description : Helper tools for parsing Kore. Meant for internal use only.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.BaseStep
 Description : Single step execution
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Condition.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Condition.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Condition.Condition
 Description : Data structure holding a condition.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Condition.Evaluator
 Description : Evaluates conditions.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Function.Data
 Description : Data structures used for function evaluation.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Function.Evaluator
 Description : Evaluates functions in a pattern.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Function.UserDefined
 Description : Evaluates user-defined functions in a pattern.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Step.Step
 Description : Single and multiple step execution
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Substitution/Class.hs
+++ b/src/main/haskell/kore/src/Kore/Substitution/Class.hs
@@ -3,7 +3,7 @@ Module      : Kore.Substitution.Class
 Description : Defines basic interfaces and main functionality needed
               to implement substitution for an 'UnifiedPatternInterface'.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Substitution/List.hs
+++ b/src/main/haskell/kore/src/Kore/Substitution/List.hs
@@ -3,7 +3,7 @@ Module      : Kore.Substitution.List
 Description : Defines an instance of 'SubstitutionClass' using a list of
               variable |-> pattern pairs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Unification/Error.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Error.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Unification.Error
 Description : Utilities for unification errors
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -4,7 +4,7 @@ Module      : Kore.Unification.SubstitutionNormalization
 Description : Normalization for substitutions resulting from unification, so
               that they can be safely used on the unified term.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Unifier.hs
@@ -3,7 +3,7 @@ Module      : Kore.Unification.Unifier
 Description : Datastructures and functionality for performing unification on
               Pure patterns
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -415,9 +415,11 @@ solveGroupedSubstitution tools ((x,p):subst) = do
           : unificationSolutionConstraints solution
         , proof)
 
+instance Semigroup (UnificationProof level variable) where
+    (<>) proof1 proof2 = CombinedUnificationProof [proof1, proof2]
+
 instance Monoid (UnificationProof level variable) where
     mempty = EmptyUnificationProof
-    mappend proof1 proof2 = CombinedUnificationProof [proof1, proof2]
     mconcat = CombinedUnificationProof
 
 -- |Takes a potentially non-normalized substitution,

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -3,7 +3,7 @@ Module      : Kore.Unification.UnifierImpl
 Description : Datastructures and functionality for performing unification on
               Pure patterns
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Unparser/Unparse.hs
+++ b/src/main/haskell/kore/src/Kore/Unparser/Unparse.hs
@@ -3,7 +3,7 @@ Module      : Kore.Unparser.Unparse
 Description : Class for unparsing and instances for it for 'Meta' and
               unified Kore constructs.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Variables/Free.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Free.hs
@@ -3,7 +3,7 @@ Module      : Kore.Variables.Free
 Description : Specifies the 'TermWithVariablesClass' which is meant to define
               a term with variables and exports 'freeVariables'
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Variables/Fresh/Class.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Fresh/Class.hs
@@ -3,7 +3,7 @@ Module      : Kore.Variables.Fresh.Class
 Description : Specifies the 'FreshVariableClass' which provides an interface for
               generating fresh variables.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Variables/Fresh/IntCounter.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Fresh/IntCounter.hs
@@ -2,7 +2,7 @@
 Module      : Kore.Variables.Fresh.IntCounter
 Description : Defines an 'IntCounter' 'Monad' encapsulating an integer counter.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Variables/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Int.hs
@@ -3,7 +3,7 @@ Module      : Kore.Variables.Int
 Description : Defines the 'IntVariable' class providing functionality for
               generating variables based on intergers.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : traian.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Kore/Variables/Sort.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Sort.hs
@@ -3,7 +3,7 @@ Module      : Kore.Variables.Sort
 Description : Specifies the 'TermWithSortVariablesClass' which is meant to
               define a term with sort variables and exports 'sortVariables'
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/src/main/haskell/kore/src/Logic/Matching/Error.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Error.hs
@@ -2,7 +2,7 @@
 Module      : Logic.Matching.Error
 Description : Helpers for errors related to matching logic
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -4,7 +4,7 @@ Module      : Test.Kore.Comparators
 Description : Declares various data types involved in testing as instances of
               the 'EqualWithExplanation' class.
 Copyright   : (c) Runtime Verification, 2018
-License     : UIUC/NCSA
+License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.3
+resolver: lts-12.2
 
 nix:
   packages : [ zlib ]


### PR DESCRIPTION
The Stack resolver is updated to LTS Haskell 12.2 using GHC 8.4.3. In addition to package updates, the newer GHC version has some fixes for `COMPLETE` pragmas that I would like to use. I believe @bmmoore was having trouble with some derived instances and unreachable code, which is also addressed in this release.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

