### PR TITLE
Disable PolyKinds by default

### DIFF
--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -67,13 +67,13 @@ default-extensions:
   - GADTs
   - GeneralizedNewtypeDeriving
   - InstanceSigs
+  - KindSignatures
   - LambdaCase
   - MonoLocalBinds
   - MultiParamTypeClasses
   - NamedFieldPuns
   - OverloadedStrings
   - PatternSynonyms
-  - PolyKinds
   - RankNTypes
   - RecordWildCards
   - ScopedTypeVariables

--- a/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
+++ b/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PolyKinds #-}
+
 {-|
 Module      : Data.Functor.Impredicative
 Description : Wrappers to work around the absence of impredicative types

--- a/src/main/haskell/kore/src/Kore/AST/Builders.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Builders.hs
@@ -71,7 +71,7 @@ It can also be used to transform a symbol or alias sentence to something that
 can be applied to patterns.
 -}
 applyPS
-    :: SentenceSymbolOrAlias s
+    :: (SentenceSymbolOrAlias s, Show level)
     => s level (Pattern level) Variable
     -> [Sort level]
     -> [CommonPurePatternStub level]
@@ -101,7 +101,7 @@ It can also be used to transform a symbol or alias sentence to something that
 can be applied to patterns.
 -}
 applyS
-    :: SentenceSymbolOrAlias s
+    :: (SentenceSymbolOrAlias s, Show level)
     => s level (Pattern level) Variable
     -> [CommonPurePatternStub level]
     -> CommonPurePatternStub level

--- a/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
+++ b/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
@@ -25,7 +25,7 @@ checking that the sorts are identical where possible, creating a pattern with
 the provided sort otherwise.
 -}
 fillCheckSorts
-    :: (Show (variable level))
+    :: (Show level, Show (variable level))
     => [Sort level]
     -> [PurePatternStub level variable]
     -> [PureMLPattern level variable]
@@ -39,7 +39,7 @@ that the pattern's sorts is identical if possible, creating a pattern with the
 provided sort otherwise.
 -}
 fillCheckSort
-    :: (Show (variable level))
+    :: (Show level, Show (variable level))
     => Sort level
     -> PurePatternStub level variable
     -> PureMLPattern level variable

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -1028,7 +1028,7 @@ data Pattern level variable child where
     VariablePattern
         :: !(variable level) -> Pattern level variable child
 
-instance Ord (variable level) => Ord1 (Pattern level variable) where
+instance (Ord level, Ord (variable level)) => Ord1 (Pattern level variable) where
     liftCompare liftedCompare a b =
         case (a, b) of
             (AndPattern a', AndPattern b') -> liftCompare liftedCompare a' b'
@@ -1091,7 +1091,7 @@ instance Ord (variable level) => Ord1 (Pattern level variable) where
             (_, TopPattern _) -> GT
             (VariablePattern a', VariablePattern b') -> compare a' b'
 
-instance Eq (variable level) => Eq1 (Pattern level variable) where
+instance (Eq level, Eq (variable level)) => Eq1 (Pattern level variable) where
     liftEq liftedEq a b =
         case (a, b) of
             (AndPattern a', AndPattern b') -> liftEq liftedEq a' b'
@@ -1118,7 +1118,7 @@ instance Eq (variable level) => Eq1 (Pattern level variable) where
             (VariablePattern a', VariablePattern b') -> a' == b'
             _ -> False
 
-instance Show (variable level) => Show1 (Pattern level variable) where
+instance (Show level, Show (variable level)) => Show1 (Pattern level variable) where
     liftShowsPrec showsPrec_ showList_ prec pat =
         showParen (prec > 9)
         (case pat of

--- a/src/main/haskell/kore/src/Kore/AST/Kore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Kore.hs
@@ -73,7 +73,7 @@ instance (ShowMetaOrObject variable) => Show1 (UnifiedPattern variable) where
             (getUnifiedPattern up)
         . showString " }"
       where
-        liftShowsPrecRotate31 :: Show (variable level)
+        liftShowsPrecRotate31 :: (Show level, Show (variable level))
                               => Rotate31 Pattern variable a level
                               -> ShowS
         liftShowsPrecRotate31 r =

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -225,7 +225,7 @@ isFunctionalPattern tools = fixBottomUpVisitorM reduceM
     reduceM _ = Left NonFunctionalPattern
 
 simplifyAnds
-    :: (SortedVariable variable, Ord (variable level))
+    :: (Eq level, Ord (variable level), SortedVariable variable)
     => MetadataTools level StepperAttributes
     -> [PureMLPattern level variable]
     -> Either
@@ -262,7 +262,7 @@ simplifyAnds tools (p:ps) =
             )
 
 simplifyAnd
-    :: Ord (variable level)
+    :: (Eq level, Ord (variable level))
     => MetadataTools level StepperAttributes
     -> PureMLPattern level variable
     -> Either
@@ -274,7 +274,7 @@ simplifyAnd tools =
 -- Performs variable and equality checks and distributes the conjunction
 -- to the children, creating sub-unification problems
 preTransform
-    :: Ord (variable level)
+    :: (Eq level, Ord (variable level))
     => MetadataTools level StepperAttributes
     -> UnFixedPureMLPattern level variable
     -> Either
@@ -401,7 +401,7 @@ groupSubstitutionByVariable =
 -- x = ((t1 /\ t2) /\ (..)) /\ tn
 -- then recursively reducing that to finally get x = t /\ subst
 solveGroupedSubstitution
-    :: (SortedVariable variable, Ord (variable level))
+    :: (Eq level, Ord (variable level), SortedVariable variable)
     => MetadataTools level StepperAttributes
     -> UnificationSubstitution level variable
     -> Either
@@ -427,7 +427,7 @@ instance Monoid (UnificationProof level variable) where
 -- `normalizeSubstitutionDuplication` recursively calls itself until it
 -- stabilizes.
 normalizeSubstitutionDuplication
-    :: (SortedVariable variable, Ord (variable level))
+    :: (Eq level, Ord (variable level), SortedVariable variable)
     => MetadataTools level StepperAttributes
     -> UnificationSubstitution level variable
     -> Either

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -31,10 +31,9 @@ import Test.Tasty.HUnit.Extensions
 
 instance
     ( EqualWithExplanation child
-    , Eq child
+    , Eq child, Eq level, Eq (variable level)
     , Show child
     , EqualWithExplanation (variable level)
-    , Eq (variable level)
     , Show (variable level))
     => SumEqualWithExplanation (Pattern level variable child)
   where
@@ -160,17 +159,19 @@ instance
 
 instance
     ( EqualWithExplanation child
-    , Eq child
+    , Eq child, Eq level, Eq (variable level)
     , Show child
     , EqualWithExplanation (variable level)
-    , Eq (variable level)
     , Show (variable level)
     ) => EqualWithExplanation (Pattern level variable child)
   where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
 
-instance SumEqualWithExplanation (StepProof level) where
+instance
+    (Eq level, Show level) =>
+    SumEqualWithExplanation (StepProof level)
+  where
     sumConstructorPair (StepProofUnification a1) (StepProofUnification a2) =
         SumConstructorSameWithArguments (EqWrap "StepProofUnification" a1 a2)
     sumConstructorPair a1@(StepProofUnification _) a2 =
@@ -192,8 +193,7 @@ instance SumEqualWithExplanation (StepProof level) where
         SumConstructorDifferent
             (printWithExplanation a1) (printWithExplanation a2)
 
-instance EqualWithExplanation (StepProof level)
-  where
+instance (Eq level, Show level) => EqualWithExplanation (StepProof level) where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
 
@@ -562,8 +562,8 @@ instance
     printWithExplanation = show
 
 instance
-    ( Eq (variable level)
-    , Show (variable level)
+    ( Eq level, Eq (variable level)
+    , Show level, Show (variable level)
     , EqualWithExplanation (variable level)
     )
     => SumEqualWithExplanation (UnificationProof level variable)
@@ -617,8 +617,8 @@ instance
             (printWithExplanation a1) (printWithExplanation a2)
 
 instance
-    ( Eq (variable level)
-    , Show (variable level)
+    ( Eq level, Eq (variable level)
+    , Show level, Show (variable level)
     , EqualWithExplanation (variable level)
     )
     => EqualWithExplanation (UnificationProof level variable)
@@ -627,8 +627,8 @@ instance
     printWithExplanation = show
 
 instance
-    ( Eq (variable level)
-    , Show (variable level)
+    ( Eq level, Eq (variable level)
+    , Show level, Show (variable level)
     , EqualWithExplanation (variable level)
     )
     => StructEqualWithExplanation (UnificationSolution level variable)
@@ -648,8 +648,8 @@ instance
     structConstructorName _ = "UnificationSolution"
 
 instance
-    ( Eq (variable level)
-    , Show (variable level)
+    ( Eq level, Eq (variable level)
+    , Show level, Show (variable level)
     , EqualWithExplanation (variable level)
     )
     => EqualWithExplanation (UnificationSolution level variable)
@@ -697,8 +697,8 @@ instance EqualWithExplanation (StepperVariable level)
     printWithExplanation = show
 
 instance
-    ( Show (variable level)
-    , Eq (variable level)
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
     , EqualWithExplanation(variable level)
     )
     => StructEqualWithExplanation (ExpandedPattern level variable)
@@ -722,8 +722,8 @@ instance
     structConstructorName _ = "ExpandedPattern"
 
 instance
-    ( Show (variable level)
-    , Eq (variable level)
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
     , EqualWithExplanation(variable level)
     )
     => EqualWithExplanation (ExpandedPattern level variable)
@@ -733,7 +733,7 @@ instance
 
 instance
     ( EqualWithExplanation (PureMLPattern level variable)
-    , Show (variable level)
+    , Show level, Show (variable level)
     )
     => EqualWithExplanation (Predicate level variable)
   where
@@ -747,8 +747,8 @@ instance
 
 
 instance
-    ( Show (variable level)
-    , Eq (variable level)
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
     , EqualWithExplanation(variable level)
     )
     => SumEqualWithExplanation (AttemptedFunction level variable)
@@ -772,8 +772,8 @@ instance
             (printWithExplanation a1) (printWithExplanation a2)
 
 instance
-    ( Show (variable level)
-    , Eq (variable level)
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
     , EqualWithExplanation(variable level)
     )
     => EqualWithExplanation (AttemptedFunction level variable)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Condition.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Condition.hs
@@ -7,7 +7,7 @@ import Kore.Step.Function.Data
 import Kore.Variables.Fresh.IntCounter
 
 mockConditionEvaluator
-    :: (Eq (variable level))
+    :: (Eq level, Eq (variable level))
     =>  [   ( Predicate level variable
             , (Predicate level variable, PredicateProof level)
             )
@@ -17,7 +17,7 @@ mockConditionEvaluator values =
     ConditionEvaluator (mockConditionEvaluatorHelper values)
 
 mockConditionEvaluatorHelper
-    :: (Eq (variable level))
+    :: (Eq level, Eq (variable level))
     =>  [   ( Predicate level variable
             , (Predicate level variable, PredicateProof level)
             )


### PR DESCRIPTION
PolyKinds makes many of our constructors much more polymorphic than
intended. The extension is only actually required in
Data.Functor.Impredicative.

Fixes: #163

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

