### PR TITLE
Parser benchmarks

### DIFF
--- a/src/main/haskell/kore/bench/parser/Main.hs
+++ b/src/main/haskell/kore/bench/parser/Main.hs
@@ -1,0 +1,28 @@
+module Main where
+
+import Criterion.Main
+
+import Kore.Parser.Parser
+       ( fromKore )
+
+import qualified Paths
+
+main :: IO ()
+main =
+    defaultMain
+    [ parse "Parse implicit Kore definition" (Paths.dataFileName "../../kore/kore.kore")
+    ]
+
+{- | Declare a parser benchmark
+
+The benchmark will parse the contents of the file. The file is read only once
+before the benchmark is run because Criterion may repeat a benchmark many times
+to gather timing statistics.
+-}
+parse
+    :: String  -- ^ benchmark name (for the report)
+    -> FilePath  -- ^ name of file to parse
+    -> Benchmark
+parse name filename =
+    env (readFile filename)  -- Read Kore definition once before benchmark
+    (bench name . nf (fromKore filename))  -- Benchmark parsing step only

--- a/src/main/haskell/kore/bench/parser/Main.hs
+++ b/src/main/haskell/kore/bench/parser/Main.hs
@@ -10,7 +10,14 @@ import qualified Paths
 main :: IO ()
 main =
     defaultMain
-    [ parse "Parse implicit Kore definition" (Paths.dataFileName "../../kore/kore.kore")
+    [ parse "kore.kore" (Paths.dataFileName "../../kore/kore.kore")
+    , parse "bool.kore" (Paths.dataFileName "../../../test/resources/bool.kore")
+    , parse "imp.kore" (Paths.dataFileName "../../../test/resources/imp.kore")
+    , parse "imp2.kore" (Paths.dataFileName "../../../test/resources/imp2.kore")
+    , parse "lambda.kore" (Paths.dataFileName "../../../test/resources/lambda.kore")
+    , parse "list.kore" (Paths.dataFileName "../../../test/resources/list.kore")
+    , parse "nat.kore" (Paths.dataFileName "../../../test/resources/nat.kore")
+    , parse "user-meta-nat.kore" (Paths.dataFileName "../../../test/resources/user-meta-nat.kore")
     ]
 
 {- | Declare a parser benchmark

--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -140,3 +140,22 @@ tests:
       - tasty-golden
       - tasty-quickcheck
       - template-haskell
+
+benchmarks:
+  kore-parser-benchmark:
+    main: Main.hs
+    other-modules:
+      - Paths
+    source-dirs:
+      - bench/parser
+      - test
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - kore
+      - criterion
+      - directory >= 1.2.2
+      - filepath
+      - template-haskell

--- a/src/main/haskell/kore/src/Control/DeepSeq/Orphans.hs
+++ b/src/main/haskell/kore/src/Control/DeepSeq/Orphans.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Control.DeepSeq.Orphans where
+
+import Control.DeepSeq
+       ( NFData (..) )
+import Data.Functor.Foldable
+       ( Fix (..) )
+
+instance NFData (f (Fix f)) => NFData (Fix f) where
+    rnf (Fix f) = rnf f

--- a/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
+++ b/src/main/haskell/kore/src/Data/Functor/Impredicative.hs
@@ -11,6 +11,11 @@ Portability : portable
 -}
 module Data.Functor.Impredicative where
 
+import Control.DeepSeq
+       ( NFData )
+import GHC.Generics
+       ( Generic )
+
 {-|'Rotate31' is a helper type useful to bring the first argument
 of a type paramaterized by three arguments to the last position,
 shifting the other arguments to the left.
@@ -22,7 +27,9 @@ to use such 'MetaOrObject' constructs as 'applyMetaObjectFunction' or
 newtype
     Rotate31 t pat variable level
   = Rotate31 { unRotate31 :: t level pat variable}
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
+
+instance NFData (t level pat variable) => NFData (Rotate31 t pat variable level)
 
 {-|'Rotate41' is a helper type useful to bring the first argument
 of a type paramaterized by four arguments to the last position,
@@ -35,4 +42,8 @@ to use such 'MetaOrObject' constructs as 'applyMetaObjectFunction' or
 newtype
     Rotate41 t sortParam pat variable level
   = Rotate41 { unRotate41 :: t level sortParam pat variable}
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
+
+instance
+    NFData (t level sortParam pat variable) =>
+    NFData (Rotate41 t sortParam pat variable level)

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -24,6 +24,8 @@ Please refer to Section 9 (The Kore Language) of the
 -}
 module Kore.AST.Common where
 
+import Control.DeepSeq
+       ( NFData (..) )
 import Data.Deriving
        ( deriveEq1, deriveOrd1, deriveShow1 )
 import Data.Functor.Classes
@@ -36,11 +38,11 @@ import Data.String
 import GHC.Generics
        ( Generic )
 
+import           Control.DeepSeq.Orphans ()
+import           Data.Text.Prettyprint.Doc.Orphans ()
 import           Kore.AST.MetaOrObject
 import           Kore.AST.Pretty
                  ( Pretty (..), (<>) )
-import           Data.Text.Prettyprint.Doc.Orphans
-                 ()
 import qualified Kore.AST.Pretty as Pretty
 import           Kore.Parser.CString
                  ( escapeCString )
@@ -55,6 +57,7 @@ data FileLocation = FileLocation
     deriving (Eq, Show, Generic)
 
 instance Hashable FileLocation
+instance NFData FileLocation
 
 {-| 'AstLocation' represents the origin of an AST node.
 
@@ -76,6 +79,7 @@ data AstLocation
     deriving (Eq, Show, Generic)
 
 instance Hashable AstLocation
+instance NFData AstLocation
 
 {-| 'prettyPrintAstLocation' displays an `AstLocation` in a way that's
 (sort of) user friendly.
@@ -125,6 +129,8 @@ instance Eq (Id level) where
 
 instance Hashable (Id level)
 
+instance NFData (Id level)
+
 instance Pretty (Id level) where
     pretty Id { getId } = fromString getId
 
@@ -146,6 +152,8 @@ newtype StringLiteral = StringLiteral { getStringLiteral :: String }
 
 instance Hashable StringLiteral
 
+instance NFData StringLiteral
+
 instance Pretty StringLiteral where
     pretty StringLiteral {..} =
         (Pretty.dquotes . fromString . escapeCString) getStringLiteral
@@ -157,6 +165,8 @@ newtype CharLiteral = CharLiteral { getCharLiteral :: Char }
     deriving (Show, Eq, Ord, Generic)
 
 instance Hashable CharLiteral
+
+instance NFData CharLiteral
 
 instance Pretty CharLiteral where
     pretty CharLiteral {..} =
@@ -176,6 +186,8 @@ data SymbolOrAlias level = SymbolOrAlias
     deriving (Show, Eq, Ord, Generic)
 
 instance Hashable (SymbolOrAlias level)
+
+instance NFData (SymbolOrAlias level)
 
 instance Pretty (SymbolOrAlias level) where
     pretty SymbolOrAlias {..} =
@@ -199,6 +211,8 @@ data Symbol level = Symbol
 
 instance Hashable (Symbol level)
 
+instance NFData (Symbol level)
+
 instance Pretty (Symbol level) where
     pretty Symbol {..} =
         pretty symbolConstructor <> Pretty.parameters symbolParams
@@ -221,6 +235,8 @@ data Alias level = Alias
 
 instance Hashable (Alias level)
 
+instance NFData (Alias level)
+
 instance Pretty (Alias level) where
     pretty Alias {..} =
         pretty aliasConstructor <> Pretty.parameters aliasParams
@@ -237,6 +253,8 @@ newtype SortVariable level = SortVariable
     deriving (Show, Eq, Ord, Generic)
 
 instance Hashable (SortVariable level)
+
+instance NFData (SortVariable level)
 
 instance Pretty (SortVariable level) where
     pretty = pretty . getSortVariable
@@ -256,6 +274,8 @@ data SortActual level = SortActual
 
 instance Hashable (SortActual level)
 
+instance NFData (SortActual level)
+
 instance Pretty (SortActual level) where
     pretty SortActual {..} =
         pretty sortActualName <> Pretty.parameters sortActualSorts
@@ -273,6 +293,8 @@ data Sort level
     deriving (Show, Eq, Ord, Generic)
 
 instance Hashable (Sort level)
+
+instance NFData (Sort level)
 
 instance Pretty (Sort level) where
     pretty (SortVariableSort sortVariable) = pretty sortVariable
@@ -351,6 +373,8 @@ data Variable level = Variable
     deriving (Show, Eq, Ord, Generic)
 
 instance Hashable (Variable level)
+
+instance NFData (Variable level)
 
 instance Pretty (Variable level) where
     pretty Variable {..} =
@@ -453,6 +477,8 @@ deriveShow1 ''And
 
 instance Hashable child => Hashable (And level child)
 
+instance NFData child => NFData (And level child)
+
 instance Pretty child => Pretty (And level child) where
     pretty And {..} =
         "\\and"
@@ -480,6 +506,8 @@ deriveShow1 ''Application
 
 instance Hashable child => Hashable (Application level child)
 
+instance NFData child => NFData (Application level child)
+
 instance Pretty child => Pretty (Application level child) where
     pretty Application {..} =
         pretty applicationSymbolOrAlias <> Pretty.arguments applicationChildren
@@ -503,6 +531,8 @@ deriveOrd1 ''Bottom
 deriveShow1 ''Bottom
 
 instance Hashable (Bottom level child)
+
+instance NFData (Bottom level child)
 
 instance Pretty child => Pretty (Bottom level child) where
     pretty Bottom {..} =
@@ -533,6 +563,8 @@ deriveOrd1 ''Ceil
 deriveShow1 ''Ceil
 
 instance Hashable child => Hashable (Ceil level child)
+
+instance NFData child => NFData (Ceil level child)
 
 instance Pretty child => Pretty (Ceil level child) where
     pretty Ceil {..} =
@@ -567,6 +599,8 @@ deriveShow1 ''DomainValue
 
 instance Hashable child => Hashable (DomainValue level child)
 
+instance NFData child => NFData (DomainValue level child)
+
 instance Pretty child => Pretty (DomainValue level child) where
     pretty DomainValue {..} =
         "\\dv"
@@ -599,6 +633,8 @@ deriveOrd1 ''Equals
 deriveShow1 ''Equals
 
 instance Hashable child => Hashable (Equals level child)
+
+instance NFData child => NFData (Equals level child)
 
 instance Pretty child => Pretty (Equals level child) where
     pretty Equals {..} =
@@ -646,6 +682,8 @@ instance (Show (Sort level), Show (v level)) => Show1 (Exists level v) where
 
 instance (Hashable child, Hashable (v level)) => Hashable (Exists level v child)
 
+instance (NFData child, NFData (var level)) => NFData (Exists level var child)
+
 instance (Pretty child, Pretty (variable level)) =>
     Pretty (Exists level variable child) where
     pretty Exists {..} =
@@ -678,6 +716,8 @@ deriveOrd1 ''Floor
 deriveShow1 ''Floor
 
 instance Hashable child => Hashable (Floor level child)
+
+instance NFData child => NFData (Floor level child)
 
 instance Pretty child => Pretty (Floor level child) where
     pretty Floor {..} =
@@ -725,6 +765,8 @@ instance (Show (Sort level), Show (v level)) => Show1 (Forall level v) where
 
 instance (Hashable child, Hashable (v level)) => Hashable (Forall level v child)
 
+instance (NFData child, NFData (v level)) => NFData (Forall level v child)
+
 instance (Pretty child, Pretty (variable level)) =>
     Pretty (Forall level variable child) where
     pretty Forall {..} =
@@ -756,6 +798,8 @@ deriveShow1 ''Iff
 
 instance Hashable child => Hashable (Iff level child)
 
+instance NFData child => NFData (Iff level child)
+
 instance Pretty child => Pretty (Iff level child) where
     pretty Iff {..} =
         "\\iff"
@@ -785,6 +829,8 @@ deriveOrd1 ''Implies
 deriveShow1 ''Implies
 
 instance Hashable child => Hashable (Implies level child)
+
+instance NFData child => NFData (Implies level child)
 
 instance Pretty child => Pretty (Implies level child) where
     pretty Implies {..} =
@@ -822,6 +868,8 @@ deriveShow1 ''In
 
 instance Hashable child => Hashable (In level child)
 
+instance NFData child => NFData (In level child)
+
 instance Pretty child => Pretty (In level child) where
     pretty In {..} =
         "\\in"
@@ -852,6 +900,8 @@ deriveShow1 ''Next
 
 instance Hashable child => Hashable (Next level child)
 
+instance NFData child => NFData (Next level child)
+
 instance Pretty child => Pretty (Next level child) where
     pretty Next {..} =
         "\\next"
@@ -880,6 +930,8 @@ deriveOrd1 ''Not
 deriveShow1 ''Not
 
 instance Hashable child => Hashable (Not level child)
+
+instance NFData child => NFData (Not level child)
 
 instance Pretty child => Pretty (Not level child) where
     pretty Not {..} =
@@ -911,6 +963,8 @@ deriveShow1 ''Or
 
 instance Hashable child => Hashable (Or level child)
 
+instance NFData child => NFData (Or level child)
+
 instance Pretty child => Pretty (Or level child) where
     pretty Or {..} =
         "\\or"
@@ -940,8 +994,9 @@ deriveEq1 ''Rewrites
 deriveOrd1 ''Rewrites
 deriveShow1 ''Rewrites
 
-
 instance Hashable child => Hashable (Rewrites level child)
+
+instance NFData child => NFData (Rewrites level child)
 
 instance Pretty child => Pretty (Rewrites level child) where
     pretty Rewrites {..} =
@@ -968,6 +1023,8 @@ deriveOrd1 ''Top
 deriveShow1 ''Top
 
 instance Hashable (Top level child)
+
+instance NFData (Top level child)
 
 instance Pretty child => Pretty (Top level child) where
     pretty Top {..} =
@@ -1214,6 +1271,31 @@ instance (Hashable child, Hashable (variable level))
     TopPattern           p -> hashWithSalt s p
     VariablePattern      p -> hashWithSalt s p
     -- FIXME: How to factor this out? with existentials?
+
+instance (NFData child, NFData (var level)) => NFData (Pattern level var child) where
+    rnf =
+        \case
+            AndPattern p -> rnf p
+            ApplicationPattern p -> rnf p
+            BottomPattern p -> rnf p
+            CeilPattern p -> rnf p
+            DomainValuePattern p -> rnf p
+            EqualsPattern p -> rnf p
+            ExistsPattern p -> rnf p
+            FloorPattern p -> rnf p
+            ForallPattern p -> rnf p
+            IffPattern p -> rnf p
+            ImpliesPattern p -> rnf p
+            InPattern p -> rnf p
+            NextPattern p -> rnf p
+            NotPattern p -> rnf p
+            OrPattern p -> rnf p
+            RewritesPattern p -> rnf p
+            StringLiteralPattern p -> rnf p
+            CharLiteralPattern p -> rnf p
+            TopPattern p -> rnf p
+            VariablePattern p -> rnf p
+
 deriving instance
     ( Eq child
     , Eq (variable level)

--- a/src/main/haskell/kore/src/Kore/AST/Kore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Kore.hs
@@ -33,8 +33,12 @@ module Kore.AST.Kore
     , transformUnifiedPattern
     ) where
 
+import Control.DeepSeq
+       ( NFData )
 import Data.Functor.Classes
 import Data.Functor.Foldable
+import GHC.Generics
+       ( Generic )
 
 import Data.Functor.Impredicative
        ( Rotate31 (..) )
@@ -50,6 +54,13 @@ allow using toghether both 'Meta' and 'Object' patterns.
 -}
 newtype UnifiedPattern variable child = UnifiedPattern
     { getUnifiedPattern :: Unified (Rotate31 Pattern variable child) }
+  deriving ( Generic )
+
+instance
+    ( NFData child
+    , NFData (variable Meta), NFData (variable Object)
+    ) =>
+    NFData (UnifiedPattern variable child)
 
 instance (EqMetaOrObject variable) => Eq1 (UnifiedPattern variable) where
     liftEq liftedEq (UnifiedPattern a) (UnifiedPattern b) =

--- a/src/main/haskell/kore/src/Kore/AST/MetaOrObject.hs
+++ b/src/main/haskell/kore/src/Kore/AST/MetaOrObject.hs
@@ -26,8 +26,12 @@ module Kore.AST.MetaOrObject
     , IsMetaOrObject (..)
     ) where
 
+import Control.DeepSeq
+       ( NFData )
 import Data.Proxy
        ( Proxy (Proxy) )
+import GHC.Generics
+       ( Generic )
 
 import Kore.AST.Pretty
        ( Pretty (..) )
@@ -36,10 +40,10 @@ toProxy :: a -> Proxy a
 toProxy _ = Proxy
 
 data Meta = Meta
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Ord, Show)
 
 data Object = Object
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Ord, Show)
 
 data IsMetaOrObject s where
     IsMeta :: IsMetaOrObject Meta
@@ -77,6 +81,7 @@ instance MetaOrObject Object where
 data Unified thing
     = UnifiedObject !(thing Object)
     | UnifiedMeta !(thing Meta)
+  deriving (Generic)
 
 type ShowMetaOrObject thing = (Show (thing Meta), Show (thing Object))
 type EqMetaOrObject thing = (Eq (thing Meta), Eq (thing Object))
@@ -85,6 +90,8 @@ type OrdMetaOrObject thing = (Ord (thing Meta), Ord (thing Object))
 deriving instance (EqMetaOrObject thing) => Eq (Unified thing)
 deriving instance (OrdMetaOrObject thing) => Ord (Unified thing)
 deriving instance (ShowMetaOrObject thing) => Show (Unified thing)
+
+instance (NFData (thing Meta), NFData (thing Object)) => NFData (Unified thing)
 
 instance
     ( Pretty (thing Object)

--- a/src/main/haskell/kore/src/Kore/AST/Sentence.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Sentence.hs
@@ -22,10 +22,14 @@ Please refer to Section 9 (The Kore Language) of the
 -}
 module Kore.AST.Sentence where
 
+import Control.DeepSeq
+       ( NFData (..) )
 import Data.Functor.Classes
 import Data.Functor.Foldable
 import Data.Maybe
        ( catMaybes )
+import GHC.Generics
+       ( Generic )
 
 import           Data.Functor.Impredicative
                  ( Rotate41 (..) )
@@ -44,14 +48,9 @@ It is parameterized by the types of Patterns, @pat@.
 
 newtype Attributes =
     Attributes { getAttributes :: [CommonKorePattern] }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    (Eq CommonKorePattern)
-     => Eq Attributes
-
-deriving instance
-    (Show CommonKorePattern)
-     => Show Attributes
+instance NFData Attributes
 
 instance Pretty Attributes where
     pretty = Pretty.attributes . getAttributes
@@ -72,18 +71,12 @@ data SentenceAlias level (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     , sentenceAliasRightPattern :: !(Pattern level variable (Fix (pat variable)))
     , sentenceAliasAttributes   :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    ( Eq1 (pat variable)
-    , Eq (variable level)
-    )
-    => Eq (SentenceAlias level pat variable)
-
-deriving instance
-    ( Show1 (pat variable)
-    , Show (variable level)
-    )
-    => Show (SentenceAlias level pat variable)
+instance
+    ( NFData (Fix (pat variable))
+    , NFData (variable level)
+    ) => NFData (SentenceAlias level pat variable)
 
 instance (Pretty (variable level), Pretty (Fix (pat variable))) =>
     Pretty (SentenceAlias level pat variable) where
@@ -114,14 +107,9 @@ data SentenceSymbol level (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     , sentenceSymbolResultSort :: !(Sort level)
     , sentenceSymbolAttributes :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    (Eq (pat variable (Fix (pat variable))))
-     => Eq (SentenceSymbol level pat variable)
-
-deriving instance
-    (Show (pat variable (Fix (pat variable))))
-     => Show (SentenceSymbol level pat variable)
+instance NFData (SentenceSymbol level pat variable)
 
 instance Pretty (Fix (pat variable)) =>
     Pretty (SentenceSymbol level pat variable) where
@@ -138,7 +126,9 @@ instance Pretty (Fix (pat variable)) =>
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 -}
 newtype ModuleName = ModuleName { getModuleName :: String }
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Generic, Ord, Show)
+
+instance NFData ModuleName
 
 instance Pretty ModuleName where
     pretty = Pretty.fromString . getModuleName
@@ -151,14 +141,9 @@ data SentenceImport (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     { sentenceImportModuleName :: !ModuleName
     , sentenceImportAttributes :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    (Eq (pat variable (Fix (pat variable))))
-     => Eq (SentenceImport pat variable)
-
-deriving instance
-    (Show (pat variable (Fix (pat variable))))
-     => Show (SentenceImport pat variable)
+instance NFData (SentenceImport pat variable)
 
 instance Pretty (Fix (pat variable)) =>
     Pretty (SentenceImport pat variable) where
@@ -177,14 +162,9 @@ data SentenceSort level (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     , sentenceSortParameters :: ![SortVariable level]
     , sentenceSortAttributes :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    (Eq (pat variable (Fix (pat variable))))
-     => Eq (SentenceSort level pat variable)
-
-deriving instance
-    (Show (pat variable (Fix (pat variable))))
-     => Show (SentenceSort level pat variable)
+instance NFData (SentenceSort level pat variable)
 
 instance Pretty (Fix (pat variable)) =>
     Pretty (SentenceSort level pat variable) where
@@ -204,16 +184,13 @@ data SentenceAxiom sortParam (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     , sentenceAxiomPattern    :: !(Fix (pat variable))
     , sentenceAxiomAttributes :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    ( Eq1 (pat variable)
-    , Eq sortParam
-    )  => Eq (SentenceAxiom sortParam pat variable)
-
-deriving instance
-    ( Show1 (pat variable)
-    , Show sortParam
-    ) => Show (SentenceAxiom sortParam pat variable)
+instance
+    ( NFData sortParam
+    , NFData (Fix (pat variable))
+    ) =>
+    NFData (SentenceAxiom sortParam pat variable)
 
 instance
     ( Pretty param
@@ -236,14 +213,9 @@ represent hooked sorts and hooked symbols.
 data SentenceHook level (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     = SentenceHookedSort !(SentenceSort level pat variable)
     | SentenceHookedSymbol !(SentenceSymbol level pat variable)
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    (Eq (pat variable (Fix (pat variable))))
-     => Eq (SentenceHook level pat variable)
-
-deriving instance
-    (Show (pat variable (Fix (pat variable))))
-     => Show (SentenceHook level pat variable)
+instance NFData (SentenceHook level pat variable)
 
 instance
     Pretty (Fix (pat variable) )
@@ -288,6 +260,22 @@ deriving instance
     , Eq (variable level)
     ) => Eq (Sentence level sortParam pat variable)
 
+instance
+    ( NFData sortParam
+    , NFData (variable level)
+    , NFData (Fix (pat variable))
+    ) =>
+    NFData (Sentence level sortParam pat variable)
+  where
+    rnf =
+        \case
+            SentenceAliasSentence p -> rnf p
+            SentenceSymbolSentence p -> rnf p
+            SentenceImportSentence p -> rnf p
+            SentenceAxiomSentence p -> rnf p
+            SentenceSortSentence p -> rnf p
+            SentenceHookSentence p -> rnf p
+
 deriving instance
     ( Show1 (pat variable), Show (pat variable (Fix (pat variable)))
     , Show sortParam
@@ -320,16 +308,11 @@ data Module sentence sortParam (pat :: (* -> *) -> * -> *) (variable :: * -> *)
     , moduleSentences  :: ![sentence sortParam pat variable]
     , moduleAttributes :: !Attributes
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    ( Eq (pat variable (Fix (pat variable)))
-    , Eq (sentence sortParam pat variable)
-    ) => Eq (Module sentence sortParam pat variable)
-
-deriving instance
-    ( Show (pat variable (Fix (pat variable)))
-    , Show (sentence sortParam pat variable)
-    ) => Show (Module sentence sortParam pat variable)
+instance
+    NFData (sentence sortParam pat variable) =>
+    NFData (Module sentence sortParam pat variable)
 
 instance
     ( Pretty (sentence sort pat variable)
@@ -360,18 +343,11 @@ data Definition sentence sortParam (pat :: (* -> *) -> * -> *) (variable :: * ->
     { definitionAttributes :: !Attributes
     , definitionModules    :: ![Module sentence sortParam pat variable]
     }
+  deriving (Eq, Generic, Show)
 
-deriving instance
-    ( Eq1 (pat variable)
-    , Eq (pat variable (Fix (pat variable)))
-    , Eq (sentence sortParam pat variable)
-    ) => Eq (Definition sentence sortParam pat variable)
-
-deriving instance
-    ( Show1 (pat variable)
-    , Show (pat variable (Fix (pat variable)))
-    , Show (sentence sortParam pat variable)
-    ) => Show (Definition sentence sortParam pat variable)
+instance
+    NFData (sentence sortParam pat variable) =>
+    NFData (Definition sentence sortParam pat variable)
 
 instance
     ( Pretty (sentence sort pat variable)
@@ -446,12 +422,20 @@ to allow using toghether both 'Meta' and 'Object' sentences.
 -}
 newtype UnifiedSentence sortParam pat variable = UnifiedSentence
     { getUnifiedSentence :: Unified (Rotate41 Sentence sortParam pat variable) }
+  deriving (Generic)
 
 deriving instance
     ( Eq1 (pat variable), Eq (pat variable (Fix (pat variable)))
     , Eq sortParam
     , EqMetaOrObject variable
     ) => Eq (UnifiedSentence sortParam pat variable)
+
+instance
+    ( NFData sortParam
+    , NFData (variable Meta), NFData (variable Object)
+    , NFData (Fix (pat variable))
+    ) =>
+    NFData (UnifiedSentence sortParam pat variable)
 
 deriving instance
     ( Show1 (pat variable), Show (pat variable (Fix (pat variable)))


### PR DESCRIPTION
@njohnwalker warned me that the parser may be fragile with respect to performance, so before I make changes to extract location information, I am adding benchmarks to ensure I do not create any performance regressions.

I modified the library to add `NFData` instances for all our abstract syntax types; no additional dependencies are introduced because the library already depends on `deepseq`. `NFData` is used by the benchmark to evaluate all data structures to normal form, ensuring that we are not bypassing the benchmark with laziness.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

