### PR TITLE
Control flow overhaul of Prover repl and addition of `Undo`  prover command

### DIFF
--- a/src/main/haskell/kore/app/prover/Main.hs
+++ b/src/main/haskell/kore/app/prover/Main.hs
@@ -1,28 +1,20 @@
-import           Data.Char
-                 ( isAlphaNum )
-import qualified Data.Map.Strict as Map
-import           Data.Reflection
-import qualified Data.Set as Set
-
+import Data.Char
+       ( isAlphaNum )
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
-import Kore.AST.Common
-       ( SymbolOrAlias, Variable )
-import Kore.AST.MetaOrObject
-       ( Meta )
 import Kore.MetaML.AST
        ( CommonMetaPattern )
 import Kore.Parser.Parser
        ( metaHeadParser, metaPatternParser, metaVariableParser )
 
-import Logic.Matching.Rules.Kore ()
-import Logic.Matching.Rules.Minimal
-import Logic.Matching.Rules.Minimal.Syntax
-       ( parseMLRule )
-import Logic.Matching.Signature.Simple
-import Logic.Proof.Hilbert
-       ( emptyProof )
+import qualified Logic.Matching.Rules.Kore as ML
+                 ( Rule )
+import           Logic.Matching.Rules.Minimal
+import           Logic.Matching.Rules.Minimal.Syntax
+                 ( parseMLRule )
+import           Logic.Proof.Hilbert
+                 ( emptyProof )
 
 import Logic.Matching.Prover.Command
        ( Command, Parser, parseCommand )
@@ -37,7 +29,7 @@ import GlobalMain
 parseName :: Parser String
 parseName = takeWhile1P Nothing isAlphaNum <* space
 
-pCommand :: Parser (Command String (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern) CommonMetaPattern)
+pCommand :: Parser (Command String ML.Rule CommonMetaPattern)
 pCommand = parseCommand parseName parseFormula parseRule
   where
     parseFormula = metaPatternParser
@@ -46,14 +38,10 @@ pCommand = parseCommand parseName parseFormula parseRule
                                parseFormula
                                parseName
 
-proveCommand
-  :: (Reifies sig ValidatedSignature)
-  => proxy (SimpleSignature sig)
-  -> IO (ProverState String
-          (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern )
-          (CommonMetaPattern))
-proveCommand _ = do
-  execReplT runProver defaultSettings proverEnv initialState
+main :: IO ()
+main = defaultMainGlobal
+       >> execReplT runProver defaultSettings proverEnv initialState
+       >> return ()
   where
     initialState = ProverState
                    { proofState = emptyProof
@@ -63,25 +51,3 @@ proveCommand _ = do
                    { commandParser = pCommand
                    , formulaVerifier = dummyFormulaVerifier
                    }
-
-testSignature :: SignatureInfo
-testSignature = SignatureInfo
-  { sorts = Set.fromList ["Nat","Bool"]
-  , labels = Map.fromList [("plus",("Nat",["Nat","Nat"]))
-                          ,("succ",("Nat",["Nat"]))
-                          ,("zero",("Nat",[]))
-                          ]
-  }
-
-main :: IO ()
-main =
-  defaultMainGlobal
-  >> ( case testSigValid of
-         Nothing -> putStrLn $ show testSigValid
-         Just validSig ->
-           reifySignature
-           validSig
-           (\proxy -> proveCommand proxy
-                      >> return ())
-     )
-  where testSigValid = validate testSignature

--- a/src/main/haskell/kore/app/prover/Main.hs
+++ b/src/main/haskell/kore/app/prover/Main.hs
@@ -1,29 +1,37 @@
-import Data.Char
-       ( isAlphaNum )
+import           Data.Char                                     (isAlphaNum)
+import qualified Data.Map.Strict                               as Map
+import qualified Data.Set                                      as Set
+import           Data.Text
 
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
 
-import Kore.AST.Common
-       ( SymbolOrAlias (..), Variable )
-import Kore.AST.MetaOrObject
-       ( Meta (..) )
-import Kore.MetaML.AST
-       ( CommonMetaPattern )
-import Kore.Parser.Parser
-import Logic.Matching.Prover.Repl
-import Logic.Matching.Rules.Kore ()
-import Logic.Matching.Rules.Minimal
-import Logic.Matching.Rules.Minimal.Syntax
-       ( parseMLRule )
-import Logic.Proof.Hilbert
+import           Data.Reflection
+
+import           Logic.Matching.Pattern
+import           Logic.Matching.Syntax
+import           Logic.Proof.Hilbert (emptyProof)
+import           Logic.Matching.Rules.Kore ()
+import           Logic.Matching.Rules.Minimal
+import           Logic.Matching.Rules.Minimal.Syntax (parseMLRule)
+
+import           Logic.Matching.Prover.Repl (ProverState(..), ProverEnv(..), runProver, execReplT, defaultSettings)
+import           Logic.Matching.Prover.Command (Command, Parser(..), parseCommand)
+
+import           Logic.Matching.Signature.Simple
+
+import           Kore.AST.MetaOrObject (Meta)
+import           Kore.AST.Common (SymbolOrAlias, Variable)
+import           Kore.MetaML.AST (CommonMetaPattern)
+import           Kore.Parser.Parser (metaPatternParser, metaHeadParser, metaVariableParser)
+import           GlobalMain (defaultMainGlobal)
 
 -- TODO: still needed?
 parseName :: Parser String
 parseName = takeWhile1P Nothing isAlphaNum <* space
 
-pCommand' :: Parser (Command String (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern) CommonMetaPattern)
-pCommand' = parseCommand parseName parseFormula parseRule
+pCommand :: Parser (Command String (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern) CommonMetaPattern)
+pCommand = parseCommand parseName parseFormula parseRule
   where
     parseFormula = metaPatternParser
     parseRule    = parseMLRule metaHeadParser
@@ -32,11 +40,41 @@ pCommand' = parseCommand parseName parseFormula parseRule
                                parseName
 
 proveCommand
-    :: IO (ProverState
-            String
-            (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern)
-            CommonMetaPattern)
-proveCommand = runProver dummyFormulaVerifier pCommand' (ProverState emptyProof)
+  :: (Reifies sig ValidatedSignature)
+  => proxy (SimpleSignature sig)
+  -> IO (ProverState String
+          (MLRule (SymbolOrAlias Meta) (Variable Meta) CommonMetaPattern )
+          (CommonMetaPattern))
+proveCommand _ = do
+  execReplT runProver defaultSettings proverEnv initialState
+  where
+    initialState = ProverState
+                   { proofState = emptyProof
+                   , commandStackState = []
+                   }
+    proverEnv    = ProverEnv
+                   { commandParser = pCommand
+                   , formulaVerifier = dummyFormulaVerifier
+                   }
+
+testSignature :: SignatureInfo
+testSignature = SignatureInfo
+  { sorts = Set.fromList ["Nat","Bool"]
+  , labels = Map.fromList [("plus",("Nat",["Nat","Nat"]))
+                          ,("succ",("Nat",["Nat"]))
+                          ,("zero",("Nat",[]))
+                          ]
+  }
 
 main :: IO ()
-main = proveCommand >> return ()
+main =
+  defaultMainGlobal 
+  >> ( case testSigValid of
+         Nothing -> putStrLn $ show testSigValid
+         Just validSig ->
+           reifySignature
+           validSig
+           (\proxy -> proveCommand proxy
+                      >> return ())
+     )
+  where testSigValid = validate testSignature

--- a/src/main/haskell/kore/app/prover/Main.hs
+++ b/src/main/haskell/kore/app/prover/Main.hs
@@ -1,22 +1,19 @@
 import           Data.Char                                     (isAlphaNum)
 import qualified Data.Map.Strict                               as Map
 import qualified Data.Set                                      as Set
-import           Data.Text
+import           Data.Reflection
 
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
 
-import           Data.Reflection
 
-import           Logic.Matching.Pattern
-import           Logic.Matching.Syntax
 import           Logic.Proof.Hilbert (emptyProof)
 import           Logic.Matching.Rules.Kore ()
 import           Logic.Matching.Rules.Minimal
 import           Logic.Matching.Rules.Minimal.Syntax (parseMLRule)
 
 import           Logic.Matching.Prover.Repl (ProverState(..), ProverEnv(..), runProver, execReplT, defaultSettings)
-import           Logic.Matching.Prover.Command (Command, Parser(..), parseCommand)
+import           Logic.Matching.Prover.Command (Command, Parser, parseCommand)
 
 import           Logic.Matching.Signature.Simple
 
@@ -68,7 +65,7 @@ testSignature = SignatureInfo
 
 main :: IO ()
 main =
-  defaultMainGlobal 
+  defaultMainGlobal
   >> ( case testSigValid of
          Nothing -> putStrLn $ show testSigValid
          Just validSig ->

--- a/src/main/haskell/kore/app/prover/Main.hs
+++ b/src/main/haskell/kore/app/prover/Main.hs
@@ -1,27 +1,37 @@
-import           Data.Char                                     (isAlphaNum)
-import qualified Data.Map.Strict                               as Map
-import qualified Data.Set                                      as Set
+import           Data.Char
+                 ( isAlphaNum )
+import qualified Data.Map.Strict as Map
 import           Data.Reflection
+import qualified Data.Set as Set
 
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Text.Megaparsec
+import Text.Megaparsec.Char
 
+import Kore.AST.Common
+       ( SymbolOrAlias, Variable )
+import Kore.AST.MetaOrObject
+       ( Meta )
+import Kore.MetaML.AST
+       ( CommonMetaPattern )
+import Kore.Parser.Parser
+       ( metaHeadParser, metaPatternParser, metaVariableParser )
 
-import           Logic.Proof.Hilbert (emptyProof)
-import           Logic.Matching.Rules.Kore ()
-import           Logic.Matching.Rules.Minimal
-import           Logic.Matching.Rules.Minimal.Syntax (parseMLRule)
+import Logic.Matching.Rules.Kore ()
+import Logic.Matching.Rules.Minimal
+import Logic.Matching.Rules.Minimal.Syntax
+       ( parseMLRule )
+import Logic.Matching.Signature.Simple
+import Logic.Proof.Hilbert
+       ( emptyProof )
 
-import           Logic.Matching.Prover.Repl (ProverState(..), ProverEnv(..), runProver, execReplT, defaultSettings)
-import           Logic.Matching.Prover.Command (Command, Parser, parseCommand)
+import Logic.Matching.Prover.Command
+       ( Command, Parser, parseCommand )
+import Logic.Matching.Prover.Repl
+       ( ProverEnv (..), ProverState (..), defaultSettings, execReplT,
+       runProver )
 
-import           Logic.Matching.Signature.Simple
-
-import           Kore.AST.MetaOrObject (Meta)
-import           Kore.AST.Common (SymbolOrAlias, Variable)
-import           Kore.MetaML.AST (CommonMetaPattern)
-import           Kore.Parser.Parser (metaPatternParser, metaHeadParser, metaVariableParser)
-import           GlobalMain (defaultMainGlobal)
+import GlobalMain
+       ( defaultMainGlobal )
 
 -- TODO: still needed?
 parseName :: Parser String

--- a/src/main/haskell/kore/app/share/GlobalMain.hs
+++ b/src/main/haskell/kore/app/share/GlobalMain.hs
@@ -14,7 +14,6 @@ import Control.Exception
        ( evaluate )
 import Control.Monad
        ( when )
-
 import Data.Semigroup
        ( mempty, (<>) )
 import Data.Time.Format
@@ -23,13 +22,10 @@ import Data.Time.LocalTime
        ( ZonedTime, getZonedTime )
 import Data.Version
        ( showVersion )
-
 import System.Clock
        ( Clock (Monotonic), diffTimeSpec, getTime )
-
 import Development.GitRev
        ( gitBranch, gitCommitDate, gitHash )
-
 import Options.Applicative
        ( InfoMod, Parser, argument, disabled, execParser, flag, flag', help,
        helper, hidden, info, internal, long, (<**>), (<|>) )

--- a/src/main/haskell/kore/app/share/GlobalMain.hs
+++ b/src/main/haskell/kore/app/share/GlobalMain.hs
@@ -10,38 +10,34 @@ module GlobalMain
     , clockSomethingIO
     ) where
 
-import           Control.Monad                          ( when )
-import           Control.Exception                      ( evaluate )
-import           Data.Semigroup                         ( (<>)
-                                                        , mempty)
-import           Development.GitRev                     ( gitBranch
-                                                        , gitHash
-                                                        , gitCommitDate )
-import           Data.Time.LocalTime                    (ZonedTime, getZonedTime)
-import           Data.Time.Format                       (formatTime, defaultTimeLocale)
-import           Data.Version                           (showVersion)
-import qualified Paths_kore                             as MetaData (version)
-import           System.Clock                           ( Clock (Monotonic)
-                                                        , diffTimeSpec
-                                                        , getTime )
-import           Options.Applicative                    ( Parser
-                                                        , InfoMod
-                                                        , (<|>)
-                                                        , (<**>)
-                                                        , flag
-                                                        , flag'
-                                                        , long
-                                                        , hidden
-                                                        , internal
-                                                        , help
-                                                        , helper
-                                                        , info
-                                                        , execParser
-                                                        , argument
-                                                        , disabled)
+import Control.Exception
+       ( evaluate )
+import Control.Monad
+       ( when )
 
+import Data.Semigroup
+       ( mempty, (<>) )
+import Data.Time.Format
+       ( defaultTimeLocale, formatTime )
+import Data.Time.LocalTime
+       ( ZonedTime, getZonedTime )
+import Data.Version
+       ( showVersion )
 
-{- | Record Type containing common command-line arguments for each executable in 
+import System.Clock
+       ( Clock (Monotonic), diffTimeSpec, getTime )
+
+import Development.GitRev
+       ( gitBranch, gitCommitDate, gitHash )
+
+import Options.Applicative
+       ( InfoMod, Parser, argument, disabled, execParser, flag, flag', help,
+       helper, hidden, info, internal, long, (<**>), (<|>) )
+
+import qualified Paths_kore as MetaData
+                 ( version )
+
+{- | Record Type containing common command-line arguments for each executable in
 the project -}
 data GlobalOptions = GlobalOptions
     { willVersion    :: !Bool -- ^ Version flag [default=false]

--- a/src/main/haskell/kore/app/share/GlobalMain.hs
+++ b/src/main/haskell/kore/app/share/GlobalMain.hs
@@ -4,6 +4,7 @@ module GlobalMain
     ( MainOptions(..)
     , GlobalOptions(..)
     , mainGlobal
+    , defaultMainGlobal
     , enableDisableFlag
     , clockSomething
     , clockSomethingIO
@@ -11,7 +12,8 @@ module GlobalMain
 
 import           Control.Monad                          ( when )
 import           Control.Exception                      ( evaluate )
-import           Data.Semigroup                         ( (<>) )
+import           Data.Semigroup                         ( (<>)
+                                                        , mempty)
 import           Development.GitRev                     ( gitBranch
                                                         , gitHash
                                                         , gitCommitDate )
@@ -34,7 +36,9 @@ import           Options.Applicative                    ( Parser
                                                         , help
                                                         , helper
                                                         , info
-                                                        , execParser )
+                                                        , execParser
+                                                        , argument
+                                                        , disabled)
 
 
 {- | Record Type containing common command-line arguments for each executable in 
@@ -63,6 +67,10 @@ mainGlobal localOptionsParser modifiers = do
   options <- commandLineParse localOptionsParser modifiers
   when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion)
   return options
+
+
+defaultMainGlobal :: IO (MainOptions options)
+defaultMainGlobal = mainGlobal (argument disabled mempty) mempty
 
 
 -- | main function to print version information

--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -26,7 +26,7 @@ dependencies:
   - array
   - bytestring >= 0.10
   - bytestring-trie
-  - containers
+  - containers >= 0.5.8
   - clock
   - data-default
   - deepseq
@@ -113,9 +113,12 @@ executables:
       - RecordWildCards
     dependencies:
       - kore
+
   prover:
-    source-dirs: app/prover
     main: Main.hs
+    source-dirs:
+      - app/prover
+      - app/share
     dependencies:
       - kore
 

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
@@ -1,6 +1,4 @@
-{-|
-Description: Module for parsing, printing prover commands
--}
+{-| Description: Module for constructing, parsing, printing prover commands -}
 module Logic.Matching.Prover.Command where
 
 import           Data.Text
@@ -11,7 +9,9 @@ import           Data.Text.Prettyprint.Doc
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
 
-
+-- | Prover command data type
+--   TODO: better way of expressing the inherent
+--   differences between [Undo,Show,Help] and the other commands
 data Command ix rule formula
   = Add ix formula
   | Prove ix (rule ix)
@@ -23,6 +23,7 @@ data Command ix rule formula
 -- Parsing --
 type Parser = Parsec String String
 
+-- | parse 'add <ix>: <formula> [by <ml-rule>]'
 parseAdd :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
 parseAdd pIx pFormula pDerivation = do
   _ <- string "add"
@@ -35,6 +36,7 @@ parseAdd pIx pFormula pDerivation = do
     (Add ix formula)
     (AddAndProve ix formula <$ string "by" <* space <*> pDerivation)
 
+-- | parse 'prove <ix> by <ml-rule>'
 parseProve :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
 parseProve pIx _ pDerivation = do
   _ <- string "prove"
@@ -46,16 +48,20 @@ parseProve pIx _ pDerivation = do
   rule <- pDerivation
   return (Prove ix rule)
 
+-- | parse 'undo'
 parseUndo :: Parser (Command ix rule formula)
 parseUndo = string "undo" >> return Undo
 
+-- | parse 'show'
 parseShow :: Parser (Command ix rule formula)
 parseShow = string "show" >> return Show
 
+-- | parse 'help'
 parseHelp :: Parser (Command ix rule formula)
 parseHelp = string "help" >> return Help
 
 
+-- | main command parser
 parseCommand :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
 parseCommand pIx pFormula pDerivation
   =  parseProve pIx pFormula pDerivation

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
@@ -1,13 +1,15 @@
 {-| Description: Module for constructing, parsing, printing prover commands -}
-module Logic.Matching.Prover.Command where
+module Logic.Matching.Prover.Command
+  (Command(..), Parser, parseCommand,)
+where
 
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty (pretty), colon, (<+>) )
+import Data.Text
+       ( Text )
+import Data.Text.Prettyprint.Doc
+       ( Pretty (pretty), colon, (<+>) )
 
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Text.Megaparsec
+import Text.Megaparsec.Char
 
 -- | Prover command data type
 --   TODO: better way of expressing the inherent

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Command.hs
@@ -1,0 +1,77 @@
+{-|
+Description: Module for parsing, printing prover commands
+-}
+module Logic.Matching.Prover.Command where
+
+import           Data.Text
+                 ( Text )
+import           Data.Text.Prettyprint.Doc
+                 ( Pretty (pretty), colon, (<+>) )
+
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
+
+
+data Command ix rule formula
+  = Add ix formula
+  | Prove ix (rule ix)
+  | AddAndProve ix formula (rule ix)
+  | Undo | Show | Help
+  deriving Show
+
+-------------
+-- Parsing --
+type Parser = Parsec String String
+
+parseAdd :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
+parseAdd pIx pFormula pDerivation = do
+  _ <- string "add"
+  space
+  ix <- pIx
+  space >> char ':' >> space
+  formula <- pFormula
+  space
+  option
+    (Add ix formula)
+    (AddAndProve ix formula <$ string "by" <* space <*> pDerivation)
+
+parseProve :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
+parseProve pIx _ pDerivation = do
+  _ <- string "prove"
+  space
+  ix <- pIx
+  space
+  _ <- string "by"
+  space
+  rule <- pDerivation
+  return (Prove ix rule)
+
+parseUndo :: Parser (Command ix rule formula)
+parseUndo = string "undo" >> return Undo
+
+parseShow :: Parser (Command ix rule formula)
+parseShow = string "show" >> return Show
+
+parseHelp :: Parser (Command ix rule formula)
+parseHelp = string "help" >> return Help
+
+
+parseCommand :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
+parseCommand pIx pFormula pDerivation
+  =  parseProve pIx pFormula pDerivation
+ <|> parseAdd pIx pFormula pDerivation
+ <|> parseUndo
+ <|> parseShow
+ <|> parseHelp
+
+--------------
+-- Printing --
+instance (Pretty ix, Pretty formula, Pretty (rule ix)) => Pretty (Command ix rule formula) where
+  pretty (Add ix formula)              =  pretty(  "add"::Text)<+>pretty ix<+>colon<+>pretty formula
+  pretty (Prove ix rule)               =  pretty("prove"::Text)<+>pretty ix<+>colon
+                                      <+> pretty(   "by"::Text)<+>pretty rule
+  pretty (AddAndProve ix formula rule) =  pretty(  "add"::Text)<+>pretty ix<+>colon<+>pretty formula
+                                      <+> pretty(   "by"::Text)<+>pretty rule
+  pretty Undo                          =  pretty( "undo"::Text)
+  pretty Show                          =  pretty( "show"::Text)
+  pretty Help                          =  pretty( "help"::Text)

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
@@ -4,7 +4,7 @@ Description: A simple textual interface for building a proof
 A simple textual interface for building a proof, offering commands
 directly corresponding to the 'Kore.MatchingLogic.HilbertProof' API.
 Parsers must be provided for the formulas, rules, and labels of
-a particular instance of 'HilbertProof'.
+a particular instance of 'ProofSystem'.
 -}
 module Logic.Matching.Prover.Repl
   ( ProverState(..)
@@ -38,21 +38,28 @@ import           Logic.Matching.Prover.Repl.Class
 import           Logic.Matching.Prover.Command
                  (Command(..), Parser)
 
-
+-- | Stack of commands executed by the prover
 type CommandStack ix rule formula = [Command ix rule formula]
 
+-- | Environment bindings for use in the prover
 data ProverEnv ix rule formula error =
   ProverEnv
   { commandParser   :: !(Parser (Command ix rule formula))
+  -- ^ Prover command parser
   , formulaVerifier :: !(formula -> Either (Error error) ())
+  -- ^ function for matching logic well-formedness verification
   }
 
+-- | Mutable state of the prover, containing the proof in
+--   progress and the command stack that built it.
 data ProverState ix rule formula =
   ProverState
   { proofState :: (Proof ix rule formula)
   , commandStackState :: (CommandStack ix rule formula)
   }
 
+-- | Type contraints required to run the prover
+--   using a given instantiation
 type ProofConstraints ix rule formula error =
   ( Ord ix
   , ProofSystem error rule formula
@@ -61,6 +68,8 @@ type ProofConstraints ix rule formula error =
   , Pretty formula
   )
 
+-- | Monad that encorporates the actions and side effects characteristic of a
+--   command-line proof assistant for Matching Logic
 type MonadProver ix rule formula error m =
   ( ProofConstraints ix rule formula error
   , MonadRepl
@@ -71,14 +80,26 @@ type MonadProver ix rule formula error m =
 
 ---------------
 -- Main loop --
+-- | prints initial prompt then calls the main Read-Eval-Print-Loop
+--   upon termination, results in the final state of the proof and
+--   command stack
 runProver
   :: MonadProver ix rule formula error m
   => m (ProverState ix rule formula)
 runProver = outputStrLn "Matching Logic prover started." >> repl >> get
 
+
+-- | main loop:
+--   parses command
+--   if Ctrl-d (`Nothing`) exits prover
+--   else if empty shows the proof in progress and the last command executed
+--        if a valid prover command, applies it to the proof state
+--        else prints parse error
+--        loops
 repl :: MonadProver ix rule formula error m => m ()
-repl =
-    getInputLine ">>> " >>= \case
+repl = do
+    mStrCmd <- getInputLine ">>> "
+    case mStrCmd of
         Nothing -> outputStrLn "Leaving Matching Logic prover..."
         Just ""     -> applyHelp >> repl
         Just strCmd -> do
@@ -86,29 +107,38 @@ repl =
           case parse pCommand "<stdin>" strCmd of
             Left  err -> outputStrLn (parseErrorPretty err) >> repl
             Right cmd' -> applyCommand cmd' >> repl
-            
+
 
 
 --------------------
 -- Command monads --
+
+-- | case split to handle the application of prover commands.
+--   For each command there is a function that handles the
+--   command that returns the new proof if successful, or Nothing
+--   if it fails.
+--   For commands that do not count as part of the
+--   history of the proof (Undo, Show, Help), Nothing is always returned
+--   TODO: clean this up
 applyCommand
   :: MonadProver ix rule formula error m
   => Command ix rule formula
   -> m ()
 applyCommand command = do
-  case command of
+  mResult <- case command of
     Add ix f              -> applyAdd ix f
     AddAndProve ix f rule -> applyAddAndProve ix f rule
     Prove ix rule         -> applyProve ix rule
-    Undo                  -> applyUndo >> return Nothing -- not added to command stack
-    Show                  -> applyShow >> return Nothing -- same
-    Help                  -> applyHelp >> return Nothing 
-  >>= \case  -- Did the command succeed?
+    Undo                  -> applyUndo >> return Nothing
+    Show                  -> applyShow >> return Nothing
+    Help                  -> applyHelp >> return Nothing
+  case mResult of -- Did the command succeed?
     Nothing -> return () -- no
     Just proof -> do     -- yes, update state
       cmds <- gets commandStackState
       put ProverState{proofState = proof, commandStackState = command:cmds}
 
+-- | add a derivation to the proof
 applyProve
   :: MonadProver ix rule formula error m
   => ix -> rule ix
@@ -118,7 +148,8 @@ applyProve ix rule = do
   let eProof = Hilbert.derive proof ix rule
   eitherError2Maybe handleKoreError eProof
 
-applyAdd 
+-- | add a claim to the proof
+applyAdd
   :: MonadProver ix rule formula error m
   => ix -> formula
   -> m (Maybe (Proof ix rule formula))
@@ -128,11 +159,12 @@ applyAdd ix formula = do
   let eProof = Hilbert.add fVerifier proof ix formula
   eitherError2Maybe handleKoreError eProof
 
+-- | add a claim and it's derivation to the proof
 applyAddAndProve
   :: MonadProver ix rule formula error m
   => ix -> formula -> rule ix
   -> m (Maybe (Proof ix rule formula))
-applyAddAndProve ix f rule = do 
+applyAddAndProve ix f rule = do
     fVerifier <- reader formulaVerifier
     proof <- gets proofState
     let eProof = Hilbert.add fVerifier proof ix f
@@ -142,12 +174,15 @@ applyAddAndProve ix f rule = do
       Just proof' ->
         eitherError2Maybe handleKoreError $ Hilbert.derive proof' ix rule
 
+-- | display the proof and the last executed (effectual) command
 applyShow :: MonadProver ix rule formula error m => m ()
 applyShow = renderProof >> showPreviousCommand
 
+-- | display the proof
 renderProof :: MonadProver ix rule formula error m => m ()
 renderProof = outputStrLn . show . Hilbert.renderProof =<< gets proofState
 
+-- | peek the top of the command stack
 showPreviousCommand :: MonadProver ix rule formula error m => m ()
 showPreviousCommand = do
   cmds <- gets commandStackState
@@ -157,13 +192,20 @@ showPreviousCommand = do
         outputStrLn $ '\t' : (show $ pretty $ head cmds)
     )
 
+-- | show the helptext
 applyHelp :: MonadProver ix rule formula error m => m ()
 applyHelp = outputStrLn helpText
 
+-- | helptext for te prover repl
+--   TODO: Write this...
 helpText :: String
-helpText = "for more information view prover_repl.md"
+helpText = "for more information view docs/prover_repl.md"
+
 ----------
 -- Undo --
+-- | case split for undo-ing the previous (effectual) prover command.
+--   At this point, unless the command stack is empty, this
+--   function always succeeds.
 applyUndo
   :: MonadProver ix rule formula error m
   => m ()
@@ -176,6 +218,7 @@ applyUndo = do
     AddAndProve ix _ _:_ -> modify $ undoAddAndProve ix
     _ -> error "Show, Help, Undo should not be added to command history"
 
+-- | remove the previously added claim
 undoAdd
   :: Ord ix => ix
   -> ProverState ix rule formula
@@ -192,7 +235,7 @@ undoAdd ix ProverState{proofState = proof, commandStackState = Add _ _:cmds} =
   }
 undoAdd _ _ = error "undoAdd: top of command stack is not an 'add ...'"
 
-
+-- | remove the previously added derivation
 undoProve
   :: Ord ix => ix
   -> ProverState ix rule formula
@@ -204,6 +247,7 @@ undoProve ix ProverState{proofState = proof, commandStackState = Prove _ _:cmds}
   }
 undoProve _ _ = error "undoProve: top of command stack is not a 'prove ... by ...'"
 
+-- | remove the previously added claim and derivation
 undoAddAndProve
   :: Ord ix => ix
   -> ProverState ix rule formula
@@ -221,16 +265,17 @@ undoAddAndProve ix
   }
 undoAddAndProve _ _ = error "undoAddAndProve: top of command stack is not an 'add ...  by ... '"
 
--- "exceptions"
+------------------
+-- "exceptions" --
+-- | converts an error to an IO action
 eitherError2Maybe
   :: MonadProver ix rule formula mlError m
   => (error -> m ())
   -> Either error result
   -> m (Maybe result)
-eitherError2Maybe handleError =
-  \case
-    Left err -> handleError err >> return Nothing
-    Right result -> return $ Just result
+eitherError2Maybe handleError (Left  err) = handleError err >> return Nothing
+eitherError2Maybe _           (Right res) = return $ Just res
 
+-- | converts an error to an IO action
 handleKoreError :: MonadProver ix rule formula error m =>  Error error -> m ()
 handleKoreError err = outputStrLn $ "command failed " ++ printError err

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
@@ -6,137 +6,231 @@ directly corresponding to the 'Kore.MatchingLogic.HilbertProof' API.
 Parsers must be provided for the formulas, rules, and labels of
 a particular instance of 'HilbertProof'.
 -}
-module Logic.Matching.Prover.Repl where
+module Logic.Matching.Prover.Repl
+  ( ProverState(..)
+  , ProverEnv(..)
+  , runProver
+  , execReplT
+  , defaultSettings )
+where
 
-import           Control.Monad.State.Strict
-                 ( MonadState (get, put), execStateT )
-import           Control.Monad.Trans
-                 ( MonadTrans (lift) )
+import Control.Monad.State.Strict
+       (get, gets, put, modify)
+import Control.Monad.Reader (reader)
+import Control.Monad (when)
+
 import qualified Data.Map.Strict as Map
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty (pretty), colon, (<+>) )
-import           System.Console.Haskeline
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Data.Sequence (Seq((:|>)))
+
+import Data.Text.Prettyprint.Doc
+       ( Pretty (pretty))
+import Text.Megaparsec
+       (parse, parseErrorPretty)
 
 import Kore.Parser.ParserUtils ()
 import Kore.Error
-import Logic.Matching.Error
-import Logic.Proof.Hilbert
 
-type Parser = Parsec String String
-
-newtype ProverState ix rule formula =
-  ProverState (Proof ix rule formula)
-
-data Command ix rule formula =
-   Add ix formula
- | Prove ix (rule ix)
- | AddAndProve ix formula (rule ix)
- deriving Show
-
-applyAddAndProve :: (Ord ix, Pretty ix, ProofSystem error rule formula)
-                 => (formula -> Either (Error error) ())
-                 -> Proof ix rule formula
-                 -> ix -> formula -> (rule ix)
-                 -> Either (Error error) (Proof ix rule formula)
-applyAddAndProve formulaVerifier proof ix f rule =
-  do
-    proof' <- add formulaVerifier proof ix f
-    derive proof' ix f rule
-
-applyProve :: (Ord ix, Pretty ix, ProofSystem error rule formula)
-           => Proof ix rule formula
-           -> ix -> (rule ix)
-           -> Either (Error error) (Proof ix rule formula)
-applyProve proof ix rule = do
-  f' <- case Map.lookup ix (index proof) of
-          Nothing    ->   mlFail ["Formula with ID ", pretty ix, "not found"]
-          Just (_,f) -> return f
-  derive proof ix f' rule
-
-applyAdd :: (Ord ix, Pretty ix, ProofSystem error rule formula)
-         => (formula -> Either (Error error) ())
-         -> Proof ix rule formula
-         -> ix -> formula
-         -> Either (Error error) (Proof ix rule formula)
-applyAdd = add
-
-applyCommand :: (Ord ix, Pretty ix, ProofSystem error rule formula)
-             => (formula -> Either (Error error) ())
-             -> Command ix rule formula
-             -> Proof ix rule formula
-             -> Either (Error error) (Proof ix rule formula)
-applyCommand formulaVerifier command proof = case command of
-  Add ix f              -> applyAdd formulaVerifier proof ix f
-  AddAndProve ix f rule -> applyAddAndProve formulaVerifier proof ix f rule
-  Prove ix rule         -> applyProve proof ix rule
+import           Logic.Proof.Hilbert
+                 (ProofSystem(..), Proof(..))
+import qualified Logic.Proof.Hilbert as Hilbert
+import           Logic.Matching.Prover.Repl.Class
+                 (MonadRepl, MonadHaskeline(..), execReplT, defaultSettings)
+import           Logic.Matching.Prover.Command
+                 (Command(..), Parser)
 
 
-parseAdd :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
-parseAdd pIx pFormula pDerivation = do
-  _ <- string "add"
-  space
-  ix <- pIx
-  space >> char ':' >> space
-  formula <- pFormula
-  space
-  option
-    (Add ix formula)
-    (AddAndProve ix formula <$ string "by" <* space <*> pDerivation)
+type CommandStack ix rule formula = [Command ix rule formula]
 
-parseProve :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
-parseProve pIx _ pDerivation = do
-  _ <- string "prove"
-  space
-  ix <- pIx
-  space
-  _ <- string "by"
-  space
-  rule <- pDerivation
-  return (Prove ix rule)
+data ProverEnv ix rule formula error =
+  ProverEnv
+  { commandParser   :: !(Parser (Command ix rule formula))
+  , formulaVerifier :: !(formula -> Either (Error error) ())
+  }
 
-parseCommand :: Parser ix -> Parser formula -> Parser (rule ix) -> Parser (Command ix rule formula)
-parseCommand pIx pFormula pDerivation
-  =  parseProve pIx pFormula pDerivation
- <|> parseAdd pIx pFormula pDerivation
+data ProverState ix rule formula =
+  ProverState
+  { proofState :: (Proof ix rule formula)
+  , commandStackState :: (CommandStack ix rule formula)
+  }
 
-instance (Pretty ix, Pretty formula, Pretty (rule ix)) => Pretty (Command ix rule formula) where
-  pretty (Add ix formula)              = pretty("add"::Text)<+>pretty ix<+>colon<+>pretty formula
-  pretty (Prove ix rule)               = pretty("prove"::Text)<+>pretty ix<+>colon<+>pretty("by"::Text)<+>pretty rule
-  pretty (AddAndProve ix formula rule) = pretty("add"::Text)<+>pretty ix<+>colon<+>pretty formula<+>pretty("by"::Text)<+>pretty rule
+type ProofConstraints ix rule formula error =
+  ( Ord ix
+  , ProofSystem error rule formula
+  , Pretty ix
+  , Pretty (rule ix)
+  , Pretty formula
+  )
 
+type MonadProver ix rule formula error m =
+  ( ProofConstraints ix rule formula error
+  , MonadRepl
+    (ProverState ix rule formula)
+    (ProverEnv ix rule formula error)
+    m
+  )
+
+---------------
+-- Main loop --
 runProver
-  ::  ( Ord ix
-      , ProofSystem error rule formula
-      , Pretty ix
-      , Pretty (rule ix)
-      , Pretty formula)
-  => (formula -> Either (Error error) ())
-  -> Parser (Command ix rule formula)
+  :: MonadProver ix rule formula error m
+  => m (ProverState ix rule formula)
+runProver = outputStrLn "Matching Logic prover started." >> repl >> get
+
+repl :: MonadProver ix rule formula error m => m ()
+repl =
+    getInputLine ">>> " >>= \case
+        Nothing -> outputStrLn "Leaving Matching Logic prover..."
+        Just ""     -> applyHelp >> repl
+        Just strCmd -> do
+          pCommand <- reader commandParser
+          case parse pCommand "<stdin>" strCmd of
+            Left  err -> outputStrLn (parseErrorPretty err) >> repl
+            Right cmd' -> applyCommand cmd' >> repl
+            
+
+
+--------------------
+-- Command monads --
+applyCommand
+  :: MonadProver ix rule formula error m
+  => Command ix rule formula
+  -> m ()
+applyCommand command = do
+  case command of
+    Add ix f              -> applyAdd ix f
+    AddAndProve ix f rule -> applyAddAndProve ix f rule
+    Prove ix rule         -> applyProve ix rule
+    Undo                  -> applyUndo >> return Nothing -- not added to command stack
+    Show                  -> applyShow >> return Nothing -- same
+    Help                  -> applyHelp >> return Nothing 
+  >>= \case  -- Did the command succeed?
+    Nothing -> return () -- no
+    Just proof -> do     -- yes, update state
+      cmds <- gets commandStackState
+      put ProverState{proofState = proof, commandStackState = command:cmds}
+
+applyProve
+  :: MonadProver ix rule formula error m
+  => ix -> rule ix
+  -> m (Maybe (Proof ix rule formula))
+applyProve ix rule = do
+  proof <- gets proofState
+  let eProof = Hilbert.derive proof ix rule
+  eitherError2Maybe handleKoreError eProof
+
+applyAdd 
+  :: MonadProver ix rule formula error m
+  => ix -> formula
+  -> m (Maybe (Proof ix rule formula))
+applyAdd ix formula = do
+  fVerifier <- reader formulaVerifier
+  proof <- gets proofState
+  let eProof = Hilbert.add fVerifier proof ix formula
+  eitherError2Maybe handleKoreError eProof
+
+applyAddAndProve
+  :: MonadProver ix rule formula error m
+  => ix -> formula -> rule ix
+  -> m (Maybe (Proof ix rule formula))
+applyAddAndProve ix f rule = do 
+    fVerifier <- reader formulaVerifier
+    proof <- gets proofState
+    let eProof = Hilbert.add fVerifier proof ix f
+    mProof <- eitherError2Maybe handleKoreError eProof
+    case mProof of
+      Nothing -> return Nothing
+      Just proof' ->
+        eitherError2Maybe handleKoreError $ Hilbert.derive proof' ix rule
+
+applyShow :: MonadProver ix rule formula error m => m ()
+applyShow = renderProof >> showPreviousCommand
+
+renderProof :: MonadProver ix rule formula error m => m ()
+renderProof = outputStrLn . show . Hilbert.renderProof =<< gets proofState
+
+showPreviousCommand :: MonadProver ix rule formula error m => m ()
+showPreviousCommand = do
+  cmds <- gets commandStackState
+  when (not $ null cmds)
+    ( do
+        outputStrLn "Last Command:"
+        outputStrLn $ '\t' : (show $ pretty $ head cmds)
+    )
+
+applyHelp :: MonadProver ix rule formula error m => m ()
+applyHelp = outputStrLn helpText
+
+helpText :: String
+helpText = "for more information view prover_repl.md"
+----------
+-- Undo --
+applyUndo
+  :: MonadProver ix rule formula error m
+  => m ()
+applyUndo = do
+  cmds <- gets commandStackState
+  case cmds of
+    [] -> outputStrLn "'Undo' failed, no previous command."
+    Add         ix _  :_ -> modify $ undoAdd         ix
+    Prove       ix _  :_ -> modify $ undoProve       ix
+    AddAndProve ix _ _:_ -> modify $ undoAddAndProve ix
+    _ -> error "Show, Help, Undo should not be added to command history"
+
+undoAdd
+  :: Ord ix => ix
   -> ProverState ix rule formula
-  -> IO (ProverState ix rule formula)
-runProver formulaVerifier pCommand' initialState =
-    execStateT (runInputT defaultSettings startRepl) initialState
-  where
-    startRepl = outputStrLn "Matching Logic prover started" >> repl
-    repl = do
-      mcommand <- getInputLine ">>> "
-      case mcommand of
-        Just "" -> do ProverState state <- lift get
-                      outputStrLn (show (renderProof state))
-                      repl
-        Just command -> case parse pCommand' "<stdin>" command of
-          Left err -> outputStrLn (parseErrorPretty err) >> repl
-          Right cmd -> do
-            ProverState state <- lift get
-            case applyCommand formulaVerifier cmd state of
-              Right state' -> do
-                lift (put (ProverState state'))
-                outputStrLn (show (renderProof state'))
-                repl
-              Left err ->
-                outputStrLn ("command failed" ++ printError err) >> repl
-        Nothing -> return ()
+  -> ProverState ix rule formula
+undoAdd ix ProverState{proofState = proof, commandStackState = Add _ _:cmds} =
+  ProverState
+  { proofState =
+      proof
+      { index = Map.delete ix $ index proof
+      , claims = (\ (claims' :|>  _) -> claims') (claims proof)
+      , derivations = derivations proof
+      }
+  , commandStackState = cmds
+  }
+undoAdd _ _ = error "undoAdd: top of command stack is not an 'add ...'"
+
+
+undoProve
+  :: Ord ix => ix
+  -> ProverState ix rule formula
+  -> ProverState ix rule formula
+undoProve ix ProverState{proofState = proof, commandStackState = Prove _ _:cmds} =
+  ProverState
+  { proofState = proof { derivations = Map.delete ix $ derivations proof }
+  , commandStackState = cmds
+  }
+undoProve _ _ = error "undoProve: top of command stack is not a 'prove ... by ...'"
+
+undoAddAndProve
+  :: Ord ix => ix
+  -> ProverState ix rule formula
+  -> ProverState ix rule formula
+undoAddAndProve ix
+  ProverState{ proofState = proof, commandStackState = AddAndProve _ _ _:cmds } =
+  ProverState
+  { proofState =
+      proof
+      { index = Map.delete ix $ index proof
+      , claims = (\(claims' :|> _) -> claims') $ claims proof
+      , derivations = Map.delete ix $ derivations proof
+      }
+  , commandStackState = cmds
+  }
+undoAddAndProve _ _ = error "undoAddAndProve: top of command stack is not an 'add ...  by ... '"
+
+-- "exceptions"
+eitherError2Maybe
+  :: MonadProver ix rule formula mlError m
+  => (error -> m ())
+  -> Either error result
+  -> m (Maybe result)
+eitherError2Maybe handleError =
+  \case
+    Left err -> handleError err >> return Nothing
+    Right result -> return $ Just result
+
+handleKoreError :: MonadProver ix rule formula error m =>  Error error -> m ()
+handleKoreError err = outputStrLn $ "command failed " ++ printError err

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl.hs
@@ -14,29 +14,32 @@ module Logic.Matching.Prover.Repl
   , defaultSettings )
 where
 
+import Control.Monad
+       ( when )
+import Control.Monad.Reader
+       ( reader )
 import Control.Monad.State.Strict
-       (get, gets, put, modify)
-import Control.Monad.Reader (reader)
-import Control.Monad (when)
+       ( get, gets, modify, put )
 
 import qualified Data.Map.Strict as Map
-import Data.Sequence (Seq((:|>)))
+import           Data.Sequence
+                 ( Seq ((:|>)) )
 
 import Data.Text.Prettyprint.Doc
-       ( Pretty (pretty))
+       ( Pretty (pretty) )
 import Text.Megaparsec
-       (parse, parseErrorPretty)
+       ( parse, parseErrorPretty )
 
-import Kore.Parser.ParserUtils ()
 import Kore.Error
+import Kore.Parser.ParserUtils ()
 
-import           Logic.Proof.Hilbert
-                 (ProofSystem(..), Proof(..))
-import qualified Logic.Proof.Hilbert as Hilbert
-import           Logic.Matching.Prover.Repl.Class
-                 (MonadRepl, MonadHaskeline(..), execReplT, defaultSettings)
 import           Logic.Matching.Prover.Command
-                 (Command(..), Parser)
+                 ( Command (..), Parser )
+import           Logic.Matching.Prover.Repl.Class
+                 ( MonadHaskeline (..), MonadRepl, defaultSettings, execReplT )
+import           Logic.Proof.Hilbert
+                 ( Proof (..), ProofSystem (..) )
+import qualified Logic.Proof.Hilbert as Hilbert
 
 -- | Stack of commands executed by the prover
 type CommandStack ix rule formula = [Command ix rule formula]

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
@@ -1,0 +1,60 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Logic.Matching.Prover.Repl.Class
+  ( C.runInputT
+  , C.defaultSettings
+  , MonadRepl
+  , MonadHaskeline(..)
+  , execReplT
+  )
+where
+
+import qualified System.Console.Haskeline as C
+  (MonadException, InputT, Settings, getInputLine, getInputChar, outputStr, outputStrLn, mapInputT, runInputT, defaultSettings)
+import qualified Control.Monad.Reader as R
+  (MonadReader(..), ReaderT, runReaderT, ask, reader, local, lift)
+import qualified Control.Monad.State.Strict as S
+  (MonadState(..), StateT, execStateT, state, lift)
+import qualified Control.Monad.IO.Class as IO
+  (MonadIO)
+
+class C.MonadException m => MonadHaskeline m where
+  getInputLine :: String -> m (Maybe String)
+  getInputChar :: String -> m (Maybe Char)
+  outputStr    :: String -> m ()
+  outputStrLn  :: String -> m ()
+
+instance C.MonadException m => MonadHaskeline (C.InputT m) where
+  getInputLine = C.getInputLine
+  getInputChar = C.getInputChar
+  outputStr    = C.outputStr
+  outputStrLn  = C.outputStrLn
+
+instance R.MonadReader e m => R.MonadReader e (C.InputT m) where
+  ask =  R.lift R.ask
+  reader = R.lift . R.reader
+  local f n = C.mapInputT (R.local f) n
+
+instance S.MonadState s m => S.MonadState s (C.InputT m) where
+  state = S.lift . S.state
+
+
+-- | REPL-like monad constraint kind
+type MonadRepl state env m =
+  ( MonadHaskeline m
+  , S.MonadState state m
+  , R.MonadReader env m
+  , IO.MonadIO m
+  )
+
+
+{- | Evaluate a computation with the given the CLI settings, initial state and environment,
+returning the final state,
+discarding the final value.  -}
+execReplT
+  :: C.MonadException m
+  => C.InputT   (R.ReaderT env (S.StateT st m)) a -- ^ REPL procedure
+  -> C.Settings (R.ReaderT env (S.StateT st m))   -- ^ CLI settings
+  -> env                                          -- ^ REPL environment
+  -> st                                           -- ^ start state
+  -> m st
+execReplT cli settings e s = S.execStateT (R.runReaderT (C.runInputT settings cli) e) s

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
@@ -1,4 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- | Description: module for the type-class style monad transformer for a REPL-like monad.
+TODO:  In order to continue using the dated 'haskeline' library instances of the MonadFoo
+are provided for the underlying monad transformer in haskeline, InputT.
+Perhaps there is a better alternative...
+-}
 module Logic.Matching.Prover.Repl.Class
   ( C.runInputT
   , C.defaultSettings
@@ -17,6 +22,7 @@ import qualified Control.Monad.State.Strict as S
 import qualified Control.Monad.IO.Class as IO
   (MonadIO)
 
+-- | type-class version of 'InputT'
 class C.MonadException m => MonadHaskeline m where
   getInputLine :: String -> m (Maybe String)
   getInputChar :: String -> m (Maybe Char)

--- a/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Prover/Repl/Class.hs
@@ -13,14 +13,17 @@ module Logic.Matching.Prover.Repl.Class
   )
 where
 
-import qualified System.Console.Haskeline as C
-  (MonadException, InputT, Settings, getInputLine, getInputChar, outputStr, outputStrLn, mapInputT, runInputT, defaultSettings)
-import qualified Control.Monad.Reader as R
-  (MonadReader(..), ReaderT, runReaderT, ask, reader, local, lift)
-import qualified Control.Monad.State.Strict as S
-  (MonadState(..), StateT, execStateT, state, lift)
 import qualified Control.Monad.IO.Class as IO
-  (MonadIO)
+                 ( MonadIO )
+import qualified Control.Monad.Reader as R
+                 ( MonadReader (..), ReaderT, ask, lift, local, reader,
+                 runReaderT )
+import qualified Control.Monad.State.Strict as S
+                 ( MonadState (..), StateT, execStateT, lift, state )
+import qualified System.Console.Haskeline as C
+                 ( InputT, MonadException, Settings, defaultSettings,
+                 getInputChar, getInputLine, mapInputT, outputStr, outputStrLn,
+                 runInputT )
 
 -- | type-class version of 'InputT'
 class C.MonadException m => MonadHaskeline m where

--- a/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
@@ -46,6 +46,9 @@ import           Logic.Proof.Hilbert
 
 type Var = Variable Meta
 type Symbol = SymbolOrAlias Meta
+type Formula = CommonMetaPattern
+type Rule = MLRule Symbol Var Formula
+
 
 -- To get an indexed module one can use `verifyAndIndexDefinition`
 formulaVerifier

--- a/src/main/haskell/kore/src/Logic/Proof/Hilbert.hs
+++ b/src/main/haskell/kore/src/Logic/Proof/Hilbert.hs
@@ -74,9 +74,9 @@ class (Traversable rule, Eq formula)
 
 derive :: (Pretty ix, Ord ix, ProofSystem error rule formula)
        => Proof ix rule formula
-       -> ix -> formula -> rule ix
+       -> ix -> rule ix
        -> Either (Error error) (Proof ix rule formula)
-derive proof ix f rule = do
+derive proof ix rule = do
   mlFailWhen (Map.member ix (derivations proof))
     [ "Formula with ID "
     , squotes (pretty ix)
@@ -87,8 +87,6 @@ derive proof ix f rule = do
       Nothing ->
         mlFail ["Formula with ID ", squotes (pretty ix), " not found."]
       Just a  -> return a
-  mlFailWhen (conclusion /= f)
-    ["Expected a different formula for id ", squotes (pretty ix), "."]
   let resolveIx name = do
         (offset',formula') <-
           case Map.lookup name (index proof) of

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
@@ -2145,15 +2145,19 @@ type MLProof =
             (MetaMLPattern Variable)
         )
         (MetaMLPattern Variable)
+
 data GoalMLProofState
     = GoalUnproven
     | GoalProven
     | GoalPartlyProven GoalNeeds
     deriving Show
+
 newtype GoalNeeds = GoalNeeds [GoalId]
     deriving (Eq, Show)
+
 emptyMLProof :: MLProof
 emptyMLProof = emptyProof
+
 goalCount :: MLProof -> Int
 goalCount proof = length (claims proof)
 
@@ -2180,12 +2184,10 @@ modusPonens
 modusPonens phiId phiImpliesPsiId conclusionId proof =
     stringError modusPonens'
   where
-    modusPonens' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    modusPonens' =
         derive
             proof
             conclusionId
-            conclusionFormula
             (ModusPonens phiId phiImpliesPsiId)
 
 proposition1
@@ -2197,12 +2199,10 @@ proposition1
 proposition1 phip psip conclusionId proof =
     stringError proposition1'
   where
-    proposition1' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    proposition1' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   Propositional1
                 <$> patternKoreToPure Meta phip
                 <*> patternKoreToPure Meta psip
@@ -2218,12 +2218,10 @@ proposition2
 proposition2 phi1p phi2p phi3p conclusionId proof =
     stringError proposition2'
   where
-    proposition2' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    proposition2' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   Propositional2
                 <$> patternKoreToPure Meta phi1p
                 <*> patternKoreToPure Meta phi2p
@@ -2239,12 +2237,10 @@ proposition3
 proposition3 phi1p phi2p conclusionId proof =
     stringError proposition3'
   where
-    proposition3' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    proposition3' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   Propositional3
                 <$> patternKoreToPure Meta phi1p
                 <*> patternKoreToPure Meta phi2p
@@ -2262,12 +2258,10 @@ variableSubstitution
   =
     stringError variableSubstitution'
   where
-    variableSubstitution' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    variableSubstitution' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   VariableSubstitution substituted
                 <$> patternKoreToPure Meta unsubstitutedPattern
                 <*> pure substituting
@@ -2285,12 +2279,10 @@ forallRule
   =
     stringError forallFormula'
   where
-    forallFormula' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    forallFormula' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   ForallRule variable
                 <$> patternKoreToPure Meta phi1p
                 <*> patternKoreToPure Meta phi2p
@@ -2301,12 +2293,10 @@ generalization
 generalization variable phiId conclusionId proof =
     stringError generalization'
   where
-    generalization' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    generalization' =
         derive
             proof
             conclusionId
-            conclusionFormula
             (Generalization variable phiId)
 
 propagateOr
@@ -2319,12 +2309,10 @@ propagateOr
 propagateOr symbol idx phi1p phi2p conclusionId proof =
     stringError propagateOr'
   where
-    propagateOr' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    propagateOr' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   PropagateOr symbol idx
                 <$> patternKoreToPure Meta phi1p
                 <*> patternKoreToPure Meta phi2p
@@ -2340,12 +2328,10 @@ propagateExists
 propagateExists symbol idx variable phip conclusionId proof =
     stringError propagateOr'
   where
-    propagateOr' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    propagateOr' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   PropagateExists symbol idx variable
                 <$> patternKoreToPure Meta phip
                 )
@@ -2359,12 +2345,10 @@ framing
 framing symbol idx hypothesisId conclusionId proof =
     stringError propagateFraming'
   where
-    propagateFraming' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    propagateFraming' =
         derive
             proof
             conclusionId
-            conclusionFormula
             (Framing symbol idx hypothesisId)
 
 existence
@@ -2374,12 +2358,10 @@ existence
 existence variable conclusionId proof =
     stringError existence'
   where
-    existence' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    existence' =
         derive
             proof
             conclusionId
-            conclusionFormula
             (Existence variable)
 
 singvar
@@ -2392,12 +2374,10 @@ singvar
 singvar variable phip path1 path2 conclusionId proof =
     stringError singvar'
   where
-    singvar' = do
-        conclusionFormula <- lookupFormula conclusionId proof
+    singvar' =
         derive
             proof
             conclusionId
-            conclusionFormula
             =<< (   Singvar variable
                 <$> patternKoreToPure Meta phip
                 <*> pure path1

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne.hs
@@ -429,7 +429,7 @@ runEntry :: (ReifiesSignature s)
               (AST.WFPattern (SimpleSignature s) Int))
 runEntry proof entry@(ix,pat,rule) = presentError $ do
     proof1 <- add (const (Right ())) proof ix pat
-    derive proof1 pat rule
+    derive proof1 ix rule
   where
     presentError (Left err) =
         Left ("Error processing "++show entry++":\n"++show err)

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne.hs
@@ -429,7 +429,7 @@ runEntry :: (ReifiesSignature s)
               (AST.WFPattern (SimpleSignature s) Int))
 runEntry proof entry@(ix,pat,rule) = presentError $ do
     proof1 <- add (const (Right ())) proof ix pat
-    derive proof1 ix pat rule
+    derive proof1 pat rule
   where
     presentError (Left err) =
         Left ("Error processing "++show entry++":\n"++show err)


### PR DESCRIPTION
improvements:
- Reimplemented the prover repl to utilize monad transformers for a more painless integration of stateful computation on matching logic proofs.
- added undo functionality

Further work:
- move functionality (to reorder proof claims) should be a minor addition.
- Testing.  I have not added tests for the user interface or the undo functionality.
- updating the `prover_repl.md`

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

