### PR TITLE
Always parse matching logic constructors the same way

### DIFF
--- a/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
@@ -601,26 +601,10 @@ koreMLConstructorParser = do
         c <- ParserUtils.peekChar'
         if c == '#'
             then asKorePattern <$>
-                mlConstructorRemainderParser korePatternParser
-                    Meta patternType (unsupportedPatternType Meta)
+                mlConstructorRemainderParser korePatternParser Meta patternType
             else asKorePattern <$>
-                mlConstructorRemainderParser korePatternParser
-                    Object patternType objectMlConstructorRemainderParser
-    objectMlConstructorRemainderParser patternType =
-        case patternType of
-            DomainValuePatternType -> DomainValuePattern <$>
-                (   DomainValue
-                <$> inCurlyBracesRemainderParser (sortParser Object)
-                <*> inParenthesesParser (purePatternParser Meta)
-                )
-            NextPatternType -> NextPattern <$>
-                unaryOperatorRemainderParser korePatternParser Object Next
-            RewritesPatternType -> RewritesPattern <$>
-                binaryOperatorRemainderParser
-                    korePatternParser
-                    Object
-                    Rewrites
-            pt -> unsupportedPatternType Object pt
+                mlConstructorRemainderParser korePatternParser Object
+                    patternType
 
 {-|'leveledMLConstructorParser' is similar to 'koreMLConstructorParser'
 in that it parses a pattern starting with @\@.  However, it only parses
@@ -665,7 +649,6 @@ leveledMLConstructorParser childParser level = do
             childParser
             level
             patternType
-            (unsupportedPatternType level)
 
 {-|'unsupportedPatternType' reports an error for a missing parser for
 a 'MLPatternType'.
@@ -689,9 +672,8 @@ mlConstructorRemainderParser
     => Parser child
     -> level
     -> MLPatternType
-    -> (MLPatternType -> Parser (Pattern level Variable child))
     -> Parser (Pattern level Variable child)
-mlConstructorRemainderParser childParser x patternType otherParsers =
+mlConstructorRemainderParser childParser x patternType =
     case patternType of
         AndPatternType -> AndPattern <$>
             binaryOperatorRemainderParser childParser x And
@@ -719,7 +701,30 @@ mlConstructorRemainderParser childParser x patternType otherParsers =
             binaryOperatorRemainderParser childParser x Or
         TopPatternType -> TopPattern <$>
             topBottomRemainderParser x Top
-        _ -> otherParsers patternType
+        DomainValuePatternType ->
+            case isMetaOrObject (toProxy x) of
+                IsMeta -> unsupportedPatternType Meta DomainValuePatternType
+                IsObject ->
+                    DomainValuePattern <$>
+                    (   DomainValue
+                    <$> inCurlyBracesRemainderParser (sortParser Object)
+                    <*> inParenthesesParser (purePatternParser Meta)
+                    )
+        NextPatternType ->
+            case isMetaOrObject (toProxy x) of
+                IsMeta -> unsupportedPatternType Meta NextPatternType
+                IsObject ->
+                    NextPattern <$>
+                    unaryOperatorRemainderParser childParser Object Next
+        RewritesPatternType ->
+            case isMetaOrObject (toProxy x) of
+                IsMeta -> unsupportedPatternType Meta RewritesPatternType
+                IsObject ->
+                    RewritesPattern <$>
+                    binaryOperatorRemainderParser
+                        childParser
+                        Object
+                        Rewrites
 
 {-|'korePatternParser' parses an unifiedPattern
 

--- a/src/test/resources/expected/test-alias-10.kore.golden
+++ b/src/test/resources/expected/test-alias-10.kore.golden
@@ -1,0 +1,42 @@
+Definition
+    { definitionAttributes = Attributes []
+    , definitionModules =
+        [ Module
+            { moduleName = ModuleName "TEST-ALIAS-10"
+            , moduleSentences =
+                [ ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                            , aliasParams =
+                                [ SortVariable ((Id "s" AstLocationNone) :: Id Object)
+                                ]
+                            }
+                    , sentenceAliasSorts = []
+                    , sentenceAliasReturnSort =
+                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams =
+                                        [ SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                        ]
+                                    }
+                            , applicationChildren = []
+                            }
+                    , sentenceAliasRightPattern =
+                        DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "f"))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
+                ]
+            , moduleAttributes = Attributes []
+            }
+        ]
+    }

--- a/src/test/resources/expected/test-alias-11.kore.golden
+++ b/src/test/resources/expected/test-alias-11.kore.golden
@@ -1,0 +1,66 @@
+Definition
+    { definitionAttributes = Attributes []
+    , definitionModules =
+        [ Module
+            { moduleName = ModuleName "TEST-ALIAS-11"
+            , moduleSentences =
+                [ ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                            , aliasParams =
+                                [ SortVariable ((Id "s" AstLocationNone) :: Id Object)
+                                ]
+                            }
+                    , sentenceAliasSorts =
+                        [ SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                        , SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                        ]
+                    , sentenceAliasReturnSort =
+                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams =
+                                        [ SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                        ]
+                                    }
+                            , applicationChildren =
+                                [ Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "a" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                                , Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "b" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                                ]
+                            }
+                    , sentenceAliasRightPattern =
+                        RewritesPattern Rewrites
+                            { rewritesSort =
+                                SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                            , rewritesFirst =
+                                Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "a" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                            , rewritesSecond =
+                                Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "b" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
+                ]
+            , moduleAttributes = Attributes []
+            }
+        ]
+    }

--- a/src/test/resources/expected/test-alias-12.kore.golden
+++ b/src/test/resources/expected/test-alias-12.kore.golden
@@ -1,0 +1,54 @@
+Definition
+    { definitionAttributes = Attributes []
+    , definitionModules =
+        [ Module
+            { moduleName = ModuleName "TEST-ALIAS-12"
+            , moduleSentences =
+                [ ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                            , aliasParams =
+                                [ SortVariable ((Id "s" AstLocationNone) :: Id Object)
+                                ]
+                            }
+                    , sentenceAliasSorts =
+                        [ SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                        ]
+                    , sentenceAliasReturnSort =
+                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "f" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams =
+                                        [ SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                        ]
+                                    }
+                            , applicationChildren =
+                                [ Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "a" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                                ]
+                            }
+                    , sentenceAliasRightPattern =
+                        NextPattern Next
+                            { nextSort =
+                                SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                            , nextChild =
+                                Fix (UnifiedPattern (UnifiedObject (Rotate31 (VariablePattern Variable
+                                    { variableName = (Id "a" AstLocationNone) :: Id Object
+                                    , variableSort =
+                                        SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                                    }))))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
+                ]
+            , moduleAttributes = Attributes []
+            }
+        ]
+    }

--- a/src/test/resources/test-alias-10.kore
+++ b/src/test/resources/test-alias-10.kore
@@ -1,0 +1,8 @@
+[]
+module TEST-ALIAS-10
+
+  alias f{s}() : s
+  where f{s}() := \dv{s}("f") []
+
+endmodule
+[]

--- a/src/test/resources/test-alias-11.kore
+++ b/src/test/resources/test-alias-11.kore
@@ -1,0 +1,8 @@
+[]
+module TEST-ALIAS-11
+
+  alias f{s}(s, s) : s
+  where f{s}(a : s, b : s) := \rewrites{s}(a : s, b : s) []
+
+endmodule
+[]

--- a/src/test/resources/test-alias-12.kore
+++ b/src/test/resources/test-alias-12.kore
@@ -1,0 +1,8 @@
+[]
+module TEST-ALIAS-12
+
+  alias f{s}(s) : s
+  where f{s}(a : s) := \next{s}(a : s) []
+
+endmodule
+[]


### PR DESCRIPTION
`Kore.Parser.ParserImpl.mlConstructorRemainderParser` is modified so that it
does not take a continuation. Instead, it parses all the matching logic
constructors itself. It takes a level parameter which is used to determine if a
particular constructor should be rejected. Dropping the continuation ensures
that matching logic constructors are always parsed by the same code path, which
fixes the parsing of domain values in aliases.
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

