### PR TITLE
Builtin pattern verifiers

### DIFF
--- a/src/main/haskell/kore/app/parser/Main.hs
+++ b/src/main/haskell/kore/app/parser/Main.hs
@@ -203,7 +203,9 @@ mainPatternVerify indexedModule patt =
     do
       verifyResult <-
         clockSomething "Verifying the pattern"
-            ( verifyStandalonePattern indexedModule patt)
+            (verifyStandalonePattern patternVerifier indexedModule patt)
       case verifyResult of
         Left err1 -> error (printError err1)
         Right _   -> return ()
+  where
+    Builtin.Verifiers { patternVerifier } = Builtin.koreBuiltins

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -248,7 +248,7 @@ verifyObjectSentence
         verifySortSentence sortSentence attributesVerification
         let SentenceSort { sentenceSortAttributes } = sortSentence
         hook <- castError (parseAttributes sentenceSortAttributes)
-        Builtin.sortVerifier builtinVerifiers hook sortSentence
+        Builtin.sortDeclVerifier builtinVerifiers hook sortSentence
         pure (VerifySuccess ())
 
 verifyObjectSentence

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -328,15 +328,15 @@ verifyAliasSentence
                 else
                     koreFail "Left and Right sorts do not match"
             verifyAliasLeftPattern
+                indexedModule
+                variables
+                (Just $ asUnified leftPatternSort)
                 (asKorePattern $ sentenceAliasLeftPattern sentence)
-                (Just $ (asUnified leftPatternSort))
-                indexedModule
-                variables
             verifyPattern
-                (asKorePattern $ sentenceAliasRightPattern sentence)
-                (Just $ (asUnified rightPatternSort))
                 indexedModule
                 variables
+                (Just $ asUnified rightPatternSort)
+                (asKorePattern $ sentenceAliasRightPattern sentence)
             verifyAttributes
                 (sentenceAliasAttributes sentence)
                 attributesVerification
@@ -363,10 +363,10 @@ verifyAxiomSentence axiom indexedModule attributesVerification =
                 buildDeclaredUnifiedSortVariables
                     (sentenceAxiomParameters axiom)
             verifyPattern
-                (sentenceAxiomPattern axiom)
-                Nothing
                 indexedModule
                 variables
+                Nothing
+                (sentenceAxiomPattern axiom)
             verifyAttributes
                 (sentenceAxiomAttributes axiom)
                 attributesVerification

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -15,16 +15,19 @@ This module is intended to be imported qualified.
  -}
 module Kore.Builtin
     ( Verifiers (..)
+    , PatternVerifier (..)
     , sortVerifier
     , symbolVerifier
     , koreBuiltins
     ) where
 
-import Data.Semigroup ( (<>) )
+import Data.Semigroup
+       ( (<>) )
 
 import qualified Kore.Builtin.Bool as Bool
 import           Kore.Builtin.Builtin
-                 ( Verifiers (..), sortVerifier, symbolVerifier )
+                 ( PatternVerifier (..), Verifiers (..), sortVerifier,
+                 symbolVerifier )
 import qualified Kore.Builtin.Int as Int
 
 {- | Verifiers for Kore builtin sorts.
@@ -41,7 +44,7 @@ koreBuiltins =
     , symbolVerifiers =
            Bool.symbolVerifiers
         <> Int.symbolVerifiers
-    , patternVerifiers =
-           Bool.patternVerifiers
-        <> Int.patternVerifiers
+    , patternVerifier =
+           Bool.patternVerifier
+        <> Int.patternVerifier
     }

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -16,7 +16,7 @@ This module is intended to be imported qualified.
 module Kore.Builtin
     ( Verifiers (..)
     , PatternVerifier (..)
-    , sortVerifier
+    , sortDeclVerifier
     , symbolVerifier
     , koreBuiltins
     ) where
@@ -26,7 +26,7 @@ import Data.Semigroup
 
 import qualified Kore.Builtin.Bool as Bool
 import           Kore.Builtin.Builtin
-                 ( PatternVerifier (..), Verifiers (..), sortVerifier,
+                 ( PatternVerifier (..), Verifiers (..), sortDeclVerifier,
                  symbolVerifier )
 import qualified Kore.Builtin.Int as Int
 
@@ -38,9 +38,9 @@ import qualified Kore.Builtin.Int as Int
 koreBuiltins :: Verifiers
 koreBuiltins =
     Verifiers
-    { sortVerifiers =
-           Bool.sortVerifiers
-        <> Int.sortVerifiers
+    { sortDeclVerifiers =
+           Bool.sortDeclVerifiers
+        <> Int.sortDeclVerifiers
     , symbolVerifiers =
            Bool.symbolVerifiers
         <> Int.symbolVerifiers

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -21,11 +21,15 @@ module Kore.Builtin.Bool
     , patternVerifier
     ) where
 
+import           Control.Monad
+                 ( void )
+import           Data.Functor
+                 ( ($>) )
 import qualified Data.HashMap.Strict as HashMap
+import qualified Text.Megaparsec as Parsec
+import qualified Text.Megaparsec.Char as Parsec
 
 import qualified Kore.Builtin.Builtin as Builtin
-import Kore.AST.Common ( StringLiteral (..) )
-import qualified Kore.Error
 
 {- | Builtin name of the @Bool@ sort.
  -}
@@ -64,10 +68,12 @@ symbolVerifiers =
 patternVerifier :: Builtin.PatternVerifier
 patternVerifier =
     Builtin.verifyDomainValue sort
-    (Builtin.verifyStringLiteral verifyBool)
+    (void . Builtin.parseDomainValue parse)
+
+{- | Parse an integer string literal.
+ -}
+parse :: Builtin.Parser Bool
+parse = (Parsec.<|>) true false
   where
-    verifyBool StringLiteral { getStringLiteral = lit }
-        | lit == "true" || lit == "false" = return ()
-        | otherwise =
-            Kore.Error.koreFail
-            ("Expected \"true\" or \"false\", but found \"" ++ lit ++ "\"")
+    true = Parsec.string "true" $> True
+    false = Parsec.string "false" $> False

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -18,12 +18,14 @@ module Kore.Builtin.Bool
     ( sort
     , sortVerifiers
     , symbolVerifiers
-    , patternVerifiers
+    , patternVerifier
     ) where
 
 import qualified Data.HashMap.Strict as HashMap
 
 import qualified Kore.Builtin.Builtin as Builtin
+import Kore.AST.Common ( StringLiteral (..) )
+import qualified Kore.Error
 
 {- | Builtin name of the @Bool@ sort.
  -}
@@ -59,7 +61,13 @@ symbolVerifiers =
 
 {- | Verify that domain value patterns are well-formed.
  -}
-patternVerifiers :: Builtin.PatternVerifiers
-patternVerifiers =
-    -- TODO (thomas.tuegel): Not implemented
-    HashMap.empty
+patternVerifier :: Builtin.PatternVerifier
+patternVerifier =
+    Builtin.verifyDomainValue sort
+    (Builtin.verifyStringLiteral verifyBool)
+  where
+    verifyBool StringLiteral { getStringLiteral = lit }
+        | lit == "true" || lit == "false" = return ()
+        | otherwise =
+            Kore.Error.koreFail
+            ("expected \"true\" or \"false\", but found \"" ++ lit ++ "\"")

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -16,7 +16,8 @@ builtin modules.
  -}
 module Kore.Builtin.Bool
     ( sort
-    , sortVerifiers
+    , assertSort
+    , sortDeclVerifiers
     , symbolVerifiers
     , patternVerifier
     ) where
@@ -36,13 +37,21 @@ import qualified Kore.Builtin.Builtin as Builtin
 sort :: String
 sort = "BOOL.Bool"
 
+{- | Verify that the sort is hooked to the builtin @Bool@ sort.
+
+  See also: 'sort', 'Builtin.verifySort'
+
+ -}
+assertSort :: Builtin.SortVerifier
+assertSort findSort = Builtin.verifySort findSort sort
+
 {- | Verify that hooked sort declarations are well-formed.
 
   See also: 'Builtin.verifySortDecl'
 
  -}
-sortVerifiers :: Builtin.SortVerifiers
-sortVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
+sortDeclVerifiers :: Builtin.SortDeclVerifiers
+sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
 
 {- | Verify that hooked symbol declarations are well-formed.
 
@@ -52,15 +61,15 @@ sortVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
     HashMap.fromList
-    [ ("BOOL.or", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.and", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.xor", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.ne", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.eq", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.not", Builtin.verifySymbol sort [sort])
-    , ("BOOL.implies", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.andThen", Builtin.verifySymbol sort [sort, sort])
-    , ("BOOL.orElse", Builtin.verifySymbol sort [sort, sort])
+    [ ("BOOL.or", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.and", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.xor", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.ne", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.eq", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.not", Builtin.verifySymbol assertSort [assertSort])
+    , ("BOOL.implies", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.andThen", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("BOOL.orElse", Builtin.verifySymbol assertSort [assertSort, assertSort])
     ]
 
 {- | Verify that domain value patterns are well-formed.

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -70,4 +70,4 @@ patternVerifier =
         | lit == "true" || lit == "false" = return ()
         | otherwise =
             Kore.Error.koreFail
-            ("expected \"true\" or \"false\", but found \"" ++ lit ++ "\"")
+            ("Expected \"true\" or \"false\", but found \"" ++ lit ++ "\"")

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -316,7 +316,8 @@ verifyDomainValue builtinSort validate =
                 (skipOtherSorts domainValueSort (validate dv))
             _ -> return ()  -- no domain value to verify
       where
-        -- | Run @next@ if @sort@ is hooked to @builtinSort@; do nothing otherwise.
+        -- | Run @next@ if @sort@ is hooked to @builtinSort@; do nothing
+        -- otherwise.
         skipOtherSorts sort next = do
             decl <- Except.catchError
                     (Just <$> verifySort findSort builtinSort sort)
@@ -327,7 +328,8 @@ verifyDomainValue builtinSort validate =
 
 verifyStringLiteral
     :: (StringLiteral -> Either (Error VerifyError) ())
-    -> (DomainValue Object (CommonPurePattern Meta) -> Either (Error VerifyError) ())
+    -> (DomainValue Object (CommonPurePattern Meta)
+    -> Either (Error VerifyError) ())
 verifyStringLiteral validate DomainValue { domainValueChild } =
     case Functor.Foldable.project domainValueChild of
         StringLiteralPattern lit@StringLiteral {} -> validate lit

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -128,9 +128,9 @@ newtype PatternVerifier =
         See also: 'verifyDomainValue'
       -}
       runPatternVerifier
-        :: (Id Object -> Either (Error VerifyError) (SortDescription Object))
-        -> Pattern Object Variable CommonKorePattern
-        -> Either (Error VerifyError) ()
+          :: (Id Object -> Either (Error VerifyError) (SortDescription Object))
+          -> Pattern Object Variable CommonKorePattern
+          -> Either (Error VerifyError) ()
     }
 
 instance Semigroup PatternVerifier where
@@ -342,8 +342,8 @@ verifyDomainValue builtinSort validate =
         \case
             DomainValuePattern dv@DomainValue { domainValueSort } ->
                 withContext
-                ("Verifying builtin sort '" ++ builtinSort ++ "'")
-                (skipOtherSorts domainValueSort (validate dv))
+                    ("Verifying builtin sort '" ++ builtinSort ++ "'")
+                    (skipOtherSorts domainValueSort (validate dv))
             _ -> return ()  -- no domain value to verify
       where
         -- | Run @next@ if @sort@ is hooked to @builtinSort@; do nothing
@@ -355,7 +355,8 @@ verifyDomainValue builtinSort validate =
             -- ^ Verifier run iff pattern sort is hooked to designated builtin
             -> Either (Error VerifyError) ()
         skipOtherSorts sort next = do
-            decl <- Except.catchError
+            decl <-
+                Except.catchError
                     (Just <$> verifySort findSort builtinSort sort)
                     (\_ -> return Nothing)
             case decl of

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -108,11 +108,19 @@ type SymbolVerifiers = HashMap String SymbolVerifier
 
 newtype PatternVerifier =
     PatternVerifier
-    { runPatternVerifier
+    {
+      {- | Verify object-level patterns in builtin sorts.
+
+        The first argument is a function to look up sorts.
+        The second argument is a (projected) object-level pattern to verify.
+        If the pattern is not in a builtin sort, the verifier should
+        @return ()@.
+
+        See also: 'verifyDomainValue'
+      -}
+      runPatternVerifier
         :: (Id Object -> Either (Error VerifyError) (SortDescription Object))
-        -- ^ Find a sort declaration
         -> Pattern Object Variable CommonKorePattern
-        -- ^ (Projected) Kore pattern to verify
         -> Either (Error VerifyError) ()
     }
 

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -332,6 +332,12 @@ verifyDomainValue
 verifyDomainValue builtinSort validate =
     PatternVerifier { runPatternVerifier }
   where
+    runPatternVerifier
+        :: (Id Object -> Either (Error VerifyError) (SortDescription Object))
+        -- ^ Function to lookup sorts by identifier
+        -> Pattern Object Variable CommonKorePattern
+        -- ^ Pattern to verify
+        -> Either (Error VerifyError) ()
     runPatternVerifier findSort =
         \case
             DomainValuePattern dv@DomainValue { domainValueSort } ->
@@ -342,6 +348,12 @@ verifyDomainValue builtinSort validate =
       where
         -- | Run @next@ if @sort@ is hooked to @builtinSort@; do nothing
         -- otherwise.
+        skipOtherSorts
+            :: Sort Object
+            -- ^ Sort of pattern under verification
+            -> Either (Error VerifyError) ()
+            -- ^ Verifier run iff pattern sort is hooked to designated builtin
+            -> Either (Error VerifyError) ()
         skipOtherSorts sort next = do
             decl <- Except.catchError
                     (Just <$> verifySort findSort builtinSort sort)

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -21,19 +21,13 @@ module Kore.Builtin.Int
     , patternVerifier
     ) where
 
+import           Control.Monad
+                 ( void )
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Void
-                 ( Void )
-import           Text.Megaparsec
-                 ( Parsec )
-import qualified Text.Megaparsec as Parsec
 import qualified Text.Megaparsec.Char.Lexer as Parsec
 
-import           Kore.AST.Common
-                 ( StringLiteral (..) )
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
-import qualified Kore.Error
 
 {- | Builtin name of the @Int@ sort.
  -}
@@ -104,18 +98,11 @@ symbolVerifiers =
 patternVerifier :: Builtin.PatternVerifier
 patternVerifier =
     Builtin.verifyDomainValue sort
-    (Builtin.verifyStringLiteral verifyInt)
-  where
-    verifyInt StringLiteral { getStringLiteral = lit } =
-        let parsed = Parsec.parse parse "<string literal>" lit in
-        case parsed of
-            Left err ->
-                Kore.Error.koreFail (Parsec.parseErrorPretty err)
-            Right _ -> pure ()
+    (void . Builtin.parseDomainValue parse)
 
 {- | Parse an integer string literal.
  -}
-parse :: Parsec Void String Integer
-parse = Parsec.signed noSpace Parsec.decimal <* Parsec.eof
+parse :: Builtin.Parser Integer
+parse = Parsec.signed noSpace Parsec.decimal
   where
     noSpace = pure ()

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -16,7 +16,8 @@ builtin modules.
  -}
 module Kore.Builtin.Int
     ( sort
-    , sortVerifiers
+    , assertSort
+    , sortDeclVerifiers
     , symbolVerifiers
     , patternVerifier
     ) where
@@ -34,13 +35,21 @@ import qualified Kore.Builtin.Builtin as Builtin
 sort :: String
 sort = "INT.Int"
 
+{- | Verify that the sort is hooked to the builtin @Int@ sort.
+
+  See also: 'sort', 'Builtin.verifySort'
+
+ -}
+assertSort :: Builtin.SortVerifier
+assertSort findSort = Builtin.verifySort findSort sort
+
 {- | Verify that hooked sort declarations are well-formed.
 
   See also: 'Builtin.verifySortDecl'
 
  -}
-sortVerifiers :: Builtin.SortVerifiers
-sortVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
+sortDeclVerifiers :: Builtin.SortDeclVerifiers
+sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
 
 {- | Verify that hooked symbol declarations are well-formed.
 
@@ -51,46 +60,52 @@ symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
     HashMap.fromList
     [
-      ("INT.bitRange", Builtin.verifySymbol sort [sort, sort, sort])
-    , ("INT.signExtendBitRange", Builtin.verifySymbol sort [sort, sort, sort])
+      ( "INT.bitRange"
+      , Builtin.verifySymbol assertSort [assertSort, assertSort, assertSort]
+      )
+    , ( "INT.signExtendBitRange"
+      , Builtin.verifySymbol assertSort [assertSort, assertSort, assertSort]
+      )
 
-    , ("INT.rand", Builtin.verifySymbol sort [])
-    , ("INT.srand", Builtin.verifySymbolArguments [sort])
+    , ("INT.rand", Builtin.verifySymbol assertSort [])
+    , ("INT.srand", Builtin.verifySymbolArguments [assertSort])
 
       -- TODO (thomas.tuegel): Implement builtin BOOL
-    , ("INT.gt", Builtin.verifySymbol Bool.sort [sort, sort])
-    , ("INT.ge", Builtin.verifySymbol Bool.sort [sort, sort])
-    , ("INT.eq", Builtin.verifySymbol Bool.sort [sort, sort])
-    , ("INT.le", Builtin.verifySymbol Bool.sort [sort, sort])
-    , ("INT.lt", Builtin.verifySymbol Bool.sort [sort, sort])
-    , ("INT.ne", Builtin.verifySymbol Bool.sort [sort, sort])
+    , ("INT.gt", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    , ("INT.ge", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    , ("INT.eq", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    , ("INT.le", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    , ("INT.lt", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    , ("INT.ne", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
 
       -- Ordering operations
-    , ("INT.min", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.max", Builtin.verifySymbol sort [sort, sort])
+    , ("INT.min", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.max", Builtin.verifySymbol assertSort [assertSort, assertSort])
 
       -- Arithmetic operations
-    , ("INT.add", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.sub", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.mul", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.abs", Builtin.verifySymbol sort [sort])
-    , ("INT.ediv", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.emod", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.tdiv", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.tmod", Builtin.verifySymbol sort [sort, sort])
+    , ("INT.add", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.sub", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.mul", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.abs", Builtin.verifySymbol assertSort [assertSort])
+    , ("INT.ediv", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.emod", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.tdiv", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.tmod", Builtin.verifySymbol assertSort [assertSort, assertSort])
 
       -- Bitwise operations
-    , ("INT.and", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.or", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.xor", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.not", Builtin.verifySymbol sort [sort])
-    , ("INT.shl", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.shr", Builtin.verifySymbol sort [sort, sort])
+    , ("INT.and", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.or", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.xor", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.not", Builtin.verifySymbol assertSort [assertSort])
+    , ("INT.shl", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ("INT.shr", Builtin.verifySymbol assertSort [assertSort, assertSort])
 
       -- Exponential and logarithmic operations
-    , ("INT.pow", Builtin.verifySymbol sort [sort, sort])
-    , ("INT.powmod", Builtin.verifySymbol sort [sort, sort, sort])
-    , ("INT.log2", Builtin.verifySymbol sort [sort])
+    , ("INT.pow", Builtin.verifySymbol assertSort [assertSort, assertSort])
+    , ( "INT.powmod"
+      , Builtin.verifySymbol assertSort [assertSort, assertSort, assertSort]
+      )
+    , ("INT.log2", Builtin.verifySymbol assertSort [assertSort])
     ]
 
 {- | Verify that domain value patterns are well-formed.

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -18,7 +18,7 @@ module Kore.Builtin.Int
     ( sort
     , sortVerifiers
     , symbolVerifiers
-    , patternVerifiers
+    , patternVerifier
     ) where
 
 import qualified Data.HashMap.Strict as HashMap
@@ -92,7 +92,6 @@ symbolVerifiers =
 
 {- | Verify that domain value patterns are well-formed.
  -}
-patternVerifiers :: Builtin.PatternVerifiers
-patternVerifiers =
-    -- TODO (thomas.tuegel): Not implemented
-    HashMap.empty
+patternVerifier :: Builtin.PatternVerifier
+patternVerifier =
+    mempty

--- a/src/main/haskell/kore/src/Kore/Proof/Unification.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Unification.hs
@@ -9,9 +9,6 @@ Stability   : experimental
 Portability : portable
 -}
 
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
 {-# OPTIONS_GHC -Wno-unused-matches    #-}
 {-# OPTIONS_GHC -Wno-name-shadowing    #-}
 

--- a/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
@@ -58,6 +58,7 @@ formulaVerifier
 formulaVerifier indexedModule formula = do
     castError
         (verifyPattern
+            mempty -- Kore.Builtin.Verifiers: don't validate builtin patterns
             indexedModule
             (sortVariables unifiedFormula)
             Nothing

--- a/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Rules/Kore.hs
@@ -58,10 +58,10 @@ formulaVerifier
 formulaVerifier indexedModule formula = do
     castError
         (verifyPattern
-            unifiedFormula
-            Nothing
             indexedModule
             (sortVariables unifiedFormula)
+            Nothing
+            unifiedFormula
         )
     return ()
   where

--- a/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -13,6 +13,8 @@ import Kore.AST.AstWithLocation
 import Kore.AST.Common
 import Kore.AST.Kore
 import Kore.AST.MetaOrObject
+import Kore.AST.PureML
+       ( asPurePattern )
 import Kore.AST.Sentence
 import Kore.Building.Implicit
 import Kore.Building.Patterns as Patterns
@@ -470,6 +472,34 @@ test_patternVerifier =
         [ objectSortSentence
         , anotherSortSentence
         ]
+        NeedsInternalDefinitions
+    , failureTestsForObjectPattern "Domain value - complex argument"
+        (ExpectedErrorMessage
+            "Domain value argument must be a literal string.")
+        (ErrorStack
+            [ "\\dv (<test data>)" ]
+        )
+        (DomainValuePattern DomainValue
+            { domainValueSort = objectSort
+            , domainValueChild =
+                (asPurePattern . AndPattern)
+                    And
+                        { andSort =
+                            updateAstLocation stringMetaSort AstLocationTest
+                        , andFirst =
+                            (asPurePattern . StringLiteralPattern)
+                                (StringLiteral "first")
+                        , andSecond =
+                            (asPurePattern . StringLiteralPattern)
+                                (StringLiteral "second")
+                        }
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort (updateAstLocation objectSort AstLocationTest))
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort objectSort)
+        [objectSortSentence]
         NeedsInternalDefinitions
     ]
   where

--- a/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -9,17 +9,18 @@ import Test.Tasty.HUnit
 
 import qualified Data.List as List
 
-import Kore.AST.AstWithLocation
-import Kore.AST.Common
-import Kore.AST.Kore
-import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-       ( asPurePattern )
-import Kore.AST.Sentence
-import Kore.Building.Implicit
-import Kore.Building.Patterns as Patterns
-import Kore.Error
-import Kore.Implicit.ImplicitSorts
+import           Kore.AST.AstWithLocation
+import           Kore.AST.Common
+import           Kore.AST.Kore
+import           Kore.AST.MetaOrObject
+import           Kore.AST.PureML
+                 ( asPurePattern )
+import           Kore.AST.Sentence
+import           Kore.Building.Implicit
+import           Kore.Building.Patterns as Patterns
+import qualified Kore.Builtin.Hook as Builtin.Hook
+import           Kore.Error
+import           Kore.Implicit.ImplicitSorts
 
 import Test.Kore
 import Test.Kore.ASTVerifier.DefinitionVerifier as Helpers
@@ -501,6 +502,124 @@ test_patternVerifier =
         (DeclaredSort objectSort)
         [objectSortSentence]
         NeedsInternalDefinitions
+    , failureTestsForObjectPattern "Domain value - INT.Int"
+        (ExpectedErrorMessage
+            "<string literal>:1:1:\n\
+            \unexpected 'a'\n\
+            \expecting '+', '-', or integer\n")
+        (ErrorStack
+            [ "\\dv (<test data>)"
+            , "Verifying builtin sort 'INT.Int'"
+            , "Parsing domain value"
+            ]
+        )
+        (DomainValuePattern DomainValue
+            { domainValueSort = intSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "abcd")  -- Not a decimal integer
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort (updateAstLocation intSort AstLocationTest))
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort intSort)
+        [ asSentence intSortSentence ]
+        NeedsInternalDefinitions
+    , successTestsForObjectPattern "Domain value - INT.Int - Negative"
+        (DomainValuePattern DomainValue
+            { domainValueSort = intSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "-256")
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort intSort)
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort intSort)
+        [ asSentence intSortSentence ]
+        NeedsInternalDefinitions
+    , successTestsForObjectPattern "Domain value - INT.Int - Positive (unsigned)"
+        (DomainValuePattern DomainValue
+            { domainValueSort = intSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "1024")
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort intSort)
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort intSort)
+        [ asSentence intSortSentence ]
+        NeedsInternalDefinitions
+    , successTestsForObjectPattern "Domain value - INT.Int - Positive (signed)"
+        (DomainValuePattern DomainValue
+            { domainValueSort = intSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "+128")
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort intSort)
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort intSort)
+        [ asSentence intSortSentence ]
+        NeedsInternalDefinitions
+    , failureTestsForObjectPattern "Domain value - BOOL.Bool"
+        (ExpectedErrorMessage
+            "<string literal>:1:1:\n\
+            \unexpected \"untru\"\n\
+            \expecting \"false\" or \"true\"\n")
+        (ErrorStack
+            [ "\\dv (<test data>)"
+            , "Verifying builtin sort 'BOOL.Bool'"
+            , "Parsing domain value"
+            ]
+        )
+        (DomainValuePattern DomainValue
+            { domainValueSort = boolSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "untrue")  -- Not a BOOL.Bool
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort (updateAstLocation boolSort AstLocationTest))
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort boolSort)
+        [ asSentence boolSortSentence ]
+        NeedsInternalDefinitions
+    , successTestsForObjectPattern "Domain value - BOOL.Bool - true"
+        (DomainValuePattern DomainValue
+            { domainValueSort = boolSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "true")
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort (updateAstLocation boolSort AstLocationTest))
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort boolSort)
+        [ asSentence boolSortSentence ]
+        NeedsInternalDefinitions
+    , successTestsForObjectPattern "Domain value - BOOL.Bool - false"
+        (DomainValuePattern DomainValue
+            { domainValueSort = boolSort
+            , domainValueChild =
+                (asPurePattern . StringLiteralPattern)
+                    (StringLiteral "false")
+            }
+        )
+        (NamePrefix "dummy")
+        (TestedPatternSort (updateAstLocation boolSort AstLocationTest))
+        (SortVariablesThatMustBeDeclared [])
+        (DeclaredSort boolSort)
+        [ asSentence boolSortSentence ]
+        NeedsInternalDefinitions
     ]
   where
     objectSortName = SortName "ObjectSort"
@@ -559,6 +678,32 @@ test_patternVerifier =
                     Attributes []
                 }
             :: KoreSentenceSymbol Object)
+    intSortName = SortName "Int"
+    intSort :: Sort Object
+    intSort = simpleSort intSortName
+    intSortSentence :: KoreSentenceSort Object
+    intSortSentence =
+        SentenceSort
+            { sentenceSortName = testId name
+            , sentenceSortParameters = []
+            , sentenceSortAttributes =
+                Attributes [ Builtin.Hook.hookAttribute "INT.Int" ]
+            }
+      where
+        SortName name = intSortName
+    boolSortName = SortName "Int"
+    boolSort :: Sort Object
+    boolSort = simpleSort boolSortName
+    boolSortSentence :: KoreSentenceSort Object
+    boolSortSentence =
+        SentenceSort
+            { sentenceSortName = testId name
+            , sentenceSortParameters = []
+            , sentenceSortAttributes =
+                Attributes [ Builtin.Hook.hookAttribute "BOOL.Bool" ]
+            }
+      where
+        SortName name = boolSortName
 
 dummyVariableAndSentences :: NamePrefix -> (Variable Object, [KoreSentence])
 dummyVariableAndSentences (NamePrefix namePrefix) =

--- a/src/test/resources/expected/test-bool-1.kore.golden
+++ b/src/test/resources/expected/test-bool-1.kore.golden
@@ -332,6 +332,72 @@ Definition
                                 }))))
                             ]
                     }))
+                , ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "trueBool" AstLocationNone) :: Id Object
+                            , aliasParams = []
+                            }
+                    , sentenceAliasSorts = []
+                    , sentenceAliasReturnSort =
+                        SortActualSort SortActual
+                            { sortActualName = (Id "Bool" AstLocationNone) :: Id Object
+                            , sortActualSorts = []
+                            }
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "trueBool" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams = []
+                                    }
+                            , applicationChildren = []
+                            }
+                    , sentenceAliasRightPattern =
+                        DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortActualSort SortActual
+                                    { sortActualName = (Id "Bool" AstLocationNone) :: Id Object
+                                    , sortActualSorts = []
+                                    }
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "true"))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
+                , ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "falseBool" AstLocationNone) :: Id Object
+                            , aliasParams = []
+                            }
+                    , sentenceAliasSorts = []
+                    , sentenceAliasReturnSort =
+                        SortActualSort SortActual
+                            { sortActualName = (Id "Bool" AstLocationNone) :: Id Object
+                            , sortActualSorts = []
+                            }
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "falseBool" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams = []
+                                    }
+                            , applicationChildren = []
+                            }
+                    , sentenceAliasRightPattern =
+                        DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortActualSort SortActual
+                                    { sortActualName = (Id "Bool" AstLocationNone) :: Id Object
+                                    , sortActualSorts = []
+                                    }
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "false"))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
                 ]
             , moduleAttributes = Attributes []
             }

--- a/src/test/resources/expected/test-bool-4.kore.golden
+++ b/src/test/resources/expected/test-bool-4.kore.golden
@@ -1,1 +1,1 @@
-Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> verifying builtin sort 'BOOL.Bool': expected "true" or "false", but found "untrue"
+Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> Verifying builtin sort 'BOOL.Bool': Expected "true" or "false", but found "untrue"

--- a/src/test/resources/expected/test-bool-4.kore.golden
+++ b/src/test/resources/expected/test-bool-4.kore.golden
@@ -1,1 +1,3 @@
-Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> Verifying builtin sort 'BOOL.Bool': Expected "true" or "false", but found "untrue"
+Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> Verifying builtin sort 'BOOL.Bool' -> Parsing domain value: <string literal>:1:1:
+unexpected "untru"
+expecting "false" or "true"

--- a/src/test/resources/expected/test-bool-4.kore.golden
+++ b/src/test/resources/expected/test-bool-4.kore.golden
@@ -1,0 +1,1 @@
+Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> verifying builtin sort 'BOOL.Bool': expected "true" or "false", but found "untrue"

--- a/src/test/resources/expected/test-dv-1.kore.golden
+++ b/src/test/resources/expected/test-dv-1.kore.golden
@@ -1,0 +1,24 @@
+Definition
+    { definitionAttributes = Attributes []
+    , definitionModules =
+        [ Module
+            { moduleName = ModuleName "DV-1"
+            , moduleSentences =
+                [ MetaSentence (SentenceAxiomSentence SentenceAxiom
+                    { sentenceAxiomParameters =
+                        [ UnifiedObject (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                        ]
+                    , sentenceAxiomPattern =
+                        Fix (UnifiedPattern (UnifiedObject (Rotate31 (DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortVariableSort (SortVariable ((Id "s" AstLocationNone) :: Id Object))
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "0"))
+                            }))))
+                    , sentenceAxiomAttributes = Attributes []
+                    })
+                ]
+            , moduleAttributes = Attributes []
+            }
+        ]
+    }

--- a/src/test/resources/expected/test-dv-2.kore.golden
+++ b/src/test/resources/expected/test-dv-2.kore.golden
@@ -1,0 +1,1 @@
+Parse error: Error in module 'DV-2' -> axiom declaration -> \dv (../../../test/resources//test-dv-2.kore 3:19): Domain value argument must be a literal string.

--- a/src/test/resources/expected/test-int-1.kore.golden
+++ b/src/test/resources/expected/test-int-1.kore.golden
@@ -1067,6 +1067,72 @@ Definition
                                 }))))
                             ]
                     }))
+                , ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "zeroInt" AstLocationNone) :: Id Object
+                            , aliasParams = []
+                            }
+                    , sentenceAliasSorts = []
+                    , sentenceAliasReturnSort =
+                        SortActualSort SortActual
+                            { sortActualName = (Id "Int" AstLocationNone) :: Id Object
+                            , sortActualSorts = []
+                            }
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "zeroInt" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams = []
+                                    }
+                            , applicationChildren = []
+                            }
+                    , sentenceAliasRightPattern =
+                        DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortActualSort SortActual
+                                    { sortActualName = (Id "Int" AstLocationNone) :: Id Object
+                                    , sortActualSorts = []
+                                    }
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "0"))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
+                , ObjectSentence (SentenceAliasSentence SentenceAlias
+                    { sentenceAliasAlias =
+                        Alias
+                            { aliasConstructor = (Id "oneInt" AstLocationNone) :: Id Object
+                            , aliasParams = []
+                            }
+                    , sentenceAliasSorts = []
+                    , sentenceAliasReturnSort =
+                        SortActualSort SortActual
+                            { sortActualName = (Id "Int" AstLocationNone) :: Id Object
+                            , sortActualSorts = []
+                            }
+                    , sentenceAliasLeftPattern =
+                        ApplicationPattern Application
+                            { applicationSymbolOrAlias =
+                                SymbolOrAlias
+                                    { symbolOrAliasConstructor = (Id "oneInt" AstLocationNone) :: Id Object
+                                    , symbolOrAliasParams = []
+                                    }
+                            , applicationChildren = []
+                            }
+                    , sentenceAliasRightPattern =
+                        DomainValuePattern DomainValue
+                            { domainValueSort =
+                                SortActualSort SortActual
+                                    { sortActualName = (Id "Int" AstLocationNone) :: Id Object
+                                    , sortActualSorts = []
+                                    }
+                            , domainValueChild =
+                                Fix (StringLiteralPattern (StringLiteral "1"))
+                            }
+                    , sentenceAliasAttributes = Attributes []
+                    })
                 ]
             , moduleAttributes = Attributes []
             }

--- a/src/test/resources/expected/test-int-5.kore.golden
+++ b/src/test/resources/expected/test-int-5.kore.golden
@@ -1,3 +1,3 @@
-Parse error: Error in module 'INT' -> alias 'abcdInt' declaration (../../../test/resources//test-int-5.kore 4:11) -> \dv (../../../test/resources//test-int-5.kore 4:56) -> verifying builtin sort 'INT.Int': <string literal>:1:1:
+Parse error: Error in module 'INT' -> alias 'abcdInt' declaration (../../../test/resources//test-int-5.kore 4:11) -> \dv (../../../test/resources//test-int-5.kore 4:56) -> Verifying builtin sort 'INT.Int' -> Parsing domain value: <string literal>:1:1:
 unexpected 'a'
 expecting '+', '-', or integer

--- a/src/test/resources/expected/test-int-5.kore.golden
+++ b/src/test/resources/expected/test-int-5.kore.golden
@@ -1,0 +1,3 @@
+Parse error: Error in module 'INT' -> alias 'abcdInt' declaration (../../../test/resources//test-int-5.kore 4:11) -> \dv (../../../test/resources//test-int-5.kore 4:56) -> verifying builtin sort 'INT.Int': <string literal>:1:1:
+unexpected 'a'
+expecting '+', '-', or integer

--- a/src/test/resources/test-bool-1.kore
+++ b/src/test/resources/test-bool-1.kore
@@ -10,5 +10,7 @@ module BOOL
     hooked-symbol neBool{}(Bool{}, Bool{}) : Bool{} [hook{}("BOOL.ne")]
     hooked-symbol eqBool{}(Bool{}, Bool{}) : Bool{} [hook{}("BOOL.eq")]
     hooked-symbol notBool{}(Bool{}) : Bool{} [hook{}("BOOL.not")]
+    alias trueBool{}() : Bool{} where trueBool{}() := \dv{Bool{}}("true") []
+    alias falseBool{}() : Bool{} where falseBool{}() := \dv{Bool{}}("false") []
 endmodule
 []

--- a/src/test/resources/test-bool-4.kore
+++ b/src/test/resources/test-bool-4.kore
@@ -1,0 +1,6 @@
+[]
+module BOOL
+    hooked-sort Bool{} [hook{}("BOOL.Bool")]
+    alias falseBool{}() : Bool{} where falseBool{}() := \dv{Bool{}}("untrue") []
+endmodule
+[]

--- a/src/test/resources/test-dv-1.kore
+++ b/src/test/resources/test-dv-1.kore
@@ -1,0 +1,5 @@
+[]
+module DV-1
+    axiom {s} \dv{s}("0") []
+endmodule
+[]

--- a/src/test/resources/test-dv-2.kore
+++ b/src/test/resources/test-dv-2.kore
@@ -1,0 +1,5 @@
+[]
+module DV-2
+    axiom {s} \dv{s}(\or{#String{}}("0", "1")) []
+endmodule
+[]

--- a/src/test/resources/test-int-1.kore
+++ b/src/test/resources/test-int-1.kore
@@ -42,5 +42,7 @@ module INT
     hooked-symbol subInt{}(Int{}, Int{}) : Int{} [hook{}("INT.sub")]
     hooked-symbol maxInt{}(Int{}, Int{}) : Int{} [hook{}("INT.max")]
     hooked-symbol pow{}(Int{}, Int{}) : Int{} [hook{}("INT.pow")]
+    alias zeroInt{}() : Int{} where zeroInt{}() := \dv{Int{}}("0") []
+    alias oneInt{}() : Int{} where oneInt{}() := \dv{Int{}}("1") []
 endmodule
 []

--- a/src/test/resources/test-int-5.kore
+++ b/src/test/resources/test-int-5.kore
@@ -1,0 +1,6 @@
+[]
+module INT
+    hooked-sort Int{} [hook{}("INT.Int")]
+    alias abcdInt{}() : Int{} where abcdInt{}() := \dv{Int{}}("abcd") []
+endmodule
+[]


### PR DESCRIPTION
Sort and symbol verification are implemented in master. This PR adds pattern verification and parsing, to decode builtin domain values. The actual implementation of the builtin functions will follow in another pull request.

@u-- : This should be what you need to get started on `MAP`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

