### PR TITLE
Builtin INT and BOOL

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -2,8 +2,6 @@ module Main (main) where
 
 import           Control.Monad
                  ( when )
-import           Control.Monad.Except
-                 ( runExceptT )
 import qualified Data.Map as Map
 import           Data.Proxy
                  ( Proxy (..) )
@@ -52,6 +50,8 @@ import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Registry
                  ( extractEvaluators )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
 import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Step
                  ( MaxStepCount (AnyStepCount), pickFirstStepper )
@@ -59,8 +59,6 @@ import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Unparser.Unparse
                  ( unparseToString )
-import           Kore.Variables.Fresh.IntCounter
-                 ( runIntCounter )
 
 import GlobalMain
        ( MainOptions (..), clockSomething, clockSomethingIO, enableDisableFlag,
@@ -151,8 +149,7 @@ main = do
                 expandedPattern = makeExpandedPattern runningPattern
             finalExpandedPattern <- clockSomething "Executing"
                     $ either (error . Kore.Error.printError) fst
-                    $ fst $ (`runIntCounter` 1)
-                    $ runExceptT
+                    $ evalSimplifier
                     $ do
                         simplifiedPatterns <-
                             ExpandedPattern.simplify

--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -2,6 +2,8 @@ module Main (main) where
 
 import           Control.Monad
                  ( when )
+import           Control.Monad.Except
+                 ( runExceptT )
 import qualified Data.Map as Map
 import           Data.Proxy
                  ( Proxy (..) )
@@ -148,7 +150,9 @@ main = do
                         else purePattern
                 expandedPattern = makeExpandedPattern runningPattern
             finalExpandedPattern <- clockSomething "Executing"
-                    $ fst $ fst $ (`runIntCounter` 1)
+                    $ either (error . Kore.Error.printError) fst
+                    $ fst $ (`runIntCounter` 1)
+                    $ runExceptT
                     $ do
                         simplifiedPatterns <-
                             ExpandedPattern.simplify

--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -230,7 +230,7 @@ mainVerify willChkAttr definition =
         clockSomething "Verifying the definition"
             (verifyAndIndexDefinition
                 attributesVerification
-                Builtin.koreBuiltins
+                Builtin.koreVerifiers
                 definition
             )
       case verifyResult of
@@ -254,7 +254,7 @@ mainPatternVerify indexedModule patt =
         Left err1 -> error (printError err1)
         Right _   -> return ()
   where
-    Builtin.Verifiers { patternVerifier } = Builtin.koreBuiltins
+    Builtin.Verifiers { patternVerifier } = Builtin.koreVerifiers
 
 makePurePattern
     :: CommonKorePattern

--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -136,7 +136,11 @@ main = do
             mainPatternVerify indexedModule parsedPattern
             let
                 functionRegistry =
-                    extractEvaluators Object indexedModule
+                    Map.unionWith (++)
+                        -- user-defined functions
+                        (extractEvaluators Object indexedModule)
+                        -- builtin functions
+                        (Builtin.koreEvaluators indexedModule)
                 axiomPatterns =
                     koreIndexedModuleToAxiomPatterns Object indexedModule
                 metadataTools = constructorFunctions (extractMetadataTools indexedModule)

--- a/src/main/haskell/kore/app/parser/Main.hs
+++ b/src/main/haskell/kore/app/parser/Main.hs
@@ -184,7 +184,7 @@ mainVerify willChkAttr definition =
         clockSomething "Verifying the definition"
             (verifyAndIndexDefinition
                 attributesVerification
-                Builtin.koreBuiltins
+                Builtin.koreVerifiers
                 definition
             )
       case verifyResult of
@@ -208,4 +208,4 @@ mainPatternVerify indexedModule patt =
         Left err1 -> error (printError err1)
         Right _   -> return ()
   where
-    Builtin.Verifiers { patternVerifier } = Builtin.koreBuiltins
+    Builtin.Verifiers { patternVerifier } = Builtin.koreVerifiers

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -20,8 +20,8 @@ module Kore.Builtin
     , Builtin.sortDeclVerifier
     , Builtin.symbolVerifier
     , koreVerifiers
-    , koreFunctionContext
-    , functionContext
+    , koreEvaluators
+    , evaluators
     ) where
 
 import           Data.Map
@@ -70,11 +70,11 @@ koreVerifiers =
   See also: 'Data.Step.Step.step'
 
  -}
-koreFunctionContext
+koreEvaluators
     :: KoreIndexedModule StepperAttributes
     -- ^ Module under which evaluation takes place
     -> Map (Kore.Id Object) [Builtin.Function]
-koreFunctionContext = functionContext builtins
+koreEvaluators = evaluators builtins
   where
     builtins :: Map String Builtin.Function
     builtins =
@@ -85,16 +85,16 @@ koreFunctionContext = functionContext builtins
   Returns a map from symbol identifiers to builtin functions used for function
   evaluation in the context of the given module.
 
-  See also: 'Data.Step.Step.step', 'koreFunctionContext'
+  See also: 'Data.Step.Step.step', 'koreEvaluators'
 
  -}
-functionContext
+evaluators
     :: Map String Builtin.Function
     -- ^ Builtin functions indexed by name
     -> KoreIndexedModule StepperAttributes
     -- ^ Module under which evaluation takes place
     -> Map (Kore.Id Object) [Builtin.Function]
-functionContext builtins indexedModule =
+evaluators builtins indexedModule =
     Map.mapMaybe lookupBuiltins (hookedSymbolAttributes indexedModule)
   where
     hookedSymbolAttributes

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -60,8 +60,17 @@ koreVerifiers =
         <> Int.patternVerifier
     }
 
+{- | Construct an evaluation context for Kore builtin functions.
+
+  Returns a map from symbol identifiers to builtin functions used for function
+  evaluation in the context of the given module.
+
+  See also: 'Data.Step.Step.step'
+
+ -}
 koreFunctionContext
     :: KoreIndexedModule StepperAttributes
+    -- ^ Module under which evaluation takes place
     -> Map (Kore.Id Object) [Builtin.Function]
 koreFunctionContext indexedModule =
     Map.mapMaybe lookupBuiltins (hookedSymbolAttributes indexedModule)

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -14,30 +14,41 @@ This module is intended to be imported qualified.
 @
  -}
 module Kore.Builtin
-    ( Verifiers (..)
-    , PatternVerifier (..)
-    , sortDeclVerifier
-    , symbolVerifier
-    , koreBuiltins
+    ( Builtin.Verifiers (..)
+    , Builtin.PatternVerifier (..)
+    , Builtin.sortDeclVerifier
+    , Builtin.symbolVerifier
+    , koreVerifiers
+    , koreFunctionContext
     ) where
 
-import Data.Semigroup
-       ( (<>) )
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Semigroup
+                 ( (<>) )
 
+import qualified Kore.AST.Common as Kore
+import           Kore.AST.MetaOrObject
+                 ( Object )
 import qualified Kore.Builtin.Bool as Bool
-import           Kore.Builtin.Builtin
-                 ( PatternVerifier (..), Verifiers (..), sortDeclVerifier,
-                 symbolVerifier )
+import qualified Kore.Builtin.Builtin as Builtin
+import qualified Kore.Builtin.Hook as Hook
 import qualified Kore.Builtin.Int as Int
+import           Kore.IndexedModule.IndexedModule
+                 ( IndexedModule (..), KoreIndexedModule )
+import qualified Kore.IndexedModule.IndexedModule as IndexedModule
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes (..) )
 
 {- | Verifiers for Kore builtin sorts.
 
   If you aren't sure which verifiers you need, use these.
 
  -}
-koreBuiltins :: Verifiers
-koreBuiltins =
-    Verifiers
+koreVerifiers :: Builtin.Verifiers
+koreVerifiers =
+    Builtin.Verifiers
     { sortDeclVerifiers =
            Bool.sortDeclVerifiers
         <> Int.sortDeclVerifiers
@@ -48,3 +59,35 @@ koreBuiltins =
            Bool.patternVerifier
         <> Int.patternVerifier
     }
+
+koreFunctionContext
+    :: KoreIndexedModule StepperAttributes
+    -> Map (Kore.Id Object) [Builtin.Function]
+koreFunctionContext indexedModule =
+    Map.mapMaybe lookupBuiltins (hookedSymbolAttributes indexedModule)
+  where
+    hookedSymbolAttributes
+        :: KoreIndexedModule StepperAttributes
+        -> Map (Kore.Id Object) StepperAttributes
+    hookedSymbolAttributes im =
+        Map.union
+            (justAttributes <$> IndexedModule.hookedObjectSymbolSentences im)
+            (Map.unions (importHookedSymbolAttributes <$> indexedModuleImports im))
+      where
+        justAttributes (attrs, _) = attrs
+
+    importHookedSymbolAttributes
+        :: (a, b, KoreIndexedModule StepperAttributes)
+        -> Map (Kore.Id Object) StepperAttributes
+    importHookedSymbolAttributes (_, _, im) = hookedSymbolAttributes im
+
+    lookupBuiltins :: StepperAttributes -> Maybe [Builtin.Function]
+    lookupBuiltins StepperAttributes { hook } =
+        do
+            name <- Hook.getHook hook
+            impl <- Map.lookup name builtins
+            pure [impl]
+
+    builtins :: Map String Builtin.Function
+    builtins =
+        Map.union Bool.builtinFunctions Int.builtinFunctions

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -22,6 +22,7 @@ module Kore.Builtin.Bool
     , patternVerifier
     , builtinFunctions
     , asPattern
+    , asExpandedPattern
     ) where
 
 import           Control.Monad
@@ -42,6 +43,9 @@ import           Kore.AST.PureML
                  ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Builtin as Builtin
+import           Kore.Step.ExpandedPattern
+                 ( CommonExpandedPattern )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 
 {- | Builtin name of the @Bool@ sort.
  -}
@@ -119,6 +123,13 @@ asPattern resultSort result =
     unparse True = "true"
     unparse False = "false"
 
+asExpandedPattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> Bool  -- ^ builtin value to render
+    -> CommonExpandedPattern Object
+asExpandedPattern resultSort =
+    ExpandedPattern.fromPurePattern . asPattern resultSort
+
 {- | @builtinFunctions@ are builtin functions on the 'Bool' sort.
  -}
 builtinFunctions :: Map String Builtin.Function
@@ -135,7 +146,7 @@ builtinFunctions =
     , ("BOOL.orElse", Builtin.notImplemented)
     ]
   where
-    unaryOperator = Builtin.unaryOperator parse asPattern
-    binaryOperator = Builtin.binaryOperator parse asPattern
+    unaryOperator = Builtin.unaryOperator parse asExpandedPattern
+    binaryOperator = Builtin.binaryOperator parse asExpandedPattern
     xor a b = (a && not b) || (not a && b)
     implies a b = not a || b

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -28,9 +28,10 @@ import           Control.Monad
                  ( void )
 import           Data.Functor
                  ( ($>) )
-import           Data.HashMap.Strict
-                 ( HashMap )
 import qualified Data.HashMap.Strict as HashMap
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
 import qualified Text.Megaparsec as Parsec
 import qualified Text.Megaparsec.Char as Parsec
 
@@ -120,9 +121,9 @@ asPattern resultSort result =
 
 {- | @builtinFunctions@ are builtin functions on the 'Bool' sort.
  -}
-builtinFunctions :: HashMap String Builtin.Function
+builtinFunctions :: Map String Builtin.Function
 builtinFunctions =
-    HashMap.fromList
+    Map.fromList
     [ ("BOOL.or", binaryOperator "BOOL.or" (||))
     , ("BOOL.and", binaryOperator "BOOL.and" (&&))
     , ("BOOL.xor", binaryOperator "BOOL.xor" xor)

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -20,16 +20,25 @@ module Kore.Builtin.Bool
     , sortDeclVerifiers
     , symbolVerifiers
     , patternVerifier
+    , builtinFunctions
     ) where
 
 import           Control.Monad
                  ( void )
 import           Data.Functor
                  ( ($>) )
+import           Data.HashMap.Strict
+                 ( HashMap )
 import qualified Data.HashMap.Strict as HashMap
 import qualified Text.Megaparsec as Parsec
 import qualified Text.Megaparsec.Char as Parsec
 
+import qualified Kore.AST.Common as Kore
+import           Kore.AST.MetaOrObject
+                 ( Object )
+import           Kore.AST.PureML
+                 ( CommonPurePattern )
+import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Builtin as Builtin
 
 {- | Builtin name of the @Bool@ sort.
@@ -86,3 +95,45 @@ parse = (Parsec.<|>) true false
   where
     true = Parsec.string "true" $> True
     false = Parsec.string "false" $> False
+
+{- | Render a 'Bool' as a domain value pattern of the given sort.
+
+  The result sort should be hooked to the builtin @Bool@ sort, but this is not
+  checked.
+
+  See also: 'sort'
+
+ -}
+asPattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> Bool  -- ^ builtin value to render
+    -> CommonPurePattern Object
+asPattern resultSort result =
+    Kore.DV_ resultSort
+        (Kore.StringLiteral_ Kore.StringLiteral
+            { getStringLiteral = unparse result })
+  where
+    unparse :: Bool -> String
+    unparse True = "true"
+    unparse False = "false"
+
+{- | @builtinFunctions@ are builtin functions on the 'Bool' sort.
+ -}
+builtinFunctions :: HashMap String Builtin.Function
+builtinFunctions =
+    HashMap.fromList
+    [ ("BOOL.or", binaryOperator "BOOL.or" (||))
+    , ("BOOL.and", binaryOperator "BOOL.and" (&&))
+    , ("BOOL.xor", binaryOperator "BOOL.xor" xor)
+    , ("BOOL.ne", binaryOperator "BOOL.ne" (/=))
+    , ("BOOL.eq", binaryOperator "BOOL.eq" (==))
+    , ("BOOL.not", unaryOperator "BOOL.not" not)
+    , ("BOOL.implies", binaryOperator "BOOL.implies" implies)
+    , ("BOOL.andThen", Builtin.notImplemented)
+    , ("BOOL.orElse", Builtin.notImplemented)
+    ]
+  where
+    unaryOperator = Builtin.unaryOperator parse asPattern
+    binaryOperator = Builtin.binaryOperator parse asPattern
+    xor a b = (a && not b) || (not a && b)
+    implies a b = not a || b

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -21,6 +21,7 @@ module Kore.Builtin.Bool
     , symbolVerifiers
     , patternVerifier
     , builtinFunctions
+    , asPattern
     ) where
 
 import           Control.Monad

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -491,14 +491,7 @@ binaryOperator
                 -- Apply the operator to two domain values
                 r <- op <$> get a <*> get b
                 (appliedFunction . asPattern resultSort) r
-            [_, DomainValuePattern _] ->
-                Kore.Error.withContext
-                    "In first argument"
-                    expectedDomainValue
-            [DomainValuePattern _, _] ->
-                Kore.Error.withContext
-                    "In second argument"
-                    expectedDomainValue
+            [_, _] -> return NotApplicable
             _ -> wrongArity
 
 {- | Construct a builtin unary operator.
@@ -535,10 +528,7 @@ unaryOperator
                 -- Apply the operator to a domain value
                 r <- op <$> get a
                 (appliedFunction . asPattern resultSort) r
-            [_] ->
-                Kore.Error.withContext
-                    "In first argument"
-                    expectedDomainValue
+            [_] -> return NotApplicable
             _ -> wrongArity
 
 functionEvaluator
@@ -569,9 +559,6 @@ functionEvaluator ctx impl =
                 attempt <- impl tools simplifier resultSort applicationChildren
                 return (attempt, SimplificationProof)
             )
-
-expectedDomainValue :: MonadError (Error w) m => m a
-expectedDomainValue = Kore.Error.koreFail "Expected domain value"
 
 wrongArity :: MonadError (Error w) m => m a
 wrongArity = Kore.Error.koreFail "Wrong number of arguments"

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -26,9 +26,10 @@ module Kore.Builtin.Int
 
 import           Control.Monad
                  ( void )
-import           Data.HashMap.Strict
-                 ( HashMap )
 import qualified Data.HashMap.Strict as HashMap
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
 import qualified Text.Megaparsec.Char.Lexer as Parsec
 
 import qualified Kore.AST.Common as Kore
@@ -151,9 +152,9 @@ asPattern resultSort result =
 
 {- | Implement builtin function evaluation.
  -}
-builtinFunctions :: HashMap String Builtin.Function
+builtinFunctions :: Map String Builtin.Function
 builtinFunctions =
-    HashMap.fromList
+    Map.fromList
     [
       -- TODO (thomas.tuegel): Implement bit ranges.
       ("INT.bitRange", Builtin.notImplemented)

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -170,7 +170,7 @@ builtinFunctions =
     , comparator "INT.eq" (==)
     , comparator "INT.le" (<=)
     , comparator "INT.lt" (<)
-    , comparator "INT.neq" (/=)
+    , comparator "INT.ne" (/=)
 
       -- Ordering operations
     , binaryOperator "INT.min" min

--- a/src/main/haskell/kore/src/Kore/Implicit/Verified.hs
+++ b/src/main/haskell/kore/src/Kore/Implicit/Verified.hs
@@ -36,7 +36,7 @@ checkedMetaDefinition :: Either (Error VerifyError) MetaDefinition
 checkedMetaDefinition = do
     _ <- verifyImplicitKoreDefinition
         attributesVerification
-        Builtin.koreBuiltins
+        Builtin.koreVerifiers
         (definitionPureToKore uncheckedMetaDefinition)
     return uncheckedMetaDefinition
   where
@@ -57,7 +57,7 @@ checkedKoreDefinition :: Either (Error VerifyError) KoreDefinition
 checkedKoreDefinition = do
     _ <- verifyImplicitKoreDefinition
         attributesVerification
-        Builtin.koreBuiltins
+        Builtin.koreVerifiers
         uncheckedKoreDefinition
     return uncheckedKoreDefinition
   where

--- a/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -28,6 +28,7 @@ module Kore.IndexedModule.IndexedModule
     , metaNameForObjectSort
     , SortDescription
     , getIndexedSentence
+    , hookedObjectSymbolSentences
     ) where
 
 import           Control.Arrow
@@ -673,3 +674,19 @@ parseAttributesInModule
     => Attributes
     -> Either (Error IndexModuleError) a
 parseAttributesInModule = castError . parseAttributes
+
+{- | Retrieve those object-level symbol sentences that are hooked.
+
+ -}
+hookedObjectSymbolSentences
+    :: IndexedModule sorts pat variable atts
+    -> Map.Map (Id Object) (atts, SentenceSymbol Object pat variable)
+hookedObjectSymbolSentences
+    IndexedModule
+        { indexedModuleObjectSymbolSentences
+        , indexedModuleHookedIdentifiers
+        }
+  =
+    Map.restrictKeys
+        indexedModuleObjectSymbolSentences
+        indexedModuleHookedIdentifiers

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -31,10 +31,8 @@ import           Kore.Step.ExpandedPattern as PredicateSubstitution
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( toExpandedPattern )
 import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..),
+                 ( PureMLPatternSimplifier (..), Simplifier,
                  SimplificationProof (SimplificationProof) )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 
 {-| 'evaluate' attempts to evaluate a Kore predicate. -}
 evaluate
@@ -49,7 +47,7 @@ evaluate
     -- ^ The condition to be evaluated.
     -- TODO: Can't it happen that I also get a substitution when evaluating
     -- functions? See the Equals case.
-    -> IntCounter
+    -> Simplifier
         (PredicateSubstitution level variable, SimplificationProof level)
 evaluate
     (PureMLPatternSimplifier simplifier)

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -22,6 +22,7 @@ module Kore.Step.ExpandedPattern
     , substitutionToPredicate
     , toMLPattern
     , top
+    , fromPurePattern
     ) where
 
 import           Data.List
@@ -232,3 +233,21 @@ isBottom
     ExpandedPattern {predicate = PredicateFalse}
   = True
 isBottom _ = False
+
+{- | Construct an 'ExpandedPattern' from a 'PureMLPattern'.
+
+  The resulting @ExpandedPattern@ has a true predicate and an empty substitution.
+
+  See also: 'makeTruePredicate'
+
+ -}
+fromPurePattern
+    :: MetaOrObject level
+    => PureMLPattern level variable
+    -> ExpandedPattern level variable
+fromPurePattern term =
+    ExpandedPattern
+        { term
+        , predicate = makeTruePredicate
+        , substitution = []
+        }

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -8,7 +8,7 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Function.Data
-    ( ApplicationFunctionEvaluator (..)
+    (  ApplicationFunctionEvaluator (..)
     , CommonApplicationFunctionEvaluator
     , AttemptedFunction (..)
     , CommonAttemptedFunction
@@ -25,11 +25,10 @@ import Kore.IndexedModule.MetadataTools
 import Kore.Step.OrOfExpandedPattern
        ( OrOfExpandedPattern )
 import Kore.Step.Simplification.Data
-       ( PureMLPatternSimplifier, SimplificationProof (..) )
+       ( PureMLPatternSimplifier, Simplifier,
+       SimplificationProof (..) )
 import Kore.Step.StepperAttributes
        ( StepperAttributes )
-import Kore.Variables.Fresh.IntCounter
-       ( IntCounter )
 
 {-| 'ApplicationFunctionEvaluator' evaluates functions on an 'Application'
 pattern. This can be either a built-in evaluator or a user-defined one.
@@ -55,7 +54,7 @@ newtype ApplicationFunctionEvaluator level variable =
         => MetadataTools level StepperAttributes
         -> PureMLPatternSimplifier level variable
         -> Application level (PureMLPattern level variable)
-        -> IntCounter
+        -> Simplifier
             ( AttemptedFunction level variable
             , SimplificationProof level
             )

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -41,13 +41,12 @@ import           Kore.Step.OrOfExpandedPattern
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( isFalse, make, merge )
 import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..), SimplificationProof (..) )
+                 ( PureMLPatternSimplifier (..), Simplifier,
+                 SimplificationProof (..) )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 import           Kore.Variables.Int
                  ( IntVariable (..) )
 
@@ -74,8 +73,7 @@ evaluateApplication
     -- ^ Aggregated children predicate and substitution.
     -> Application level (PureMLPattern level variable)
     -- ^ The pattern to be evaluated
-    -> IntCounter
-        (OrOfExpandedPattern level variable, SimplificationProof level)
+    -> Simplifier (OrOfExpandedPattern level variable, SimplificationProof level)
 evaluateApplication
     tools
     simplifier
@@ -173,8 +171,7 @@ mergeWithConditionAndSubstitution
     -- ^ Condition and substitution to add.
     -> (AttemptedFunction level variable, SimplificationProof level)
     -- ^ AttemptedFunction to which the condition should be added.
-    -> IntCounter
-        (AttemptedFunction level variable, SimplificationProof level)
+    -> Simplifier (AttemptedFunction level variable, SimplificationProof level)
 mergeWithConditionAndSubstitution
     _ _ _ (AttemptedFunction.NotApplicable, _proof)
   =

--- a/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
@@ -25,13 +25,12 @@ import           Kore.Step.OrOfExpandedPattern
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( traverseWithPairs )
 import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..), SimplificationProof (..) )
+                 ( PureMLPatternSimplifier (..), Simplifier,
+                 SimplificationProof (..) )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 import           Kore.Variables.Int
                  ( IntVariable (..) )
 
@@ -57,8 +56,7 @@ mergeWithPredicateSubstitution
     -- ^ PredicateSubstitution to add.
     -> OrOfExpandedPattern level variable
     -- ^ Pattern to which the condition should be added.
-    -> IntCounter
-        (OrOfExpandedPattern level variable, SimplificationProof level)
+    -> Simplifier (OrOfExpandedPattern level variable, SimplificationProof level)
 mergeWithPredicateSubstitution
     tools
     simplifier

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
@@ -10,13 +10,14 @@ Portability : portable
 module Kore.Step.Simplification.Data
     ( SimplificationError
     , Simplifier
+    , evalSimplifier
     , PureMLPatternSimplifier (..)
     , CommonPureMLPatternSimplifier
     , SimplificationProof (..)
     ) where
 
 import Control.Monad.Except
-       ( ExceptT )
+       ( ExceptT, runExceptT )
 
 import Kore.AST.Common
        ( Variable )
@@ -27,7 +28,7 @@ import Kore.Error
 import Kore.Step.OrOfExpandedPattern
        ( OrOfExpandedPattern )
 import Kore.Variables.Fresh.IntCounter
-       ( IntCounter )
+       ( IntCounter, runIntCounter )
 
 
 {- | A tag for errors during simplification
@@ -50,6 +51,18 @@ data SimplificationProof level = SimplificationProof
 -- the counter and the proof.
 -- TODO (thomas.tuegel): Lift the StateT to the outer level.
 type Simplifier = ExceptT (Error SimplificationError) IntCounter
+
+{- | Evaluate a simplifier computation.
+
+  Only the result (or error) is returned. The 'IntCounter' is discarded.
+
+  -}
+evalSimplifier :: Simplifier a -> Either (Error SimplificationError) a
+evalSimplifier simp =
+    let
+        (result, _) = runIntCounter (runExceptT simp) 0
+    in
+      result
 
 {-| 'PureMLPatternSimplifier' wraps a function that evaluates
 Kore functions on PureMLPatterns.

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
@@ -8,19 +8,34 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Data
-    ( PureMLPatternSimplifier (..)
+    ( SimplificationError
+    , Simplifier
+    , PureMLPatternSimplifier (..)
     , CommonPureMLPatternSimplifier
     , SimplificationProof (..)
     ) where
+
+import Control.Monad.Except
+       ( ExceptT )
 
 import Kore.AST.Common
        ( Variable )
 import Kore.AST.PureML
        ( PureMLPattern )
+import Kore.Error
+       ( Error )
 import Kore.Step.OrOfExpandedPattern
        ( OrOfExpandedPattern )
 import Kore.Variables.Fresh.IntCounter
        ( IntCounter )
+
+
+{- | A tag for errors during simplification
+
+  See also: 'Error'
+
+ -}
+data SimplificationError
 
 {-| 'SimplificationProof' is a placeholder for proofs showing that the
 simplification of a MetaMLPattern was correct.
@@ -28,13 +43,21 @@ simplification of a MetaMLPattern was correct.
 data SimplificationProof level = SimplificationProof
     deriving (Show, Eq)
 
+{- | The concrete monad in which simplification occurs.
+
+ -}
+-- TODO (thomas.tuegel): Replace IntCounter with a single state carrying both
+-- the counter and the proof.
+-- TODO (thomas.tuegel): Lift the StateT to the outer level.
+type Simplifier = ExceptT (Error SimplificationError) IntCounter
+
 {-| 'PureMLPatternSimplifier' wraps a function that evaluates
 Kore functions on PureMLPatterns.
 -}
 newtype PureMLPatternSimplifier level variable =
     PureMLPatternSimplifier
         ( PureMLPattern level variable
-        -> IntCounter
+        -> Simplifier
             ( OrOfExpandedPattern level variable
             , SimplificationProof level
             )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
@@ -51,7 +51,7 @@ import qualified Kore.Step.Simplification.And as And
 import qualified Kore.Step.Simplification.Ceil as Ceil
                  ( makeEvaluate )
 import           Kore.Step.Simplification.Data
-                 ( SimplificationProof (..) )
+                 ( SimplificationProof (..), Simplifier )
 import qualified Kore.Step.Simplification.Iff as Iff
                  ( makeEvaluate )
 import qualified Kore.Step.Simplification.Not as Not
@@ -64,8 +64,6 @@ import qualified Kore.Step.StepperAttributes as StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 import           Kore.Variables.Int
                  ( IntVariable (..) )
 
@@ -137,7 +135,7 @@ simplify
         )
     => MetadataTools level StepperAttributes
     -> Equals level (OrOfExpandedPattern level variable)
-    -> IntCounter
+    -> Simplifier
         ( OrOfExpandedPattern level variable
         , SimplificationProof level
         )
@@ -163,7 +161,7 @@ simplifyEvaluated
     => MetadataTools level StepperAttributes
     -> OrOfExpandedPattern level variable
     -> OrOfExpandedPattern level variable
-    -> IntCounter
+    -> Simplifier
         (OrOfExpandedPattern level variable, SimplificationProof level)
 simplifyEvaluated tools first second
   | first == second =
@@ -199,7 +197,7 @@ makeEvaluate
     => MetadataTools level StepperAttributes
     -> ExpandedPattern level variable
     -> ExpandedPattern level variable
-    -> IntCounter
+    -> Simplifier
         (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluate
     tools
@@ -281,7 +279,7 @@ makeEvaluateTermsAssumesNoBottom
     => MetadataTools level StepperAttributes
     -> PureMLPattern level variable
     -> PureMLPattern level variable
-    -> IntCounter
+    -> Simplifier
         (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateTermsAssumesNoBottom
     tools first second
@@ -324,7 +322,7 @@ differentCharLiterals
     :: PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 differentCharLiterals
@@ -337,7 +335,7 @@ differentStringLiterals
     :: PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 differentStringLiterals
@@ -350,7 +348,7 @@ differentDomainValues
     :: PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 differentDomainValues
@@ -365,7 +363,7 @@ variableEqualsFunctional
     -> PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 variableEqualsFunctional
@@ -392,7 +390,7 @@ functionalEqualsVariable
     -> PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 functionalEqualsVariable
@@ -427,7 +425,7 @@ constructorAtTheTop
     -> PureMLPattern level variable
     -> PureMLPattern level variable
     -> Maybe
-        (IntCounter
+        (Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
         )
 constructorAtTheTop
@@ -470,7 +468,7 @@ constructorAtTheTop
         => MetadataTools level StepperAttributes
         -> (OrOfExpandedPattern level variable, SimplificationProof level)
         -> (OrOfExpandedPattern level variable, SimplificationProof level)
-        -> IntCounter
+        -> Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
     combineWithAnd tools' (thing1, _proof1) (thing2, _proof2) =
         And.simplifyEvaluated tools' thing1 thing2

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/ExpandedPattern.hs
@@ -34,15 +34,14 @@ import           Kore.Step.OrOfExpandedPattern
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( traverseWithPairs )
 import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..), SimplificationProof (..) )
+                 ( PureMLPatternSimplifier (..), SimplificationProof (..),
+                 Simplifier )
 import qualified Kore.Step.Simplification.Pattern as Pattern
                  ( simplifyToOr )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 import           Kore.Variables.Int
                  ( IntVariable (..) )
 
@@ -62,7 +61,7 @@ simplify
     -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
     -- ^ Map from symbol IDs to defined functions
     -> ExpandedPattern level variable
-    -> IntCounter
+    -> Simplifier
         ( OrOfExpandedPattern level variable
         , SimplificationProof level
         )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -44,7 +44,8 @@ import qualified Kore.Step.Simplification.Ceil as Ceil
 import qualified Kore.Step.Simplification.CharLiteral as CharLiteral
                  ( simplify )
 import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..), SimplificationProof (..) )
+                 ( PureMLPatternSimplifier (..), SimplificationProof (..),
+                 Simplifier )
 import qualified Kore.Step.Simplification.DomainValue as DomainValue
                  ( simplify )
 import qualified Kore.Step.Simplification.Equals as Equals
@@ -79,8 +80,6 @@ import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
 import           Kore.Variables.Int
                  ( IntVariable (..) )
 
@@ -104,7 +103,7 @@ simplify
     -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
     -- ^ Map from symbol IDs to defined functions
     -> PureMLPattern level variable
-    -> IntCounter
+    -> Simplifier
         ( ExpandedPattern level variable
         , SimplificationProof level
         )
@@ -133,7 +132,7 @@ simplifyToOr
     -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
     -- ^ Map from symbol IDs to defined functions
     -> PureMLPattern level variable
-    -> IntCounter
+    -> Simplifier
         ( OrOfExpandedPattern level variable
         , SimplificationProof level
         )
@@ -166,7 +165,7 @@ simplifyInternal
     -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
     -- ^ Map from symbol IDs to defined functions
     -> Pattern level variable (PureMLPattern level variable)
-    -> IntCounter
+    -> Simplifier
         ( OrOfExpandedPattern level variable
         , SimplificationProof level
         )

--- a/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -83,7 +83,7 @@ expectSuccess description definition =
             verifySuccess
             (verifyDefinition
                 attributesVerificationForTests
-                Builtin.koreBuiltins
+                Builtin.koreVerifiers
                 definition
             )
         )
@@ -96,7 +96,7 @@ expectFailureWithError description expectedError definition =
         (case
             verifyDefinition
                 attributesVerificationForTests
-                Builtin.koreBuiltins
+                Builtin.koreVerifiers
                 definition
           of
             Right _ ->

--- a/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -510,7 +510,7 @@ test_patternVerifier =
         (ErrorStack
             [ "\\dv (<test data>)"
             , "Verifying builtin sort 'INT.Int'"
-            , "Parsing domain value"
+            , "While parsing domain value"
             ]
         )
         (DomainValuePattern DomainValue
@@ -576,7 +576,7 @@ test_patternVerifier =
         (ErrorStack
             [ "\\dv (<test data>)"
             , "Verifying builtin sort 'BOOL.Bool'"
-            , "Parsing domain value"
+            , "While parsing domain value"
             ]
         )
         (DomainValuePattern DomainValue

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -50,6 +50,9 @@ prop_xor = propBinary xor xorSymbol
 prop_ne :: Bool -> Bool -> Property
 prop_ne = propBinary (/=) neSymbol
 
+prop_eq :: Bool -> Bool -> Property
+prop_eq = propBinary (==) eqSymbol
+
 prop_not :: Bool -> Property
 prop_not = propUnary not notSymbol
 
@@ -85,6 +88,10 @@ propUnary impl symb =
 -- | Specialize 'Bool.asPattern' to the builtin sort 'boolSort'.
 asPattern :: Bool -> CommonPurePattern Object
 asPattern = Bool.asPattern boolSort
+
+-- | Specialize 'Bool.asExpandedPattern' to the builtin sort 'boolSort'.
+asExpandedPattern :: Bool -> CommonExpandedPattern Object
+asExpandedPattern = Bool.asExpandedPattern boolSort
 
 -- | A sort to hook to the builtin @BOOL.Bool@.
 boolSort :: Sort Object
@@ -126,6 +133,9 @@ xorSymbol = builtinSymbol "xorBool"
 neSymbol :: SymbolOrAlias Object
 neSymbol = builtinSymbol "neBool"
 
+eqSymbol :: SymbolOrAlias Object
+eqSymbol = builtinSymbol "eqBool"
+
 notSymbol :: SymbolOrAlias Object
 notSymbol = builtinSymbol "notBool"
 
@@ -166,6 +176,7 @@ boolModule =
             , binarySymbolDecl "BOOL.and" andSymbol
             , binarySymbolDecl "BOOL.xor" xorSymbol
             , binarySymbolDecl "BOOL.ne" neSymbol
+            , binarySymbolDecl "BOOL.eq" eqSymbol
             , unarySymbolDecl "BOOL.not" notSymbol
             , binarySymbolDecl "BOOL.implies" impliesSymbol
             ]

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -1,0 +1,218 @@
+module Test.Kore.Builtin.Bool where
+
+import Test.QuickCheck
+       ( Property, (===) )
+
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+                 ( Object )
+import           Kore.AST.PureML
+                 ( CommonPurePattern )
+import           Kore.AST.Sentence
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.ASTVerifier.DefinitionVerifier
+import           Kore.ASTVerifier.Error
+                 ( VerifyError )
+import qualified Kore.Builtin as Builtin
+import qualified Kore.Builtin.Bool as Bool
+import           Kore.Builtin.Hook
+                 ( hookAttribute )
+import qualified Kore.Error
+import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Step.ExpandedPattern
+import           Kore.Step.Simplification.Data
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
+
+import Test.Kore
+       ( testId )
+
+prop_or :: Bool -> Bool -> Property
+prop_or a b =
+    asPattern (a || b) === evaluate pat
+  where
+    pat = App_ orSymbol (asPattern <$> [a, b])
+
+prop_and :: Bool -> Bool -> Property
+prop_and a b =
+    asPattern (a && b) === evaluate pat
+  where
+    pat = App_ andSymbol (asPattern <$> [a, b])
+
+
+prop_xor :: Bool -> Bool -> Property
+prop_xor a b =
+    asPattern (xor a b) === evaluate pat
+  where
+    pat = App_ xorSymbol (asPattern <$> [a, b])
+    xor u v = (u && not v) || (not u && v)
+
+prop_ne :: Bool -> Bool -> Property
+prop_ne a b =
+    asPattern (a /= b) === evaluate pat
+  where
+    pat = App_ neSymbol (asPattern <$> [a, b])
+
+prop_not :: Bool -> Property
+prop_not a =
+    asPattern (not a) === evaluate pat
+  where
+    pat = App_ notSymbol (asPattern <$> [a])
+
+prop_implies :: Bool -> Bool -> Property
+prop_implies a b =
+    asPattern (implies a b) === evaluate pat
+  where
+    pat = App_ impliesSymbol (asPattern <$> [a, b])
+    implies u v = not u || v
+
+asPattern :: Bool -> CommonPurePattern Object
+asPattern = Bool.asPattern boolSort
+
+boolId :: Id Object
+boolId = testId "Bool"
+
+boolSort :: Sort Object
+boolSort =
+    SortActualSort SortActual
+        { sortActualName = boolId
+        , sortActualSorts = []
+        }
+
+boolSortDecl :: KoreSentence
+boolSortDecl =
+    asSentence (SentenceSort
+        { sentenceSortName = boolId
+        , sentenceSortParameters = []
+        , sentenceSortAttributes = Attributes [ hookAttribute "BOOL.Bool" ]
+        }
+        :: KoreSentenceSort Object)
+
+builtinSymbol :: String -> SymbolOrAlias Object
+builtinSymbol name =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId name
+        , symbolOrAliasParams = []
+        }
+
+orSymbol :: SymbolOrAlias Object
+orSymbol = builtinSymbol "orBool"
+
+andSymbol :: SymbolOrAlias Object
+andSymbol = builtinSymbol "andBool"
+
+xorSymbol :: SymbolOrAlias Object
+xorSymbol = builtinSymbol "xorBool"
+
+neSymbol :: SymbolOrAlias Object
+neSymbol = builtinSymbol "neBool"
+
+notSymbol :: SymbolOrAlias Object
+notSymbol = builtinSymbol "notBool"
+
+impliesSymbol :: SymbolOrAlias Object
+impliesSymbol = builtinSymbol "impliesBool"
+
+hookedSymbolDecl
+    :: String
+    -> SymbolOrAlias Object
+    -> Sort Object
+    -> [Sort Object]
+    -> KoreSentence
+hookedSymbolDecl
+    builtinName
+    SymbolOrAlias { symbolOrAliasConstructor }
+    sentenceSymbolResultSort
+    sentenceSymbolSorts
+  =
+    (asSentence . SentenceHookedSymbol)
+        (SentenceSymbol
+            { sentenceSymbolSymbol
+            , sentenceSymbolSorts
+            , sentenceSymbolResultSort
+            , sentenceSymbolAttributes
+            }
+            :: KoreSentenceSymbol Object
+        )
+  where
+    sentenceSymbolSymbol =
+        Symbol
+            { symbolConstructor = symbolOrAliasConstructor
+            , symbolParams = []
+            }
+    sentenceSymbolAttributes = Attributes [ hookAttribute builtinName ]
+
+binarySymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+binarySymbolDecl builtinName symbol =
+    hookedSymbolDecl builtinName symbol boolSort [boolSort, boolSort]
+
+unarySymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+unarySymbolDecl builtinName symbol =
+    hookedSymbolDecl builtinName symbol boolSort [boolSort]
+
+boolModuleName :: ModuleName
+boolModuleName = ModuleName "BOOL"
+
+boolModule :: KoreModule
+boolModule =
+    Module
+        { moduleName = boolModuleName
+        , moduleAttributes = Attributes []
+        , moduleSentences =
+            [ boolSortDecl
+            , binarySymbolDecl "BOOL.or" orSymbol
+            , binarySymbolDecl "BOOL.and" andSymbol
+            , binarySymbolDecl "BOOL.xor" xorSymbol
+            , binarySymbolDecl "BOOL.ne" neSymbol
+            , unarySymbolDecl "BOOL.not" notSymbol
+            , binarySymbolDecl "BOOL.implies" impliesSymbol
+            ]
+        }
+
+evaluate :: CommonPurePattern Object -> CommonPurePattern Object
+evaluate pat =
+    case evalSimplifier (Pattern.simplify tools builtinFunctions pat) of
+        Left err -> error (Kore.Error.printError err)
+        Right (ExpandedPattern { term }, _) -> term
+  where
+    tools = extractMetadataTools indexedModule
+
+boolDefinition :: KoreDefinition
+boolDefinition =
+    Definition
+        { definitionAttributes = Attributes []
+        , definitionModules = [ boolModule ]
+        }
+
+indexedModules :: Map ModuleName (KoreIndexedModule StepperAttributes)
+Right indexedModules = verify boolDefinition
+
+indexedModule :: KoreIndexedModule StepperAttributes
+Just indexedModule = Map.lookup boolModuleName indexedModules
+
+builtinFunctions :: Map (Id Object) [Builtin.Function]
+builtinFunctions = Builtin.functionContext Bool.builtinFunctions indexedModule
+
+verify
+    :: KoreDefinition
+    -> Either (Kore.Error.Error VerifyError)
+        (Map ModuleName (KoreIndexedModule StepperAttributes))
+verify = verifyAndIndexDefinition attrVerify builtinVerifiers
+  where
+    attrVerify = defaultAttributesVerification Proxy
+
+builtinVerifiers :: Builtin.Verifiers
+builtinVerifiers =
+    Builtin.Verifiers
+        { sortDeclVerifiers = Bool.sortDeclVerifiers
+        , symbolVerifiers = Bool.symbolVerifiers
+        , patternVerifier = Bool.patternVerifier
+        }

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -184,7 +184,7 @@ boolModule =
 
 evaluate :: CommonPurePattern Object -> CommonPurePattern Object
 evaluate pat =
-    case evalSimplifier (Pattern.simplify tools builtinFunctions pat) of
+    case evalSimplifier (Pattern.simplify tools evaluators pat) of
         Left err -> error (Kore.Error.printError err)
         Right (ExpandedPattern { term }, _) -> term
   where
@@ -203,8 +203,8 @@ Right indexedModules = verify boolDefinition
 indexedModule :: KoreIndexedModule StepperAttributes
 Just indexedModule = Map.lookup boolModuleName indexedModules
 
-builtinFunctions :: Map (Id Object) [Builtin.Function]
-builtinFunctions = Builtin.functionContext Bool.builtinFunctions indexedModule
+evaluators :: Map (Id Object) [Builtin.Function]
+evaluators = Builtin.evaluators Bool.builtinFunctions indexedModule
 
 verify
     :: KoreDefinition

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -1,0 +1,45 @@
+module Test.Kore.Builtin.Builtin
+    ( hookedSymbolDecl
+    ) where
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+                 ( Object )
+import           Kore.AST.Sentence
+import           Kore.Builtin.Hook
+                 ( hookAttribute )
+
+
+-- | Declare a symbol hooked to the given builtin name.
+hookedSymbolDecl
+    :: String
+    -- ^ builtin name
+    -> SymbolOrAlias Object
+    -- ^ symbol
+    -> Sort Object
+    -- ^ result sort
+    -> [Sort Object]
+    -- ^ argument sorts
+    -> KoreSentence
+hookedSymbolDecl
+    builtinName
+    SymbolOrAlias { symbolOrAliasConstructor }
+    sentenceSymbolResultSort
+    sentenceSymbolSorts
+  =
+    (asSentence . SentenceHookedSymbol)
+        (SentenceSymbol
+            { sentenceSymbolSymbol
+            , sentenceSymbolSorts
+            , sentenceSymbolResultSort
+            , sentenceSymbolAttributes
+            }
+            :: KoreSentenceSymbol Object
+        )
+  where
+    sentenceSymbolSymbol =
+        Symbol
+            { symbolConstructor = symbolOrAliasConstructor
+            , symbolParams = []
+            }
+    sentenceSymbolAttributes = Attributes [ hookAttribute builtinName ]

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -1,0 +1,215 @@
+module Test.Kore.Builtin.Int where
+
+import Test.QuickCheck
+       ( Property, (===) )
+
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+                 ( Object )
+import           Kore.AST.PureML
+                 ( CommonPurePattern )
+import           Kore.AST.Sentence
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.ASTVerifier.DefinitionVerifier
+import qualified Kore.Builtin as Builtin
+import qualified Kore.Builtin.Int as Int
+import           Kore.Builtin.Hook
+                 ( hookAttribute )
+import qualified Kore.Error
+import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Step.ExpandedPattern
+import           Kore.Step.Simplification.Data
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
+
+import Test.Kore
+       ( testId )
+import qualified Test.Kore.Builtin.Bool as Test.Bool
+import Test.Kore.Builtin.Builtin
+
+prop_gt :: Integer -> Integer -> Property
+prop_gt = propComparison (>) gtSymbol
+
+prop_ge :: Integer -> Integer -> Property
+prop_ge = propComparison (>=) geSymbol
+
+prop_eq :: Integer -> Integer -> Property
+prop_eq = propComparison (==) eqSymbol
+
+prop_le :: Integer -> Integer -> Property
+prop_le = propComparison (<=) leSymbol
+
+prop_lt :: Integer -> Integer -> Property
+prop_lt = propComparison (<) ltSymbol
+
+prop_ne :: Integer -> Integer -> Property
+prop_ne = propComparison (/=) neSymbol
+
+gtSymbol :: SymbolOrAlias Object
+gtSymbol = builtinSymbol "gtInt"
+
+geSymbol :: SymbolOrAlias Object
+geSymbol = builtinSymbol "geInt"
+
+eqSymbol :: SymbolOrAlias Object
+eqSymbol = builtinSymbol "eqInt"
+
+leSymbol :: SymbolOrAlias Object
+leSymbol = builtinSymbol "leInt"
+
+ltSymbol :: SymbolOrAlias Object
+ltSymbol = builtinSymbol "ltInt"
+
+neSymbol :: SymbolOrAlias Object
+neSymbol = builtinSymbol "neInt"
+
+propComparison
+    :: (Integer -> Integer -> Bool)
+    -- ^ implementation
+    -> SymbolOrAlias Object
+    -- ^ symbol
+    -> (Integer -> Integer -> Property)
+propComparison impl symb =
+    \a b ->
+        let pat = App_ symb (asPattern <$> [a, b])
+        in Test.Bool.asPattern (impl a b) === evaluate pat
+
+-- | Specialize 'Int.asPattern' to the builtin sort 'intSort'.
+asPattern :: Integer -> CommonPurePattern Object
+asPattern = Int.asPattern intSort
+
+-- | A sort to hook to the builtin @INT.Int@.
+intSort :: Sort Object
+intSort =
+    SortActualSort SortActual
+        { sortActualName = testId "Int"
+        , sortActualSorts = []
+        }
+
+-- | Declare 'intSort' in a Kore module.
+intSortDecl :: KoreSentence
+intSortDecl =
+    (asSentence . SentenceHookedSort) (SentenceSort
+        { sentenceSortName =
+            let SortActualSort SortActual { sortActualName } = intSort
+            in sortActualName
+        , sentenceSortParameters = []
+        , sentenceSortAttributes = Attributes [ hookAttribute "INT.Int" ]
+        }
+        :: KoreSentenceSort Object)
+
+-- | Make an unparameterized builtin symbol with the given name.
+builtinSymbol :: String -> SymbolOrAlias Object
+builtinSymbol name =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId name
+        , symbolOrAliasParams = []
+        }
+
+{- | Declare a hooked symbol with two arguments.
+
+  The result and arguments all have sort 'intSort'.
+
+  -}
+binarySymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+binarySymbolDecl builtinName symbol =
+    hookedSymbolDecl builtinName symbol intSort [intSort, intSort]
+
+{- | Declare a hooked symbol with one argument.
+
+  The result and argument have sort 'intSort'.
+
+ -}
+unarySymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+unarySymbolDecl builtinName symbol =
+    hookedSymbolDecl builtinName symbol intSort [intSort]
+
+{- | Declare a hooked symbol with two arguments.
+
+  The arguments have sort 'intSort' and the result is 'Test.Bool.boolSort'.
+
+  -}
+comparisonSymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+comparisonSymbolDecl builtinName symbol =
+    hookedSymbolDecl builtinName symbol Test.Bool.boolSort [intSort, intSort]
+
+importBool :: KoreSentence
+importBool =
+    asSentence 
+        (SentenceImport
+            { sentenceImportModuleName = Test.Bool.boolModuleName
+            , sentenceImportAttributes = Attributes []
+            }
+            :: KoreSentenceImport
+        )
+
+intModuleName :: ModuleName
+intModuleName = ModuleName "INT"
+
+{- | Declare the @INT@ builtins.
+ -}
+intModule :: KoreModule
+intModule =
+    Module
+        { moduleName = intModuleName
+        , moduleAttributes = Attributes []
+        , moduleSentences =
+            [ importBool
+            , intSortDecl
+            , comparisonSymbolDecl "INT.gt" gtSymbol
+            , comparisonSymbolDecl "INT.ge" geSymbol
+            , comparisonSymbolDecl "INT.eq" eqSymbol
+            , comparisonSymbolDecl "INT.le" leSymbol
+            , comparisonSymbolDecl "INT.lt" ltSymbol
+            , comparisonSymbolDecl "INT.ne" neSymbol
+            ]
+        }
+
+evaluate :: CommonPurePattern Object -> CommonPurePattern Object
+evaluate pat =
+    case evalSimplifier (Pattern.simplify tools builtinFunctions pat) of
+        Left err -> error (Kore.Error.printError err)
+        Right (ExpandedPattern { term }, _) -> term
+  where
+    tools = extractMetadataTools indexedModule
+
+intDefinition :: KoreDefinition
+intDefinition =
+    Definition
+        { definitionAttributes = Attributes []
+        , definitionModules = [ Test.Bool.boolModule, intModule ]
+        }
+
+indexedModules :: Map ModuleName (KoreIndexedModule StepperAttributes)
+indexedModules = verify intDefinition
+
+indexedModule :: KoreIndexedModule StepperAttributes
+Just indexedModule = Map.lookup intModuleName indexedModules
+
+builtinFunctions :: Map (Id Object) [Builtin.Function]
+builtinFunctions = Builtin.functionContext Int.builtinFunctions indexedModule
+
+verify
+    :: KoreDefinition
+    -> Map ModuleName (KoreIndexedModule StepperAttributes)
+verify defn =
+    either (error . Kore.Error.printError) id
+        (verifyAndIndexDefinition attrVerify builtinVerifiers defn)
+  where
+    attrVerify = defaultAttributesVerification Proxy
+
+builtinVerifiers :: Builtin.Verifiers
+builtinVerifiers =
+    Builtin.Verifiers
+        { sortDeclVerifiers = Int.sortDeclVerifiers
+        , symbolVerifiers = Int.symbolVerifiers
+        , patternVerifier = Int.patternVerifier
+        }

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -82,6 +82,66 @@ propComparison impl symb =
         let pat = App_ symb (asPattern <$> [a, b])
         in Test.Bool.asPattern (impl a b) === evaluate pat
 
+prop_min :: Integer -> Integer -> Property
+prop_min = propBinary min minSymbol
+
+prop_max :: Integer -> Integer -> Property
+prop_max = propBinary max maxSymbol
+
+prop_add :: Integer -> Integer -> Property
+prop_add = propBinary (+) addSymbol
+
+prop_sub :: Integer -> Integer -> Property
+prop_sub = propBinary (-) subSymbol
+
+prop_mul :: Integer -> Integer -> Property
+prop_mul = propBinary (*) mulSymbol
+
+minSymbol :: SymbolOrAlias Object
+minSymbol = builtinSymbol "minInt"
+
+maxSymbol :: SymbolOrAlias Object
+maxSymbol = builtinSymbol "maxInt"
+
+addSymbol :: SymbolOrAlias Object
+addSymbol = builtinSymbol "addInt"
+
+subSymbol :: SymbolOrAlias Object
+subSymbol = builtinSymbol "subInt"
+
+mulSymbol :: SymbolOrAlias Object
+mulSymbol = builtinSymbol "mulInt"
+
+-- | Test a binary operator hooked to the given symbol.
+propBinary
+    :: (Integer -> Integer -> Integer)
+    -- ^ operator
+    -> SymbolOrAlias Object
+    -- ^ hooked symbol
+    -> (Integer -> Integer -> Property)
+propBinary impl symb =
+    \a b ->
+        let pat = App_ symb (asPattern <$> [a, b])
+        in asPattern (impl a b) === evaluate pat
+
+prop_abs :: Integer -> Property
+prop_abs = propUnary abs absSymbol
+
+absSymbol :: SymbolOrAlias Object
+absSymbol = builtinSymbol "absInt"
+
+-- | Test a unary operator hooked to the given symbol
+propUnary
+    :: (Integer -> Integer)
+    -- ^ operator
+    -> SymbolOrAlias Object
+    -- ^ hooked symbol
+    -> (Integer -> Property)
+propUnary impl symb =
+    \a ->
+        let pat = App_ symb (asPattern <$> [a])
+        in asPattern (impl a) === evaluate pat
+
 -- | Specialize 'Int.asPattern' to the builtin sort 'intSort'.
 asPattern :: Integer -> CommonPurePattern Object
 asPattern = Int.asPattern intSort
@@ -143,7 +203,7 @@ comparisonSymbolDecl builtinName symbol =
 
 importBool :: KoreSentence
 importBool =
-    asSentence 
+    asSentence
         (SentenceImport
             { sentenceImportModuleName = Test.Bool.boolModuleName
             , sentenceImportAttributes = Attributes []
@@ -170,6 +230,12 @@ intModule =
             , comparisonSymbolDecl "INT.le" leSymbol
             , comparisonSymbolDecl "INT.lt" ltSymbol
             , comparisonSymbolDecl "INT.ne" neSymbol
+            , binarySymbolDecl "INT.min" minSymbol
+            , binarySymbolDecl "INT.max" maxSymbol
+            , binarySymbolDecl "INT.add" addSymbol
+            , binarySymbolDecl "INT.sub" subSymbol
+            , binarySymbolDecl "INT.mul" mulSymbol
+            , unarySymbolDecl "INT.abs" absSymbol
             ]
         }
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -306,7 +306,7 @@ intModule =
 
 evaluate :: CommonPurePattern Object -> CommonExpandedPattern Object
 evaluate pat =
-    case evalSimplifier (Pattern.simplify tools builtinFunctions pat) of
+    case evalSimplifier (Pattern.simplify tools evaluators pat) of
         Left err -> error (Kore.Error.printError err)
         Right (epat, _) -> epat
   where
@@ -325,8 +325,8 @@ indexedModules = verify intDefinition
 indexedModule :: KoreIndexedModule StepperAttributes
 Just indexedModule = Map.lookup intModuleName indexedModules
 
-builtinFunctions :: Map (Id Object) [Builtin.Function]
-builtinFunctions = Builtin.functionContext Int.builtinFunctions indexedModule
+evaluators :: Map (Id Object) [Builtin.Function]
+evaluators = Builtin.evaluators Int.builtinFunctions indexedModule
 
 verify
     :: KoreDefinition

--- a/src/main/haskell/kore/test/Test/Kore/IndexedModule/MetadataTools.hs
+++ b/src/main/haskell/kore/test/Test/Kore/IndexedModule/MetadataTools.hs
@@ -108,7 +108,7 @@ testIndexedModule =
     case
         verifyAndIndexDefinition
             DoNotVerifyAttributes
-            Builtin.koreBuiltins
+            Builtin.koreVerifiers
             testDefinition
       of
         Right modulesMap ->

--- a/src/main/haskell/kore/test/Test/Kore/IndexedModule/Resolvers.hs
+++ b/src/main/haskell/kore/test/Test/Kore/IndexedModule/Resolvers.hs
@@ -155,7 +155,7 @@ testIndexedModule =
     case
         verifyAndIndexDefinition
             DoNotVerifyAttributes
-            Builtin.koreBuiltins
+            Builtin.koreVerifiers
             testDefinition
       of
         Right modulesMap ->

--- a/src/main/haskell/kore/test/Test/Kore/Parser/Regression.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Parser/Regression.hs
@@ -94,7 +94,7 @@ verify definition =
     case
         verifyDefinition
             attributesVerification
-            Builtin.koreBuiltins
+            Builtin.koreVerifiers
             definition
       of
         Left e  -> Left (printError e)

--- a/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
@@ -78,7 +78,7 @@ axiomPatternsUnitTests =
                 $ extractIndexedModule "TEST"
                     (verifyAndIndexDefinition
                         DoNotVerifyAttributes
-                        Builtin.koreBuiltins
+                        Builtin.koreVerifiers
                         (Definition
                             { definitionAttributes = Attributes []
                             , definitionModules =

--- a/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
@@ -1,9 +1,0 @@
-module Test.Kore.Step.Condition.Evaluator (test_conditionEvaluator) where
-
-import Test.Tasty
-       ( TestTree )
-
-test_conditionEvaluator :: [TestTree]
-test_conditionEvaluator =
-    []
-

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -5,8 +5,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import           Control.Monad.Except
-                 ( runExceptT )
 import qualified Data.Map as Map
 import           Data.Reflection
                  ( give )
@@ -40,12 +38,10 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make )
 import           Kore.Step.Simplification.Data
                  ( CommonPureMLPatternSimplifier, SimplificationProof (..),
-                 Simplifier )
+                 Simplifier, evalSimplifier )
 import qualified Kore.Step.Simplification.Pattern as Pattern
                  ( simplify )
 import           Kore.Step.StepperAttributes
-import           Kore.Variables.Fresh.IntCounter
-                 ( runIntCounter )
 
 import           Test.Kore.Comparators ()
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
@@ -274,16 +270,9 @@ evaluate
     -> CommonPurePattern level
     -> CommonExpandedPattern level
 evaluate metadataTools functionIdToEvaluator patt =
-    case result of
-        Right (p, _) -> p
-        Left err -> error (printError err)
-  where
-    (result, _) =
-        runIntCounter
-            (runExceptT
-                (Pattern.simplify metadataTools functionIdToEvaluator patt)
-            )
-            0
+    either (error . printError) fst
+        $ evalSimplifier
+        $ Pattern.simplify metadataTools functionIdToEvaluator patt
 
 mockSortTools :: SortTools Object
 mockSortTools = Mock.makeSortTools Mock.sortToolsMapping

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -5,8 +5,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import Control.Monad.Except
-       ( runExceptT )
 import Data.Default
        ( def )
 import Data.List
@@ -47,9 +45,9 @@ import           Kore.Step.Function.UserDefined
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make )
 import           Kore.Step.Simplification.Data
-                 ( CommonPureMLPatternSimplifier, SimplificationProof (..) )
+                 ( CommonPureMLPatternSimplifier, SimplificationProof (..),
+                 evalSimplifier )
 import           Kore.Step.StepperAttributes
-import           Kore.Variables.Fresh.IntCounter
 
 import Test.Kore.Comparators ()
 import Test.Kore.Step.Simplifier
@@ -447,12 +445,9 @@ evaluateWithAxiom
             }
     evaluated =
         either (error . printError) fst
-            (fst $ runIntCounter
-                (runExceptT $ axiomFunctionEvaluator
-                    axiom
-                    metadataTools
-                    simplifier
-                    app
-                )
-                0
-            )
+            $ evalSimplifier
+            $ axiomFunctionEvaluator
+                axiom
+                metadataTools
+                simplifier
+                app

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -5,6 +5,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import Control.Monad.Except
+       ( runExceptT )
 import Data.Default
        ( def )
 import Data.List
@@ -444,11 +446,13 @@ evaluateWithAxiom
             , substitution = sort substitution
             }
     evaluated =
-        fst $ fst $ runIntCounter
-            (axiomFunctionEvaluator
-                axiom
-                metadataTools
-                simplifier
-                app
+        either (error . printError) fst
+            (fst $ runIntCounter
+                (runExceptT $ axiomFunctionEvaluator
+                    axiom
+                    metadataTools
+                    simplifier
+                    app
+                )
+                0
             )
-            0

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -7,6 +7,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import Control.Monad.Except
+       ( runExceptT )
 import Data.Reflection
        ( give )
 
@@ -20,6 +22,8 @@ import           Kore.ASTUtils.SmartConstructors
                  ( getSort, mkAnd, mkApp, mkBottom, mkTop, mkVar )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
+import           Kore.Error
+                 ( printError )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (MetadataTools), SortTools )
 import qualified Kore.IndexedModule.MetadataTools
@@ -373,8 +377,8 @@ evaluate
     :: And Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluate patt =
-    fst $ fst $ runIntCounter
-        (simplify mockMetadataTools patt)
+    either (error . printError) fst $ fst $ runIntCounter
+        (runExceptT $ simplify mockMetadataTools patt)
         0
 
 evaluatePatterns

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -7,8 +7,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import Control.Monad.Except
-       ( runExceptT )
 import Data.Reflection
        ( give )
 
@@ -41,6 +39,8 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make )
 import           Kore.Step.Simplification.And
                  ( makeEvaluate, simplify )
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import           Kore.Variables.Fresh.IntCounter
@@ -377,9 +377,9 @@ evaluate
     :: And Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluate patt =
-    either (error . printError) fst $ fst $ runIntCounter
-        (runExceptT $ simplify mockMetadataTools patt)
-        0
+    either (error . printError) fst
+        $ evalSimplifier
+        $ simplify mockMetadataTools patt
 
 evaluatePatterns
     :: CommonExpandedPattern Object

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -7,8 +7,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import           Control.Monad.Except
-                 ( runExceptT )
 import qualified Data.Map as Map
 import           Data.Reflection
                  ( give )
@@ -46,10 +44,10 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Simplification.Application
                  ( simplify )
 import           Kore.Step.Simplification.Data
-                 ( CommonPureMLPatternSimplifier, SimplificationProof (..) )
+                 ( CommonPureMLPatternSimplifier, SimplificationProof (..),
+                 evalSimplifier )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
-import           Kore.Variables.Fresh.IntCounter
 
 import           Test.Kore
                  ( testId )
@@ -442,9 +440,6 @@ evaluate
     symbolIdToEvaluator
     application
   =
-    either (error . printError) fst $ fst $
-        runIntCounter
-            (runExceptT
-                (simplify tools simplifier symbolIdToEvaluator application)
-            )
-            0
+    either (error . printError) fst
+        $ evalSimplifier
+        $ simplify tools simplifier symbolIdToEvaluator application

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -7,6 +7,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import           Control.Monad.Except
+                 ( runExceptT )
 import qualified Data.Map as Map
 import           Data.Reflection
                  ( give )
@@ -21,6 +23,8 @@ import           Kore.ASTUtils.SmartConstructors
                  ( mkApp, mkBottom )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
+import           Kore.Error
+                 ( printError )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Predicate.Predicate
@@ -438,7 +442,9 @@ evaluate
     symbolIdToEvaluator
     application
   =
-    fst $ fst $
+    either (error . printError) fst $ fst $
         runIntCounter
-            (simplify tools simplifier symbolIdToEvaluator application)
+            (runExceptT
+                (simplify tools simplifier symbolIdToEvaluator application)
+            )
             0

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -7,8 +7,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import Control.Monad.Except
-       ( runExceptT )
 import Data.Reflection
        ( give )
 
@@ -36,12 +34,12 @@ import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make )
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
 import           Kore.Step.Simplification.Equals
                  ( makeEvaluate, simplify )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
-import           Kore.Variables.Fresh.IntCounter
-                 ( runIntCounter )
 
 import           Test.Kore.Comparators ()
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
@@ -619,9 +617,9 @@ evaluateOr
     -> Equals Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluateOr tools equals =
-    either (error . Kore.Error.printError) fst $ fst $ runIntCounter
-        (runExceptT $ simplify tools equals)
-        0
+    either (error . Kore.Error.printError) fst
+        $ evalSimplifier
+        $ simplify tools equals
 
 evaluate
     :: MetadataTools Object StepperAttributes
@@ -637,7 +635,7 @@ evaluateGeneric
     -> CommonExpandedPattern level
     -> CommonOrOfExpandedPattern level
 evaluateGeneric tools first second =
-    either (error . Kore.Error.printError) fst $ fst $ runIntCounter
-        (runExceptT $ makeEvaluate tools first second)
-        0
+    either (error . Kore.Error.printError) fst
+        $ evalSimplifier
+        $ makeEvaluate tools first second
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -7,6 +7,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import Control.Monad.Except
+       ( runExceptT )
 import Data.Reflection
        ( give )
 
@@ -19,6 +21,7 @@ import           Kore.ASTUtils.SmartConstructors
                  mkStringLiteral, mkTop, mkVar )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
+import qualified Kore.Error
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools, SortTools )
 import           Kore.Predicate.Predicate
@@ -616,8 +619,8 @@ evaluateOr
     -> Equals Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluateOr tools equals =
-    fst $ fst $ runIntCounter
-        (simplify tools equals)
+    either (error . Kore.Error.printError) fst $ fst $ runIntCounter
+        (runExceptT $ simplify tools equals)
         0
 
 evaluate
@@ -634,7 +637,7 @@ evaluateGeneric
     -> CommonExpandedPattern level
     -> CommonOrOfExpandedPattern level
 evaluateGeneric tools first second =
-    fst $ fst $ runIntCounter
-        (makeEvaluate tools first second)
+    either (error . Kore.Error.printError) fst $ fst $ runIntCounter
+        (runExceptT $ makeEvaluate tools first second)
         0
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
@@ -14,14 +14,13 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern (ExpandedPattern) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( ExpandedPattern (..) )
-import           Kore.Step.Simplification.Data
-                 ( PureMLPatternSimplifier (..), SimplificationProof (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make )
-import           Kore.Variables.Fresh.IntCounter
-                 ( IntCounter )
+import           Kore.Step.Simplification.Data
+                 ( PureMLPatternSimplifier (..), SimplificationProof (..),
+                 Simplifier )
 
 mockSimplifier
     :: (MetaOrObject level, Eq level, Eq (variable level))
@@ -66,7 +65,7 @@ mockSimplifierHelper
             )
         ]
     -> PureMLPattern level variable
-    -> IntCounter
+    -> Simplifier
         (OrOfExpandedPattern level variable, SimplificationProof level)
 mockSimplifierHelper unevaluatedConverter [] patt =
     return

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -5,8 +5,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import           Control.Monad.Except
-                 ( runExceptT )
 import           Data.Default
                  ( def )
 import qualified Data.Map as Map
@@ -39,12 +37,11 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.PatternAttributes
                  ( FunctionalProof (..) )
 import           Kore.Step.Simplification.Data
-                 ( SimplificationProof (..) )
+                 ( SimplificationProof (..), evalSimplifier )
 import           Kore.Step.Step
 import           Kore.Step.StepperAttributes
 import           Kore.Unification.Unifier
                  ( UnificationProof (..) )
-import           Kore.Variables.Fresh.IntCounter
 
 import Test.Kore.Comparators ()
 import Test.Tasty.HUnit.Extensions
@@ -648,14 +645,13 @@ runStep
     -> [AxiomPattern level]
     -> (CommonOrOfExpandedPattern level, StepProof level)
 runStep metadataTools configuration axioms =
-    either (error . printError) id $ fst $ runIntCounter
-        (runExceptT $ step
+    either (error . printError) id
+        $ evalSimplifier
+        $ step
             metadataTools
             Map.empty
             axioms
             (OrOfExpandedPattern.make [configuration])
-        )
-        0
 
 runStepsPickFirst
     :: MetaOrObject level
@@ -667,9 +663,7 @@ runStepsPickFirst
     -> [AxiomPattern level]
     -> (CommonExpandedPattern level, StepProof level)
 runStepsPickFirst metadataTools maxStepCount configuration axioms =
-    either (error . printError) id $ fst $
-        runIntCounter
-            (runExceptT $ pickFirstStepper
-                metadataTools Map.empty axioms maxStepCount configuration
-            )
-            0
+    either (error . printError) id
+        $ evalSimplifier
+        $ pickFirstStepper
+            metadataTools Map.empty axioms maxStepCount configuration

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -5,6 +5,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import           Control.Monad.Except
+                 ( runExceptT )
 import           Data.Default
                  ( def )
 import qualified Data.Map as Map
@@ -646,8 +648,8 @@ runStep
     -> [AxiomPattern level]
     -> (CommonOrOfExpandedPattern level, StepProof level)
 runStep metadataTools configuration axioms =
-    fst $ runIntCounter
-        (step
+    either (error . printError) id $ fst $ runIntCounter
+        (runExceptT $ step
             metadataTools
             Map.empty
             axioms
@@ -665,9 +667,9 @@ runStepsPickFirst
     -> [AxiomPattern level]
     -> (CommonExpandedPattern level, StepProof level)
 runStepsPickFirst metadataTools maxStepCount configuration axioms =
-    fst $
+    either (error . printError) id $ fst $
         runIntCounter
-            (pickFirstStepper
+            (runExceptT $ pickFirstStepper
                 metadataTools Map.empty axioms maxStepCount configuration
             )
             0

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
@@ -2785,7 +2785,7 @@ defaultIndexedModuleWithError = do
         castError
         (verifyAndIndexDefinition
             DoNotVerifyAttributes
-            Builtin.koreBuiltins
+            Builtin.koreVerifiers
             definition
         )
     case Map.lookup moduleName1 modules of

--- a/src/test/resources/expected/test-bool-4.kore.golden
+++ b/src/test/resources/expected/test-bool-4.kore.golden
@@ -1,3 +1,3 @@
-Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> Verifying builtin sort 'BOOL.Bool' -> Parsing domain value: <string literal>:1:1:
+Parse error: Error in module 'BOOL' -> alias 'falseBool' declaration (../../../test/resources//test-bool-4.kore 4:11) -> \dv (../../../test/resources//test-bool-4.kore 4:61) -> Verifying builtin sort 'BOOL.Bool' -> While parsing domain value: <string literal>:1:1:
 unexpected "untru"
 expecting "false" or "true"

--- a/src/test/resources/expected/test-int-5.kore.golden
+++ b/src/test/resources/expected/test-int-5.kore.golden
@@ -1,3 +1,3 @@
-Parse error: Error in module 'INT' -> alias 'abcdInt' declaration (../../../test/resources//test-int-5.kore 4:11) -> \dv (../../../test/resources//test-int-5.kore 4:56) -> Verifying builtin sort 'INT.Int' -> Parsing domain value: <string literal>:1:1:
+Parse error: Error in module 'INT' -> alias 'abcdInt' declaration (../../../test/resources//test-int-5.kore 4:11) -> \dv (../../../test/resources//test-int-5.kore 4:56) -> Verifying builtin sort 'INT.Int' -> While parsing domain value: <string literal>:1:1:
 unexpected 'a'
 expecting '+', '-', or integer


### PR DESCRIPTION
Although Kore execution is not yet finished, I would like to get this merged so that @u-- can merge the builtin MAP and so that we can start integrating some of the other fixes from the execution demo.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

