### PR TITLE
Reimplementing KEQUAL hooks using \Equals

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -25,7 +25,7 @@ import           Data.Map
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
-                 ( Application(..), Variable (..) )
+                 ( Application (..), Variable (..) )
 import           Kore.AST.MetaOrObject
                  ( Object )
 import           Kore.AST.PureML
@@ -33,19 +33,17 @@ import           Kore.AST.PureML
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
-import qualified Kore.Predicate.Predicate as Predicate
-import           Kore.Step.Error
-                 ( unificationToStepError )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
                  ( ApplicationFunctionEvaluator (..), AttemptedFunction (..),
                  notApplicableFunctionEvaluator, purePatternFunctionEvaluator )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Simplification.Data
                  ( PureMLPatternSimplifier, SimplificationProof (..),
                  Simplifier )
+import qualified Kore.Step.Simplification.Equals as Equals
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
-import           Kore.Unification.Unifier
-                 ( unificationProcedure )
 
 {- | Verify that hooked symbol declarations are well-formed.
 
@@ -64,7 +62,9 @@ symbolVerifiers =
     trivialVerifier :: Builtin.SortVerifier
     trivialVerifier = const $ const $ Right ()
 
-{- | @builtinFunctions@ are builtin functions on the 'Bool' sort.
+{- | @builtinFunctions@ defines the hooks for @KEQUAL.eq@ and @KEQUAL.neq@
+which can take arbitrary terms (of the same sort) and check whether they are
+equal or not, producing a builtin boolean value.
  -}
 builtinFunctions :: Map String Builtin.Function
 builtinFunctions =
@@ -92,18 +92,14 @@ evalKEq true false tools _ pat =
             } -> evalEq resultSort t1 t2
         _ -> notApplicableFunctionEvaluator
   where
-    evalEq resultSort t1 t2 =
-        case unificationProcedure tools t1 t2 of
-            Right (subst, predicate, _)
-                | Predicate.isFalse predicate ->
-                    purePatternFunctionEvaluator
-                        (Bool.asPattern resultSort false)
-                | null subst ->
-                    purePatternFunctionEvaluator
-                        (Bool.asPattern resultSort true)
-                | otherwise -> notApplicableFunctionEvaluator
-            Left err -> case unificationToStepError () (Left err) of
-                Right () ->
-                    purePatternFunctionEvaluator
-                        (Bool.asPattern resultSort false)
-                Left _ -> notApplicableFunctionEvaluator
+    evalEq resultSort t1 t2 = do
+        (result, _proof) <- Equals.makeEvaluate tools ep1 ep2
+        if OrOfExpandedPattern.isTrue result
+            then purePatternFunctionEvaluator (Bool.asPattern resultSort true)
+        else if OrOfExpandedPattern.isFalse result
+            then purePatternFunctionEvaluator (Bool.asPattern resultSort false)
+        else notApplicableFunctionEvaluator
+      where
+        ep1 = ExpandedPattern.fromPurePattern t1
+        ep2 = ExpandedPattern.fromPurePattern t2
+

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -1,0 +1,158 @@
+module Test.Kore.Builtin.KEqual (prop_keq, prop_kneq, test_KEqual) where
+
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
+import Test.QuickCheck
+       ( Property, (===) )
+
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+                ( Object )
+import           Kore.AST.PureML
+                ( CommonPurePattern )
+import           Kore.AST.Sentence
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.ASTVerifier.DefinitionVerifier
+import           Kore.ASTVerifier.Error
+                ( VerifyError )
+import qualified Kore.Builtin as Builtin
+import qualified Kore.Builtin.Bool as Bool
+import qualified Kore.Builtin.KEqual as KEqual
+import qualified Kore.Error as Error
+import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Step.ExpandedPattern
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+import           Kore.Step.Simplification.Data
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import           Kore.Step.StepperAttributes
+                ( StepperAttributes )
+
+
+import           Test.Kore
+                 ( testId )
+import qualified Test.Kore.Builtin.Bool as Test.Bool
+
+prop_kneq :: Bool -> Bool -> Property
+prop_kneq = propBinary (/=) kneqSymbol
+
+prop_keq :: Bool -> Bool -> Property
+prop_keq = propBinary (==) keqSymbol
+
+-- | Test a binary operator hooked to the given symbol.
+propBinary
+    :: (Bool -> Bool -> Bool)
+    -- ^ operator
+    -> SymbolOrAlias Object
+    -- ^ hooked symbol
+    -> (Bool -> Bool -> Property)
+propBinary impl symb =
+    \a b ->
+        let pat = App_ symb (Test.Bool.asPattern <$> [a, b])
+        in Test.Bool.asPattern (impl a b) === evaluate pat
+
+keqSymbol :: SymbolOrAlias Object
+keqSymbol = Test.Bool.builtinSymbol "keqBool"
+
+kneqSymbol :: SymbolOrAlias Object
+kneqSymbol = Test.Bool.builtinSymbol "kneqBool"
+
+kEqualModuleName :: ModuleName
+kEqualModuleName = ModuleName "KEQUAL"
+
+{- | Declare the @KEQUAL@ builtins.
+ -}
+kEqualModule :: KoreModule
+kEqualModule =
+    Module
+        { moduleName = kEqualModuleName
+        , moduleAttributes = Attributes []
+        , moduleSentences =
+            [ Test.Bool.boolSortDecl
+            , Test.Bool.binarySymbolDecl "KEQUAL.eq" keqSymbol
+            , Test.Bool.binarySymbolDecl "KEQUAL.neq" kneqSymbol
+            ]
+        }
+
+evaluate :: CommonPurePattern Object -> CommonPurePattern Object
+evaluate pat =
+    case evalSimplifier (Pattern.simplify tools evaluators pat) of
+        Left err -> error (Error.printError err)
+        Right (ExpandedPattern { term }, _) -> term
+  where
+    tools = extractMetadataTools indexedModule
+
+kEqualDefinition :: KoreDefinition
+kEqualDefinition =
+    Definition
+        { definitionAttributes = Attributes []
+        , definitionModules = [ kEqualModule ]
+        }
+
+indexedModules :: Map ModuleName (KoreIndexedModule StepperAttributes)
+Right indexedModules = verify kEqualDefinition
+
+indexedModule :: KoreIndexedModule StepperAttributes
+Just indexedModule = Map.lookup kEqualModuleName indexedModules
+
+evaluators :: Map (Id Object) [Builtin.Function]
+evaluators = Builtin.evaluators KEqual.builtinFunctions indexedModule
+
+verify
+    :: KoreDefinition
+    -> Either (Error.Error VerifyError)
+        (Map ModuleName (KoreIndexedModule StepperAttributes))
+verify = verifyAndIndexDefinition attrVerify builtinVerifiers
+    where
+    attrVerify = defaultAttributesVerification Proxy
+
+builtinVerifiers :: Builtin.Verifiers
+builtinVerifiers =
+    Builtin.Verifiers
+        { sortDeclVerifiers = Bool.sortDeclVerifiers
+        , symbolVerifiers = Bool.symbolVerifiers
+        , patternVerifier = Bool.patternVerifier
+        }
+
+test_KEqual :: [TestTree]
+test_KEqual =
+    [ testCase "equals with variable"
+        (assertEqual ""
+            (Right
+                ( ExpandedPattern.fromPurePattern (pat keqSymbol)
+                , SimplificationProof
+                )
+            )
+            (evalSimplifier
+                (Pattern.simplify tools evaluators (pat keqSymbol))
+            )
+        )
+    , testCase "not equals with variable"
+        (assertEqual ""
+            (Right
+                ( ExpandedPattern.fromPurePattern (pat kneqSymbol)
+                , SimplificationProof
+                )
+            )
+            (evalSimplifier
+                (Pattern.simplify tools evaluators (pat kneqSymbol))
+            )
+        )
+    ]
+  where
+    tools = extractMetadataTools indexedModule
+    pat symbol = App_  symbol
+        [ Test.Bool.asPattern True
+        , Var_ Variable
+            { variableName = testId "x"
+            , variableSort = Test.Bool.boolSort
+            }
+        ]


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

