### PR TITLE
stack.yaml: Include Z3 in nix.packages

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,9 @@
 resolver: lts-11.3
 
 nix:
-  packages : [ zlib ]
+  packages:
+    - z3
+    - zlib
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The SMT tests require Z3 to be installed. By adding it to nix.packages, Stack
will ensure it is provided automatically for Nix users.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

