### PR TITLE
Simplifier cannot return error

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -167,9 +167,9 @@ main = do
                             $ makeKInitConfig purePattern
                         else purePattern
                 expandedPattern = makeExpandedPattern runningPattern
-            finalExpandedPattern <- clockSomething "Executing"
-                    $ either (error . Kore.Error.printError) fst
-                    $ evalSimplifier
+            finalExpandedPattern <-
+                clockSomething "Executing"
+                    $ fst $ evalSimplifier
                     $ do
                         simplifiedPatterns <-
                             ExpandedPattern.simplify

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -12,7 +12,6 @@ module Kore.Step.Function.UserDefined
     , axiomFunctionEvaluator
     ) where
 
-import qualified Control.Monad.Except as Except
 import           Data.Reflection
                  ( give )
 
@@ -46,7 +45,7 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make, traverseWithPairs )
 import           Kore.Step.Simplification.Data
                  ( CommonPureMLPatternSimplifier, PureMLPatternSimplifier (..),
-                 SimplificationProof (..), Simplifier )
+                 Simplifier, SimplificationProof (..) )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import           Kore.Step.Substitution
@@ -84,7 +83,7 @@ axiomFunctionEvaluator
             return (AttemptedFunction.NotApplicable, SimplificationProof)
         Right stepPatternWithProof ->
             do
-                (stepPattern, _) <- Except.lift stepPatternWithProof
+                (stepPattern, _) <- stepPatternWithProof
                 (   rewrittenPattern@ExpandedPattern
                         { predicate = rewritingCondition }
                     , _
@@ -206,12 +205,11 @@ evaluatePredicate
             , substitution = mergedSubstitution
             }
         , _proof
-        ) <- Except.lift
-            (mergePredicatesAndSubstitutions
+        ) <-
+            mergePredicatesAndSubstitutions
                 tools
                 [evaluatedPredicate]
                 [substitution, evaluatedSubstitution]
-            )
     -- TODO(virgil): Do I need to re-evaluate the predicate?
     return
         ( ExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
@@ -11,7 +11,6 @@ module Kore.Step.Merging.ExpandedPattern
     ( mergeWithPredicateSubstitution
     ) where
 
-import qualified Control.Monad.Except as Except
 import           Data.Reflection
                  ( give )
 
@@ -86,21 +85,17 @@ mergeWithPredicateSubstitution
             , substitution = mergedSubstitution
             }
         , _proof ) <-
-            Except.lift
-                (mergePredicatesAndSubstitutions
-                    tools
-                    [pattPredicate, conditionToMerge]
-                    [pattSubstitution, substitutionToMerge]
-                )
+            mergePredicatesAndSubstitutions
+                tools
+                [pattPredicate, conditionToMerge]
+                [pattSubstitution, substitutionToMerge]
     (evaluatedCondition, _) <-
         give (MetadataTools.sortTools tools)
             $ Predicate.evaluate simplifier mergedCondition
-    Except.lift
-        (mergeWithEvaluatedCondition
-            tools
-            patt {substitution = mergedSubstitution}
-            evaluatedCondition
-        )
+    mergeWithEvaluatedCondition
+        tools
+        patt {substitution = mergedSubstitution}
+        evaluatedCondition
 
 mergeWithEvaluatedCondition
     ::  ( MetaOrObject level

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
@@ -13,7 +13,6 @@ module Kore.Step.Simplification.And
     , simplifyEvaluated
     ) where
 
-import qualified Control.Monad.Trans as Monad.Trans
 import Data.Reflection
        ( Given, give )
 
@@ -127,10 +126,9 @@ simplifyEvaluated tools first second
     return (first, SimplificationProof)
 
   | otherwise = do
-    orWithProof <- Monad.Trans.lift
-        (OrOfExpandedPattern.crossProductGenericF
+    orWithProof <-
+        OrOfExpandedPattern.crossProductGenericF
             (makeEvaluate tools) first second
-        )
     return
         -- TODO: It's not obvious at all when filtering occurs and when it doesn't.
         ( OrOfExpandedPattern.filterOr

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -11,7 +11,6 @@ module Kore.Step.Simplification.Application
     ( simplify
     ) where
 
-import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
@@ -206,12 +205,11 @@ makeExpandedApplication tools symbol children
             { predicate = mergedPredicate
             , substitution = mergedSubstitution
             }
-        , _proof) <- Monad.Trans.lift
-            (mergePredicatesAndSubstitutions
+        , _proof) <-
+            mergePredicatesAndSubstitutions
                 tools
                 (map ExpandedPattern.predicate children)
                 (map ExpandedPattern.substitution children)
-            )
     return
         ( ExpandedApplication
             { term = Application

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
@@ -13,7 +13,6 @@ module Kore.Step.Simplification.Exists
     ) where
 
 import qualified Control.Arrow as Arrow
-import qualified Control.Monad.Except as Except
 import           Data.Proxy
                  ( Proxy (..) )
 import           Data.Reflection
@@ -169,12 +168,11 @@ makeEvaluate
             return (makeEvaluateNoFreeVarInSubstitution variable patt)
         _ -> do
             (substitutedPat, _proof) <-
-                Except.lift $
-                    substituteTermPredicate
-                        term
-                        predicate
-                        localSubstitutionList
-                        globalSubstitution
+                substituteTermPredicate
+                    term
+                    predicate
+                    localSubstitutionList
+                    globalSubstitution
             (result, _proof) <-
                 ExpandedPattern.simplify tools simplifier substitutedPat
             return (result , SimplificationProof)

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -13,7 +13,6 @@ module Kore.Step.Step
     , MaxStepCount(..)
     ) where
 
-import qualified Control.Monad.Trans as Monad.Trans
 import           Data.Either
                  ( rights )
 import qualified Data.Map as Map
@@ -67,11 +66,10 @@ step
     -> Simplifier
         (CommonOrOfExpandedPattern level, StepProof level)
 step tools symbolIdToEvaluator axioms configuration = do
-    (stepPattern, stepProofs) <- Monad.Trans.lift
-        (OrOfExpandedPattern.traverseFlattenWithPairs
+    (stepPattern, stepProofs) <-
+        OrOfExpandedPattern.traverseFlattenWithPairs
             (baseStepWithPattern tools axioms)
             configuration
-        )
     (simplifiedPattern, simplificationProofs) <-
         OrOfExpandedPattern.traverseFlattenWithPairs
             (ExpandedPattern.simplify

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -184,9 +184,9 @@ boolModule =
 
 evaluate :: CommonPurePattern Object -> CommonPurePattern Object
 evaluate pat =
-    case evalSimplifier (Pattern.simplify tools evaluators pat) of
-        Left err -> error (Kore.Error.printError err)
-        Right (ExpandedPattern { term }, _) -> term
+    let (ExpandedPattern { term }, _) =
+            evalSimplifier (Pattern.simplify tools evaluators pat)
+    in term
   where
     tools = extractMetadataTools indexedModule
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -312,9 +312,7 @@ intModule =
 
 evaluate :: CommonPurePattern Object -> CommonExpandedPattern Object
 evaluate pat =
-    case evalSimplifier (Pattern.simplify tools evaluators pat) of
-        Left err -> error (Kore.Error.printError err)
-        Right (epat, _) -> epat
+    fst $ evalSimplifier $ Pattern.simplify tools evaluators pat
   where
     tools = extractMetadataTools indexedModule
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -84,11 +84,11 @@ kEqualModule =
 
 evaluate :: CommonPurePattern Object -> CommonPurePattern Object
 evaluate pat =
-    case evalSimplifier (Pattern.simplify tools evaluators pat) of
-        Left err -> error (Error.printError err)
-        Right (ExpandedPattern { term }, _) -> term
-  where
-    tools = extractMetadataTools indexedModule
+    let
+        tools = extractMetadataTools indexedModule
+        (ExpandedPattern { term }, _) =
+            evalSimplifier (Pattern.simplify tools evaluators pat)
+    in term
 
 kEqualDefinition :: KoreDefinition
 kEqualDefinition =
@@ -126,10 +126,8 @@ test_KEqual :: [TestTree]
 test_KEqual =
     [ testCase "equals with variable"
         (assertEqual ""
-            (Right
-                ( ExpandedPattern.fromPurePattern (pat keqSymbol)
-                , SimplificationProof
-                )
+            ( ExpandedPattern.fromPurePattern (pat keqSymbol)
+            , SimplificationProof
             )
             (evalSimplifier
                 (Pattern.simplify tools evaluators (pat keqSymbol))
@@ -137,10 +135,8 @@ test_KEqual =
         )
     , testCase "not equals with variable"
         (assertEqual ""
-            (Right
-                ( ExpandedPattern.fromPurePattern (pat kneqSymbol)
-                , SimplificationProof
-                )
+            ( ExpandedPattern.fromPurePattern (pat kneqSymbol)
+            , SimplificationProof
             )
             (evalSimplifier
                 (Pattern.simplify tools evaluators (pat kneqSymbol))

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -18,8 +18,6 @@ import           Kore.AST.PureML
                  ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkOr, mkVar )
-import           Kore.Error
-                 ( printError )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..), SortTools )
 import           Kore.Predicate.Predicate
@@ -273,7 +271,7 @@ evaluate
     -> CommonPurePattern level
     -> CommonExpandedPattern level
 evaluate metadataTools functionIdToEvaluator patt =
-    either (error . printError) fst
+    fst
         $ evalSimplifier
         $ Pattern.simplify metadataTools functionIdToEvaluator patt
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
@@ -248,8 +248,7 @@ test_functionRegistry =
         (assertEqual ""
             (App_ sHead [])
             ( ExpandedPattern.term
-            $ head $ OrOfExpandedPattern.extractPatterns
-            $ either (error . Kore.Error.printError) fst
+            $ head $ OrOfExpandedPattern.extractPatterns $ fst
             $ evalSimplifier
             $ ExpandedPattern.simplify
                 testMetadataTools

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -453,7 +453,7 @@ evaluateWithAxiom
             , substitution = sort substitution
             }
     evaluated =
-        either (error . printError) fst
+        fst
             $ evalSimplifier
             $ axiomFunctionEvaluator
                 axiom

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -20,8 +20,6 @@ import           Kore.ASTUtils.SmartConstructors
                  ( getSort, mkAnd, mkApp, mkBottom, mkTop, mkVar )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
-import           Kore.Error
-                 ( printError )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (MetadataTools), SortTools )
 import qualified Kore.IndexedModule.MetadataTools
@@ -43,8 +41,6 @@ import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
-import           Kore.Variables.Fresh.IntCounter
-                 ( runIntCounter )
 
 import           Test.Kore.Comparators ()
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
@@ -377,18 +373,14 @@ evaluate
     :: And Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluate patt =
-    either (error . printError) fst
-        $ evalSimplifier
-        $ simplify mockMetadataTools patt
+    fst $ evalSimplifier $ simplify mockMetadataTools patt
 
 evaluatePatterns
     :: CommonExpandedPattern Object
     -> CommonExpandedPattern Object
     -> CommonExpandedPattern Object
 evaluatePatterns first second =
-    fst $ fst $ runIntCounter
-        (makeEvaluate mockMetadataTools first second)
-        0
+    fst $ evalSimplifier $ makeEvaluate mockMetadataTools first second
 
 evaluatePatternsWithAttributes
     :: [(SymbolOrAlias Object, StepperAttributes)]
@@ -396,13 +388,12 @@ evaluatePatternsWithAttributes
     -> CommonExpandedPattern Object
     -> CommonExpandedPattern Object
 evaluatePatternsWithAttributes attributes first second =
-    fst $ fst $ runIntCounter
-        (makeEvaluate
+    fst
+        $ evalSimplifier
+        $ makeEvaluate
             (mockMetadataToolsWithAttributes attributes)
             first
             second
-        )
-        0
 
 mockSortTools :: SortTools Object
 mockSortTools = const

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -21,8 +21,6 @@ import           Kore.ASTUtils.SmartConstructors
                  ( mkApp, mkBottom )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
-import           Kore.Error
-                 ( printError )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Predicate.Predicate
@@ -440,6 +438,6 @@ evaluate
     symbolIdToEvaluator
     application
   =
-    either (error . printError) fst
+    fst
         $ evalSimplifier
         $ simplify tools simplifier symbolIdToEvaluator application

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -19,7 +19,6 @@ import           Kore.ASTUtils.SmartConstructors
                  mkStringLiteral, mkTop, mkVar )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_ )
-import qualified Kore.Error
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools, SortTools )
 import           Kore.Predicate.Predicate
@@ -777,9 +776,7 @@ evaluateOr
     -> Equals Object (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluateOr tools equals =
-    either (error . Kore.Error.printError) fst
-        $ evalSimplifier
-        $ simplify tools equals
+    fst $ evalSimplifier $ simplify tools equals
 
 evaluate
     :: MetadataTools Object StepperAttributes
@@ -795,7 +792,5 @@ evaluateGeneric
     -> CommonExpandedPattern level
     -> CommonOrOfExpandedPattern level
 evaluateGeneric tools first second =
-    either (error . Kore.Error.printError) fst
-        $ evalSimplifier
-        $ makeEvaluate tools first second
+    fst $ evalSimplifier $ makeEvaluate tools first second
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -17,7 +17,6 @@ import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkApp, mkEquals, mkExists, mkTop, mkVar )
-import qualified Kore.Error
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools, SortTools )
 import           Kore.Predicate.Predicate
@@ -301,8 +300,7 @@ evaluate
     -> Exists level Variable (CommonOrOfExpandedPattern level)
     -> CommonOrOfExpandedPattern level
 evaluate tools exists =
-    either (error . Kore.Error.printError) fst
-        $ evalSimplifier
+    fst $ evalSimplifier
         $ Exists.simplify tools (Simplifier.create tools Map.empty) exists
 
 makeEvaluate
@@ -314,7 +312,6 @@ makeEvaluate
     -> CommonExpandedPattern level
     -> CommonOrOfExpandedPattern level
 makeEvaluate tools variable child =
-    either (error . Kore.Error.printError) fst
-        $ evalSimplifier
+    fst $ evalSimplifier
         $ Exists.makeEvaluate tools (Simplifier.create tools Map.empty) variable child
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -658,8 +658,7 @@ runStep
     -> [AxiomPattern level]
     -> (CommonOrOfExpandedPattern level, StepProof level)
 runStep metadataTools configuration axioms =
-    either (error . printError) id
-        $ evalSimplifier
+    evalSimplifier
         $ step
             metadataTools
             Map.empty
@@ -676,7 +675,6 @@ runStepsPickFirst
     -> [AxiomPattern level]
     -> (CommonExpandedPattern level, StepProof level)
 runStepsPickFirst metadataTools maxStepCount configuration axioms =
-    either (error . printError) id
-        $ evalSimplifier
+    evalSimplifier
         $ pickFirstStepper
             metadataTools Map.empty axioms maxStepCount configuration


### PR DESCRIPTION
Any error that the simplifier would catch has already been detected during the
well-formedness check. Therefore, it does not make sense to have complicated
error handling.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

