### PR TITLE
Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+
+[*.hs]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tags
 .settings
 *-kompiled/
 src/main/haskell/stack.yaml
+.dir-locals.el


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org) is a standard file format for configuring style settings across a project. The provided settings will automatically configure any compliant editor with some of our Haskell style settings (particularly, 4-space indentation and no trailing whitespace). This should make it easier for new contributors to conform to our style guide.

If we have particular style demands for other types of source files, EditorConfig can also enforce those.

I also added a `.gitignore` entry for Emacs' project-local configuration file. I don't know if we have any other Emacs users, but we probably don't want to accidentally clobber each others' configurations. :wink: 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

