### PR TITLE
Concrete collection keys

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -27,7 +27,7 @@ import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
                  ( Object (..) )
 import           Kore.AST.PureML
-                 ( CommonPurePattern, UnfixedCommonPurePattern, groundHead )
+                 ( UnfixedCommonPurePattern, groundHead )
 import           Kore.AST.PureToKore
                  ( patternKoreToPure )
 import           Kore.AST.Sentence

--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -64,6 +64,7 @@ default-extensions:
   - DeriveGeneric
   - DeriveTraversable
   - DuplicateRecordFields
+  - EmptyCase
   - ExistentialQuantification
   - FlexibleContexts
   - FlexibleInstances

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -547,7 +547,11 @@ data DomainValue level child = DomainValue
     { domainValueSort  :: !(Sort level)
     , domainValueChild :: !child
     }
-    deriving (Eq, Generic, Ord, Show)
+    deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
+
+deriveEq1 ''DomainValue
+deriveOrd1 ''DomainValue
+deriveShow1 ''DomainValue
 
 instance Hashable child => Hashable (DomainValue level child)
 
@@ -927,7 +931,7 @@ data Pattern level variable child where
     CeilPattern
         :: !(Ceil level child) -> Pattern level variable child
     DomainValuePattern
-        :: !(DomainValue Object (BuiltinDomain (Fix (Pattern Meta Variable))))
+        :: !(DomainValue Object (BuiltinDomain child))
         -> Pattern Object variable child
     EqualsPattern
         :: !(Equals level child) -> Pattern level variable child
@@ -976,12 +980,15 @@ type CommonPurePattern level = PureMLPattern level Variable
 type ConcretePurePattern level = PureMLPattern level Concrete
 
 data BuiltinDomain child
-    = BuiltinDomainPattern !child
-    | BuiltinDomainMap
-        !(Map (Fix (Pattern Object Variable)) (Fix (Pattern Object Variable)))
-    | BuiltinDomainList !(Seq (Fix (Pattern Object Variable)))
-    | BuiltinDomainSet !(Set (Fix (Pattern Object Variable)))
-    deriving (Generic)
+    = BuiltinDomainPattern !(CommonPurePattern Meta)
+    | BuiltinDomainMap !(Map (ConcretePurePattern Object) child)
+    | BuiltinDomainList !(Seq child)
+    | BuiltinDomainSet !(Set (ConcretePurePattern Object))
+    deriving (Foldable, Functor, Generic, Traversable)
+
+deriveEq1 ''BuiltinDomain
+deriveOrd1 ''BuiltinDomain
+deriveShow1 ''BuiltinDomain
 
 instance Hashable child => Hashable (BuiltinDomain child) where
     hashWithSalt salt =

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -960,6 +960,21 @@ data Pattern level variable child where
     VariablePattern
         :: !(variable level) -> Pattern level variable child
 
+{-|'PureMLPattern' corresponds to "fixed point" representations
+of the 'Pattern' class where the level is fixed to a given @level@.
+
+@var@ is the type of variables.
+-}
+type PureMLPattern level var = Fix (Pattern level var)
+
+-- |'CommonPurePattern' is the instantiation of 'PureMLPattern' with common
+-- 'Variable's.
+type CommonPurePattern level = PureMLPattern level Variable
+
+{- | @ConcretePurePattern level@ is a concrete pattern at level @level@.
+ -}
+type ConcretePurePattern level = PureMLPattern level Concrete
+
 data BuiltinDomain child
     = BuiltinDomainPattern !child
     | BuiltinDomainMap

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
 {-|
 Module      : Kore.AST.Common
 Description : Data Structures for representing the Kore language AST that do not
@@ -341,6 +343,21 @@ data Variable level = Variable
 instance Hashable (Variable level)
 
 instance NFData (Variable level)
+
+{- | @Concrete level@ is a variable occuring in a concrete pattern.
+
+    Concrete patterns do not contain variables, so this is an uninhabited type
+    (it has no constructors).
+
+    See also: 'Data.Void.Void'
+
+ -}
+data Concrete level
+    deriving (Eq, Generic, Ord, Read, Show)
+
+instance Hashable (Concrete level)
+
+instance NFData (Concrete level)
 
 {-| 'SortedVariable' is a variable which has a sort.
 -}

--- a/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
@@ -201,7 +201,7 @@ data PatternLeveledFunction level variable child result = PatternLeveledFunction
     , stringLeveledFunction :: StringLiteral -> result Meta
     , charLeveledFunction :: CharLiteral -> result Meta
     , domainValueLeveledFunction
-        :: DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+        :: DomainValue Object (BuiltinDomain child)
         -> result Object
     , applicationLeveledFunction :: !(Application level child -> result level)
     , variableLeveledFunction :: !(variable level -> result level)
@@ -272,7 +272,7 @@ data PatternFunction level variable child result = PatternFunction
     , applicationFunction :: !(Application level child -> result)
     , variableFunction :: !(variable level -> result)
     , domainValueFunction
-        :: DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+        :: DomainValue Object (BuiltinDomain child)
         -> result
     }
 

--- a/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/AST/MLPatterns.hs
@@ -21,7 +21,6 @@ module Kore.AST.MLPatterns
 import Kore.AST.Common
 import Kore.AST.Kore
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
 import Kore.ASTHelpers
        ( ApplicationSorts (..) )
 import Kore.Implicit.ImplicitSorts

--- a/src/main/haskell/kore/src/Kore/AST/PureML.hs
+++ b/src/main/haskell/kore/src/Kore/AST/PureML.hs
@@ -18,13 +18,6 @@ import Data.Functor.Foldable
 import Kore.AST.Common
 import Kore.AST.Sentence
 
-{-|'PureMLPattern' corresponds to "fixed point" representations
-of the 'Pattern' class where the level is fixed to a given @level@.
-
-@var@ is the type of variables.
--}
-type PureMLPattern level var = Fix (Pattern level var)
-
 asPurePattern
     :: Pattern level var (PureMLPattern level var) -> PureMLPattern level var
 asPurePattern = embed
@@ -98,9 +91,6 @@ constant
     :: SymbolOrAlias level -> Pattern level variable child
 constant patternHead = apply patternHead []
 
--- |'CommonPurePattern' is the instantiation of 'PureMLPattern' with common
--- 'Variable's.
-type CommonPurePattern level = PureMLPattern level Variable
 type UnFixedPureMLPattern level variable =
     Pattern level variable (PureMLPattern level variable)
 type UnfixedCommonPurePattern level = UnFixedPureMLPattern level Variable

--- a/src/main/haskell/kore/src/Kore/ASTHelpers.hs
+++ b/src/main/haskell/kore/src/Kore/ASTHelpers.hs
@@ -28,7 +28,6 @@ import qualified Data.Set as Set
 
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
 import Kore.AST.Sentence
 import Kore.Error
 import Kore.Variables.Free

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -148,6 +148,9 @@ printableList = intersperse (Doc.line <> comma <> space)
 instance PrettyPrint Void where
     prettyPrint _ = \case {}
 
+instance PrettyPrint () where
+    prettyPrint _ () = "()"
+
 instance MetaOrObject level => PrettyPrint (Id level) where
     prettyPrint flags id'@(Id _ _) =
         betweenParentheses

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -16,7 +16,6 @@ import           Data.Functor.Impredicative
 import           Kore.AST.Common
 import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.AST.Sentence
 import qualified Kore.Builtin as Builtin
 import           Kore.Parser.CString

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -11,6 +11,7 @@ import Data.String
        ( fromString )
 import Data.Text.Prettyprint.Doc as Doc
 import Data.Text.Prettyprint.Doc.Render.String
+import Data.Void ( Void )
 
 import           Data.Functor.Impredicative
 import           Kore.AST.Common
@@ -21,8 +22,8 @@ import qualified Kore.Builtin as Builtin
 import           Kore.Parser.CString
                  ( escapeCString )
 import           Kore.Predicate.Predicate
+import           Kore.Proof.Functional
 import           Kore.Step.ExpandedPattern
-import           Kore.Step.PatternAttributes
 import           Kore.Unification.Unifier
 
 {-# ANN module ("HLint: ignore Use record patterns" :: String) #-}
@@ -143,6 +144,9 @@ writeStructure name fields =
 
 printableList :: [Doc ann] -> [Doc ann]
 printableList = intersperse (Doc.line <> comma <> space)
+
+instance PrettyPrint Void where
+    prettyPrint _ = \case {}
 
 instance MetaOrObject level => PrettyPrint (Id level) where
     prettyPrint flags id'@(Id _ _) =

--- a/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
@@ -105,8 +105,7 @@ patternLens
   And_       s2   a b -> And_      <$>          o s2           <*> c a <*> c b
   Bottom_    s2       -> Bottom_   <$>          o s2
   Ceil_   s1 s2   a   -> Ceil_     <$> i s1 <*> o s2           <*> c a
-  -- DV_        s2   a   -> DV_       <$>          o s2           <*> c a
-  Fix (DomainValuePattern (DomainValue s2 a )) -> DV_ <$> o s2 <*> pure a
+  DV_        s2   a   -> DV_       <$>          o s2           <*> traverse c a
   Equals_ s1 s2   a b -> Equals_   <$> i s1 <*> o s2           <*> c a <*> c b
   Exists_    s2 v a   -> Exists_   <$>          o s2 <*> var v <*> c a
   Floor_  s1 s2   a   -> Floor_    <$> i s1 <*> o s2           <*> c a
@@ -343,7 +342,7 @@ mkCeil a = Ceil_ (getSort a) predicateSort a
 mkDomainValue
     :: (MetaOrObject Object, Given (SymbolOrAliasSorts Object))
     => Sort Object
-    -> BuiltinDomain (CommonPurePattern Meta)
+    -> BuiltinDomain (PureMLPattern Object var)
     -> PureMLPattern Object var
 mkDomainValue = DV_
 

--- a/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/SmartConstructors.hs
@@ -66,7 +66,6 @@ import Data.Reflection
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
 import Kore.AST.MLPatterns
-import Kore.AST.PureML
 import Kore.ASTUtils.SmartPatterns
 import Kore.IndexedModule.MetadataTools
 

--- a/src/main/haskell/kore/src/Kore/ASTUtils/SmartPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/SmartPatterns.hs
@@ -44,9 +44,6 @@ import Data.Functor.Foldable
 
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-       ( PureMLPattern )
-
 
 pattern And_
     :: Sort level

--- a/src/main/haskell/kore/src/Kore/ASTUtils/SmartPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/SmartPatterns.hs
@@ -69,7 +69,7 @@ pattern Ceil_
 pattern DV_
   :: () => (level ~ Object) =>
      Sort level
-  -> BuiltinDomain (PureMLPattern Meta Variable)
+  -> BuiltinDomain (PureMLPattern level var)
   -> PureMLPattern level var
 
 pattern Equals_

--- a/src/main/haskell/kore/src/Kore/ASTUtils/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/Substitution.hs
@@ -28,7 +28,6 @@ import qualified Data.Set as S
 
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
 import Kore.ASTUtils.SmartConstructors
 import Kore.ASTUtils.SmartPatterns
 
@@ -85,5 +84,3 @@ localSubst
     -> CommonPurePattern level
     -> CommonPurePattern level
 localSubst a b path pat = localInPattern path (subst a b) pat
-
-

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -456,7 +456,7 @@ verifyVariableUsage variable _ verifyHelpers _ _ = do
 
 verifyDomainValue
     :: (MetaOrObject level)
-    => DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+    => DomainValue Object (BuiltinDomain CommonKorePattern)
     -> VerifyHelpers level
     -> Set.Set UnifiedSortVariable
     -> Either (Error VerifyError) (Sort Object)

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -28,8 +28,6 @@ import           Kore.AST.Error
 import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
 import           Kore.AST.MLPatterns
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTHelpers
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -42,8 +42,6 @@ import           GHC.Stack
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Meta, Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
@@ -63,7 +61,7 @@ import           Kore.Step.StepperAttributes
 {- | The default type of builtin domain values.
  -}
 type Builtin =
-    Kore.DomainValue Object (Kore.BuiltinDomain (CommonPurePattern Meta))
+    Kore.DomainValue Object (Kore.BuiltinDomain (Kore.CommonPurePattern Meta))
 
 {- | Verifiers for Kore builtin sorts.
 
@@ -165,7 +163,7 @@ asPattern
     -- ^ indexed module defining hooks for builtin domains
     -> Builtin
     -- ^ domain value
-    -> Either (Error e) (CommonPurePattern Object)
+    -> Either (Error e) (Kore.CommonPurePattern Object)
 asPattern
     indexedModule
     Kore.DomainValue { domainValueSort, domainValueChild }
@@ -196,8 +194,8 @@ asPattern
 externalizePattern
     :: KoreIndexedModule attrs
     -- ^ indexed module defining hooks for builtin domains
-    -> CommonPurePattern Object
-    -> Either (Error e) (CommonPurePattern Object)
+    -> Kore.CommonPurePattern Object
+    -> Either (Error e) (Kore.CommonPurePattern Object)
 externalizePattern indexedModule =
     Functor.Foldable.fold externalizePattern0
   where
@@ -215,7 +213,7 @@ externalizePattern indexedModule =
  -}
 asMetaPattern
     :: Builtin
-    -> CommonPurePattern Meta
+    -> Kore.CommonPurePattern Meta
 asMetaPattern Kore.DomainValue { domainValueChild } =
     case domainValueChild of
         Kore.BuiltinDomainPattern pat -> pat

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -61,7 +61,7 @@ import           Kore.Step.StepperAttributes
 {- | The default type of builtin domain values.
  -}
 type Builtin =
-    Kore.DomainValue Object (Kore.BuiltinDomain (Kore.CommonPurePattern Meta))
+    Kore.DomainValue Object (Kore.BuiltinDomain (Kore.CommonPurePattern Object))
 
 {- | Verifiers for Kore builtin sorts.
 
@@ -202,7 +202,7 @@ externalizePattern indexedModule =
     externalizePattern0 =
         \case
             Kore.DomainValuePattern dv ->
-                asPattern indexedModule dv
+                asPattern indexedModule =<< traverse sequence dv
             pat -> Functor.Foldable.embed <$> sequence pat
 
 {- | Extract the meta-level pattern argument of a domain value.
@@ -212,10 +212,10 @@ externalizePattern indexedModule =
 
  -}
 asMetaPattern
-    :: Builtin
+    :: Kore.BuiltinDomain child
     -> Kore.CommonPurePattern Meta
-asMetaPattern Kore.DomainValue { domainValueChild } =
-    case domainValueChild of
+asMetaPattern =
+    \case
         Kore.BuiltinDomainPattern pat -> pat
         Kore.BuiltinDomainMap _ -> notImplementedInternal
         Kore.BuiltinDomainList _ -> notImplementedInternal

--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -40,8 +40,6 @@ import qualified Text.Megaparsec.Char as Parsec
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Meta, Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Builtin as Builtin
 import           Kore.Step.ExpandedPattern
@@ -114,13 +112,13 @@ parse = (Parsec.<|>) true false
 asPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Bool  -- ^ builtin value to render
-    -> CommonPurePattern Object
+    -> Kore.CommonPurePattern Object
 asPattern resultSort result =
     Kore.DV_ resultSort
         $ Kore.BuiltinDomainPattern
         $ asMetaPattern result
 
-asMetaPattern :: Bool -> CommonPurePattern Meta
+asMetaPattern :: Bool -> Kore.CommonPurePattern Meta
 asMetaPattern True = Kore.StringLiteral_ "true"
 asMetaPattern False = Kore.StringLiteral_ "false"
 

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -66,16 +66,14 @@ import           Text.Megaparsec
 import qualified Text.Megaparsec as Parsec
 
 import           Kore.AST.Common
-                 ( Application (..), BuiltinDomain (..), DomainValue (..),
-                 Id (..), Pattern (DomainValuePattern), Sort (..),
-                 SortActual (..), SortVariable (..), SymbolOrAlias (..),
-                 Variable )
+                 ( Application (..), BuiltinDomain (..), CommonPurePattern,
+                 DomainValue (..), Id (..), Pattern (DomainValuePattern),
+                 Sort (..), SortActual (..), SortVariable (..),
+                 SymbolOrAlias (..), Variable )
 import           Kore.AST.Kore
                  ( CommonKorePattern )
 import           Kore.AST.MetaOrObject
                  ( Meta, Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
                  ( KoreSentenceSort, KoreSentenceSymbol, SentenceSort (..),
                  SentenceSymbol (..) )

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -46,10 +46,14 @@ module Kore.Builtin.Builtin
     , runParser
     , appliedFunction
     , lookupSymbol
+    , expectConcretePurePattern
+    , getAttemptedFunction
     ) where
 
 import           Control.Monad
                  ( zipWithM_ )
+import           Control.Monad.Except
+                 ( ExceptT, MonadError, runExceptT )
 import qualified Control.Monad.Except as Except
 import qualified Data.Functor.Foldable as Functor.Foldable
 import           Data.HashMap.Strict
@@ -67,13 +71,16 @@ import qualified Text.Megaparsec as Parsec
 
 import           Kore.AST.Common
                  ( Application (..), BuiltinDomain (..), CommonPurePattern,
-                 DomainValue (..), Id (..), Pattern (DomainValuePattern),
-                 Sort (..), SortActual (..), SortVariable (..),
-                 SymbolOrAlias (..), Variable )
+                 ConcretePurePattern, DomainValue (..), Id (..),
+                 Pattern (DomainValuePattern), PureMLPattern, Sort (..),
+                 SortActual (..), SortVariable (..), SymbolOrAlias (..),
+                 Variable )
 import           Kore.AST.Kore
                  ( CommonKorePattern )
 import           Kore.AST.MetaOrObject
-                 ( Meta, Object )
+                 ( Object )
+import           Kore.AST.PureML
+                 ( asConcretePurePattern )
 import           Kore.AST.Sentence
                  ( KoreSentenceSort, KoreSentenceSymbol, SentenceSort (..),
                  SentenceSymbol (..) )
@@ -176,7 +183,7 @@ instance Monoid PatternVerifier where
     mappend = (<>)
 
 type DomainValueVerifier =
-    DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+    DomainValue Object (BuiltinDomain CommonKorePattern)
     -> Either (Error VerifyError) ()
 
 {- | Verify builtin sorts, symbols, and patterns.
@@ -404,7 +411,7 @@ verifyStringLiteral validate DomainValue { domainValueChild } =
  -}
 parseDomainValue
     :: Parser a
-    -> DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+    -> DomainValue Object (BuiltinDomain child)
     -> Either (Error VerifyError) a
 parseDomainValue
     parser
@@ -629,3 +636,15 @@ lookupSymbol builtinName indexedModule
         { symbolOrAliasConstructor
         , symbolOrAliasParams = []
         }
+
+expectConcretePurePattern
+    :: MonadError (AttemptedFunction Object Variable) m
+    => PureMLPattern level variable
+    -> m (ConcretePurePattern level)
+expectConcretePurePattern purePattern =
+    case asConcretePurePattern purePattern of
+        Nothing -> Except.throwError NotApplicable
+        Just concretePattern -> return concretePattern
+
+getAttemptedFunction :: Monad m => ExceptT r m r -> m r
+getAttemptedFunction = fmap (either id id) . runExceptT

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -53,8 +53,6 @@ import qualified Text.Megaparsec.Char.Lexer as Parsec
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Meta, Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
@@ -166,7 +164,7 @@ parse = Parsec.signed noSpace Parsec.decimal
 expectBuiltinDomainInt
     :: Monad m
     => String  -- ^ Context for error message
-    -> CommonPurePattern Object  -- ^ Operand pattern
+    -> Kore.CommonPurePattern Object  -- ^ Operand pattern
     -> ExceptT (AttemptedFunction Object Kore.Variable) m Integer
 expectBuiltinDomainInt ctx =
     \case
@@ -192,13 +190,13 @@ expectBuiltinDomainInt ctx =
 asPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
-    -> CommonPurePattern Object
+    -> Kore.CommonPurePattern Object
 asPattern resultSort result =
     Kore.DV_ resultSort
         $ Kore.BuiltinDomainPattern
         $ asMetaPattern result
 
-asMetaPattern :: Integer -> CommonPurePattern Meta
+asMetaPattern :: Integer -> Kore.CommonPurePattern Meta
 asMetaPattern result = Kore.StringLiteral_ $ show result
 
 asExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -39,7 +39,8 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Simplification.Data
                  ( PureMLPatternSimplifier, SimplificationProof (..),
                  Simplifier )
-import qualified Kore.Step.Simplification.Equals as Equals
+import           Kore.Step.Simplification.Equals
+                 ( makeEvaluate )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 
@@ -91,7 +92,7 @@ evalKEq true false tools _ pat =
         _ -> notApplicableFunctionEvaluator
   where
     evalEq resultSort t1 t2 = do
-        (result, _proof) <- Equals.makeEvaluate tools ep1 ep2
+        (result, _proof) <- makeEvaluate tools ep1 ep2
         if OrOfExpandedPattern.isTrue result
             then purePatternFunctionEvaluator (Bool.asPattern resultSort true)
         else if OrOfExpandedPattern.isFalse result

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -25,11 +25,9 @@ import           Data.Map
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
-                 ( Application (..), Variable (..) )
+                 ( Application (..), PureMLPattern, Variable (..) )
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -102,4 +100,3 @@ evalKEq true false tools _ pat =
       where
         ep1 = ExpandedPattern.fromPurePattern t1
         ep2 = ExpandedPattern.fromPurePattern t2
-

--- a/src/main/haskell/kore/src/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/List.hs
@@ -44,8 +44,6 @@ import qualified Data.Sequence as Seq
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.Int as Int
@@ -105,7 +103,7 @@ symbolVerifiers =
     anySort :: Builtin.SortVerifier
     anySort = const $ const $ Right ()
 
-type Builtin = Seq (CommonPurePattern Object)
+type Builtin = Seq (Kore.CommonPurePattern Object)
 
 {- | Abort function evaluation if the argument is not a List domain value.
 
@@ -117,7 +115,7 @@ type Builtin = Seq (CommonPurePattern Object)
 expectBuiltinDomainList
     :: Monad m
     => String  -- ^ Context for error message
-    -> CommonPurePattern Object  -- ^ Operand pattern
+    -> Kore.CommonPurePattern Object  -- ^ Operand pattern
     -> ExceptT (AttemptedFunction Object Kore.Variable) m Builtin
 expectBuiltinDomainList ctx =
     \case
@@ -225,7 +223,7 @@ asPattern
     :: KoreIndexedModule attrs
     -- ^ indexed module where pattern would appear
     -> Kore.Sort Object
-    -> Either (Kore.Error e) (Builtin -> CommonPurePattern Object)
+    -> Either (Kore.Error e) (Builtin -> Kore.CommonPurePattern Object)
 asPattern indexedModule _ = do
     symbolUnit <- lookupSymbolUnit indexedModule
     let applyUnit = Kore.App_ symbolUnit []

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -44,8 +44,6 @@ import qualified Data.Set as Set
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
@@ -112,7 +110,7 @@ symbolVerifiers =
     anySort :: Builtin.SortVerifier
     anySort = const $ const $ Right ()
 
-type Builtin = Map (CommonPurePattern Object) (CommonPurePattern Object)
+type Builtin = Map (Kore.CommonPurePattern Object) (Kore.CommonPurePattern Object)
 
 {- | Abort function evaluation if the argument is not a Map domain value.
 
@@ -124,7 +122,7 @@ type Builtin = Map (CommonPurePattern Object) (CommonPurePattern Object)
 expectBuiltinDomainMap
     :: Monad m
     => String  -- ^ Context for error message
-    -> CommonPurePattern Object  -- ^ Operand pattern
+    -> Kore.CommonPurePattern Object  -- ^ Operand pattern
     -> ExceptT (AttemptedFunction Object Kore.Variable) m Builtin
 expectBuiltinDomainMap ctx =
     \case
@@ -268,7 +266,7 @@ asPattern
     :: KoreIndexedModule attrs
     -- ^ indexed module where pattern would appear
     -> Kore.Sort Object
-    -> Either (Kore.Error e) (Builtin -> CommonPurePattern Object)
+    -> Either (Kore.Error e) (Builtin -> Kore.CommonPurePattern Object)
 asPattern indexedModule _
   = do
     symbolUnit <- lookupSymbolUnit indexedModule

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -153,14 +153,14 @@ evalLookup :: Builtin.Function
 evalLookup =
     Builtin.functionEvaluator evalLookup0
   where
-    evalLookup0 _ _ _ arguments =
+    evalLookup0 tools _ _ arguments =
         Builtin.getAttemptedFunction
         (do
             let (_map, _key) =
                     case arguments of
                         [_map, _key] -> (_map, _key)
                         _ -> Builtin.wrongArity "MAP.lookup"
-            _key <- Builtin.expectConcretePurePattern _key
+            _key <- Builtin.expectNormalConcreteTerm tools _key
             _map <- expectBuiltinDomainMap "MAP.lookup" _map
             Builtin.appliedFunction
                 $ maybe ExpandedPattern.bottom ExpandedPattern.fromPurePattern
@@ -171,14 +171,14 @@ evalElement :: Builtin.Function
 evalElement =
     Builtin.functionEvaluator evalElement0
   where
-    evalElement0 _ _ resultSort = \arguments ->
+    evalElement0 tools _ resultSort = \arguments ->
         Builtin.getAttemptedFunction
         (do
             let (_key, _value) =
                     case arguments of
                         [_key, _value] -> (_key, _value)
                         _ -> Builtin.wrongArity "MAP.element"
-            _key <- Builtin.expectConcretePurePattern _key
+            _key <- Builtin.expectNormalConcreteTerm tools _key
             returnMap resultSort (Map.singleton _key _value)
         )
 
@@ -218,14 +218,14 @@ evalUpdate :: Builtin.Function
 evalUpdate =
     Builtin.functionEvaluator evalUpdate0
   where
-    evalUpdate0 _ _ resultSort = \arguments ->
+    evalUpdate0 tools _ resultSort = \arguments ->
         Builtin.getAttemptedFunction
         (do
             let (_map, _key, value) =
                     case arguments of
                         [_map, _key, value'] -> (_map, _key, value')
                         _ -> Builtin.wrongArity "MAP.update"
-            _key <- Builtin.expectConcretePurePattern _key
+            _key <- Builtin.expectNormalConcreteTerm tools _key
             _map <- expectBuiltinDomainMap "MAP.update" _map
             returnMap resultSort (Map.insert _key value _map)
         )
@@ -234,14 +234,14 @@ evalInKeys :: Builtin.Function
 evalInKeys =
     Builtin.functionEvaluator evalInKeys0
   where
-    evalInKeys0 _ _ resultSort = \arguments ->
+    evalInKeys0 tools _ resultSort = \arguments ->
         Builtin.getAttemptedFunction
         (do
             let (_key, _map) =
                     case arguments of
                         [_key, _map] -> (_key, _map)
                         _ -> Builtin.wrongArity "MAP.in_keys"
-            _key <- Builtin.expectConcretePurePattern _key
+            _key <- Builtin.expectNormalConcreteTerm tools _key
             _map <- expectBuiltinDomainMap "MAP.in_keys" _map
             Builtin.appliedFunction
                 $ Bool.asExpandedPattern resultSort

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -33,7 +33,7 @@ module Kore.Builtin.Map
 
 import qualified Control.Monad as Monad
 import           Control.Monad.Except
-                 ( ExceptT, runExceptT )
+                 ( ExceptT )
 import qualified Control.Monad.Except as Except
 import qualified Data.HashMap.Strict as HashMap
 import           Data.Map.Strict
@@ -44,6 +44,7 @@ import qualified Data.Set as Set
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Object )
+import qualified Kore.AST.PureML as Kore
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
@@ -110,7 +111,8 @@ symbolVerifiers =
     anySort :: Builtin.SortVerifier
     anySort = const $ const $ Right ()
 
-type Builtin = Map (Kore.CommonPurePattern Object) (Kore.CommonPurePattern Object)
+type Builtin =
+    Map (Kore.ConcretePurePattern Object) (Kore.CommonPurePattern Object)
 
 {- | Abort function evaluation if the argument is not a Map domain value.
 
@@ -124,17 +126,17 @@ expectBuiltinDomainMap
     => String  -- ^ Context for error message
     -> Kore.CommonPurePattern Object  -- ^ Operand pattern
     -> ExceptT (AttemptedFunction Object Kore.Variable) m Builtin
-expectBuiltinDomainMap ctx =
-    \case
-        Kore.DV_ _ domain ->
-            case domain of
-                Kore.BuiltinDomainMap map' -> return map'
-                _ -> Builtin.verifierBug (ctx ++ ": Domain value is not a map")
-        _ ->
-            Except.throwError NotApplicable
-
-getAttemptedFunction :: Monad m => ExceptT r m r -> m r
-getAttemptedFunction = fmap (either id id) . runExceptT
+expectBuiltinDomainMap ctx _map =
+    do
+        case _map of
+            Kore.DV_ _ domain ->
+                case domain of
+                    Kore.BuiltinDomainMap map' -> return map'
+                    _ ->
+                        Builtin.verifierBug
+                            (ctx ++ ": Domain value is not a map")
+            _ ->
+                Except.throwError NotApplicable
 
 returnMap
     :: Monad m
@@ -152,16 +154,17 @@ evalLookup =
     Builtin.functionEvaluator evalLookup0
   where
     evalLookup0 _ _ _ arguments =
-        getAttemptedFunction
+        Builtin.getAttemptedFunction
         (do
-            let (_map, key) =
+            let (_map, _key) =
                     case arguments of
-                        [_map, key'] -> (_map, key')
+                        [_map, _key] -> (_map, _key)
                         _ -> Builtin.wrongArity "MAP.lookup"
+            _key <- Builtin.expectConcretePurePattern _key
             _map <- expectBuiltinDomainMap "MAP.lookup" _map
             Builtin.appliedFunction
                 $ maybe ExpandedPattern.bottom ExpandedPattern.fromPurePattern
-                $ Map.lookup key _map
+                $ Map.lookup _key _map
         )
 
 evalElement :: Builtin.Function
@@ -169,16 +172,22 @@ evalElement =
     Builtin.functionEvaluator evalElement0
   where
     evalElement0 _ _ resultSort = \arguments ->
-        case arguments of
-            [_key, _value] -> returnMap resultSort (Map.singleton _key _value)
-            _ -> Builtin.wrongArity "MAP.element"
+        Builtin.getAttemptedFunction
+        (do
+            let (_key, _value) =
+                    case arguments of
+                        [_key, _value] -> (_key, _value)
+                        _ -> Builtin.wrongArity "MAP.element"
+            _key <- Builtin.expectConcretePurePattern _key
+            returnMap resultSort (Map.singleton _key _value)
+        )
 
 evalConcat :: Builtin.Function
 evalConcat =
     Builtin.functionEvaluator evalConcat0
   where
     evalConcat0 _ _ resultSort = \arguments ->
-        getAttemptedFunction
+        Builtin.getAttemptedFunction
         (do
             let (_map1, _map2) =
                     case arguments of
@@ -210,14 +219,15 @@ evalUpdate =
     Builtin.functionEvaluator evalUpdate0
   where
     evalUpdate0 _ _ resultSort = \arguments ->
-        getAttemptedFunction
+        Builtin.getAttemptedFunction
         (do
-            let (_map, key, value) =
+            let (_map, _key, value) =
                     case arguments of
-                        [_map, key', value'] -> (_map, key', value')
+                        [_map, _key, value'] -> (_map, _key, value')
                         _ -> Builtin.wrongArity "MAP.update"
+            _key <- Builtin.expectConcretePurePattern _key
             _map <- expectBuiltinDomainMap "MAP.update" _map
-            returnMap resultSort (Map.insert key value _map)
+            returnMap resultSort (Map.insert _key value _map)
         )
 
 evalInKeys :: Builtin.Function
@@ -225,16 +235,17 @@ evalInKeys =
     Builtin.functionEvaluator evalInKeys0
   where
     evalInKeys0 _ _ resultSort = \arguments ->
-        getAttemptedFunction
+        Builtin.getAttemptedFunction
         (do
-            let (key, _map) =
+            let (_key, _map) =
                     case arguments of
-                        [key', _map] -> (key', _map)
+                        [_key, _map] -> (_key, _map)
                         _ -> Builtin.wrongArity "MAP.in_keys"
+            _key <- Builtin.expectConcretePurePattern _key
             _map <- expectBuiltinDomainMap "MAP.in_keys" _map
             Builtin.appliedFunction
                 $ Bool.asExpandedPattern resultSort
-                $ Map.member key _map
+                $ Map.member _key _map
         )
 
 {- | Implement builtin function evaluation.
@@ -272,7 +283,8 @@ asPattern indexedModule _
     symbolUnit <- lookupSymbolUnit indexedModule
     let applyUnit = Kore.App_ symbolUnit []
     symbolElement <- lookupSymbolElement indexedModule
-    let applyElement (k, v) = Kore.App_ symbolElement [k, v]
+    let applyElement (key, value) =
+            Kore.App_ symbolElement [Kore.fromConcretePurePattern key, value]
     symbolConcat <- lookupSymbolConcat indexedModule
     let applyConcat map1 map2 = Kore.App_ symbolConcat [map1, map2]
         asPattern0 result =
@@ -291,7 +303,10 @@ asExpandedPattern
     -> Kore.Sort Object
     -> Either (Kore.Error e) (Builtin -> CommonExpandedPattern Object)
 asExpandedPattern symbols resultSort =
-    (ExpandedPattern.fromPurePattern .) <$> asPattern symbols resultSort
+    asExpandedPattern0 <$> asPattern symbols resultSort
+  where
+    asExpandedPattern0 = \asPattern0 builtin ->
+        ExpandedPattern.fromPurePattern $ asPattern0 builtin
 
 {- | Find the symbol hooked to @MAP.unit@ in an indexed module.
  -}

--- a/src/main/haskell/kore/src/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Set.hs
@@ -45,8 +45,6 @@ import qualified Data.Set as Set
 import qualified Kore.AST.Common as Kore
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
@@ -109,7 +107,7 @@ symbolVerifiers =
     anySort :: Builtin.SortVerifier
     anySort = const $ const $ Right ()
 
-type Builtin = Set (CommonPurePattern Object)
+type Builtin = Set (Kore.CommonPurePattern Object)
 
 {- | Abort function evaluation if the argument is not a @Set@ domain value.
 
@@ -121,7 +119,7 @@ type Builtin = Set (CommonPurePattern Object)
 expectBuiltinDomainSet
     :: Monad m
     => String  -- ^ Context for error message
-    -> CommonPurePattern Object  -- ^ Operand pattern
+    -> Kore.CommonPurePattern Object  -- ^ Operand pattern
     -> ExceptT (AttemptedFunction Object Kore.Variable) m Builtin
 expectBuiltinDomainSet ctx =
     \case
@@ -243,7 +241,7 @@ asPattern
     :: KoreIndexedModule attrs
     -- ^ indexed module where pattern would appear
     -> Kore.Sort Object
-    -> Either (Kore.Error e) (Builtin -> CommonPurePattern Object)
+    -> Either (Kore.Error e) (Builtin -> Kore.CommonPurePattern Object)
 asPattern indexedModule _ = do
     symbolUnit <- lookupSymbolUnit indexedModule
     let applyUnit = Kore.App_ symbolUnit []

--- a/src/main/haskell/kore/src/Kore/MetaML/Lift.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/Lift.hs
@@ -164,7 +164,7 @@ liftObjectReducer p = case p of
     DomainValuePattern dvp ->
         applyMetaMLPatternHead DomainValuePatternType
             [ liftToMeta (domainValueSort dvp)
-            , Builtin.asMetaPattern dvp
+            , Builtin.asMetaPattern (domainValueChild dvp)
             ]
     EqualsPattern cp -> applyMetaMLPatternHead EqualsPatternType
         [ liftToMeta (equalsOperandSort cp)

--- a/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
@@ -56,8 +56,6 @@ import           Data.Functor.Impredicative
 import           Kore.AST.Common
 import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.MetaML.AST
 import           Kore.Parser.Lexeme

--- a/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
+++ b/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
@@ -45,10 +45,10 @@ import Data.Set
        ( Set )
 
 import Kore.AST.Common
-       ( SortedVariable, Variable )
+       ( PureMLPattern, SortedVariable, Variable )
 import Kore.AST.MetaOrObject
 import Kore.AST.PureML
-       ( PureMLPattern, mapPatternVariables )
+       ( mapPatternVariables )
 import Kore.ASTUtils.SmartConstructors
        ( mkAnd, mkBottom, mkCeil, mkEquals, mkExists, mkFloor, mkIff,
        mkImplies, mkIn, mkNot, mkOr, mkTop )

--- a/src/main/haskell/kore/src/Kore/Proof/Functional.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Functional.hs
@@ -1,0 +1,69 @@
+{-|
+Module      : Kore.Proof.Functional
+Description : Proofs of functionality and totality of patterns
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : thomas.tuegel@runtimeverification.com
+-}
+
+module Kore.Proof.Functional
+    ( FunctionProof (..)
+    , FunctionalProof (..)
+    , TotalProof (..)
+    ) where
+
+import Data.Void
+       ( Void )
+
+import Kore.AST.Common
+
+-- |'FunctionalProof' is used for providing arguments that a pattern is
+-- functional.  Currently we only support arguments stating that a
+-- pattern consists of domain values, functional symbols and variables.
+-- Hence, a proof that a pattern is functional is a list of 'FunctionalProof'.
+-- TODO: replace this datastructures with proper ones representing
+-- both hypotheses and conclusions in the proof object.
+data FunctionalProof level variable
+    = FunctionalVariable (variable level)
+    -- ^Variables are functional as per Corollary 5.19
+    -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
+    -- |= ∃y . x = y
+    | FunctionalDomainValue
+        (DomainValue level (BuiltinDomain Void))
+    -- ^ Domain value pattern without children are functional: they represent
+    -- one value in the model.
+    | FunctionalHead (SymbolOrAlias level)
+    -- ^Head of a total function, conforming to Definition 5.21
+    -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
+    | FunctionalStringLiteral StringLiteral
+    -- ^A string literal is the repeated application of functional constructors.
+    | FunctionalCharLiteral CharLiteral
+    -- ^A char literal is a functional constructor without arguments.
+  deriving (Eq, Show)
+
+-- |'FunctionProof' is used for providing arguments that a pattern is
+-- function-like.  Currently we only support arguments stating that a
+-- pattern consists of domain values, functional and function symbols and
+-- variables.
+-- Hence, a proof that a pattern is function-like is a list of 'FunctionProof'.
+-- TODO: replace this datastructures with proper ones representing
+-- both hypotheses and conclusions in the proof object.
+data FunctionProof level variable
+    = FunctionProofFunctional (FunctionalProof level variable)
+    -- ^ A functional component is also function-like.
+    | FunctionHead (SymbolOrAlias level)
+    -- ^Head of a partial function.
+  deriving (Eq, Show)
+
+-- |'TotalProof' is used for providing arguments that a pattern is
+-- total/not bottom.  Currently we only support arguments stating that a
+-- pattern is functional or a constructor.
+-- Hence, a proof that a pattern is total is a list of 'TotalProof'.
+-- TODO: replace this datastructures with proper ones representing
+-- both hypotheses and conclusions in the proof object.
+data TotalProof level variable
+    = TotalProofFunctional (FunctionalProof level variable)
+    -- ^A functional component is also total.
+    | TotalHead (SymbolOrAlias level)
+    -- ^Head of a total symbol.
+  deriving (Eq, Show)

--- a/src/main/haskell/kore/src/Kore/Proof/Functional.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Functional.hs
@@ -12,9 +12,6 @@ module Kore.Proof.Functional
     , TotalProof (..)
     ) where
 
-import Data.Void
-       ( Void )
-
 import Kore.AST.Common
 
 -- |'FunctionalProof' is used for providing arguments that a pattern is
@@ -28,8 +25,7 @@ data FunctionalProof level variable
     -- ^Variables are functional as per Corollary 5.19
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
     -- |= ∃y . x = y
-    | FunctionalDomainValue
-        (DomainValue level (BuiltinDomain Void))
+    | FunctionalDomainValue (DomainValue level (BuiltinDomain ()))
     -- ^ Domain value pattern without children are functional: they represent
     -- one value in the model.
     | FunctionalHead (SymbolOrAlias level)

--- a/src/main/haskell/kore/src/Kore/Proof/Proof.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Proof.hs
@@ -9,23 +9,7 @@ Stability   : experimental
 Portability : portable
 -}
 
-{-# LANGUAGE AllowAmbiguousTypes       #-}
-{-# LANGUAGE ConstraintKinds           #-}
-{-# LANGUAGE DeriveFoldable            #-}
-{-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE DeriveGeneric             #-}
-{-# LANGUAGE DeriveTraversable         #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE FunctionalDependencies    #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE PatternSynonyms           #-}
-{-# LANGUAGE Rank2Types                #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeFamilies              #-}
-{-# LANGUAGE TypeSynonymInstances      #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -Wno-unused-matches    #-}
 {-# OPTIONS_GHC -Wno-name-shadowing    #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns  #-}

--- a/src/main/haskell/kore/src/Kore/Proof/Proof.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Proof.hs
@@ -61,7 +61,6 @@ import           Data.Reflection
 import qualified Data.Set as S
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.IndexedModule.MetadataTools
 
 import Data.Text.Prettyprint.Doc as P

--- a/src/main/haskell/kore/src/Kore/Proof/Value.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Value.hs
@@ -1,0 +1,137 @@
+{- |
+Module      : Kore.Proof.Value
+Description : Proof that a pattern is a fully-evaluated term
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : thomas.tuegel@runtimeverification.com
+ -}
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kore.Proof.Value
+    ( ValueF (..)
+    , Value
+    , fromPattern
+    , fromConcretePurePattern
+    , asPattern
+    , asConcretePurePattern
+    ) where
+
+import           Data.Deriving
+                 ( deriveEq1, deriveOrd1, deriveShow1 )
+import           Data.Functor.Foldable
+                 ( Fix (..) )
+import qualified Data.Functor.Foldable as Functor.Foldable
+import           Data.Reflection
+                 ( give )
+
+import           Kore.AST.Common
+                 ( Concrete, ConcretePurePattern, Pattern (..) )
+import qualified Kore.AST.Common as Pattern
+import           Kore.AST.MetaOrObject
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Step.StepperAttributes
+
+{- | Proof (by construction) that a pattern is a normalized value.
+
+    A normal pattern head is either a constructor (or a constructor-like domain
+    value), a sort injection, or a domain value.
+ -}
+data ValueF level child where
+    Constructor :: !(Pattern.Application level child) -> ValueF level child
+    SortInjection :: !(Pattern.Application level child) -> ValueF level child
+    DomainValue
+        :: !(Pattern.DomainValue Object (Pattern.BuiltinDomain child))
+        -> ValueF Object child
+
+deriving instance Eq child => Eq (ValueF level child)
+deriving instance Ord child => Ord (ValueF level child)
+deriving instance Show child => Show (ValueF level child)
+
+deriving instance Functor (ValueF level)
+deriving instance Foldable (ValueF level)
+deriving instance Traversable (ValueF level)
+
+deriveEq1 ''ValueF
+deriveOrd1 ''ValueF
+deriveShow1 ''ValueF
+
+type Value level = Fix (ValueF level)
+
+{- | Project a sort injection head to @Nothing@.
+
+    Used in 'fromPattern' to ensure that the children of a sort injection are
+    not sort injections, i.e. that the triangle axiom for sort injections has
+    been fully applied.
+ -}
+eraseSortInjection :: Value level -> Maybe (Value level)
+eraseSortInjection val =
+    case Functor.Foldable.project val of
+        Constructor _ -> Just val
+        DomainValue _ -> Just val
+        SortInjection _ -> Nothing
+
+{- | Embed the normalized pattern head if its children are normal values.
+
+    See also: 'fromConcretePurePattern'.
+
+ -}
+fromPattern
+    :: MetadataTools level StepperAttributes
+    -> Pattern level Concrete (Maybe (Value level))
+    -> Maybe (Value level)
+fromPattern tools =
+    \case
+        ApplicationPattern
+            appP@Pattern.Application
+                { applicationSymbolOrAlias = symbolOrAlias }
+          | isConstructor symbolOrAlias ->
+            -- The constructor application is normal if all its children are
+            -- normal.
+            Fix . Constructor <$> sequence appP
+          | isSortInjection symbolOrAlias ->
+            -- The sort injection application is normal if all its children are
+            -- normal and none are sort injections.
+            Fix . SortInjection <$> traverse (>>= eraseSortInjection) appP
+        DomainValuePattern dvP ->
+            -- A domain value is not technically a constructor, but it is
+            -- constructor-like for builtin domains, at least from the
+            -- perspective of normalization.
+            -- TODO (thomas.tuegel): Builtin domain parsers may violate the
+            -- assumption that domain values are concrete. We should remove
+            -- BuiltinDomainPattern and always run the stepper with internal
+            -- representations only.
+            Fix . DomainValue <$> traverse sequence dvP
+        _ -> Nothing
+  where
+    isConstructor = give tools isConstructor_
+    isSortInjection = give tools isSortInjection_
+
+{- | View a 'ConcretePurePattern' as a normalized value.
+
+    The pattern is considered normalized if it is a domain value, a constructor,
+    or a sort injection applied only to normalized value.
+
+    See also: 'fromPattern'
+
+ -}
+fromConcretePurePattern
+    :: MetadataTools level StepperAttributes
+    -> ConcretePurePattern level
+    -> Maybe (Value level)
+fromConcretePurePattern tools =
+    Functor.Foldable.fold (fromPattern tools)
+
+{- | Project a 'Value' to a concrete 'Pattern' head.
+ -}
+asPattern :: Value level -> Pattern level Concrete (Value level)
+asPattern val =
+    case Functor.Foldable.project val of
+        Constructor appP -> ApplicationPattern appP
+        SortInjection appP -> ApplicationPattern appP
+        DomainValue dvP -> DomainValuePattern dvP
+
+{- | View a normalized value as a 'ConcretePurePattern'.
+ -}
+asConcretePurePattern :: Value level -> ConcretePurePattern level
+asConcretePurePattern = Functor.Foldable.unfold asPattern

--- a/src/main/haskell/kore/src/Kore/SMT/SMT.hs
+++ b/src/main/haskell/kore/src/Kore/SMT/SMT.hs
@@ -33,7 +33,6 @@ import           Text.Read
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.Attribute.Parser

--- a/src/main/haskell/kore/src/Kore/SMT/SMT.hs
+++ b/src/main/haskell/kore/src/Kore/SMT/SMT.hs
@@ -41,10 +41,10 @@ import           Kore.Builtin.Hook
 import           Kore.IndexedModule.MetadataTools
 import qualified Kore.Predicate.Predicate as KorePredicate
 
-import           Data.Reflection
-import           Data.SBV
+import Data.Reflection
+import Data.SBV
 
-import           GHC.IO.Unsafe
+import GHC.IO.Unsafe
 
 
 data TranslatePredicateError

--- a/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
@@ -21,7 +21,6 @@ import Data.Functor
 import           Kore.AST.Common
 import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.AST.PureToKore
                  ( patternKoreToPure )
 import           Kore.AST.Sentence

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -38,7 +38,7 @@ import qualified Data.Set as Set
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( CommonPurePattern, PureMLPattern, mapPatternVariables )
+                 ( mapPatternVariables )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkBottom )
 import           Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -46,13 +46,13 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( Predicate, makeMultipleAndPredicate )
 import qualified Kore.Predicate.Predicate as Predicate
+import           Kore.Proof.Functional
+                 ( FunctionalProof (..) )
 import           Kore.Step.AxiomPatterns
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern
                  ( PredicateSubstitution (..), Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-import           Kore.Step.PatternAttributes
-                 ( FunctionalProof (..) )
 import           Kore.Step.Simplification.Data
                  ( SimplificationProof (..) )
 import           Kore.Step.StepperAttributes

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -15,7 +15,6 @@ import Data.Reflection
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..), SymbolOrAliasSorts )

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -35,10 +35,10 @@ import           Data.Reflection
 import qualified Data.Set as Set
 
 import           Kore.AST.Common
-                 ( SortedVariable, Variable )
+                 ( PureMLPattern, SortedVariable, Variable )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( PureMLPattern, mapPatternVariables )
+                 ( mapPatternVariables )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkBottom, mkTop, mkVar )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -17,11 +17,9 @@ module Kore.Step.Function.Data
     ) where
 
 import Kore.AST.Common
-       ( Application, Variable )
+       ( Application, PureMLPattern, Variable )
 import Kore.AST.MetaOrObject
        ( MetaOrObject )
-import Kore.AST.PureML
-       ( PureMLPattern )
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools )
 import Kore.Step.OrOfExpandedPattern
@@ -97,4 +95,3 @@ purePatternFunctionEvaluator p =
         (Applied (makeFromSinglePurePattern p)
         , SimplificationProof
         )
-

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -18,11 +18,11 @@ import           Data.List
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
-                 ( Application (..), Id (..), Pattern (..), Sort,
-                 SortedVariable, SymbolOrAlias (..) )
+                 ( Application (..), Id (..), Pattern (..), PureMLPattern,
+                 Sort, SortedVariable, SymbolOrAlias (..) )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( PureMLPattern, asPurePattern )
+                 ( asPurePattern )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern App_ )
 import           Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
@@ -25,10 +25,8 @@ import           Data.Reflection
 import           Control.Monad.Counter
                  ( Counter )
 import           Kore.AST.Common
-                 ( SortedVariable )
+                 ( PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern And_, pattern App_, pattern Bottom_, pattern Ceil_,
                  pattern CharLiteral_, pattern DV_, pattern Equals_,

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -17,11 +17,12 @@ import Control.Monad.Except
 import Data.Reflection
 
 import           Kore.AST.Common
-                 ( Application (..), Pattern (..), SortedVariable )
+                 ( Application (..), CommonPurePattern, Pattern (..),
+                 PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
                  ( Meta, MetaOrObject, Object )
 import           Kore.AST.PureML
-                 ( CommonPurePattern, PureMLPattern, asPurePattern )
+                 ( asPurePattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Predicate.Predicate

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -57,7 +57,7 @@ import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 TODO(virgil): Make this a list-like monad, many things would be nicer.
 -}
 newtype MultiOr child = MultiOr [child]
-    deriving (Eq, Foldable, Functor, Show, Traversable)
+    deriving (Applicative, Eq, Foldable, Functor, Monad, Show, Traversable)
 
 
 {-| 'OrOfExpandedPattern' is a 'MultiOr' of 'ExpandedPatterns', which is the

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -38,10 +38,8 @@ import Data.Reflection
        ( Given )
 
 import           Kore.AST.Common
-                 ( SortedVariable, Variable )
+                 ( PureMLPattern, SortedVariable, Variable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkOr )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
@@ -25,8 +25,8 @@ import           Data.Functor.Foldable
                  ( cata )
 
 import           Kore.AST.Common
-                 ( Application (..), BuiltinDomain (..), DomainValue (..),
-                 Pattern (..), PureMLPattern )
+                 ( Application (..), DomainValue (..), Pattern (..),
+                 PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -108,22 +108,13 @@ isPreconstructedPattern
     -> Pattern level variable pat
     -> Either err (PartialPatternProof (FunctionalProof level variable))
 isPreconstructedPattern
-    err
+    _
     (DomainValuePattern dv@DomainValue { domainValueChild })
   =
-    case domainValueChild of
-        BuiltinDomainPattern pat ->
-            (Right . DoNotDescend)
-                (FunctionalDomainValue dv
-                    { domainValueChild = BuiltinDomainPattern pat }
-                )
-        BuiltinDomainSet set ->
-            (Right . DoNotDescend)
-                (FunctionalDomainValue dv
-                    { domainValueChild = BuiltinDomainSet set }
-                )
-        _ ->
-            Left err
+    (Right . Descend)
+        (FunctionalDomainValue dv
+            { domainValueChild = () <$ domainValueChild }
+        )
 isPreconstructedPattern _ (StringLiteralPattern str) =
     Right (DoNotDescend (FunctionalStringLiteral str))
 isPreconstructedPattern _ (CharLiteralPattern str) =

--- a/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
@@ -9,85 +9,33 @@ Portability : portable
 -}
 
 module Kore.Step.PatternAttributes
-    ( FunctionProof(..)
-    , FunctionalProof(..)
-    , isConstructorLikeTop
+    ( isConstructorLikeTop
     , isFunctionPattern
     , isFunctionalPattern
     , isTotalPattern
     , mapFunctionalProofVariables
     ) where
 
-import Control.Lens
-import Data.Either
-       ( isRight )
-import Data.Functor.Foldable
-       ( cata )
+import           Control.Lens
+                 ( Prism )
+import qualified Control.Lens as Lens
+import           Data.Either
+                 ( isRight )
+import           Data.Functor.Foldable
+                 ( cata )
 
 import           Kore.AST.Common
-                 ( Application (..), BuiltinDomain, CharLiteral,
-                 CommonPurePattern, DomainValue, Pattern (..), PureMLPattern,
-                 StringLiteral, SymbolOrAlias )
-import           Kore.AST.MetaOrObject
-                 ( Meta )
+                 ( Application (..), BuiltinDomain (..), DomainValue (..),
+                 Pattern (..), PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
                  ( MetadataTools (..) )
+import           Kore.Proof.Functional
 import           Kore.Step.PatternAttributesError
                  ( FunctionError (..), FunctionalError (..), TotalError (..) )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..), isTotal )
-
--- |'FunctionalProof' is used for providing arguments that a pattern is
--- functional.  Currently we only support arguments stating that a
--- pattern consists of domain values, functional symbols and variables.
--- Hence, a proof that a pattern is functional is a list of 'FunctionalProof'.
--- TODO: replace this datastructures with proper ones representing
--- both hypotheses and conclusions in the proof object.
-data FunctionalProof level variable
-    = FunctionalVariable (variable level)
-    -- ^Variables are functional as per Corollary 5.19
-    -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
-    -- |= ∃y . x = y
-    | FunctionalDomainValue
-        (DomainValue level (BuiltinDomain (CommonPurePattern Meta)))
-    -- ^Domain values are functional as ther represent one value in the model.
-    | FunctionalHead (SymbolOrAlias level)
-    -- ^Head of a total function, conforming to Definition 5.21
-    -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
-    | FunctionalStringLiteral StringLiteral
-    -- ^A string literal is the repeated application of functional constructors.
-    | FunctionalCharLiteral CharLiteral
-    -- ^A char literal is a functional constructor without arguments.
-  deriving (Eq, Show)
-
--- |'FunctionProof' is used for providing arguments that a pattern is
--- function-like.  Currently we only support arguments stating that a
--- pattern consists of domain values, functional and function symbols and
--- variables.
--- Hence, a proof that a pattern is function-like is a list of 'FunctionProof'.
--- TODO: replace this datastructures with proper ones representing
--- both hypotheses and conclusions in the proof object.
-data FunctionProof level variable
-    = FunctionProofFunctional (FunctionalProof level variable)
-    -- ^ A functional component is also function-like.
-    | FunctionHead (SymbolOrAlias level)
-    -- ^Head of a partial function.
-  deriving (Eq, Show)
-
--- |'TotalProof' is used for providing arguments that a pattern is
--- total/not bottom.  Currently we only support arguments stating that a
--- pattern is functional or a constructor.
--- Hence, a proof that a pattern is total is a list of 'TotalProof'.
--- TODO: replace this datastructures with proper ones representing
--- both hypotheses and conclusions in the proof object.
-data TotalProof level variable
-    = TotalProofFunctional (FunctionalProof level variable)
-    -- ^A functional component is also total.
-    | TotalHead (SymbolOrAlias level)
-    -- ^Head of a total symbol.
-  deriving (Eq, Show)
 
 functionalProofVars
     :: Prism
@@ -95,7 +43,7 @@ functionalProofVars
          (FunctionalProof level variableTo)
          (variableFrom level)
          (variableTo level)
-functionalProofVars = prism FunctionalVariable isVar
+functionalProofVars = Lens.prism FunctionalVariable isVar
   where
     isVar (FunctionalVariable v) = Right v
     isVar (FunctionalDomainValue dv) = Left (FunctionalDomainValue dv)
@@ -110,7 +58,7 @@ mapFunctionalProofVariables
     :: (variableFrom level -> variableTo level)
     -> FunctionalProof level variableFrom
     -> FunctionalProof level variableTo
-mapFunctionalProofVariables mapper = functionalProofVars %~ mapper
+mapFunctionalProofVariables mapper = Lens.over functionalProofVars mapper
 
 {-| checks whether a pattern is functional or not and, if it is, returns a proof
     certifying that.
@@ -159,8 +107,23 @@ isPreconstructedPattern
     :: err
     -> Pattern level variable pat
     -> Either err (PartialPatternProof (FunctionalProof level variable))
-isPreconstructedPattern _ (DomainValuePattern dv) =
-    Right (DoNotDescend (FunctionalDomainValue dv))
+isPreconstructedPattern
+    err
+    (DomainValuePattern dv@DomainValue { domainValueChild })
+  =
+    case domainValueChild of
+        BuiltinDomainPattern pat ->
+            (Right . DoNotDescend)
+                (FunctionalDomainValue dv
+                    { domainValueChild = BuiltinDomainPattern pat }
+                )
+        BuiltinDomainSet set ->
+            (Right . DoNotDescend)
+                (FunctionalDomainValue dv
+                    { domainValueChild = BuiltinDomainSet set }
+                )
+        _ ->
+            Left err
 isPreconstructedPattern _ (StringLiteralPattern str) =
     Right (DoNotDescend (FunctionalStringLiteral str))
 isPreconstructedPattern _ (CharLiteralPattern str) =

--- a/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/PatternAttributes.hs
@@ -25,12 +25,11 @@ import Data.Functor.Foldable
        ( cata )
 
 import           Kore.AST.Common
-                 ( Application (..), BuiltinDomain, CharLiteral, DomainValue,
-                 Pattern (..), StringLiteral, SymbolOrAlias )
+                 ( Application (..), BuiltinDomain, CharLiteral,
+                 CommonPurePattern, DomainValue, Pattern (..), PureMLPattern,
+                 StringLiteral, SymbolOrAlias )
 import           Kore.AST.MetaOrObject
                  ( Meta )
-import           Kore.AST.PureML
-                 ( CommonPurePattern, PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
@@ -14,10 +14,8 @@ module Kore.Step.Simplification.And
     ) where
 
 import           Kore.AST.Common
-                 ( And (..), SortedVariable )
+                 ( And (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Step.ExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -24,11 +24,9 @@ import Data.Reflection
 
 import           Data.Result
 import           Kore.AST.Common
-                 ( BuiltinDomain (..), Sort, SortedVariable,
+                 ( BuiltinDomain (..), PureMLPattern, Sort, SortedVariable,
                  SymbolOrAlias (..) )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkApp, mkBottom, mkTop )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
@@ -3,11 +3,9 @@ module Kore.Step.Simplification.AndTerms where
 import Control.Monad.Counter
        ( MonadCounter )
 import Kore.AST.Common
-       ( SortedVariable )
+       ( PureMLPattern, SortedVariable )
 import Kore.AST.MetaOrObject
        ( Meta, MetaOrObject, Object )
-import Kore.AST.PureML
-       ( PureMLPattern )
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools )
 import Kore.Step.ExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -14,10 +14,9 @@ module Kore.Step.Simplification.Application
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
-                 ( Application (..), Id, SortedVariable, SymbolOrAlias )
+                 ( Application (..), Id, PureMLPattern, SortedVariable,
+                 SymbolOrAlias )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Step.ExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -20,10 +20,8 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( Ceil (..), SortedVariable )
+                 ( Ceil (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkTop )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Data.hs
@@ -17,9 +17,7 @@ module Kore.Step.Simplification.Data
     ) where
 
 import Kore.AST.Common
-       ( Variable )
-import Kore.AST.PureML
-       ( PureMLPattern )
+       ( PureMLPattern, Variable )
 import Kore.Step.OrOfExpandedPattern
        ( OrOfExpandedPattern )
 import Kore.Variables.Fresh

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
@@ -11,20 +11,21 @@ module Kore.Step.Simplification.DomainValue
     ( simplify
     ) where
 
+import Data.Reflection
+       ( Given, give )
+
 import           Kore.AST.Common
-                 ( BuiltinDomain, CommonPurePattern, DomainValue (..),
-                 Pattern (DomainValuePattern) )
+                 ( BuiltinDomain (..), DomainValue (..), PureMLPattern,
+                 SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( asPurePattern )
-import           Kore.Predicate.Predicate
-                 ( makeTruePredicate )
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools (..), SymbolOrAliasSorts )
 import           Kore.Step.ExpandedPattern
                  ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
-                 ( OrOfExpandedPattern )
+                 ( MultiOr, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
-                 ( make )
 import           Kore.Step.Simplification.Data
                  ( SimplificationProof (..) )
 
@@ -32,17 +33,41 @@ import           Kore.Step.Simplification.Data
 an or containing a term made of that value.
 -}
 simplify
-    :: DomainValue Object (BuiltinDomain (CommonPurePattern Meta))
+    :: ( Eq (variable Object), Show (variable Object)
+       , SortedVariable variable
+       )
+    => MetadataTools Object attrs
+    -> DomainValue Object (BuiltinDomain (OrOfExpandedPattern Object variable))
     -> ( OrOfExpandedPattern Object variable
        , SimplificationProof Object
        )
-simplify dv =
-    ( OrOfExpandedPattern.make
-        [Predicated
-            { term = asPurePattern (DomainValuePattern dv)
-            , predicate = makeTruePredicate
-            , substitution = []
-            }
-        ]
+simplify
+    MetadataTools { symbolOrAliasSorts }
+    DomainValue { domainValueSort, domainValueChild }
+  =
+    ( OrOfExpandedPattern.filterOr
+        (do
+            child <-
+                give symbolOrAliasSorts simplifyBuiltinDomain domainValueChild
+            return (DV_ domainValueSort <$> child)
+        )
     , SimplificationProof
     )
+
+simplifyBuiltinDomain
+    :: ( Eq (variable Object), Show (variable Object)
+       , Given (SymbolOrAliasSorts Object)
+       , SortedVariable variable
+       )
+    => BuiltinDomain (OrOfExpandedPattern Object variable)
+    -> MultiOr (Predicated Object variable (BuiltinDomain (PureMLPattern Object variable)))
+simplifyBuiltinDomain =
+    \case
+        BuiltinDomainPattern pat -> (return . pure) (BuiltinDomainPattern pat)
+        BuiltinDomainMap _map -> do
+            _map <- sequence _map
+            return (BuiltinDomainMap <$> sequenceA _map)
+        BuiltinDomainList _list -> do
+            _list <- sequence _list
+            return (BuiltinDomainList <$> sequenceA _list)
+        BuiltinDomainSet set -> (return . pure) (BuiltinDomainSet set)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
@@ -12,11 +12,11 @@ module Kore.Step.Simplification.DomainValue
     ) where
 
 import           Kore.AST.Common
-                 ( BuiltinDomain, DomainValue (..),
+                 ( BuiltinDomain, CommonPurePattern, DomainValue (..),
                  Pattern (DomainValuePattern) )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( CommonPurePattern, asPurePattern )
+                 ( asPurePattern )
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
@@ -19,10 +19,8 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( Equals (..), SortedVariable )
+                 ( Equals (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkTop )
 import           Kore.ASTUtils.SmartPatterns
@@ -419,4 +417,3 @@ makeEvaluateTermsToPredicateSubstitution tools first second
                 )
   where
     symbolOrAliasSorts = MetadataTools.symbolOrAliasSorts tools
-

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
@@ -20,10 +20,8 @@ import           Data.Reflection
 import qualified Data.Set as Set
 
 import           Kore.AST.Common
-                 ( Exists (..), SortedVariable )
+                 ( Exists (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkExists )
 import           Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
@@ -17,7 +17,7 @@ import Data.Reflection
        ( Given )
 
 import           Kore.AST.Common
-                 ( PureMLPattern, Not (..), SortedVariable )
+                 ( Not (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartConstructors
                  ( mkBottom, mkNot, mkTop )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
@@ -17,10 +17,8 @@ import Data.Reflection
        ( Given )
 
 import           Kore.AST.Common
-                 ( Not (..), SortedVariable )
+                 ( PureMLPattern, Not (..), SortedVariable )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkBottom, mkNot, mkTop )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -17,10 +17,10 @@ import           Data.Reflection
                  ( Given, give )
 
 import           Kore.AST.Common
-                 ( Id, Pattern (..), SortedVariable )
+                 ( Id, Pattern (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( PureMLPattern, fromPurePattern )
+                 ( fromPurePattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools, SymbolOrAliasSorts )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -194,7 +194,7 @@ simplifyInternal
                 p
         BottomPattern p -> return $ Bottom.simplify p
         CeilPattern p -> return $ Ceil.simplify tools p
-        DomainValuePattern p -> return $ DomainValue.simplify p
+        DomainValuePattern p -> return $ DomainValue.simplify tools p
         EqualsPattern p -> Equals.simplify tools p
         ExistsPattern p -> Exists.simplify tools simplifier p
         FloorPattern p -> return $ Floor.simplify p

--- a/src/main/haskell/kore/src/Kore/Unification/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Data.hs
@@ -12,7 +12,7 @@ module Kore.Unification.Data where
 
 import Kore.AST.Common
 import Kore.AST.PureML
-import Kore.Step.PatternAttributes
+import Kore.Proof.Functional
        ( FunctionalProof (..) )
 
 type UnificationSubstitution level variable

--- a/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
@@ -22,13 +22,11 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( SortedVariable )
+                 ( PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
                  ( Meta, MetaOrObject, Object )
 import           Kore.AST.MLPatterns
                  ( getPatternResultSort )
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools

--- a/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -30,7 +30,6 @@ import qualified Data.Set as Set
 import           Data.Graph.TopologicalSort
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Bottom_, pattern Var_ )
 import           Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -20,8 +20,8 @@ import Control.Monad.Counter
        ( MonadCounter )
 import Control.Monad.Except
        ( ExceptT (..) )
-import Control.Monad.Trans.Except
-       ( throwE )
+import Control.Monad.Except
+       ( throwError )
 import Data.Function
        ( on )
 import Data.Functor.Foldable
@@ -116,7 +116,7 @@ simplifyAnds
         ( ExpandedPattern level variable
         , UnificationProof level variable
         )
-simplifyAnds _ [] = throwE UnsupportedPatterns
+simplifyAnds _ [] = throwError UnsupportedPatterns
 simplifyAnds tools patterns = do
      result <- foldM
         simplifyAnds'
@@ -188,7 +188,7 @@ solveGroupedSubstitution
         ( PredicateSubstitution level variable
         , UnificationProof level variable
         )
-solveGroupedSubstitution _ _ [] = throwE UnsupportedPatterns
+solveGroupedSubstitution _ _ [] = throwError UnsupportedPatterns
 solveGroupedSubstitution tools var patterns = do
     (predSubst, proof) <- simplifyAnds tools patterns
     return

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -32,7 +32,6 @@ import Data.Reflection
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.IndexedModule.MetadataTools
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools

--- a/src/main/haskell/kore/src/Kore/Variables/Free.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Free.hs
@@ -24,8 +24,6 @@ import qualified Data.Set as Set
 
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-       ( PureMLPattern )
 
 {-| 'freeVariables' extracts the set of free variables of a pattern. -}
 freeVariables

--- a/src/main/haskell/kore/test/Test/Kore.hs
+++ b/src/main/haskell/kore/test/Test/Kore.hs
@@ -213,7 +213,7 @@ equalsGen childGen x = equalsInGen childGen x Equals
 domainValueGen
     :: MetaOrObject level
     => level
-    -> Gen (DomainValue level (BuiltinDomain (CommonPurePattern Meta)))
+    -> Gen (DomainValue level (BuiltinDomain CommonKorePattern))
 domainValueGen x =
     DomainValue
         <$> scale (`div` 2) (sortGen x)

--- a/src/main/haskell/kore/test/Test/Kore.hs
+++ b/src/main/haskell/kore/test/Test/Kore.hs
@@ -9,7 +9,6 @@ import Data.Functor.Foldable
 import Kore.AST.Common
 import Kore.AST.Kore
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
 import Kore.AST.Sentence
 import Kore.ASTUtils.SmartPatterns
 import Kore.MetaML.AST

--- a/src/main/haskell/kore/test/Test/Kore/ASTUtils.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTUtils.hs
@@ -22,7 +22,6 @@ import Data.Reflection
 
 import Kore.AST.Common
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
 import Kore.ASTHelpers
        ( ApplicationSorts (..) )
 import Kore.ASTUtils.SmartConstructors

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -12,8 +12,6 @@ import           Data.Proxy
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.ASTVerifier.DefinitionVerifier

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -11,7 +11,6 @@ import           Data.Proxy
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.ASTVerifier.DefinitionVerifier

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -21,7 +21,6 @@ import           GHC.Integer.Logarithms
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.ASTVerifier.DefinitionVerifier
@@ -298,7 +297,11 @@ intLiteral = asPattern
 asPattern :: Integer -> CommonPurePattern Object
 asPattern = Int.asPattern intSort
 
--- | Specialize 'Int.asPattern' to the builtin sort 'intSort'.
+-- | Specialize 'Int.asConcretePattern' to the builtin sort 'intSort'.
+asConcretePattern :: Integer -> ConcretePurePattern Object
+asConcretePattern = Int.asConcretePattern intSort
+
+-- | Specialize 'Int.asExpandedPattern' to the builtin sort 'intSort'.
 asExpandedPattern :: Integer -> CommonExpandedPattern Object
 asExpandedPattern = Int.asExpandedPattern intSort
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -22,8 +22,6 @@ import           GHC.Integer.Logarithms
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.ASTVerifier.DefinitionVerifier

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -19,7 +19,7 @@ import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
 import           Kore.AST.PureML
-                 ( CommonPurePattern, PureSentenceSymbol, groundHead )
+                 ( PureSentenceSymbol, groundHead )
 import           Kore.AST.PureToKore
                  ( sentencePureToKore )
 import           Kore.AST.Sentence

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -17,7 +17,6 @@ import           Kore.AST.Builders
                  ( parameterizedSymbol_, sortParameter, symbol_ )
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.PureML
                  ( PureSentenceSymbol, groundHead )
 import           Kore.AST.PureToKore

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
@@ -143,11 +143,11 @@ prop_concatAssociates values1 values2 values3 =
             , ExpandedPattern.top === evaluate predicate
             ]
 
--- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
+-- | Specialize 'List.asPattern' to the builtin sort 'listSort'.
 asPattern :: List.Builtin -> CommonPurePattern Object
 Right asPattern = List.asPattern indexedModule listSort
 
--- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
+-- | Specialize 'List.asPattern' to the builtin sort 'listSort'.
 asExpandedPattern :: List.Builtin -> CommonExpandedPattern Object
 Right asExpandedPattern = List.asExpandedPattern indexedModule listSort
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
@@ -16,7 +16,6 @@ import qualified Data.Sequence as Seq
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
@@ -17,8 +17,6 @@ import qualified Data.Sequence as Seq
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
@@ -13,7 +13,6 @@ import           Data.Reflection
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns
@@ -69,7 +68,7 @@ prop_lookupUpdate (key, value) map' =
                 ]
         patMap =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map'
         patKey = Test.Int.asPattern key
         patValue = Test.Int.asPattern value
@@ -92,7 +91,7 @@ prop_concatUnit map' =
         patUnit = App_ symbolUnit []
         patMap =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map'
         predicate1 = give testSymbolOrAliasSorts $ mkEquals patMap patConcat1
         predicate2 = give testSymbolOrAliasSorts $ mkEquals patMap patConcat2
@@ -190,11 +189,11 @@ prop_concatCommutes map1 map2 =
         patConcat2 = App_ symbolConcat [ patMap2, patMap1 ]
         patMap1 =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map1
         patMap2 =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map2
         predicate = give testSymbolOrAliasSorts (mkEquals patConcat1 patConcat2)
     in
@@ -218,15 +217,15 @@ prop_concatAssociates
 prop_concatAssociates map1 map2 map3 =
     let patMap1 =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map1
         patMap2 =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map2
         patMap3 =
             asPattern
-            $ Map.mapKeys Test.Int.asPattern
+            $ Map.mapKeys Test.Int.asConcretePattern
             $ Map.map Test.Int.asPattern map3
         patConcat12 = App_ symbolConcat [ patMap1, patMap2 ]
         patConcat23 = App_ symbolConcat [ patMap2, patMap3 ]

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
@@ -14,8 +14,6 @@ import           Data.Reflection
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
@@ -1,7 +1,7 @@
 module Test.Kore.Builtin.Set where
 
 import Test.QuickCheck
-       ( Property, property, (.&&.), (===) )
+       ( Property, property, (.&&.), (===), (==>) )
 
 import           Data.Map
                  ( Map )
@@ -17,7 +17,7 @@ import qualified Data.Set as Set
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
 import           Kore.AST.Sentence
-import           Kore.ASTUtils.SmartConstructors
+import qualified Kore.ASTUtils.SmartConstructors as Kore
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.ASTVerifier.DefinitionVerifier
 import           Kore.Attribute.Parser
@@ -51,7 +51,7 @@ prop_getUnit :: Integer -> Property
 prop_getUnit k =
     let patIn = App_ symbolIn [ Test.Int.asPattern k, App_ symbolUnit [] ]
         patFalse = Test.Bool.asPattern False
-        predicate = give testSymbolOrAliasSorts $ mkEquals patFalse patIn
+        predicate = mkEquals patFalse patIn
     in
         allProperties
             [ Test.Bool.asExpandedPattern False === evaluate patIn
@@ -69,7 +69,7 @@ prop_inElement value =
         patElement = App_ symbolElement [ patValue ]
         patValue = Test.Int.asPattern value
         patTrue = Test.Bool.asPattern True
-        predicate = give testSymbolOrAliasSorts $ mkEquals patIn patTrue
+        predicate = mkEquals patIn patTrue
     in
         allProperties
             [ Test.Bool.asExpandedPattern True === evaluate patIn
@@ -87,7 +87,7 @@ prop_inConcat elem' values =
         patSet = asPattern (Set.insert elem' values)
         patElem = Test.Int.asPattern elem'
         patTrue = Test.Bool.asPattern True
-        predicate = give testSymbolOrAliasSorts $ mkEquals patTrue patIn
+        predicate = mkEquals patTrue patIn
     in
         allProperties
             [ Test.Bool.asExpandedPattern True === evaluate patIn
@@ -105,8 +105,8 @@ prop_concatUnit values =
         patValues = asPattern values
         patConcat1 = App_ symbolConcat [ patUnit, patValues ]
         patConcat2 = App_ symbolConcat [ patValues, patUnit ]
-        predicate1 = give testSymbolOrAliasSorts $ mkEquals patValues patConcat1
-        predicate2 = give testSymbolOrAliasSorts $ mkEquals patValues patConcat2
+        predicate1 = mkEquals patValues patConcat1
+        predicate2 = mkEquals patValues patConcat2
     in
         allProperties
             [ evaluate patValues === evaluate patConcat1
@@ -131,7 +131,7 @@ prop_concatAssociates values1 values2 values3 =
         patConcat23 = App_ symbolConcat [ patSet2, patSet3 ]
         patConcat12_3 = App_ symbolConcat [ patConcat12, patSet3 ]
         patConcat1_23 = App_ symbolConcat [ patSet1, patConcat23 ]
-        predicate = give testSymbolOrAliasSorts (mkEquals patConcat12_3 patConcat1_23)
+        predicate = mkEquals patConcat12_3 patConcat1_23
     in
         allProperties
             [ evaluate patConcat12_3 === evaluate patConcat1_23
@@ -145,12 +145,33 @@ prop_difference set1 set2 =
         set3 = Set.difference set1 set2
         patSet3 = asPattern set3
         patDifference = App_ symbolDifference [ patSet1, patSet2 ]
-        predicate = give testSymbolOrAliasSorts (mkEquals patSet3 patDifference)
+        predicate = mkEquals patSet3 patDifference
     in
         allProperties
             [ evaluate patSet3 === evaluate patDifference
             , ExpandedPattern.top === evaluate predicate
             ]
+
+-- | Sets with symbolic keys are not simplified.
+prop_symbolic :: Set String -> Property
+prop_symbolic values =
+    let patMap =
+            asSymbolicPattern
+            $ Set.map (mkIntVar . testId) values
+    in
+        not (Set.null values) ==>
+        (ExpandedPattern.fromPurePattern patMap === evaluate patMap)
+
+-- | Construct a pattern for a map which may have symbolic keys.
+asSymbolicPattern
+    :: Set (CommonPurePattern Object)
+    -> CommonPurePattern Object
+asSymbolicPattern result =
+    foldr applyConcat applyUnit (applyElement <$> Set.toAscList result)
+  where
+    applyUnit = mkDomainValue setSort $ BuiltinDomainSet Set.empty
+    applyElement key = App_ symbolElement [key]
+    applyConcat set1 set2 = App_ symbolConcat [set1, set2]
 
 -- | Specialize 'Set.asPattern' to the builtin sort 'setSort'.
 asPattern :: Set Integer -> CommonPurePattern Object
@@ -291,3 +312,45 @@ MetadataTools { symbolOrAliasSorts = testSymbolOrAliasSorts } = extractMetadataT
 
 allProperties :: [Property] -> Property
 allProperties = foldr (.&&.) (property True)
+
+-- * Constructors
+
+mkBottom :: CommonPurePattern Object
+mkBottom = Kore.mkBottom
+
+mkEquals
+    :: CommonPurePattern Object
+    -> CommonPurePattern Object
+    -> CommonPurePattern Object
+mkEquals = give testSymbolOrAliasSorts Kore.mkEquals
+
+mkAnd
+    :: CommonPurePattern Object
+    -> CommonPurePattern Object
+    -> CommonPurePattern Object
+mkAnd = give testSymbolOrAliasSorts Kore.mkAnd
+
+mkTop :: CommonPurePattern Object
+mkTop = Kore.mkTop
+
+mkVar :: Variable Object -> CommonPurePattern Object
+mkVar = give testSymbolOrAliasSorts Kore.mkVar
+
+mkDomainValue
+    :: Sort Object
+    -> BuiltinDomain (CommonPurePattern Object)
+    -> CommonPurePattern Object
+mkDomainValue = give testSymbolOrAliasSorts Kore.mkDomainValue
+
+mkImplies
+    :: CommonPurePattern Object
+    -> CommonPurePattern Object
+    -> CommonPurePattern Object
+mkImplies = give testSymbolOrAliasSorts Kore.mkImplies
+
+mkNot :: CommonPurePattern Object -> CommonPurePattern Object
+mkNot = give testSymbolOrAliasSorts Kore.mkNot
+
+mkIntVar :: Id Object -> CommonPurePattern Object
+mkIntVar variableName =
+    mkVar Variable { variableName, variableSort = Test.Int.intSort }

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
@@ -156,7 +156,7 @@ prop_difference set1 set2 =
 asPattern :: Set Integer -> CommonPurePattern Object
 Right asPattern = (. Set.map Test.Int.asConcretePattern) <$> Set.asPattern indexedModule setSort
 
--- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
+-- | Specialize 'Set.asPattern' to the builtin sort 'setSort'.
 asExpandedPattern :: Set.Builtin -> CommonExpandedPattern Object
 Right asExpandedPattern = Set.asExpandedPattern indexedModule setSort
 

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
@@ -16,7 +16,6 @@ import qualified Data.Set as Set
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-                 ( Object )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns
@@ -155,7 +154,7 @@ prop_difference set1 set2 =
 
 -- | Specialize 'Set.asPattern' to the builtin sort 'setSort'.
 asPattern :: Set Integer -> CommonPurePattern Object
-Right asPattern = (. Set.map Test.Int.asPattern) <$> Set.asPattern indexedModule setSort
+Right asPattern = (. Set.map Test.Int.asConcretePattern) <$> Set.asPattern indexedModule setSort
 
 -- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
 asExpandedPattern :: Set.Builtin -> CommonExpandedPattern Object

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
@@ -17,8 +17,6 @@ import qualified Data.Set as Set
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
                  ( Object )
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.Sentence
 import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -11,10 +11,8 @@ Portability : portable
 -}
 module Test.Kore.Comparators where
 
-
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
 import           Kore.Predicate.Predicate
 import           Kore.Step.BaseStep
 import           Kore.Step.Error

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -12,8 +12,8 @@ Portability : portable
 module Test.Kore.Comparators where
 
 import           Kore.AST.Common
-import           Kore.AST.MetaOrObject
 import           Kore.Predicate.Predicate
+import           Kore.Proof.Functional
 import           Kore.Step.BaseStep
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern as ExpandedPattern
@@ -23,7 +23,6 @@ import           Kore.Step.ExpandedPattern as PredicateSubstitution
 import           Kore.Step.Function.Data as AttemptedFunction
                  ( AttemptedFunction (..) )
 import           Kore.Step.OrOfExpandedPattern
-import           Kore.Step.PatternAttributes
 import qualified Kore.Step.PatternAttributesError as PatternAttributesError
 import           Kore.Step.Simplification.Data
                  ( SimplificationProof )
@@ -298,7 +297,9 @@ instance (EqualWithExplanation child, Show child)
     compareWithExplanation = structCompareWithExplanation
     printWithExplanation = show
 
-instance EqualWithExplanation (DomainValue level (BuiltinDomain (CommonPurePattern Meta)))
+instance
+    (Eq child, Show child) =>
+    EqualWithExplanation (DomainValue level (BuiltinDomain child))
   where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show

--- a/src/main/haskell/kore/test/Test/Kore/Predicate/Predicate.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Predicate/Predicate.hs
@@ -9,10 +9,8 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( AstLocation (..) )
+                 ( AstLocation (..), CommonPurePattern )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.AST.PureToKore
                  ( patternKoreToPure )
 import           Kore.ASTHelpers

--- a/src/main/haskell/kore/test/Test/Kore/Proof/Value.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Proof/Value.hs
@@ -1,0 +1,199 @@
+module Test.Kore.Proof.Value where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.Functor.Foldable as Functor.Foldable
+import           Data.Reflection
+                 ( give )
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+import           Kore.AST.MLPatterns
+import           Kore.AST.PureML
+import           Kore.ASTHelpers
+                 ( ApplicationSorts (..) )
+import qualified Kore.ASTUtils.SmartConstructors as Kore
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import qualified Kore.Proof.Value as Value
+import           Kore.Step.StepperAttributes
+
+import           Test.Kore
+import           Test.Kore.Builtin.Int
+                 ( intSort )
+import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
+
+unit_constructorUnit :: Assertion
+unit_constructorUnit = assertValue unitPattern
+
+unit_domainValue :: Assertion
+unit_domainValue = assertValue onePattern
+
+unit_injConstructor :: Assertion
+unit_injConstructor = assertValue (mkInj unitPattern)
+
+unit_injInj :: Assertion
+unit_injInj = assertNotValue (mkInj (mkInj unitPattern))
+
+unit_pairConstructor :: Assertion
+unit_pairConstructor = assertValue (mkPair unitPattern unitPattern)
+
+test_pairDomainValue :: [TestTree]
+test_pairDomainValue =
+    [ testValue "(0, 0)" (mkPair zeroPattern zeroPattern)
+    , testValue "(0, 1)" (mkPair zeroPattern onePattern)
+    , testValue "(1, 1)" (mkPair onePattern onePattern)
+    , testValue "(1, 0)" (mkPair onePattern zeroPattern)
+    ]
+
+unit_fun :: Assertion
+unit_fun = assertNotValue (mkApp funSymbol [onePattern])
+
+mkApp
+    :: SymbolOrAlias Object
+    -> [PureMLPattern Object var]
+    -> PureMLPattern Object var
+mkApp = give symbolOrAliasSorts Kore.mkApp
+
+mkInj :: CommonPurePattern Object -> CommonPurePattern Object
+mkInj input = mkApp (injSymbol inputSort supSort) [input]
+  where
+    inputSort =
+        getPatternResultSort
+            symbolOrAliasSorts
+            (Functor.Foldable.project input)
+
+mkPair
+    :: CommonPurePattern Object
+    -> CommonPurePattern Object
+    -> CommonPurePattern Object
+mkPair a b = mkApp (pairSymbol inputSort) [a, b]
+  where
+    inputSort =
+        getPatternResultSort
+            symbolOrAliasSorts
+            (Functor.Foldable.project a)
+
+mkDomainValue
+    :: Sort Object
+    -> BuiltinDomain (PureMLPattern Object var)
+    -> PureMLPattern Object var
+mkDomainValue = give symbolOrAliasSorts Kore.mkDomainValue
+
+unitPattern :: CommonPurePattern Object
+unitPattern = mkApp unitSymbol []
+
+onePattern :: CommonPurePattern Object
+onePattern =
+    (mkDomainValue intSort . BuiltinDomainPattern)
+        (Kore.mkStringLiteral "1")
+
+zeroPattern :: CommonPurePattern Object
+zeroPattern =
+    (mkDomainValue intSort . BuiltinDomainPattern)
+        (Kore.mkStringLiteral "1")
+
+unitSort :: Sort Object
+unitSort =
+    SortActualSort SortActual
+        { sortActualName = testId "Unit"
+        , sortActualSorts = []
+        }
+
+unitSymbol :: SymbolOrAlias Object
+unitSymbol =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId "unit"
+        , symbolOrAliasParams = []
+        }
+
+pairSort :: Sort Object -> Sort Object
+pairSort sort =
+    SortActualSort SortActual
+        { sortActualName = testId "Pair"
+        , sortActualSorts = [sort]
+        }
+
+pairSymbol :: Sort Object -> SymbolOrAlias Object
+pairSymbol sort =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId "pair"
+        , symbolOrAliasParams = [sort]
+        }
+
+injSymbol :: Sort Object -> Sort Object -> SymbolOrAlias Object
+injSymbol sub sup =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId "inj"
+        , symbolOrAliasParams = [sub, sup]
+        }
+
+funSymbol :: SymbolOrAlias Object
+funSymbol =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId "fun"
+        , symbolOrAliasParams = []
+        }
+
+symbolOrAliasSorts :: SymbolOrAlias Object -> ApplicationSorts Object
+symbolOrAliasSorts =
+    Mock.makeSymbolOrAliasSorts
+        [ (unitSymbol, ApplicationSorts [] unitSort)
+        , (injSymbol subSort supSort, ApplicationSorts [subSort] supSort)
+        , (injSymbol unitSort supSort, ApplicationSorts [unitSort] supSort)
+        , (injSymbol supSort supSort, ApplicationSorts [supSort] supSort)
+        , ( pairSymbol unitSort
+          , ApplicationSorts [unitSort, unitSort] (pairSort unitSort)
+          )
+        , ( pairSymbol intSort
+          , ApplicationSorts [intSort, intSort] (pairSort intSort)
+          )
+        , (funSymbol, ApplicationSorts [intSort] intSort)
+        ]
+
+subSort :: Sort level
+subSort = (SortVariableSort . SortVariable) (testId "sub")
+
+supSort :: Sort level
+supSort = (SortVariableSort . SortVariable) (testId "sup")
+
+symbolOrAliasAttrs :: [(SymbolOrAlias Object, StepperAttributes)]
+symbolOrAliasAttrs =
+    [ (unitSymbol, Mock.constructorAttributes)
+    , (injSymbol subSort supSort, Mock.sortInjectionAttributes)
+    , (injSymbol unitSort supSort, Mock.sortInjectionAttributes)
+    , (injSymbol supSort supSort, Mock.sortInjectionAttributes)
+    , (pairSymbol unitSort, Mock.constructorAttributes)
+    , (pairSymbol intSort, Mock.constructorAttributes)
+    , (funSymbol, Mock.functionAttributes)
+    ]
+
+tools :: MetadataTools Object StepperAttributes
+tools =
+    Mock.makeMetadataTools
+        symbolOrAliasSorts
+        symbolOrAliasAttrs
+        []
+
+assertValue :: CommonPurePattern Object -> Assertion
+assertValue purePattern =
+    assertEqual "Expected normalized pattern"
+        concretePattern
+        (concretePattern >>= roundTrip)
+  where
+    concretePattern = asConcretePurePattern purePattern
+    roundTrip patt = do
+        value <- Value.fromConcretePurePattern tools patt
+        return (Value.asConcretePurePattern value)
+
+testValue :: TestName -> CommonPurePattern Object -> TestTree
+testValue name = testCase name . assertValue
+
+assertNotValue :: CommonPurePattern Object -> Assertion
+assertNotValue purePattern =
+    assertEqual "Unexpected normalized pattern"
+        Nothing
+        (concretePattern >>= Value.fromConcretePurePattern tools)
+  where
+    concretePattern = asConcretePurePattern purePattern

--- a/src/main/haskell/kore/test/Test/Kore/SMT/SMT.hs
+++ b/src/main/haskell/kore/test/Test/Kore/SMT/SMT.hs
@@ -7,17 +7,14 @@ import Test.QuickCheck
 import Data.Map
 import Data.Reflection
 
-import           Kore.AST.PureML
-import           Kore.AST.Sentence
-import           Kore.AST.MetaOrObject
-import           Kore.ASTUtils.SmartConstructors
-import           Kore.ASTUtils.SmartPatterns
-import           Kore.Proof.Dummy
-
-
-
+import Kore.AST.Common
+import Kore.AST.MetaOrObject
+import Kore.AST.Sentence
+import Kore.ASTUtils.SmartConstructors
+import Kore.ASTUtils.SmartPatterns
 import Kore.IndexedModule.IndexedModule
 import Kore.IndexedModule.MetadataTools
+import Kore.Proof.Dummy
 import Kore.SMT.SMT
 
 import Test.Kore.Builtin.Bool
@@ -49,9 +46,9 @@ p, q :: CommonPurePattern Object
 p = vBool "p"
 q = vBool "q"
 
-add, sub, mul, div 
-    :: CommonPurePattern Object 
-    -> CommonPurePattern Object 
+add, sub, mul, div
+    :: CommonPurePattern Object
+    -> CommonPurePattern Object
     -> CommonPurePattern Object
 add  a b = App_ addSymbol  [a, b]
 sub a b = App_ subSymbol  [a, b]
@@ -62,20 +59,20 @@ run :: CommonPurePattern Object -> Property
 run prop = (give tools $ unsafeTryRefutePattern prop) === Just False
 
 
-prop_1 :: Property 
-prop_1 = run $ dummyEnvironment $ 
-  App_ ltSymbol [a, intLiteral 0] 
-  `mkAnd` 
+prop_1 :: Property
+prop_1 = run $ dummyEnvironment $
+  App_ ltSymbol [a, intLiteral 0]
+  `mkAnd`
   App_ ltSymbol [intLiteral 0, a]
 
 prop_2 :: Property
-prop_2 = run $ dummyEnvironment $ 
+prop_2 = run $ dummyEnvironment $
   App_ ltSymbol [a `add` a, a `add` b]
-  `mkAnd` 
+  `mkAnd`
   App_ ltSymbol [b `add` b, a `add` b]
 
-prop_3 :: Property 
-prop_3 = run $ dummyEnvironment $ mkNot $ 
+prop_3 :: Property
+prop_3 = run $ dummyEnvironment $ mkNot $
   App_ ltSymbol [a, b]
   `mkImplies`
   (App_ ltSymbol [b, c]
@@ -84,13 +81,13 @@ prop_3 = run $ dummyEnvironment $ mkNot $
 
 prop_4 :: Property
 prop_4 = run $ dummyEnvironment $
-  App_ eqSymbol 
+  App_ eqSymbol
   [ intLiteral 1 `add` (intLiteral 2 `mul` a)
   , intLiteral 2 `mul` b
   ]
- 
-prop_5 :: Property 
-prop_5 = run $ dummyEnvironment $ mkNot $ 
+
+prop_5 :: Property
+prop_5 = run $ dummyEnvironment $ mkNot $
   App_ eqSymbol
   [ intLiteral 0 `sub` (a `mul` a)
   , b `mul` b
@@ -102,24 +99,24 @@ prop_5 = run $ dummyEnvironment $ mkNot $
   ]
 
 
-prop_div :: Property 
-prop_div = run $ dummyEnvironment $ mkNot $ 
+prop_div :: Property
+prop_div = run $ dummyEnvironment $ mkNot $
   App_ ltSymbol [intLiteral 0, a]
   `mkImplies`
   App_ ltSymbol [App_ tdivSymbol [a, intLiteral 2], a]
 
-prop_mod :: Property 
-prop_mod = run $ dummyEnvironment $ mkNot $ 
-  App_ eqSymbol 
+prop_mod :: Property
+prop_mod = run $ dummyEnvironment $ mkNot $
+  App_ eqSymbol
     [ App_ tmodSymbol [a `mul` intLiteral 2, intLiteral 2]
     , intLiteral 0
     ]
 
-prop_pierce :: Property 
-prop_pierce = run $ dummyEnvironment $ mkNot $ 
+prop_pierce :: Property
+prop_pierce = run $ dummyEnvironment $ mkNot $
   ((p `mkImplies` q) `mkImplies` p) `mkImplies` p
 
-prop_demorgan :: Property 
+prop_demorgan :: Property
 prop_demorgan = run $ dummyEnvironment $ mkNot $
   (mkNot $ p `mkOr` q) `mkIff` (mkNot p `mkAnd` mkNot q)
 
@@ -128,5 +125,3 @@ prop_true = run $ dummyEnvironment $ mkNot $ mkTop
 
 prop_false :: Property
 prop_false = run $ dummyEnvironment $ mkNot $ mkIff (mkNot p) (p `mkImplies` mkBottom)
-
-

--- a/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
@@ -8,35 +8,26 @@ import Test.Tasty.HUnit
 import           Data.Map
                  ( Map )
 import qualified Data.Map as Map
+import           Data.Proxy
+import           Data.Reflection
 
-import Data.Proxy
-import Data.Reflection
-
-import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-import Kore.AST.Sentence
-
-import Kore.ASTUtils.SmartConstructors
-import Kore.ASTUtils.SmartPatterns
-
-import Kore.ASTVerifier.DefinitionVerifier
-import Kore.ASTVerifier.Error
-
-import Kore.IndexedModule.IndexedModule
-import Kore.IndexedModule.MetadataTools
-
-import Kore.Step.StepperAttributes
-import Test.Kore.Step.Simplifier
-
-import Kore.Error
-
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+import           Kore.AST.Sentence
+import           Kore.ASTUtils.SmartConstructors
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.ASTVerifier.DefinitionVerifier
+import           Kore.ASTVerifier.Error
+import qualified Kore.Builtin as Builtin
+import           Kore.Error
+import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Predicate.Predicate
 import qualified Kore.Step.Condition.Evaluator as Eval
 import           Kore.Step.ExpandedPattern
 import           Kore.Step.Simplification.Data
-
-import Kore.Predicate.Predicate
-
-import qualified Kore.Builtin as Builtin
+import           Kore.Step.StepperAttributes
+import           Test.Kore.Step.Simplifier
 
 import Test.Kore.Builtin.Bool
        ( boolDefinition, boolModuleName, boolSort )
@@ -83,4 +74,3 @@ test_conditionEvaluator =
         ]
     where a :: Given (SymbolOrAliasSorts Object) => CommonPurePattern Object
           a = V $ "a" `varS` boolSort
-

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -10,11 +10,9 @@ import Test.Tasty.HUnit
        ( assertEqual, testCase )
 
 import Kore.AST.Common
-       ( AstLocation (..), Id (..), Sort (..), SortVariable (..),
+       ( AstLocation (..), Id (..), PureMLPattern, Sort (..), SortVariable (..),
        SortedVariable (..) )
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-       ( PureMLPattern )
 import Kore.ASTHelpers
        ( ApplicationSorts (..) )
 import Kore.ASTUtils.SmartConstructors

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -10,8 +10,8 @@ import Test.Tasty.HUnit
        ( assertEqual, testCase )
 
 import Kore.AST.Common
-       ( AstLocation (..), Id (..), PureMLPattern, Sort (..), SortVariable (..),
-       SortedVariable (..) )
+       ( AstLocation (..), Id (..), PureMLPattern, Sort (..),
+       SortVariable (..), SortedVariable (..) )
 import Kore.AST.MetaOrObject
 import Kore.ASTHelpers
        ( ApplicationSorts (..) )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -12,10 +12,8 @@ import           Data.Reflection
                  ( give )
 
 import           Kore.AST.Common
-                 ( Application (..), Id (..) )
+                 ( Application (..), CommonPurePattern, Id (..) )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkOr, mkVar )
 import           Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
@@ -16,10 +16,8 @@ import Data.Reflection
 import           Control.Monad.Counter
                  ( runCounter )
 import           Kore.AST.Common
-                 ( BuiltinDomain (..) )
+                 ( BuiltinDomain (..), CommonPurePattern )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkBottom, mkCeil, mkCharLiteral, mkDomainValue,
                  mkEquals, mkExists, mkFloor, mkForall, mkIff, mkImplies, mkIn,

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
@@ -15,7 +15,7 @@ import           Kore.AST.Common
 import           Kore.AST.Kore
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( CommonPurePattern, groundHead )
+                 ( groundHead )
 import           Kore.AST.PureToKore
                  ( patternPureToKore )
 import           Kore.AST.Sentence
@@ -267,4 +267,3 @@ test_functionRegistry =
         , predicate = makeTruePredicate
         , substitution = []
         }
-

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -13,11 +13,11 @@ import Data.List
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 
 import           Kore.AST.Common
-                 ( Application (..), AstLocation (..), Id (..), Pattern (..),
-                 SymbolOrAlias (..) )
+                 ( Application (..), AstLocation (..), CommonPurePattern,
+                 Id (..), Pattern (..), SymbolOrAlias (..) )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( CommonPurePattern, fromPurePattern )
+                 ( fromPurePattern )
 import           Kore.AST.PureToKore
                  ( patternKoreToPure )
 import           Kore.ASTHelpers

--- a/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -25,11 +25,9 @@ import Data.Reflection
        ( Given )
 
 import           Kore.AST.Common
-                 ( Id (..), Sort (..), SortActual (..), SymbolOrAlias (..),
-                 Variable (..) )
+                 ( Id (..), PureMLPattern, Sort (..), SortActual (..),
+                 SymbolOrAlias (..), Variable (..) )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( PureMLPattern )
 import           Kore.ASTHelpers
                  ( ApplicationSorts (..) )
 import           Kore.ASTUtils.SmartConstructors

--- a/src/main/haskell/kore/test/Test/Kore/Step/PatternAttributes.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/PatternAttributes.hs
@@ -11,11 +11,9 @@ import Data.Reflection
        ( give )
 
 import Kore.AST.Common
-       ( BuiltinDomain (..), CharLiteral (..), DomainValue (..), Sort (..),
-       SortActual (..), StringLiteral (..) )
+       ( BuiltinDomain (..), CharLiteral (..), CommonPurePattern,
+       DomainValue (..), Sort (..), SortActual (..), StringLiteral (..) )
 import Kore.AST.MetaOrObject
-import Kore.AST.PureML
-       ( CommonPurePattern )
 import Kore.ASTUtils.SmartConstructors
        ( mkCharLiteral, mkOr, mkStringLiteral, mkVar )
 import Kore.IndexedModule.MetadataTools

--- a/src/main/haskell/kore/test/Test/Kore/Step/PatternAttributes.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/PatternAttributes.hs
@@ -18,6 +18,7 @@ import Kore.ASTUtils.SmartConstructors
        ( mkCharLiteral, mkOr, mkStringLiteral, mkVar )
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools, SymbolOrAliasSorts )
+import Kore.Proof.Functional
 import Kore.Step.PatternAttributes
 import Kore.Step.PatternAttributesError
        ( FunctionError (..), FunctionalError (..) )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -12,10 +12,8 @@ import Data.Reflection
 
 import           Control.Monad.Counter
 import           Kore.AST.Common
-                 ( BuiltinDomain (..) )
+                 ( BuiltinDomain (..), CommonPurePattern )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkBottom, mkCharLiteral, mkDomainValue,
                  mkStringLiteral, mkTop, mkVar )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
@@ -11,10 +11,9 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( BuiltinDomain (..), DomainValue (..), Sort (..) )
+                 ( BuiltinDomain (..), CommonPurePattern, DomainValue (..),
+                 Sort (..) )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkBottom, mkDomainValue, mkStringLiteral )
 import           Kore.ASTUtils.SmartPatterns

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -13,11 +13,9 @@ import Data.Reflection
        ( give )
 
 import           Kore.AST.Common
-                 ( AstLocation (..), BuiltinDomain (..), Equals (..), Id (..),
-                 Sort (..), SortActual (..) )
+                 ( AstLocation (..), BuiltinDomain (..), CommonPurePattern,
+                 Equals (..), Id (..), Sort (..), SortActual (..) )
 import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
-                 ( CommonPurePattern )
 import           Kore.ASTUtils.SmartConstructors
                  ( mkBottom, mkCharLiteral, mkDomainValue, mkStringLiteral,
                  mkStringLiteral, mkTop, mkVar )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
@@ -3,9 +3,9 @@ module Test.Kore.Step.Simplifier
     , mockPredicateSimplifier
     ) where
 
-import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
+import           Kore.AST.Common
                  ( PureMLPattern )
+import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartConstructors
                  ( mkTop )
 import           Kore.Predicate.Predicate

--- a/src/main/haskell/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
@@ -11,11 +11,11 @@ import Test.Tasty.HUnit
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 
 import           Kore.AST.Common
-                 ( AstLocation (..), Sort (..), SortVariable (..), Variable,
-                 noLocationId )
+                 ( AstLocation (..), CommonPurePattern, Sort (..),
+                 SortVariable (..), Variable, noLocationId )
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
-                 ( CommonPurePattern, groundHead )
+                 ( groundHead )
 import           Kore.AST.PureToKore
                  ( patternKoreToPure )
 import           Kore.ASTHelpers


### PR DESCRIPTION
The keys of builtin collections (Map and Set) are fixed to be concrete patterns, in the sense that they do not contain variables. The restriction to concrete patterns is made at the type level, which makes some more instances derivable for `DomainValue` and `BuiltinDomain`.

During builtin function evaluation, keys are also checked for normalization. Keys should consist only of constructors, `\dv` patterns, and sort injections, so that two keys are equal under `(==)` if and only if they are actually equivalent patterns.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

