### PR TITLE
.stylish-haskell.yaml: Wrap lines to 100 columns

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -212,7 +212,7 @@ steps:
 
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account. Default: 80.
-columns: 80
+columns: 100
 
 # By default, line endings are converted according to the OS. You can override
 # preferred format here.
@@ -265,4 +265,3 @@ language_extensions:
   - TypeSynonymInstances
   - UndecidableInstances
   - ViewPatterns
-


### PR DESCRIPTION
Update the stylish-haskell configuration following changes to the style guide by @bmmoore.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

