### PR TITLE
Make ExpandedPattern Applicative

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -54,7 +54,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.AxiomPatterns
                  ( koreIndexedModuleToAxiomPatterns )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (..) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Registry
                  ( extractEvaluators )
@@ -373,7 +373,7 @@ makeExpandedPattern
     :: CommonPurePattern Object
     -> CommonExpandedPattern Object
 makeExpandedPattern pat =
-    ExpandedPattern
+    Predicated
     { term = pat
     , predicate = makeTruePredicate
     , substitution = []

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -773,5 +773,5 @@ instance (MetaOrObject level, PrettyPrint (variable level))
 instance (MetaOrObject level, PrettyPrint (variable level))
     => PrettyPrint (ExpandedPattern level variable)
   where
-    prettyPrint flags (ExpandedPattern t p s) =
-        writeThreeFieldStruct flags "ExpandedPattern" t p s
+    prettyPrint flags (Predicated t p s) =
+        writeThreeFieldStruct flags "Predicated" t p s

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -49,8 +49,7 @@ import qualified Kore.Predicate.Predicate as Predicate
 import           Kore.Step.AxiomPatterns
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern),
-                 PredicateSubstitution (..) )
+                 ( PredicateSubstitution (..), Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.PatternAttributes
                  ( FunctionalProof (..) )
@@ -202,7 +201,7 @@ stepWithAxiom
             ExpandedPattern.mapVariables ConfigurationVariable expandedPattern
         (startPattern, startCondition, startSubstitution) =
             case wrappedExpandedPattern of
-                ExpandedPattern { term, predicate, substitution } ->
+                Predicated { term, predicate, substitution } ->
                     (term, predicate, substitution)
         wrapAxiomVariables = mapPatternVariables AxiomVariable
         axiomLeft = wrapAxiomVariables axiomLeftRaw
@@ -296,7 +295,7 @@ stepWithAxiom
         orElse :: a -> a -> a
         p1 `orElse` p2 = if Predicate.isFalse condition then p2 else p1
     return
-        ( ExpandedPattern
+        ( Predicated
             { term = result `orElse` mkBottom
             , predicate = condition
             -- TODO(virgil): Can there be unused variables? Should we

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -24,9 +24,7 @@ import           Kore.Predicate.Predicate
                  unwrapPredicate, wrapPredicate )
 import           Kore.SMT.SMT
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern, PredicateSubstitution )
-import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, PredicateSubstitution, Predicated (..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -99,7 +97,7 @@ asPredicateSubstitution
     => ExpandedPattern level variable
     -> (PredicateSubstitution level variable, SimplificationProof level)
 asPredicateSubstitution
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   =
     let
         (andPatt, _proof) = makeAndPredicate predicate (wrapPredicate term)

--- a/src/main/haskell/kore/src/Kore/Step/Error.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Error.hs
@@ -6,7 +6,8 @@ module Kore.Step.Error
     , unificationOrSubstitutionToStepError
     ) where
 
-import Data.Bifunctor ( first )
+import           Data.Bifunctor
+                 ( first )
 import qualified Data.Set as Set
 
 import Kore.Unification.Error

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -74,6 +74,9 @@ data Predicated level variable child = Predicated
 instance Functor (Predicated level variable) where
     fmap f (Predicated a p s) = Predicated (f a) p s
 
+-- `<*>` does not do normalization for now. 
+-- Don't use it until we figure that out.
+
 instance
   ( MetaOrObject level
   , SortedVariable variable

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -11,9 +11,9 @@ Portability : portable
 -}
 module Kore.Step.ExpandedPattern
     ( CommonExpandedPattern
-    , CommonPredicateSubstitution  -- TODO(virgil): Stop exporting this.
-    , ExpandedPattern (..)
-    , PredicateSubstitution (..)  -- TODO(virgil): Stop exporting this.
+    , PredicateSubstitution.CommonPredicateSubstitution  -- TODO(virgil): Stop exporting this.
+    , ExpandedPattern
+    , PredicateSubstitution.PredicateSubstitution (..)  -- TODO(virgil): Stop exporting this.
     , allVariables
     , bottom
     , isBottom
@@ -23,6 +23,7 @@ module Kore.Step.ExpandedPattern
     , toMLPattern
     , top
     , fromPurePattern
+    , Predicated(..)
     ) where
 
 import           Data.List
@@ -49,7 +50,7 @@ import           Kore.Predicate.Predicate
                  makeAndPredicate, makeEqualsPredicate, makeFalsePredicate,
                  makeTruePredicate, unwrapPredicate )
 import qualified Kore.Predicate.Predicate as Predicate
-import           Kore.Step.PredicateSubstitution
+import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( CommonPredicateSubstitution, PredicateSubstitution (..) )
 import           Kore.Unification.Data
 import           Kore.Variables.Free
@@ -59,16 +60,40 @@ import           Kore.Variables.Free
 to use when executing Kore. It consists of an "and" between a term, a
 predicate and a substitution
 -}
-data ExpandedPattern level variable = ExpandedPattern
-    { term         :: !(PureMLPattern level variable)
-    -- ^ Free-form pattern.
-    , predicate    :: !(Predicate level variable)
-    -- ^ pattern that only evaluates to Top or Bottom.
+
+type ExpandedPattern level variable =
+    Predicated level variable (PureMLPattern level variable)
+
+data Predicated level variable child = Predicated
+    { term :: child
+    , predicate :: !(Predicate level variable)
     , substitution :: !(UnificationSubstitution level variable)
-    -- ^ special kind of predicate of the type
-    -- variable1 = term1 /\ variable2 = term2 /\ ...
     }
-    deriving (Eq, Show)
+    deriving(Eq, Ord, Show)
+
+instance Functor (Predicated level variable) where
+    fmap f (Predicated a p s) = Predicated (f a) p s
+
+instance
+  ( MetaOrObject level
+  , SortedVariable variable
+  , Show (variable level)
+  , Eq (variable level)
+  , Given (SymbolOrAliasSorts level)
+  )
+  => Applicative (Predicated level variable) where
+    pure a = Predicated a makeTruePredicate []
+    a <*> b = Predicated
+        { term = f x
+        , predicate = fst (predicate1 `makeAndPredicate` predicate2)
+        , substitution = substitution1 ++ substitution2
+        }
+        where
+            Predicated f predicate1 substitution1 = a
+            Predicated x predicate2 substitution2 = b
+
+-- The monad instance for `Predicated` is intentionally omitted.
+-- It's not needed for anything, and has bad performance properties.
 
 {-|'CommonExpandedPattern' particularizes ExpandedPattern to Variable.
 -}
@@ -83,9 +108,9 @@ mapVariables
     -> ExpandedPattern level variableTo
 mapVariables
     variableMapper
-    ExpandedPattern { term, predicate, substitution }
+    Predicated { term, predicate, substitution }
   =
-    ExpandedPattern
+    Predicated
         { term = mapPatternVariables variableMapper term
         , predicate = Predicate.mapVariables variableMapper predicate
         , substitution = mapSubstitutionVariables variableMapper substitution
@@ -99,7 +124,7 @@ allVariables
     => ExpandedPattern level variable
     -> Set.Set (variable level)
 allVariables
-    ExpandedPattern { term, predicate, substitution }
+    Predicated { term, predicate, substitution }
   =
     pureAllVariables term
     <> Predicate.allVariables predicate
@@ -125,7 +150,7 @@ toMLPattern
         , Show (variable level))
     => ExpandedPattern level variable -> PureMLPattern level variable
 toMLPattern
-    ExpandedPattern { term, predicate, substitution }
+    Predicated { term, predicate, substitution }
   =
     simpleAnd
         (simpleAnd term predicate)
@@ -182,7 +207,7 @@ should become Bottom when transformed to a ML pattern.
 -}
 bottom :: MetaOrObject level => ExpandedPattern level variable
 bottom =
-    ExpandedPattern
+    Predicated
         { term      = mkBottom
         , predicate = makeFalsePredicate
         , substitution = []
@@ -193,7 +218,7 @@ should become Top when transformed to a ML pattern.
 -}
 top :: MetaOrObject level => ExpandedPattern level variable
 top =
-    ExpandedPattern
+    Predicated
         { term      = mkTop
         , predicate = makeTruePredicate
         , substitution = []
@@ -203,7 +228,7 @@ top =
 -}
 isTop :: ExpandedPattern level variable -> Bool
 isTop
-    ExpandedPattern
+    Predicated
         { term = Top_ _, predicate = PredicateTrue, substitution = [] }
   = True
 isTop _ = False
@@ -213,10 +238,10 @@ Pattern.
 -}
 isBottom :: ExpandedPattern level variable -> Bool
 isBottom
-    ExpandedPattern {term = Bottom_ _}
+    Predicated {term = Bottom_ _}
   = True
 isBottom
-    ExpandedPattern {predicate = PredicateFalse}
+    Predicated {predicate = PredicateFalse}
   = True
 isBottom _ = False
 
@@ -235,7 +260,7 @@ fromPurePattern term =
     case term of
         Bottom_ _ -> bottom
         _ ->
-            ExpandedPattern
+            Predicated
                 { term
                 , predicate = makeTruePredicate
                 , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -30,9 +30,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( PredicateSubstitution )
-import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( PredicateSubstitution, Predicated(..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Function.Data
@@ -134,7 +132,7 @@ evaluateApplication
     unchangedPatt =
         case childrenPredicateSubstitution of
             PredicateSubstitution {predicate, substitution} ->
-                ExpandedPattern
+                Predicated
                     { term         = asPurePattern $ ApplicationPattern app
                     , predicate    = predicate
                     , substitution = substitution
@@ -172,7 +170,7 @@ evaluateSortInjection tools unchanged ap = case apChild of
             assert (toSort' == fromSort) $
             return
                 ( OrOfExpandedPattern.make
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = App_ apHeadNew grandChildren
                         , predicate = makeTruePredicate
                         , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -31,7 +31,7 @@ import           Kore.Step.BaseStep
 import qualified Kore.Step.Condition.Evaluator as Predicate
                  ( evaluate )
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, Predicated(..))
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.ExpandedPattern
@@ -84,7 +84,7 @@ axiomFunctionEvaluator
             return (AttemptedFunction.NotApplicable, SimplificationProof)
         Right (stepPattern, _) ->
             do
-                (   rewrittenPattern@ExpandedPattern
+                (   rewrittenPattern@Predicated
                         { predicate = rewritingCondition }
                     , _
                     ) <- evaluatePredicate tools simplifier stepPattern
@@ -111,7 +111,7 @@ axiomFunctionEvaluator
         => Application level (PureMLPattern level variable)
         -> ExpandedPattern level variable
     stepperConfiguration app' =
-        ExpandedPattern
+        Predicated
             { term = asPurePattern $ ApplicationPattern app'
             , predicate = makeTruePredicate
             , substitution = []
@@ -141,7 +141,7 @@ reevaluateFunctions
 reevaluateFunctions
     tools
     wrappedSimplifier@(PureMLPatternSimplifier simplifier)
-    ExpandedPattern
+    Predicated
         { term   = rewrittenPattern
         , predicate = rewritingCondition
         , substitution = rewrittenSubstitution
@@ -192,7 +192,7 @@ evaluatePredicate
 evaluatePredicate
     tools
     simplifier
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   = do
     (   PredicateSubstitution
             { predicate = evaluatedPredicate
@@ -214,7 +214,7 @@ evaluatePredicate
                 [substitution, evaluatedSubstitution]
     -- TODO(virgil): Do I need to re-evaluate the predicate?
     return
-        ( ExpandedPattern
+        ( Predicated
             { term = term
             , predicate = mergedPredicate
             , substitution = mergedSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
@@ -23,10 +23,9 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Step.Condition.Evaluator as Predicate
                  ( evaluate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern),
-                 PredicateSubstitution (PredicateSubstitution) )
-import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern,
+                 PredicateSubstitution (PredicateSubstitution),
+                 Predicated (..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Simplification.Data
@@ -70,7 +69,7 @@ mergeWithPredicateSubstitution
         { predicate = conditionToMerge
         , substitution = substitutionToMerge
         }
-    patt@ExpandedPattern
+    patt@Predicated
         { predicate = pattPredicate
         , substitution = pattSubstitution
         }
@@ -108,7 +107,7 @@ mergeWithEvaluatedCondition
     -> Simplifier (ExpandedPattern level variable, SimplificationProof level)
 mergeWithEvaluatedCondition
     tools
-    ExpandedPattern
+    Predicated
         { term = pattTerm
         , substitution = pattSubstitution
         }  -- The predicate was already included in the PredicateSubstitution
@@ -125,7 +124,7 @@ mergeWithEvaluatedCondition
             [predPredicate]
             [pattSubstitution, predSubstitution]
     return
-        ( ExpandedPattern
+        ( Predicated
             { term = pattTerm
             , predicate = mergedPredicate
             , substitution = mergedSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
@@ -11,7 +11,7 @@ module Kore.Step.Merging.OrOfExpandedPattern
     ( mergeWithPredicateSubstitution
     ) where
 
-import           Data.Reflection
+import Data.Reflection
 
 import           Kore.AST.Common
                  ( SortedVariable )

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -51,7 +51,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( pattern PredicateTrue, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 
 {-| 'MultiOr' is a Matching logic or of its children
@@ -133,7 +133,7 @@ Assumes that the pattern was filtered.
 isTrue :: OrOfExpandedPattern level variable -> Bool
 isTrue
     (MultiOr
-        [ ExpandedPattern
+        [ Predicated
             {term = Top_ _, predicate = PredicateTrue, substitution = []}
         ]
     )
@@ -385,7 +385,7 @@ toExpandedPattern (MultiOr patts) =
     case map ExpandedPattern.toMLPattern patts of
         [] -> error "Not expecting empty pattern list."
         (p : ps) ->
-            ExpandedPattern
+            Predicated
                 { term = foldl' mkOr p ps
                 , predicate = makeTruePredicate
                 , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
@@ -21,12 +21,11 @@ import           Kore.AST.PureML
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern),
-                 PredicateSubstitution (PredicateSubstitution) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, isBottom, isTop )
+                 ( bottom, isBottom, isTop )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -191,25 +190,25 @@ makeEvaluateNonBool
     -> Simplifier (ExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNonBool
     tools
-    ExpandedPattern
+    Predicated
         { term = firstTerm
         , predicate = firstPredicate
         , substitution = firstSubstitution
         }
-    ExpandedPattern
+    Predicated
         { term = secondTerm
         , predicate = secondPredicate
         , substitution = secondSubstitution
         }
   = do -- IntCounter monad
-    ( ExpandedPattern
+    ( Predicated
             { term = termTerm
             , predicate = termPredicate
             , substitution = termSubstitution
             }
         , _proof
         ) <- makeTermAnd tools firstTerm secondTerm
-    (   PredicateSubstitution
+    (   PredicateSubstitution.PredicateSubstitution
             { predicate = mergedPredicate
             , substitution = mergedSubstitution
             }
@@ -219,7 +218,7 @@ makeEvaluateNonBool
             [firstPredicate, secondPredicate, termPredicate]
             [firstSubstitution, secondSubstitution, termSubstitution]
     return
-        ( ExpandedPattern
+        ( Predicated
             { term = termTerm
             , predicate = mergedPredicate
             , substitution = mergedSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -345,7 +345,12 @@ addToolsArg
 addToolsArg = pure
 
 toExpanded
-    :: (MetaOrObject level, SortedVariable variable, Show (variable level), Eq (variable level))
+    :: 
+    ( MetaOrObject level
+    , SortedVariable variable
+    , Show (variable level)
+    , Eq (variable level)
+    )
     =>   (  MetadataTools level StepperAttributes
         -> PureMLPattern level variable
         -> PureMLPattern level variable

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -34,19 +34,17 @@ import           Kore.ASTUtils.SmartPatterns
                  pattern DV_, pattern StringLiteral_, pattern Top_,
                  pattern Var_ )
 import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Predicate.Predicate
                  ( pattern PredicateTrue, makeEqualsPredicate,
                  makeNotPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern),
-                 PredicateSubstitution (PredicateSubstitution) )
+                 ( ExpandedPattern, Predicated (..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, fromPurePattern, isBottom )
+                 ( Predicated (..), bottom, fromPurePattern, isBottom )
 import           Kore.Step.PatternAttributes
                  ( isFunctionPattern )
 import qualified Kore.Step.Simplification.Ceil as Ceil
@@ -95,7 +93,7 @@ termEquals tools first second =
     termEquals0 = do  -- Result monad
         result <- termEqualsAnd tools first second
         return $ do  -- Counter monad
-            (ExpandedPattern {predicate, substitution}, _pred) <- result
+            (Predicated {predicate, substitution}, _pred) <- result
             return
                 ( PredicateSubstitution
                     {predicate = predicate, substitution = substitution}
@@ -142,7 +140,7 @@ termEqualsAndChild tools first second =
     fromResult
         (give (MetadataTools.symbolOrAliasSorts tools) $
             return
-                ( ExpandedPattern
+                ( Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate first second
                     , substitution = []
@@ -347,8 +345,8 @@ addToolsArg
 addToolsArg = pure
 
 toExpanded
-    :: MetaOrObject level
-    =>  (  MetadataTools level StepperAttributes
+    :: (MetaOrObject level, SortedVariable variable, Show (variable level), Eq (variable level))
+    =>   (  MetadataTools level StepperAttributes
         -> PureMLPattern level variable
         -> PureMLPattern level variable
         -> Result (PureMLPattern level variable, SimplificationProof level)
@@ -364,7 +362,7 @@ toExpanded transformer tools first second =
     toExpanded0 (Bottom_ _, _proof) =
         (ExpandedPattern.bottom, SimplificationProof)
     toExpanded0 (term, _proof) =
-        ( ExpandedPattern
+        ( Predicated
             { term = term
             , predicate = makeTruePredicate
             , substitution = []
@@ -454,7 +452,7 @@ bottomTermEquals
         return (ExpandedPattern.bottom, SimplificationProof)
     (predicate, _proof) ->
         return
-            ( ExpandedPattern
+            ( Predicated
                 { term = mkTop
                 , predicate = give (MetadataTools.symbolOrAliasSorts tools) $
                     case makeNotPredicate predicate of
@@ -502,7 +500,7 @@ variableFunctionAndEquals
     first@(Var_ v1)
     second@(Var_ v2)
   = return
-        ( ExpandedPattern
+        ( Predicated
             { term = if v2 > v1 then second else first
             , predicate = makeTruePredicate
             , substitution =
@@ -523,7 +521,7 @@ variableFunctionAndEquals
     Right _proof ->
         -- assumes functional implies function.
         return
-            ( ExpandedPattern
+            ( Predicated
                 { term = second  -- different for Equals
                 , predicate =
                     case simplificationType of
@@ -609,9 +607,9 @@ equalInjectiveHeadsAndEquals
                 (map (ExpandedPattern.predicate . fst) children)
                 (map (ExpandedPattern.substitution . fst) children)
         return
-            ( ExpandedPattern
+            ( Predicated
                 { term = give (MetadataTools.symbolOrAliasSorts tools) $
-                    mkApp firstHead (map (ExpandedPattern.term . fst) children)
+                    mkApp firstHead (map (term . fst) children)
                 , predicate = mergedPredicate
                 , substitution = mergedSubstitution
                 }
@@ -630,7 +628,7 @@ to be different.
 Returns NotHandled if it could not handle the input.
 -}
 sortInjectionAndEqualsAssumesDifferentHeads
-    ::  forall level variable m.
+    ::  forall level variable m .
         ( Eq (variable Object)
         , MetaOrObject level
         , MonadCounter m
@@ -700,17 +698,11 @@ sortInjectionAndEqualsAssumesDifferentHeads
     termSortInjection
         originSort
         destinationSort
-        patt@ExpandedPattern
-            {term, predicate, substitution}
+        patt
       =
         if ExpandedPattern.isBottom patt
         then (ExpandedPattern.bottom, SimplificationProof)
-        else
-            ( ExpandedPattern
-                { term = sortInjection originSort destinationSort term
-                , predicate = predicate
-                , substitution = substitution
-                }
+        else ( sortInjection originSort destinationSort <$> patt
             , SimplificationProof
             )
     sortInjection
@@ -906,7 +898,7 @@ functionAnd
             Left _ -> empty
             Right _proof ->
                 return
-                    ( ExpandedPattern
+                    ( Predicated
                         { term = first  -- different for Equals
                         -- Ceil predicate not needed since first being
                         -- bottom will make the entire term bottom. However,

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -614,7 +614,7 @@ equalInjectiveHeadsAndEquals
         return
             ( Predicated
                 { term = give (MetadataTools.symbolOrAliasSorts tools) $
-                    mkApp firstHead (map (term . fst) children)
+                    mkApp firstHead (map (ExpandedPattern.term . fst) children)
                 , predicate = mergedPredicate
                 , substitution = mergedSubstitution
                 }

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
@@ -1,25 +1,25 @@
 module Kore.Step.Simplification.AndTerms where
 
-import           Control.Monad.Counter
-                 ( MonadCounter )
-import           Kore.AST.Common
-                 ( SortedVariable )
-import           Kore.AST.MetaOrObject
-                 ( Meta, MetaOrObject, Object )
-import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools )
-import           Kore.AST.PureML
-                 ( PureMLPattern )
-import           Kore.Substitution.Class
-                 ( Hashable )
-import           Kore.Step.StepperAttributes
-                 ( StepperAttributes )
-import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern )
-import           Kore.Step.Simplification.Data
-                 ( SimplificationProof )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Control.Monad.Counter
+       ( MonadCounter )
+import Kore.AST.Common
+       ( SortedVariable )
+import Kore.AST.MetaOrObject
+       ( Meta, MetaOrObject, Object )
+import Kore.AST.PureML
+       ( PureMLPattern )
+import Kore.IndexedModule.MetadataTools
+       ( MetadataTools )
+import Kore.Step.ExpandedPattern
+       ( ExpandedPattern )
+import Kore.Step.Simplification.Data
+       ( SimplificationProof )
+import Kore.Step.StepperAttributes
+       ( StepperAttributes )
+import Kore.Substitution.Class
+       ( Hashable )
+import Kore.Variables.Fresh
+       ( FreshVariable )
 
 termAnd
     ::  ( MetaOrObject level

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -20,13 +20,10 @@ import           Kore.AST.PureML
                  ( PureMLPattern )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
-import           Kore.Predicate.Predicate
-                 ( Predicate )
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern,
-                 PredicateSubstitution (PredicateSubstitution) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 PredicateSubstitution (PredicateSubstitution),
+                 Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Function.Data
@@ -46,16 +43,17 @@ import           Kore.Step.Substitution
                  ( mergePredicatesAndSubstitutions )
 import           Kore.Substitution.Class
                  ( Hashable )
-import           Kore.Unification.Unifier
-                 ( UnificationSubstitution )
 import           Kore.Variables.Fresh
 
-data ExpandedApplication level variable = ExpandedApplication
-    { term         :: !(Application level (PureMLPattern level variable))
-    , predicate    :: !(Predicate level variable)
-    , substitution :: !(UnificationSubstitution level variable)
-    }
-    deriving (Eq, Show)
+-- data ExpandedApplication level variable = ExpandedApplication
+--     { term         :: !(Application level (PureMLPattern level variable))
+--     , predicate    :: !(Predicate level variable)
+--     , substitution :: !(UnificationSubstitution level variable)
+--     }
+--     deriving (Eq, Show)
+
+type ExpandedApplication level variable =
+    Predicated level variable (Application level (PureMLPattern level variable))
 
 {-|'simplify' simplifies an 'Application' of 'OrOfExpandedPattern'.
 
@@ -169,7 +167,7 @@ evaluateApplicationFunction
     tools
     simplifier
     symbolIdToEvaluator
-    ExpandedApplication
+    Predicated
         { term, predicate, substitution }
   =
     evaluateApplication
@@ -207,13 +205,13 @@ makeExpandedApplication tools symbol children
         , _proof) <-
             mergePredicatesAndSubstitutions
                 tools
-                (map ExpandedPattern.predicate children)
-                (map ExpandedPattern.substitution children)
+                (map predicate children)
+                (map substitution children)
     return
-        ( ExpandedApplication
+        ( Predicated
             { term = Application
                 { applicationSymbolOrAlias = symbol
-                , applicationChildren = map ExpandedPattern.term children
+                , applicationChildren = map term children
                 }
             , predicate = mergedPredicate
             , substitution = mergedSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -24,6 +24,8 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern,
                  PredicateSubstitution (PredicateSubstitution),
                  Predicated (..) )
+import           Kore.Step.ExpandedPattern as ExpandedPattern
+                 ( Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Function.Data
@@ -205,8 +207,8 @@ makeExpandedApplication tools symbol children
         , _proof) <-
             mergePredicatesAndSubstitutions
                 tools
-                (map predicate children)
-                (map substitution children)
+                (map ExpandedPattern.predicate children)
+                (map ExpandedPattern.substitution children)
     return
         ( Predicated
             { term = Application

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -213,7 +213,7 @@ makeExpandedApplication tools symbol children
         ( Predicated
             { term = Application
                 { applicationSymbolOrAlias = symbol
-                , applicationChildren = map term children
+                , applicationChildren = map ExpandedPattern.term children
                 }
             , predicate = mergedPredicate
             , substitution = mergedSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -37,9 +37,8 @@ import           Kore.Predicate.Predicate
                  makeFalsePredicate, makeMultipleAndPredicate,
                  makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, isBottom, isTop, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -127,14 +126,14 @@ makeEvaluateNonBoolCeil
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNonBoolCeil
     _
-    patt@ExpandedPattern { term = Top_ _ }
+    patt@Predicated { term = Top_ _ }
   =
     ( OrOfExpandedPattern.make [patt]
     , SimplificationProof
     )
 makeEvaluateNonBoolCeil
     tools
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   =
     let
         (termCeil, _proof1) = makeEvaluateTerm tools term
@@ -142,7 +141,7 @@ makeEvaluateNonBoolCeil
             give symbolOrAliasSorts $ makeAndPredicate predicate termCeil
     in
         ( OrOfExpandedPattern.make
-            [ ExpandedPattern
+            [ Predicated
                 { term = mkTop
                 , predicate = ceilPredicate
                 , substitution = substitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/CharLiteral.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/CharLiteral.hs
@@ -19,9 +19,7 @@ import           Kore.AST.PureML
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -39,7 +37,7 @@ simplify
        )
 simplify str =
     ( OrOfExpandedPattern.make
-        [ExpandedPattern
+        [Predicated
             { term = asPurePattern (CharLiteralPattern str)
             , predicate = makeTruePredicate
             , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
@@ -20,9 +20,7 @@ import           Kore.AST.PureML
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -40,7 +38,7 @@ simplify
        )
 simplify dv =
     ( OrOfExpandedPattern.make
-        [ExpandedPattern
+        [Predicated
             { term = asPurePattern (DomainValuePattern dv)
             , predicate = makeTruePredicate
             , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
@@ -36,9 +36,9 @@ import           Kore.Predicate.Predicate
                  makeAndPredicate, makeEqualsPredicate, makeNotPredicate,
                  makeOrPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), top )
+                 ( top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -208,9 +208,9 @@ makeEvaluate
         (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluate
     tools
-    first@ExpandedPattern
+    first@Predicated
         { term = Top_ _ }
-    second@ExpandedPattern
+    second@Predicated
         { term = Top_ _ }
   =
     let
@@ -220,12 +220,12 @@ makeEvaluate
         return (result, SimplificationProof)
 makeEvaluate
     tools
-    ExpandedPattern
+    Predicated
         { term = firstTerm
         , predicate = PredicateTrue
         , substitution = []
         }
-    ExpandedPattern
+    Predicated
         { term = secondTerm
         , predicate = PredicateTrue
         , substitution = []
@@ -239,7 +239,7 @@ makeEvaluate
         PredicateSubstitution {predicate, substitution} ->
             return
                 (OrOfExpandedPattern.make
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = mkTop
                         , predicate = predicate
                         , substitution = substitution
@@ -249,22 +249,22 @@ makeEvaluate
                 )
 makeEvaluate
     tools
-    first@ExpandedPattern
+    first@Predicated
         { term = firstTerm }
-    second@ExpandedPattern
+    second@Predicated
         { term = secondTerm }
   = do
     let
         (firstCeil, _proof1) =
             Ceil.makeEvaluate tools
                 first
-                    { ExpandedPattern.term =
+                    { term =
                         if termsAreEqual then mkTop else firstTerm
                     }
         (secondCeil, _proof2) =
             Ceil.makeEvaluate tools
                 second
-                    { ExpandedPattern.term =
+                    { term =
                         if termsAreEqual then mkTop else secondTerm
                     }
         (firstCeilNegation, _proof3) =
@@ -311,7 +311,7 @@ makeEvaluateTermsAssumesNoBottom
     fromMaybe
         (return
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate = give (MetadataTools.symbolOrAliasSorts tools)
                         $ makeEqualsPredicate firstTerm secondTerm
@@ -349,7 +349,7 @@ makeEvaluateTermsAssumesNoBottomMaybe tools first second =
             (PredicateSubstitution {predicate, substitution}, _proof) <- result
             return
                 ( OrOfExpandedPattern.make
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = mkTop
                         , predicate = predicate
                         , substitution = substitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
@@ -32,9 +32,9 @@ import           Kore.Predicate.Predicate
                  ( Predicate, makeExistsPredicate, makeTruePredicate,
                  unwrapPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), toMLPattern )
+                 ( toMLPattern )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -162,7 +162,7 @@ makeEvaluate
     tools
     simplifier
     variable
-    patt@ExpandedPattern { term, predicate, substitution }
+    patt@Predicated { term, predicate, substitution }
   =
     case localSubstitution of
         [] ->
@@ -200,7 +200,7 @@ makeEvaluateNoFreeVarInSubstitution
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNoFreeVarInSubstitution
     variable
-    patt@ExpandedPattern { term, predicate, substitution }
+    patt@Predicated { term, predicate, substitution }
   =
     (OrOfExpandedPattern.make [simplifiedPattern], SimplificationProof)
   where
@@ -221,23 +221,23 @@ makeEvaluateNoFreeVarInSubstitution
                 (predicate', _proof) =
                     makeExistsPredicate variable predicate
             in
-                ExpandedPattern
+                Predicated
                     { term = term
                     , predicate = predicate'
                     , substitution = substitution
                     }
         (True, False) ->
-            ExpandedPattern
+            Predicated
                 { term = mkExists variable term
                 , predicate = predicate
                 , substitution = substitution
                 }
         (True, True) ->
-            ExpandedPattern
+            Predicated
                 { term =
                     mkExists variable
                         (ExpandedPattern.toMLPattern
-                            ExpandedPattern
+                            Predicated
                                 { term = term
                                 , predicate = predicate
                                 , substitution = []
@@ -271,7 +271,7 @@ substituteTermPredicate term predicate substitution globalSubstitution = do
     substitutedPredicate <-
         traverse (`substitute` substitution) predicate
     return
-        ( ExpandedPattern
+        ( Predicated
             { term = substitutedTerm
             , predicate = substitutedPredicate
             , substitution = globalSubstitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/ExpandedPattern.hs
@@ -11,16 +11,16 @@ module Kore.Step.Simplification.ExpandedPattern
     ( simplify
     ) where
 
+import           Data.Reflection
 import           Kore.AST.Common
                  ( SortedVariable )
 import           Kore.AST.MetaOrObject
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern),
-                 PredicateSubstitution (PredicateSubstitution) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern,
+                 PredicateSubstitution (PredicateSubstitution),
+                 Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.Merging.ExpandedPattern as ExpandedPattern
@@ -37,7 +37,6 @@ import           Kore.Step.StepperAttributes
 import           Kore.Substitution.Class
                  ( Hashable )
 import           Kore.Variables.Fresh
-import           Data.Reflection
 
 {-| Simplifies an 'ExpandedPattern', returning an 'OrOfExpandedPattern'.
 -}
@@ -64,7 +63,7 @@ simplify
 simplify
     tools
     wrappedSimplifier@(PureMLPatternSimplifier simplifier)
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   = do
     (simplifiedTerm, _)
         <- simplifier term

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Floor.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Floor.hs
@@ -27,9 +27,8 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeFloorPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, isBottom, isTop, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -111,7 +110,7 @@ makeEvaluateNonBoolFloor
     => ExpandedPattern level variable
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNonBoolFloor
-    patt@ExpandedPattern { term = Top_ _ }
+    patt@Predicated { term = Top_ _ }
   =
     ( OrOfExpandedPattern.make [patt]
     , SimplificationProof
@@ -119,10 +118,10 @@ makeEvaluateNonBoolFloor
 -- TODO(virgil): Also evaluate functional patterns to bottom for non-singleton
 -- sorts, and maybe other cases also
 makeEvaluateNonBoolFloor
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = mkTop
             , predicate =
                 case makeAndPredicate (makeFloorPredicate term) predicate of

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Forall.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Forall.hs
@@ -25,10 +25,8 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, isBottom, isTop, toMLPattern,
-                 top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -113,7 +111,7 @@ makeEvaluate variable patt
     , SimplificationProof
     )
   | otherwise =
-    ( ExpandedPattern
+    ( Predicated
         { term = mkForall
             variable
             (ExpandedPattern.toMLPattern patt)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Iff.hs
@@ -28,9 +28,8 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeIffPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern), substitutionToPredicate )
+                 ( ExpandedPattern, Predicated (..), substitutionToPredicate )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), isBottom, isTop, toMLPattern )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -137,19 +136,19 @@ makeEvaluateNonBoolIff
     -> ExpandedPattern level variable
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNonBoolIff
-    ExpandedPattern
+    Predicated
         { term = t@(Top_ _)
         , predicate = firstPredicate
         , substitution = firstSubstitution
         }
-    ExpandedPattern
+    Predicated
         { term = Top_ _
         , predicate = secondPredicate
         , substitution = secondSubstitution
         }
   =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = t
             , predicate =
                 -- TODO: Remove fst
@@ -170,7 +169,7 @@ makeEvaluateNonBoolIff
     )
 makeEvaluateNonBoolIff patt1 patt2 =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = mkIff
                 (ExpandedPattern.toMLPattern patt1)
                 (ExpandedPattern.toMLPattern patt2)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Implies.hs
@@ -26,9 +26,8 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeImpliesPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern), substitutionToPredicate )
+                 ( ExpandedPattern, Predicated (..), substitutionToPredicate )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), isBottom, isTop, toMLPattern, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -162,19 +161,19 @@ makeEvaluateImpliesNonBool
     -> ExpandedPattern level variable
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateImpliesNonBool
-    ExpandedPattern
+    Predicated
         { term = t@(Top_ _)
         , predicate = firstPredicate
         , substitution = firstSubstitution
         }
-    ExpandedPattern
+    Predicated
         { term = Top_ _
         , predicate = secondPredicate
         , substitution = secondSubstitution
         }
   =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = t
             , predicate =
                 -- TODO: Remove fst
@@ -195,7 +194,7 @@ makeEvaluateImpliesNonBool
     )
 makeEvaluateImpliesNonBool patt1 patt2 =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = mkImplies
                 (ExpandedPattern.toMLPattern patt1)
                 (ExpandedPattern.toMLPattern patt2)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/In.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/In.hs
@@ -26,9 +26,8 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeInPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), isBottom, isTop, toMLPattern )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -134,7 +133,7 @@ makeEvaluateNonBoolIn
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluateNonBoolIn tools patt1 patt2 =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = mkTop
             , predicate = give symbolOrAliasSorts $ makeInPredicate
                 -- TODO: Wrap in 'contained' and 'container'.

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Next.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Next.hs
@@ -24,9 +24,8 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), toMLPattern )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -69,7 +68,7 @@ simplifyEvaluated
     -> (OrOfExpandedPattern Object variable, SimplificationProof Object)
 simplifyEvaluated simplified =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term =
                 mkNext
                     $ ExpandedPattern.toMLPattern

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
@@ -30,9 +30,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeNotPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern), substitutionToPredicate )
+                 ( ExpandedPattern, Predicated (..), substitutionToPredicate )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), toMLPattern, top )
+                 ( toMLPattern, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern, makeFromSinglePurePattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -112,15 +112,15 @@ makeEvaluate
     => ExpandedPattern level variable
     -> (OrOfExpandedPattern level variable, SimplificationProof level)
 makeEvaluate
-    ExpandedPattern {term, predicate, substitution}
+    Predicated {term, predicate, substitution}
   =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = makeTermNot term
             , predicate = makeTruePredicate
             , substitution = []
             }
-        , ExpandedPattern
+        , Predicated
             -- TODO: Remove fst.
             { term = mkTop
             , predicate =

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
@@ -25,9 +25,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeOrPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -100,7 +98,7 @@ halfSimplifyEvaluated
         , SimplificationProof level
         )
 halfSimplifyEvaluated
-    first@ExpandedPattern
+    first@Predicated
         { term = Top_ _
         , predicate = firstPredicate
         , substitution = []
@@ -112,7 +110,7 @@ halfSimplifyEvaluated
             ( OrOfExpandedPattern.make [first]
             , SimplificationProof
             )
-        ( ExpandedPattern
+        ( Predicated
             { term, predicate, substitution}
          : patts
          ) ->
@@ -121,7 +119,7 @@ halfSimplifyEvaluated
                     makeOrPredicate firstPredicate predicate
             in
                 ( OrOfExpandedPattern.make
-                    ( ExpandedPattern
+                    ( Predicated
                         { term = term
                         , predicate = mergedPredicate
                         , substitution = substitution

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -24,9 +24,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), toMLPattern )
+                 ( toMLPattern )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -87,7 +87,7 @@ makeEvaluateRewrites
     -> (OrOfExpandedPattern Object variable, SimplificationProof Object)
 makeEvaluateRewrites first second =
     ( OrOfExpandedPattern.make
-        [ ExpandedPattern
+        [ Predicated
             { term = mkRewrites
                 (ExpandedPattern.toMLPattern first)
                 (ExpandedPattern.toMLPattern second)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/StringLiteral.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/StringLiteral.hs
@@ -19,9 +19,7 @@ import           Kore.AST.PureML
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -39,7 +37,7 @@ simplify
        )
 simplify str =
     ( OrOfExpandedPattern.make
-        [ExpandedPattern
+        [Predicated
             { term = asPurePattern (StringLiteralPattern str)
             , predicate = makeTruePredicate
             , substitution = []

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Variable.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Variable.hs
@@ -19,9 +19,7 @@ import           Kore.AST.PureML
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -40,7 +38,7 @@ simplify
        )
 simplify var =
     ( OrOfExpandedPattern.make
-        [ExpandedPattern
+        [Predicated
             { term = asPurePattern (VariablePattern var)
             , predicate = makeTruePredicate
             , substitution = []

--- a/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
@@ -38,7 +38,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.ExpandedPattern
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), isBottom )
+                 ( Predicated (..), isBottom )
 import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( bottom )
 import           Kore.Step.Simplification.AndTerms

--- a/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -32,7 +32,7 @@ import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
 import           Kore.AST.PureML
 import           Kore.ASTUtils.SmartPatterns
-                 ( pattern Var_, pattern Bottom_ )
+                 ( pattern Bottom_, pattern Var_ )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Predicate.Predicate
@@ -43,13 +43,13 @@ import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( PredicateSubstitution (..), bottom )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes (..) )
-import           Kore.Unification.Data
-                 ( UnificationSubstitution )
-import           Kore.Variables.Free
 import           Kore.Substitution.Class
 import qualified Kore.Substitution.List as ListSubstitution
+import           Kore.Unification.Data
+                 ( UnificationSubstitution )
 import           Kore.Unification.Error
                  ( SubstitutionError (..) )
+import           Kore.Variables.Free
 import           Kore.Variables.Fresh
 
 {-| 'normalizeSubstitution' transforms a substitution into an equivalent one

--- a/src/main/haskell/kore/src/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Unifier.hs
@@ -15,8 +15,8 @@ module Kore.Unification.Unifier
     ) where
 
 import Kore.Unification.Data as Data
-       ( UnificationSubstitution, mapSubstitutionVariables,
-         UnificationProof (..) )
+       ( UnificationProof (..), UnificationSubstitution,
+       mapSubstitutionVariables )
 import Kore.Unification.Error as Error
        ( ClashReason (..), UnificationError (..) )
 import Kore.Unification.UnifierImpl as UnifierImpl

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -40,9 +40,9 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Predicate.Predicate as Predicate
                  ( isFalse, makeAndPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern, PredicateSubstitution (..) )
+                 ( ExpandedPattern, PredicateSubstitution(..))
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( Predicated (..), bottom, top, )
 import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( PredicateSubstitution (..), top )
 import           Kore.Step.StepperAttributes
@@ -148,7 +148,7 @@ simplifyAnds tools patterns = do
           , ExpandedPattern.substitution intermediate
           ]
 
-        return $ ExpandedPattern.ExpandedPattern
+        return $ ExpandedPattern.Predicated
             ( ExpandedPattern.term result )
             ( PredicateSubstitution.predicate predSubst )
             ( PredicateSubstitution.substitution predSubst )

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Bool.hs
@@ -184,7 +184,7 @@ boolModule =
 
 evaluate :: CommonPurePattern Object -> CommonPurePattern Object
 evaluate pat =
-    let (ExpandedPattern { term }, _) =
+    let (Predicated { term }, _) =
             evalSimplifier (Pattern.simplify tools evaluators pat)
     in term
   where

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -108,7 +108,7 @@ evaluate :: CommonPurePattern Object -> CommonPurePattern Object
 evaluate pat =
     let
         tools = extractMetadataTools indexedModule
-        (ExpandedPattern { term }, _) =
+        (Predicated { term }, _) =
             evalSimplifier (Pattern.simplify tools evaluators pat)
     in term
 

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -19,7 +19,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.BaseStep
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, Predicated(..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Function.Data as AttemptedFunction
@@ -758,8 +758,8 @@ instance
     => StructEqualWithExplanation (ExpandedPattern level variable)
   where
     structFieldsWithNames
-        expected@(ExpandedPattern _ _ _)
-        actual@(ExpandedPattern _ _ _)
+        expected@(Predicated _ _ _)
+        actual@(Predicated _ _ _)
       = [ EqWrap
             "term = "
             (ExpandedPattern.term expected)

--- a/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
@@ -37,7 +37,7 @@ import Kore.Predicate.Predicate
 import Kore.Step.BaseStep
 import Kore.Step.Error
 import Kore.Step.ExpandedPattern as ExpandedPattern
-       ( ExpandedPattern (..), bottom )
+       ( Predicated (..), bottom )
 import Kore.Step.ExpandedPattern
        ( CommonExpandedPattern )
 import Kore.Step.StepperAttributes
@@ -53,7 +53,7 @@ test_baseStep =
     [ testCase "Substituting a variable."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term = asPureMetaPattern (v1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -68,7 +68,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPureMetaPattern (v1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -84,7 +84,7 @@ test_baseStep =
     , testCase "Substituting a variable with a larger one."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term = asPureMetaPattern (y1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -99,7 +99,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPureMetaPattern (y1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -115,7 +115,7 @@ test_baseStep =
     , testCase "Substituting a variable with itself."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term = asPureMetaPattern (v1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -130,7 +130,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma (v1 PatternSort) (v1 PatternSort))
@@ -152,7 +152,7 @@ test_baseStep =
     , testCase "Merging configuration patterns."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         asPureMetaPattern
                             (metaF (b1 PatternSort))
@@ -173,7 +173,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -198,7 +198,7 @@ test_baseStep =
     , testCase "Substitution with symbol matching."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term = asPureMetaPattern (metaF (b1 PatternSort))
                     , predicate = makeTruePredicate
                     , substitution =
@@ -217,7 +217,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -253,7 +253,7 @@ test_baseStep =
     , testCase "Merge multiple variables."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma (b1 PatternSort) (b1 PatternSort))
@@ -274,7 +274,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -314,7 +314,7 @@ test_baseStep =
     , testCase "Rename quantified rhs variables."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         asPureMetaPattern
                             (metaExists
@@ -338,7 +338,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPureMetaPattern (a1 PatternSort)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -365,7 +365,7 @@ test_baseStep =
             (Right ExpandedPattern.bottom)
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             ( metaSigma
@@ -394,7 +394,7 @@ test_baseStep =
             (Right ExpandedPattern.bottom)
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             ( metaSigma
@@ -438,7 +438,7 @@ test_baseStep =
             (Right ExpandedPattern.bottom)
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -472,7 +472,7 @@ test_baseStep =
     -- sigma(a, h(b)) with substitution b=a
     , testCase "Substitution (non-ctor)."
         (assertEqualWithExplanation ""
-            (Right ExpandedPattern
+            (Right Predicated
                 { term = asPureMetaPattern (metaH (b1 PatternSort))
                 , predicate = give mockSymbolOrAliasSorts $ makeEqualsPredicate
                     (asPureMetaPattern (b1 PatternSort))
@@ -486,7 +486,7 @@ test_baseStep =
             )
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -523,7 +523,7 @@ test_baseStep =
             (Left $ StepErrorUnification UnsupportedPatterns)
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma
@@ -552,7 +552,7 @@ test_baseStep =
     -- sigma(sigma(a, a), sigma(sigma(b, c), sigma(b, b)))
     , testCase "Unification is applied repeatedly"
         (assertEqualWithExplanation ""
-            (Right ExpandedPattern
+            (Right Predicated
                 { term = asPureMetaPattern
                     (metaSigma
                         (metaSigma (c1 PatternSort) (c1 PatternSort))
@@ -572,7 +572,7 @@ test_baseStep =
             )
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPureMetaPattern
                         ( metaSigma
                             ( metaSigma (a1 PatternSort) (a1 PatternSort))
@@ -608,7 +608,7 @@ test_baseStep =
         testCase "Substitution normalization."
             (assertEqualWithExplanation ""
                 (Right
-                    ( ExpandedPattern
+                    ( Predicated
                         { term = asPureMetaPattern (metaSigma fOfB fOfB)
                         , predicate = makeTruePredicate
                         , substitution =
@@ -627,7 +627,7 @@ test_baseStep =
                 )
                 (runStep
                     mockMetadataTools
-                    ExpandedPattern
+                    Predicated
                         { term =
                             asPureMetaPattern
                                 (metaSigma
@@ -668,7 +668,7 @@ test_baseStep =
         testCase "Merging substitution with existing one."
             (assertEqualWithExplanation ""
                 (Right
-                    ( ExpandedPattern
+                    ( Predicated
                         { term = asPureMetaPattern (metaSigma fOfC fOfC)
                         , predicate = makeTruePredicate
                         , substitution =
@@ -690,7 +690,7 @@ test_baseStep =
                 )
                 (runStep
                     mockMetadataTools
-                    ExpandedPattern
+                    Predicated
                         { term =
                             asPureMetaPattern
                                 (metaSigma
@@ -733,7 +733,7 @@ test_baseStep =
             (Right ExpandedPattern.bottom)
             (fst <$> runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPurePattern
                         ( StringLiteralPattern (StringLiteral "sl2")
                         :: UnFixedPureMLPattern Meta Variable
@@ -759,7 +759,7 @@ test_baseStep =
     , testCase "Preserving initial condition."
         (assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term = asPureMetaPattern (a1 PatternSort)
                     , predicate =
                         makeEquals
@@ -777,7 +777,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = asPureMetaPattern (a1 PatternSort)
                     , predicate =
                         makeEquals
@@ -803,7 +803,7 @@ test_baseStep =
         testCase "Substitution normalization."
             (assertEqualWithExplanation ""
                 (Right
-                    ( ExpandedPattern
+                    ( Predicated
                         { term = asPureMetaPattern (metaSigma fOfB fOfB)
                         , predicate =
                             makeEquals
@@ -825,7 +825,7 @@ test_baseStep =
                 )
                 (runStep
                     mockMetadataTools
-                    ExpandedPattern
+                    Predicated
                         { term =
                             asPureMetaPattern
                                 (metaSigma
@@ -871,7 +871,7 @@ test_baseStep =
         testCase "Conjoins axiom pre-condition"
           (assertEqualWithExplanation ""
               (Right
-                  ( ExpandedPattern
+                  ( Predicated
                       { term = asPureMetaPattern (a1 PatternSort)
                       , predicate = preCondition a1
                       , substitution = []
@@ -886,7 +886,7 @@ test_baseStep =
               )
               (runStep
                   mockMetadataTools
-                  ExpandedPattern
+                  Predicated
                       { term = asPureMetaPattern (a1 PatternSort)
                       , predicate = makeTruePredicate
                       , substitution = []
@@ -938,7 +938,7 @@ test_baseStep =
     identicalVariablesAssertion var =
         assertEqualWithExplanation ""
             (Right
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         asPureMetaPattern (var PatternSort)
                     , predicate = makeTruePredicate
@@ -954,7 +954,7 @@ test_baseStep =
             )
             (runStep
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         asPureMetaPattern
                             (metaSigma

--- a/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Condition/Evaluator.hs
@@ -5,40 +5,41 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( assertEqual, testCase )
 
+import           Data.Map
+                 ( Map )
 import qualified Data.Map as Map
-import           Data.Map ( Map )
 
-import           Data.Proxy
-import           Data.Reflection
+import Data.Proxy
+import Data.Reflection
 
-import           Kore.AST.Sentence
-import           Kore.AST.MetaOrObject
-import           Kore.AST.PureML
+import Kore.AST.MetaOrObject
+import Kore.AST.PureML
+import Kore.AST.Sentence
 
-import           Kore.ASTUtils.SmartConstructors
-import           Kore.ASTUtils.SmartPatterns
+import Kore.ASTUtils.SmartConstructors
+import Kore.ASTUtils.SmartPatterns
 
-import           Kore.ASTVerifier.DefinitionVerifier
-import           Kore.ASTVerifier.Error
+import Kore.ASTVerifier.DefinitionVerifier
+import Kore.ASTVerifier.Error
 
-import           Kore.IndexedModule.IndexedModule
-import           Kore.IndexedModule.MetadataTools
+import Kore.IndexedModule.IndexedModule
+import Kore.IndexedModule.MetadataTools
 
-import           Kore.Step.StepperAttributes
-import           Test.Kore.Step.Simplifier
+import Kore.Step.StepperAttributes
+import Test.Kore.Step.Simplifier
 
-import           Kore.Error
+import Kore.Error
 
-import           Kore.Step.ExpandedPattern
 import qualified Kore.Step.Condition.Evaluator as Eval
+import           Kore.Step.ExpandedPattern
 import           Kore.Step.Simplification.Data
 
-import           Kore.Predicate.Predicate
+import Kore.Predicate.Predicate
 
 import qualified Kore.Builtin as Builtin
 
-import           Test.Kore.Builtin.Bool 
-                   (boolDefinition, boolModuleName, boolSort)
+import Test.Kore.Builtin.Bool
+       ( boolDefinition, boolModuleName, boolSort )
 
 indexedModules :: Map ModuleName (KoreIndexedModule StepperAttributes)
 Right indexedModules = verify' boolDefinition
@@ -63,17 +64,17 @@ test_conditionEvaluator =
         "Condition Evaluator"
         [ testCase "a /\\ ~a"
             (assertEqual ""
-                ( fst $ fst $ 
+                ( fst $ fst $
                     give tools $
-                    give (symbolOrAliasSorts tools) $ 
-                    flip runSimplifier 0 $ 
+                    give (symbolOrAliasSorts tools) $
+                    flip runSimplifier 0 $
                     Eval.evaluate
                     (mockSimplifier [])
-                    ( wrapPredicate 
+                    ( wrapPredicate
                         (mkAnd a (mkNot a) :: CommonPurePattern Object)
                     )
                 )
-                ( PredicateSubstitution 
+                ( PredicateSubstitution
                     { predicate = makeFalsePredicate :: CommonPredicate Object
                     , substitution = []
                     }

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -26,7 +26,7 @@ import Kore.Predicate.Predicate
        ( Predicate, makeEqualsPredicate, makeFalsePredicate,
        makeTruePredicate )
 import Kore.Step.ExpandedPattern as ExpandedPattern
-       ( ExpandedPattern (..), allVariables, mapVariables, toMLPattern )
+       ( Predicated(..), allVariables, mapVariables, toMLPattern )
 
 import Test.Kore.Comparators ()
 import Test.Tasty.HUnit.Extensions
@@ -35,13 +35,13 @@ test_expandedPattern :: [TestTree]
 test_expandedPattern =
     [ testCase "Mapping variables"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = war "1"
                 , predicate = makeEquals (war "2") (war "3")
                 , substitution = [(W "4", war "5")]
                 }
             (ExpandedPattern.mapVariables showVar
-                ExpandedPattern
+                Predicated
                     { term = var 1
                     , predicate = makeEquals (var 2) (var 3)
                     , substitution = [(V 4, var 5)]
@@ -53,7 +53,7 @@ test_expandedPattern =
             [V 1, V 2, V 3, V 4, V 5]
             (Set.toList
                 (ExpandedPattern.allVariables
-                    ExpandedPattern
+                    Predicated
                         { term = var 1
                         , predicate = makeEquals (var 2) (var 3)
                         , substitution = [(V 4, var 5)]
@@ -71,7 +71,7 @@ test_expandedPattern =
                 (makeEq (var 4) (var 5))
             )
             (give mockSymbolOrAliasSorts $ ExpandedPattern.toMLPattern
-                ExpandedPattern
+                Predicated
                     { term = var 1
                     , predicate = makeEquals (var 2) (var 3)
                     , substitution = [(V 4, var 5)]
@@ -85,7 +85,7 @@ test_expandedPattern =
                 (makeEq (var 4) (var 5))
             )
             (give mockSymbolOrAliasSorts $ ExpandedPattern.toMLPattern
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeEquals (var 2) (var 3)
                     , substitution = [(V 4, var 5)]
@@ -96,7 +96,7 @@ test_expandedPattern =
         (assertEqualWithExplanation ""
             (var 1)
             (give mockSymbolOrAliasSorts $ ExpandedPattern.toMLPattern
-                ExpandedPattern
+                Predicated
                     { term = var 1
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -107,7 +107,7 @@ test_expandedPattern =
         (assertEqualWithExplanation ""
             mkBottom
             (give mockSymbolOrAliasSorts $ ExpandedPattern.toMLPattern
-                ExpandedPattern
+                Predicated
                     { term = mkBottom
                     , predicate = makeEquals (var 2) (var 3)
                     , substitution = [(V 4, var 5)]
@@ -118,7 +118,7 @@ test_expandedPattern =
         (assertEqualWithExplanation ""
             mkBottom
             (give mockSymbolOrAliasSorts $ ExpandedPattern.toMLPattern
-                ExpandedPattern
+                Predicated
                     { term = var 1
                     , predicate = makeFalsePredicate
                     , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -26,7 +26,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.BaseStep
                  ( AxiomPattern (..) )
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (..) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import           Kore.Step.Function.Data
                  ( ApplicationFunctionEvaluator (..),
                  CommonApplicationFunctionEvaluator, CommonAttemptedFunction )
@@ -53,7 +53,7 @@ test_functionIntegration :: [TestTree]
 test_functionIntegration = give mockSymbolOrAliasSorts
     [ testCase "Simple evaluation"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = Mock.g Mock.c
                 , predicate = makeTruePredicate
                 , substitution = []
@@ -71,7 +71,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Evaluates inside functions"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = Mock.functional10 (Mock.functional10 Mock.c)
                 , predicate = makeTruePredicate
                 , substitution = []
@@ -89,7 +89,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Evaluates 'or'"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term =
                     mkOr
                         (Mock.functional10 (Mock.functional10 Mock.c))
@@ -115,7 +115,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Evaluates on multiple branches"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term =
                     Mock.functional10
                         (Mock.functional20
@@ -143,7 +143,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Returns conditions"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = Mock.f Mock.d
                 , predicate = makeCeilPredicate (Mock.plain10 Mock.e)
                 , substitution = []
@@ -151,7 +151,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
             (evaluate
                 mockMetadataTools
                 (Map.singleton Mock.cId
-                    [ appliedMockEvaluator ExpandedPattern
+                    [ appliedMockEvaluator Predicated
                         { term   = Mock.d
                         , predicate = makeCeilPredicate (Mock.plain10 Mock.e)
                         , substitution = []
@@ -163,7 +163,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Merges conditions"
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = Mock.functional11 (Mock.functional20 Mock.e Mock.e)
                 , predicate =
                     fst $ makeAndPredicate
@@ -175,7 +175,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
                 mockMetadataTools
                 (Map.fromList
                     [   ( Mock.cId
-                        ,   [ appliedMockEvaluator ExpandedPattern
+                        ,   [ appliedMockEvaluator Predicated
                                 { term = Mock.e
                                 , predicate = makeCeilPredicate Mock.cg
                                 , substitution = []
@@ -183,7 +183,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
                             ]
                         )
                     ,   ( Mock.dId
-                        ,   [ appliedMockEvaluator ExpandedPattern
+                        ,   [ appliedMockEvaluator Predicated
                                 { term = Mock.e
                                 , predicate = makeCeilPredicate Mock.cf
                                 , substitution = []
@@ -203,7 +203,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
         )
     , testCase "Reevaluates user-defined function results."
         (assertEqualWithExplanation ""
-            ExpandedPattern
+            Predicated
                 { term = Mock.f Mock.e
                 , predicate = makeEqualsPredicate (Mock.f Mock.e) Mock.e
                 , substitution = []
@@ -215,7 +215,7 @@ test_functionIntegration = give mockSymbolOrAliasSorts
                         ,   [ axiomEvaluator Mock.c Mock.d ]
                         )
                     ,   ( Mock.dId
-                        ,   [ appliedMockEvaluator ExpandedPattern
+                        ,   [ appliedMockEvaluator Predicated
                                 { term = Mock.e
                                 , predicate =
                                     makeEqualsPredicate (Mock.f Mock.e) Mock.e

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
@@ -33,7 +33,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.AxiomPatterns
                  ( koreIndexedModuleToAxiomPatterns )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (..) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
                  ( CommonApplicationFunctionEvaluator )
@@ -262,7 +262,7 @@ test_functionRegistry =
         :: CommonPurePattern Object
         -> CommonExpandedPattern Object
     makeExpandedPattern pat =
-        ExpandedPattern
+        Predicated
         { term = pat
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -37,7 +37,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.BaseStep
                  ( AxiomPattern (..) )
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom )
+                 ( Predicated (..), bottom )
 import           Kore.Step.Function.Data as AttemptedFunction
                  ( AttemptedFunction (..) )
 import           Kore.Step.Function.Data
@@ -81,7 +81,7 @@ test_userDefinedFunction =
     , testCase "Applies one step"
         (assertEqualWithExplanation "f(x) => g(x)"
             (AttemptedFunction.Applied $ OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = asPureMetaPattern (metaG (x PatternSort))
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -144,7 +144,7 @@ test_userDefinedFunction =
     , testCase "Reevaluates the step application"
         (assertEqualWithExplanation "f(x) => g(x) and g(x) => h(x)"
             (AttemptedFunction.Applied $ OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = asPureMetaPattern (metaH (x PatternSort))
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -163,7 +163,7 @@ test_userDefinedFunction =
                     }
                 (mockSimplifier
                     [   ( asPureMetaPattern (metaG (x PatternSort))
-                        ,   (   [ ExpandedPattern
+                        ,   (   [ Predicated
                                     { term =
                                         asPureMetaPattern (metaH (x PatternSort))
                                     , predicate = makeTruePredicate
@@ -195,7 +195,7 @@ test_userDefinedFunction =
                     }
                 (mockSimplifier
                     [   ( asPureMetaPattern (metaG (x PatternSort))
-                        ,   (   [ ExpandedPattern
+                        ,   (   [ Predicated
                                     { term =
                                         asPureMetaPattern (metaH (x PatternSort))
                                     , predicate = makeFalsePredicate
@@ -213,7 +213,7 @@ test_userDefinedFunction =
     , testCase "Preserves step substitution"
         (assertEqualWithExplanation "sigma(x,x) => g(x) vs sigma(a, b)"
             (AttemptedFunction.Applied $ OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = asPureMetaPattern (metaG (b PatternSort))
                     , predicate = makeTruePredicate
                     , substitution =
@@ -243,7 +243,7 @@ test_userDefinedFunction =
         (assertEqualWithExplanation
             "sigma(x,x) => g(x) vs sigma(a, b) and g(b) => h(c) + a=c,b=c"
             (AttemptedFunction.Applied $ OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = asPureMetaPattern (metaH (c PatternSort))
                     , predicate = makeTruePredicate
                     , substitution =
@@ -271,7 +271,7 @@ test_userDefinedFunction =
                     }
                 (mockSimplifier
                     [   ( asPureMetaPattern (metaG (b PatternSort))
-                        ,   (   [ ExpandedPattern
+                        ,   (   [ Predicated
                                     { term =
                                         asPureMetaPattern (metaH (c PatternSort))
                                     , predicate = makeTruePredicate
@@ -436,8 +436,8 @@ evaluateWithAxiom
             AttemptedFunction.Applied (fmap sortSubstitution orPattern)
         result -> result
   where
-    sortSubstitution ExpandedPattern {term, predicate, substitution} =
-        ExpandedPattern
+    sortSubstitution Predicated {term, predicate, substitution} =
+        Predicated
             { term = term
             , predicate = predicate
             , substitution = sort substitution

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -23,9 +23,9 @@ import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeCeilPredicate, makeEqualsPredicate,
                  makeFalsePredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -117,7 +117,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
     , testCase "And with normal patterns"
         (do
             assertEqualWithExplanation "And random terms"
-                ExpandedPattern
+                Predicated
                     { term = mkAnd plain0OfX plain1OfX
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -126,7 +126,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
                     plain0OfXExpanded plain1OfXExpanded
                 )
             assertEqualWithExplanation "And function terms"
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeEqualsPredicate fOfX gOfX
                     , substitution = []
@@ -135,7 +135,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
                     fOfXExpanded gOfXExpanded
                 )
             assertEqualWithExplanation "And predicates"
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -144,30 +144,30 @@ test_andSimplification = give mockSymbolOrAliasSorts
                     , substitution = []
                     }
                 (evaluatePatterns
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeCeilPredicate fOfX
                         , substitution = []
                         }
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeCeilPredicate gOfX
                         , substitution = []
                         }
                 )
             assertEqualWithExplanation "And substitutions - simple"
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeTruePredicate
                     , substitution = [(Mock.y, fOfX), (Mock.z, gOfX)]
                     }
                 (evaluatePatterns
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeTruePredicate
                         , substitution = [(Mock.y, fOfX)]
                         }
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeTruePredicate
                         , substitution = [(Mock.z, gOfX)]
@@ -200,13 +200,13 @@ test_andSimplification = give mockSymbolOrAliasSorts
                 )
             -}
             assertEqualWithExplanation "And substitutions - failure"
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeFalsePredicate
                     , substitution = []
                     }
                 (evaluatePatterns
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeTruePredicate
                         , substitution =
@@ -215,7 +215,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
                                 )
                             ]
                         }
-                    ExpandedPattern
+                    Predicated
                         { term = mkTop
                         , predicate = makeTruePredicate
                         , substitution =
@@ -262,7 +262,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
     , testCase "Variable-function and"
         (do
             assertEqualWithExplanation "variable-term"
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeTruePredicate
                     , substitution = [(Mock.y, fOfX)]
@@ -271,7 +271,7 @@ test_andSimplification = give mockSymbolOrAliasSorts
                     yExpanded fOfXExpanded
                 )
             assertEqualWithExplanation "term-variable"
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeTruePredicate
                     , substitution = [(Mock.y, fOfX)]
@@ -283,18 +283,18 @@ test_andSimplification = give mockSymbolOrAliasSorts
     , testCase "constructor and"
         (do
             assertEqualWithExplanation "same constructors"
-                ExpandedPattern
+                Predicated
                     { term = Mock.constr10 fOfX
                     , predicate = makeEqualsPredicate fOfX gOfX
                     , substitution = []
                     }
                 (evaluatePatterns
-                    ExpandedPattern
+                    Predicated
                         { term = Mock.constr10 fOfX
                         , predicate = makeTruePredicate
                         , substitution = []
                         }
-                    ExpandedPattern
+                    Predicated
                         { term = Mock.constr10 gOfX
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -303,12 +303,12 @@ test_andSimplification = give mockSymbolOrAliasSorts
             assertEqualWithExplanation "different constructors"
                 ExpandedPattern.bottom
                 (evaluatePatterns
-                    ExpandedPattern
+                    Predicated
                         { term = Mock.constr10 fOfX
                         , predicate = makeTruePredicate
                         , substitution = []
                         }
-                    ExpandedPattern
+                    Predicated
                         { term = Mock.constr11 gOfX
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -319,22 +319,22 @@ test_andSimplification = give mockSymbolOrAliasSorts
     , testCase "And-Or distribution"
         (assertEqualWithExplanation "Distributes or"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = fOfX
                     , predicate = makeEqualsPredicate fOfX gOfX
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = fOfX
                     , predicate = makeCeilPredicate gOfX
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = gOfX
                     , predicate = makeCeilPredicate fOfX
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -347,14 +347,14 @@ test_andSimplification = give mockSymbolOrAliasSorts
             (evaluate
                 (makeAnd
                     [ fOfXExpanded
-                    , ExpandedPattern
+                    , Predicated
                         { term = mkTop
                         , predicate = makeCeilPredicate fOfX
                         , substitution = []
                         }
                     ]
                     [ gOfXExpanded
-                    , ExpandedPattern
+                    , Predicated
                         { term = mkTop
                         , predicate = makeCeilPredicate gOfX
                         , substitution = []
@@ -365,41 +365,41 @@ test_andSimplification = give mockSymbolOrAliasSorts
         )
     ]
   where
-    yExpanded = ExpandedPattern
+    yExpanded = Predicated
         { term = give mockSymbolOrAliasSorts $ mkVar Mock.y
         , predicate = makeTruePredicate
         , substitution = []
         }
     fOfX = give mockSymbolOrAliasSorts $ Mock.f (mkVar Mock.x)
-    fOfXExpanded = ExpandedPattern
+    fOfXExpanded = Predicated
         { term = fOfX
         , predicate = makeTruePredicate
         , substitution = []
         }
     gOfX = give mockSymbolOrAliasSorts $ Mock.g (mkVar Mock.x)
-    gOfXExpanded = ExpandedPattern
+    gOfXExpanded = Predicated
         { term = gOfX
         , predicate = makeTruePredicate
         , substitution = []
         }
     plain0OfX = give mockSymbolOrAliasSorts $ Mock.plain10 (mkVar Mock.x)
-    plain0OfXExpanded = ExpandedPattern
+    plain0OfXExpanded = Predicated
         { term = plain0OfX
         , predicate = makeTruePredicate
         , substitution = []
         }
     plain1OfX = give mockSymbolOrAliasSorts $ Mock.plain11 (mkVar Mock.x)
-    plain1OfXExpanded = ExpandedPattern
+    plain1OfXExpanded = Predicated
         { term = plain1OfX
         , predicate = makeTruePredicate
         , substitution = []
         }
-    bottomTerm = ExpandedPattern
+    bottomTerm = Predicated
         { term = mkBottom
         , predicate = makeTruePredicate
         , substitution = []
         }
-    falsePredicate = ExpandedPattern
+    falsePredicate = Predicated
         { term = mkTop
         , predicate = makeFalsePredicate
         , substitution = []
@@ -419,7 +419,7 @@ makeAnd first second =
 findSort :: [CommonExpandedPattern Object] -> Sort Object
 findSort [] = testSort
 findSort
-    ( ExpandedPattern {term} : _ )
+    ( Predicated {term} : _ )
   =
     give mockSymbolOrAliasSorts $ getSort term
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -24,9 +24,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeEqualsPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom )
+                 ( bottom )
 import           Kore.Step.Simplification.AndTerms
                  ( termAnd, termUnification )
 import           Kore.Step.StepperAttributes
@@ -44,7 +44,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "pattern and top"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -57,7 +57,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation "top and pattern"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -88,7 +88,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
     , testCase "equal patterns and"
         (assertEqualWithExplanation ""
             (let
-                expected = ExpandedPattern
+                expected = Predicated
                     { term = fOfA
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -104,7 +104,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation ""
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
                         , substitution = [(Mock.x, fOfA)]
@@ -117,7 +117,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation ""
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
                         , substitution = [(Mock.x, fOfA)]
@@ -133,7 +133,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "same head"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = Mock.injective10 fOfA
                         , predicate = makeEqualsPredicate fOfA gOfA
                         , substitution = []
@@ -146,7 +146,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation "same head same child"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = Mock.injective10 fOfA
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -158,7 +158,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.injective10 fOfA) (Mock.injective10 fOfA)
                 )
             assertEqualWithExplanation "different head"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         mkAnd
                             (Mock.injective10 fOfA)
@@ -177,7 +177,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "same head"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = Mock.sortInjection10 Mock.cfSort0
                         , predicate =
                             makeEqualsPredicate Mock.cfSort0 Mock.cgSort0
@@ -192,7 +192,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation "same head same child"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term =
                             Mock.sortInjection10 Mock.cfSort0
                         , predicate = makeTruePredicate
@@ -206,7 +206,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.sortInjection10 Mock.cfSort0)
                 )
             assertEqualWithExplanation "different head not subsort"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         mkAnd
                             (Mock.sortInjectionSubToTop Mock.plain00Subsort)
@@ -222,7 +222,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.sortInjection0ToTop Mock.plain00Sort0)
                 )
             assertEqualWithExplanation "different head subsort first"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         Mock.sortInjectionSubToTop
                             (mkAnd
@@ -242,7 +242,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.sortInjectionSubToTop Mock.plain00Subsort)
                 )
             assertEqualWithExplanation "different head subsort second"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         Mock.sortInjectionSubToTop
                             (mkAnd
@@ -262,7 +262,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.sortInjectionSubSubToTop Mock.plain00SubSubsort)
                 )
             assertEqualWithExplanation "different head constructors not subsort"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         mkAnd
                             (Mock.sortInjection10 Mock.aSort0)
@@ -291,7 +291,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "same head"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = Mock.constr10 Mock.cf
                         , predicate = makeEqualsPredicate Mock.cf Mock.cg
                         , substitution = []
@@ -305,7 +305,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation "same head same child"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = Mock.constr10 Mock.cf
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -342,7 +342,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "equal values"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = aDomainValue
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -366,7 +366,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "equal values"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = mkStringLiteral "a"
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -392,7 +392,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "equal values"
                 (let
-                    expected = ExpandedPattern
+                    expected = Predicated
                         { term = mkCharLiteral 'a'
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -418,7 +418,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         (do
             assertEqualWithExplanation "equal values"
                 (let
-                    expanded = ExpandedPattern
+                    expanded = Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -431,7 +431,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 )
             assertEqualWithExplanation "not equal values"
                 (let
-                    expanded = ExpandedPattern
+                    expanded = Predicated
                         { term = fOfA
                         , predicate = makeEqualsPredicate fOfA gOfA
                         , substitution = []
@@ -446,7 +446,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
     , testCase "unhandled cases"
         (do
             assertEqualWithExplanation "top level"
-                ( ExpandedPattern
+                ( Predicated
                     { term = mkAnd plain0OfA plain1OfA
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -458,7 +458,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     plain0OfA plain1OfA
                 )
             assertEqualWithExplanation "one level deep"
-                ( ExpandedPattern
+                ( Predicated
                     { term = Mock.constr10 (mkAnd plain0OfA plain1OfA)
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -470,7 +470,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.constr10 plain0OfA) (Mock.constr10 plain1OfA)
                 )
             assertEqualWithExplanation "two levels deep"
-                ( ExpandedPattern
+                ( Predicated
                     { term =
                         Mock.constr10
                             (Mock.constr10 (mkAnd plain0OfA plain1OfA))
@@ -487,7 +487,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
         )
     , testCase "binary constructor of non-specialcased values"
         (assertEqualWithExplanation ""
-            ( ExpandedPattern
+            ( Predicated
                 { term =
                     Mock.functionalConstr20
                         (mkAnd plain0OfA plain1OfA) (mkAnd plain0OfB plain1OfB)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -26,9 +26,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeEqualsPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
+                 ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom )
+                 ( bottom )
 import           Kore.Step.Function.Data
                  ( ApplicationFunctionEvaluator (ApplicationFunctionEvaluator),
                  CommonApplicationFunctionEvaluator )
@@ -63,25 +63,25 @@ test_applicationSimplification =
         --     sigma(b, d) or sigma(b, c) or sigma(a, d) or sigma(a, c)
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp sigmaSymbol [a, c]
                     , predicate = makeTruePredicate
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp sigmaSymbol [a, d]
                     , predicate = makeTruePredicate
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp sigmaSymbol [b, c]
                     , predicate = makeTruePredicate
                     , substitution = []
                     }
-                ,  ExpandedPattern
+                ,  Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp sigmaSymbol [b, d]
                     , predicate = makeTruePredicate
@@ -151,7 +151,7 @@ test_applicationSimplification =
         --    = sigma(a, b) and (f(a)=f(b) and g(a)=g(b)) and [x=f(a), y=g(a)]
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp sigmaSymbol [a, b]
                     , predicate = fst $ give mockSymbolOrAliasSorts $ makeAndPredicate
@@ -170,14 +170,14 @@ test_applicationSimplification =
                 Map.empty
                 (makeApplication
                     sigmaSymbol
-                    [   [ ExpandedPattern
+                    [   [ Predicated
                             { term = a
                             , predicate = give mockSymbolOrAliasSorts $
                                 makeEqualsPredicate fOfA fOfB
                             , substitution = [ (x, fOfA) ]
                             }
                         ]
-                    ,   [ ExpandedPattern
+                    ,   [ Predicated
                             { term = b
                             , predicate = give mockSymbolOrAliasSorts $
                                 makeEqualsPredicate gOfA gOfB
@@ -198,7 +198,7 @@ test_applicationSimplification =
         -- if sigma(a, b) => f(a) and f(a)=g(a) and [z=f(b)]
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = give mockSymbolOrAliasSorts $
                         mkApp fSymbol [a]
                     , predicate =
@@ -225,7 +225,7 @@ test_applicationSimplification =
                         (const $ const $ const $ return
                             ( AttemptedFunction.Applied
                                 (OrOfExpandedPattern.make
-                                    [ ExpandedPattern
+                                    [ Predicated
                                         { term = give mockSymbolOrAliasSorts $
                                             mkApp fSymbol [a]
                                         , predicate =
@@ -243,14 +243,14 @@ test_applicationSimplification =
                 )
                 (makeApplication
                     sigmaSymbol
-                    [   [ ExpandedPattern
+                    [   [ Predicated
                             { term = a
                             , predicate = give mockSymbolOrAliasSorts $
                                 makeEqualsPredicate fOfA fOfB
                             , substitution = [ (x, fOfA) ]
                             }
                         ]
-                    ,   [ ExpandedPattern
+                    ,   [ Predicated
                             { term = b
                             , predicate = give mockSymbolOrAliasSorts $
                                 makeEqualsPredicate gOfA gOfB
@@ -306,27 +306,27 @@ test_applicationSimplification =
     fOfB = give mockSymbolOrAliasSorts $ mkApp fSymbol [b]
     gOfA = give mockSymbolOrAliasSorts $ mkApp gSymbol [a]
     gOfB = give mockSymbolOrAliasSorts $ mkApp gSymbol [b]
-    aExpanded = ExpandedPattern
+    aExpanded = Predicated
         { term = a
         , predicate = makeTruePredicate
         , substitution = []
         }
-    bExpanded = ExpandedPattern
+    bExpanded = Predicated
         { term = b
         , predicate = makeTruePredicate
         , substitution = []
         }
-    cExpanded = ExpandedPattern
+    cExpanded = Predicated
         { term = c
         , predicate = makeTruePredicate
         , substitution = []
         }
-    dExpanded = ExpandedPattern
+    dExpanded = Predicated
         { term = d
         , predicate = makeTruePredicate
         , substitution = []
         }
-    gOfAExpanded = ExpandedPattern
+    gOfAExpanded = Predicated
         { term = gOfA
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -23,9 +23,9 @@ import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeCeilPredicate, makeEqualsPredicate,
                  makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -47,12 +47,12 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         -- ceil(a or b) = (top and ceil(a)) or (top and ceil(b))
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate = makeCeilPredicate somethingOfA
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = mkTop
                     , predicate = makeCeilPredicate somethingOfB
                     , substitution = []
@@ -113,7 +113,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         --     = top and (ceil(term) and predicate) and subst
         (assertEqualWithExplanation "ceil(something(a) and equals(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -124,7 +124,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = somethingOfA
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -141,7 +141,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
             (assertEqualWithExplanation
                 "ceil(constr(something(a), something(b)) and eq(f(a), g(a)))"
                 (OrOfExpandedPattern.make
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = mkTop
                         , predicate =
                             fst $ makeAndPredicate
@@ -155,7 +155,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                     ]
                 )
                 (makeEvaluate mockMetadataTools
-                    ExpandedPattern
+                    Predicated
                         { term = constructorTerm
                         , predicate = makeEqualsPredicate fOfA gOfA
                         , substitution = [(Mock.x, fOfB)]
@@ -166,7 +166,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make [ExpandedPattern.top])
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = Mock.constr10 Mock.a
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -180,7 +180,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation
             "ceil(functional(something(a), something(b)) and eq(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -194,7 +194,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = Mock.functional20 somethingOfA somethingOfB
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -208,7 +208,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation
             "ceil(f(a)) and eq(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -219,7 +219,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -233,7 +233,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation
             "ceil(f(a)) and eq(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -244,7 +244,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -258,7 +258,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation
             "ceil(functional and eq(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -266,7 +266,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = Mock.a
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -282,7 +282,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
         (assertEqualWithExplanation
             "ceil(functional(non-funct, non-funct) and eq(f(a), g(a)))"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeAndPredicate
@@ -296,7 +296,7 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
                 ]
             )
             (makeEvaluate mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = Mock.functional20 fOfA fOfB
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(Mock.x, fOfB)]
@@ -310,12 +310,12 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
     gOfA = give mockSymbolOrAliasSorts $ Mock.g Mock.a
     somethingOfA = give mockSymbolOrAliasSorts $ Mock.plain10 Mock.a
     somethingOfB = give mockSymbolOrAliasSorts $ Mock.plain10 Mock.b
-    somethingOfAExpanded = ExpandedPattern
+    somethingOfAExpanded = Predicated
         { term = somethingOfA
         , predicate = makeTruePredicate
         , substitution = []
         }
-    somethingOfBExpanded = ExpandedPattern
+    somethingOfBExpanded = Predicated
         { term = somethingOfB
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
@@ -15,9 +15,7 @@ import           Kore.ASTUtils.SmartConstructors
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -33,7 +31,7 @@ test_charLiteralSimplification =
     [ testCase "CharLiteral evaluates to CharLiteral"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkCharLiteral 'a'
                     , predicate = makeTruePredicate
                     , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
@@ -24,9 +24,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -44,7 +42,7 @@ test_domainValueSimplification =
     [ testCase "DomainValue evaluates to DomainValue"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term =
                         give mockSymbolOrAliasSorts $
                             mkDomainValue

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -32,9 +32,9 @@ import           Kore.Predicate.Predicate
                  makeEqualsPredicate, makeIffPredicate, makeNotPredicate,
                  makeOrPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -82,14 +82,14 @@ test_equalsSimplification_OrOfExpandedPatterns = give mockSymbolOrAliasSorts
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
                     , equalsFirst = OrOfExpandedPattern.make
-                        [ ExpandedPattern
+                        [ Predicated
                             { term = Mock.a
                             , predicate = makeTruePredicate
                             , substitution = []
                             }
                         ]
                     , equalsSecond = OrOfExpandedPattern.make
-                        [ ExpandedPattern
+                        [ Predicated
                             { term = Mock.a
                             , predicate = makeTruePredicate
                             , substitution = []
@@ -108,7 +108,7 @@ test_equalsSimplification_OrOfExpandedPatterns = give mockSymbolOrAliasSorts
                     , equalsResultSort = testSort
                     , equalsFirst = OrOfExpandedPattern.make []
                     , equalsSecond = OrOfExpandedPattern.make
-                        [ ExpandedPattern
+                        [ Predicated
                             { term = Mock.a
                             , predicate = makeTruePredicate
                             , substitution = []
@@ -120,7 +120,7 @@ test_equalsSimplification_OrOfExpandedPatterns = give mockSymbolOrAliasSorts
     , testCase "f(a) vs g(a)"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = []
@@ -133,14 +133,14 @@ test_equalsSimplification_OrOfExpandedPatterns = give mockSymbolOrAliasSorts
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
                     , equalsFirst = OrOfExpandedPattern.make
-                        [ ExpandedPattern
+                        [ Predicated
                             { term = fOfA
                             , predicate = makeTruePredicate
                             , substitution = []
                             }
                         ]
                     , equalsSecond = OrOfExpandedPattern.make
-                        [ ExpandedPattern
+                        [ Predicated
                             { term = gOfA
                             , predicate = makeTruePredicate
                             , substitution = []
@@ -156,7 +156,7 @@ test_equalsSimplification_ExpandedPatterns = give mockSymbolOrAliasSorts
     [ testCase "predicate-substitution vs predicate-substitution"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeIffPredicate
@@ -168,12 +168,12 @@ test_equalsSimplification_ExpandedPatterns = give mockSymbolOrAliasSorts
             )
             (evaluate
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate fOfA fOfB
                     , substitution = []
                     }
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate gOfA gOfB
                     , substitution = []
@@ -183,7 +183,7 @@ test_equalsSimplification_ExpandedPatterns = give mockSymbolOrAliasSorts
     , testCase "constructor-patt vs constructor-patt"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ makeOrPredicate
@@ -220,12 +220,12 @@ test_equalsSimplification_ExpandedPatterns = give mockSymbolOrAliasSorts
             )
             (evaluate
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term = Mock.functionalConstr10 hOfA
                     , predicate = makeEqualsPredicate fOfA fOfB
                     , substitution = []
                     }
-                ExpandedPattern
+                Predicated
                     { term = Mock.functionalConstr10 hOfB
                     , predicate = makeEqualsPredicate gOfA gOfB
                     , substitution = []
@@ -524,7 +524,7 @@ assertTermEqualsGeneric tools expected first second =
     termToExpandedPattern (Bottom_ _) =
         ExpandedPattern.bottom
     termToExpandedPattern term =
-        ExpandedPattern
+        Predicated
             { term = term
             , predicate = makeTruePredicate
             , substitution = []
@@ -540,7 +540,7 @@ assertTermEqualsGeneric tools expected first second =
     predSubstToExpandedPattern
         PredicateSubstitution {predicate, substitution}
       =
-        ExpandedPattern
+        Predicated
             { term = mkTop
             , predicate = predicate
             , substitution = substitution

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -23,9 +23,9 @@ import           Kore.Predicate.Predicate
                  ( makeCeilPredicate, makeEqualsPredicate, makeExistsPredicate,
                  makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -51,12 +51,12 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         -- exists(a or b) = exists(a) or exists(b)
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkExists Mock.x something1OfX
                     , predicate = makeTruePredicate
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = mkExists Mock.x something2OfX
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -121,7 +121,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         --    = t(alpha) and p(alpha) and [others]
         (assertEqualWithExplanation "exists with substitution"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkApp Mock.fSymbol [gOfA]
                     , predicate = makeCeilPredicate (mkApp Mock.hSymbol [gOfA])
                     , substitution = [(Mock.y, fOfA)]
@@ -130,7 +130,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = mkApp Mock.fSymbol [mkVar Mock.x]
                     , predicate = makeCeilPredicate (Mock.h (mkVar Mock.x))
                     , substitution = [(Mock.x, gOfA), (Mock.y, fOfA)]
@@ -143,7 +143,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         --    if t, p, s do not depend on x.
         (assertEqualWithExplanation "exists with substitution"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = fOfA
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -152,7 +152,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -165,7 +165,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         --    if p, s do not depend on x.
         (assertEqualWithExplanation "exists on term"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkExists Mock.x fOfX
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -174,7 +174,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -187,7 +187,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         --    if t, s do not depend on x.
         (assertEqualWithExplanation "exists on predicate"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = fOfA
                     , predicate = fst $
                         makeExistsPredicate Mock.x (makeCeilPredicate fOfX)
@@ -197,7 +197,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeCeilPredicate fOfX
                     , substitution = []
@@ -210,7 +210,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
         --    if s do not depend on x.
         (assertEqualWithExplanation "exists moves substitution"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkExists Mock.x (mkAnd fOfX (mkEquals fOfX gOfA))
                     , predicate = makeTruePredicate
                     , substitution = [(Mock.y, hOfA)]
@@ -219,7 +219,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeEqualsPredicate fOfX gOfA
                     , substitution = [(Mock.y, hOfA)]
@@ -235,7 +235,7 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             )
             (makeEvaluate mockMetadataTools
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = mkTop
                     , predicate = makeEqualsPredicate fOfX (Mock.f gOfA)
                     , substitution = [(Mock.x, gOfA)]
@@ -250,12 +250,12 @@ test_existsSimplification = give mockSymbolOrAliasSorts
     hOfA = give mockSymbolOrAliasSorts $ Mock.h Mock.a
     something1OfX = give mockSymbolOrAliasSorts $ Mock.plain10 (mkVar Mock.x)
     something2OfX = give mockSymbolOrAliasSorts $ Mock.plain11 (mkVar Mock.x)
-    something1OfXExpanded = ExpandedPattern
+    something1OfXExpanded = Predicated
         { term = something1OfX
         , predicate = makeTruePredicate
         , substitution = []
         }
-    something2OfXExpanded = ExpandedPattern
+    something2OfXExpanded = Predicated
         { term = something2OfX
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Floor.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Floor.hs
@@ -26,9 +26,9 @@ import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeEqualsPredicate, makeFloorPredicate,
                  makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -49,7 +49,7 @@ test_floorSimplification =
         -- floor(a or b) = (top and floor(a)) or (top and floor(b))
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate = give mockSymbolOrAliasSorts $
                         makeFloorPredicate (mkOr a b)
@@ -110,7 +110,7 @@ test_floorSimplification =
         --     = top and (floor(term) and predicate) and subst
         (assertEqualWithExplanation "floor(top)"
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkTop
                     , predicate =
                         fst $ give mockSymbolOrAliasSorts $ makeAndPredicate
@@ -121,7 +121,7 @@ test_floorSimplification =
                 ]
             )
             (give mockSymbolOrAliasSorts $ makeEvaluate
-                ExpandedPattern
+                Predicated
                     { term = a
                     , predicate = makeEqualsPredicate fOfA gOfA
                     , substitution = [(x, fOfB)]
@@ -155,12 +155,12 @@ test_floorSimplification =
     fOfA = give mockSymbolOrAliasSorts $ mkApp fSymbol [a]
     fOfB = give mockSymbolOrAliasSorts $ mkApp fSymbol [b]
     gOfA = give mockSymbolOrAliasSorts $ mkApp gSymbol [a]
-    aExpanded = ExpandedPattern
+    aExpanded = Predicated
         { term = a
         , predicate = makeTruePredicate
         , substitution = []
         }
-    bExpanded = ExpandedPattern
+    bExpanded = Predicated
         { term = b
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Forall.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Forall.hs
@@ -21,9 +21,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeCeilPredicate, makeEqualsPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom, top )
+                 ( bottom, top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -43,12 +43,12 @@ test_forallSimplification = give mockSymbolOrAliasSorts
         -- forall(a or b) = forall(a) or forall(b)
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkForall Mock.x something1OfX
                     , predicate = makeTruePredicate
                     , substitution = []
                     }
-                , ExpandedPattern
+                , Predicated
                     { term = mkForall Mock.x something2OfX
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -107,7 +107,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     , testCase "forall applies substitution if possible"
         -- forall x . (t(x) and p(x) and [x = alpha, others])
         (assertEqualWithExplanation "forall with substitution"
-            ExpandedPattern
+            Predicated
                 { term =
                     mkForall Mock.x
                         (mkAnd
@@ -125,7 +125,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
                 }
             (makeEvaluate
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = mkApp Mock.fSymbol [mkVar Mock.x]
                     , predicate = makeCeilPredicate (Mock.h (mkVar Mock.x))
                     , substitution = [(Mock.x, gOfA), (Mock.y, fOfA)]
@@ -135,7 +135,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     , testCase "forall disappears if variable not used"
         -- forall x . (t and p and s)
         (assertEqualWithExplanation "forall with substitution"
-            ExpandedPattern
+            Predicated
                 { term =
                     mkForall Mock.x (mkAnd fOfA (mkCeil gOfA))
                 , predicate = makeTruePredicate
@@ -143,7 +143,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
                 }
             (makeEvaluate
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -153,14 +153,14 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     , testCase "forall applied on term if not used elsewhere"
         -- forall x . (t(x) and p and s)
         (assertEqualWithExplanation "forall on term"
-            ExpandedPattern
+            Predicated
                 { term = mkForall Mock.x (mkAnd fOfX (mkCeil gOfA))
                 , predicate = makeTruePredicate
                 , substitution = []
                 }
             (makeEvaluate
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeCeilPredicate gOfA
                     , substitution = []
@@ -172,14 +172,14 @@ test_forallSimplification = give mockSymbolOrAliasSorts
         --    = t and (forall x . p(x)) and s
         --    if t, s do not depend on x.
         (assertEqualWithExplanation "forall on predicate"
-            ExpandedPattern
+            Predicated
                 { term = mkForall Mock.x (mkAnd fOfA (mkCeil fOfX))
                 , predicate = makeTruePredicate
                 , substitution = []
                 }
             (makeEvaluate
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfA
                     , predicate = makeCeilPredicate fOfX
                     , substitution = []
@@ -189,7 +189,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     , testCase "forall moves substitution above"
         -- forall x . (t(x) and p(x) and s)
         (assertEqualWithExplanation "forall moves substitution"
-            ExpandedPattern
+            Predicated
                 { term =
                     mkForall Mock.x
                         (mkAnd
@@ -201,7 +201,7 @@ test_forallSimplification = give mockSymbolOrAliasSorts
                 }
             (makeEvaluate
                 Mock.x
-                ExpandedPattern
+                Predicated
                     { term = fOfX
                     , predicate = makeEqualsPredicate fOfX gOfA
                     , substitution = [(Mock.y, hOfA)]
@@ -233,12 +233,12 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     hOfA = give mockSymbolOrAliasSorts $ Mock.h Mock.a
     something1OfX = give mockSymbolOrAliasSorts $ Mock.plain10 (mkVar Mock.x)
     something2OfX = give mockSymbolOrAliasSorts $ Mock.plain11 (mkVar Mock.x)
-    something1OfXExpanded = ExpandedPattern
+    something1OfXExpanded = Predicated
         { term = something1OfX
         , predicate = makeTruePredicate
         , substitution = []
         }
-    something2OfXExpanded = ExpandedPattern
+    something2OfXExpanded = Predicated
         { term = something2OfX
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -20,9 +20,9 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), top )
+                 ( top )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -49,7 +49,7 @@ test_simplificationIntegration = give mockSymbolOrAliasSorts
             (OrOfExpandedPattern.make [])
             (evaluate
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         -- Use the exact form we expect from an owise condition
                         -- for f(constr10(x)) = something
@@ -87,7 +87,7 @@ test_simplificationIntegration = give mockSymbolOrAliasSorts
             (OrOfExpandedPattern.make [ExpandedPattern.top])
             (evaluate
                 mockMetadataTools
-                ExpandedPattern
+                Predicated
                     { term =
                         -- Use the exact form we expect from an owise condition
                         -- for f(constr10(x)) = something

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Next.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Next.hs
@@ -20,9 +20,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeEqualsPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -41,7 +39,7 @@ test_nextSimplification = give mockSymbolOrAliasSorts
     [ testCase "Next evaluates to Next"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkNext Mock.a
                     , predicate = makeTruePredicate
                     , substitution = []
@@ -50,7 +48,7 @@ test_nextSimplification = give mockSymbolOrAliasSorts
             )
             (evaluate
                 (makeNext
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = Mock.a
                         , predicate = makeTruePredicate
                         , substitution = []
@@ -62,7 +60,7 @@ test_nextSimplification = give mockSymbolOrAliasSorts
     , testCase "Next collapses or"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term =
                         mkNext
                             (mkOr
@@ -76,12 +74,12 @@ test_nextSimplification = give mockSymbolOrAliasSorts
             )
             (evaluate
                 (makeNext
-                    [ ExpandedPattern
+                    [ Predicated
                         { term = Mock.a
                         , predicate = makeTruePredicate
                         , substitution = []
                         }
-                    , ExpandedPattern
+                    , Predicated
                         { term = Mock.b
                         , predicate = makeEqualsPredicate Mock.a Mock.b
                         , substitution = []
@@ -98,7 +96,7 @@ mockSymbolOrAliasSorts = Mock.makeSymbolOrAliasSorts Mock.symbolOrAliasSortsMapp
 findSort :: [CommonExpandedPattern Object] -> Sort Object
 findSort [] = Mock.testSort
 findSort
-    ( ExpandedPattern {term} : _ )
+    ( Predicated {term} : _ )
   =
     give mockSymbolOrAliasSorts $ getSort term
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
@@ -15,9 +15,7 @@ import           Kore.ASTUtils.SmartConstructors
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -33,7 +31,7 @@ test_stringLiteralSimplification =
     [ testCase "StringLiteral evaluates to StringLiteral"
         (assertEqualWithExplanation ""
             (OrOfExpandedPattern.make
-                [ ExpandedPattern
+                [ Predicated
                     { term = mkStringLiteral "a"
                     , predicate = makeTruePredicate
                     , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
@@ -11,9 +11,7 @@ import           Kore.ASTUtils.SmartConstructors
 import           Kore.Predicate.Predicate
                  ( makeTruePredicate, wrapPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (ExpandedPattern) )
-import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, Predicated (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -32,7 +30,7 @@ mockSimplifier
 mockSimplifier values =
     PureMLPatternSimplifier
         ( mockSimplifierHelper
-            (\patt -> ExpandedPattern
+            (\patt -> Predicated
                 {term = patt, predicate = makeTruePredicate, substitution = []}
             )
             values
@@ -48,7 +46,7 @@ mockPredicateSimplifier
 mockPredicateSimplifier values =
     PureMLPatternSimplifier
         (mockSimplifierHelper
-            (\patt -> ExpandedPattern
+            (\patt -> Predicated
                 { term = mkTop
                 , predicate = wrapPredicate patt
                 , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -31,7 +31,7 @@ import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.BaseStep
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern (..) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated(..) )
 import           Kore.Step.Simplification.Data
                  ( SimplificationProof (..), evalSimplifier )
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
@@ -78,7 +78,7 @@ rewriteImplies =
 expectTwoAxioms :: [(ExpandedPattern Meta Variable, StepProof Meta)]
 expectTwoAxioms =
     [
-        ( ExpandedPattern
+        ( Predicated
             { term = asPureMetaPattern (v1 PatternSort)
             , predicate = makeTruePredicate
             , substitution = []
@@ -90,7 +90,7 @@ expectTwoAxioms =
             ]
         )
     ,
-        ( ExpandedPattern
+        ( Predicated
             { term =
                 asPureMetaPattern
                     (metaImplies PatternSort
@@ -112,7 +112,7 @@ actualTwoAxioms :: [(CommonExpandedPattern Meta, StepProof Meta)]
 actualTwoAxioms =
     runStep
         mockMetadataTools
-        ExpandedPattern
+        Predicated
             { term = asPureMetaPattern (v1 PatternSort)
             , predicate = makeTruePredicate
             , substitution = []
@@ -123,7 +123,7 @@ actualTwoAxioms =
 
 initialFailSimple :: ExpandedPattern Meta Variable
 initialFailSimple =
-    ExpandedPattern
+    Predicated
         { term =
             asPureMetaPattern
                 ( metaSigma
@@ -155,7 +155,7 @@ actualFailSimple =
 
 initialFailCycle :: ExpandedPattern Meta Variable
 initialFailCycle =
-    ExpandedPattern
+    Predicated
         { term =
             asPureMetaPattern
                 ( metaSigma
@@ -190,7 +190,7 @@ actualFailCycle =
 
 initialIdentity :: ExpandedPattern Meta Variable
 initialIdentity =
-    ExpandedPattern
+    Predicated
         { term = asPureMetaPattern (v1 PatternSort)
         , predicate = makeTruePredicate
         , substitution = []
@@ -290,7 +290,7 @@ axiomsSimpleStrategy =
 
 expectOneStep :: (ExpandedPattern Meta Variable, StepProof Meta)
 expectOneStep =
-    ( ExpandedPattern
+    ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
         , predicate = makeTruePredicate
         , substitution = []
@@ -309,7 +309,7 @@ actualOneStep =
     runSteps
         mockMetadataTools
         Unlimited
-        ExpandedPattern
+        Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
             , predicate = makeTruePredicate
             , substitution = []
@@ -326,7 +326,7 @@ actualOneStep =
 
 expectTwoSteps :: (ExpandedPattern Meta Variable, StepProof Meta)
 expectTwoSteps =
-    ( ExpandedPattern
+    ( Predicated
         { term = asPureMetaPattern (metaH (v1 PatternSort))
         , predicate = makeTruePredicate
         , substitution = []
@@ -346,7 +346,7 @@ actualTwoSteps =
     runSteps
         mockMetadataTools
         Unlimited
-        ExpandedPattern
+        Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
             , predicate = makeTruePredicate
             , substitution = []
@@ -356,7 +356,7 @@ actualTwoSteps =
 
 expectZeroStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta)
 expectZeroStepLimit =
-        ( ExpandedPattern
+        ( Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
             , predicate = makeTruePredicate
             , substitution = []
@@ -369,7 +369,7 @@ actualZeroStepLimit =
     runSteps
         mockMetadataTools
         (Limit 0)
-        ExpandedPattern
+        Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
             , predicate = makeTruePredicate
             , substitution = []
@@ -378,7 +378,7 @@ actualZeroStepLimit =
 
 expectStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta)
 expectStepLimit =
-    ( ExpandedPattern
+    ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
         , predicate = makeTruePredicate
         , substitution = []
@@ -395,7 +395,7 @@ actualStepLimit =
     runSteps
         mockMetadataTools
         (Limit 1)
-        ExpandedPattern
+        Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
             , predicate = makeTruePredicate
             , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Substitution.hs
@@ -2,15 +2,15 @@ module Test.Kore.Step.Substitution
     ( test_mergeAndNormalizeSubstitutions
     ) where
 
+import Control.Monad.Counter
+       ( evalCounter )
+import Control.Monad.Except
+import Data.Reflection
+       ( give )
 import Test.Tasty
        ( TestTree )
 import Test.Tasty.HUnit
        ( assertEqual, testCase )
-import Control.Monad.Except
-import Control.Monad.Counter
-       ( evalCounter )
-import Data.Reflection
-       ( give )
 
 import Kore.AST.Common
        ( Variable )

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -44,9 +44,9 @@ import           Kore.Predicate.Predicate
 import qualified Kore.Predicate.Predicate as Predicate
                  ( makeEqualsPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern (..) )
+                 ( ExpandedPattern, Predicated(..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern (..), bottom )
+                 ( bottom )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -269,7 +269,7 @@ unificationResult
     -> Predicate Object Variable
     -> ExpandedPattern Object Variable
 unificationResult (UnificationResultTerm pat) sub predicate =
-    ExpandedPattern.ExpandedPattern
+    Predicated
         { term = extractPurePattern pat
         , predicate = predicate
         , substitution = unificationSubstitution sub
@@ -306,7 +306,7 @@ andSimplifySuccess message term1 term2 resultTerm subst predicate proof =
 
     subst'' = subst'
         { substitution =
-            sortBy (compare `on` fst) (ExpandedPattern.substitution subst')
+            sortBy (compare `on` fst) (substitution subst')
         }
 
 
@@ -691,7 +691,7 @@ simplifyPattern :: UnificationTerm Object -> UnificationTerm Object
 simplifyPattern (UnificationTerm pStub) =
     let pat =
             project
-            $ ExpandedPattern.term
+            $ term
             $ evalSimplifier
             $ do
                 simplifiedPatterns <-
@@ -708,7 +708,7 @@ simplifyPattern (UnificationTerm pStub) =
     in UnificationTerm (SortedPatternStub (SortedPattern pat resultSort))
   where
     functionRegistry = Map.empty
-    expandedPattern = ExpandedPattern
+    expandedPattern = Predicated
         { term = extractPurePattern pStub
         , predicate = makeTruePredicate
         , substitution = []

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -691,7 +691,7 @@ simplifyPattern :: UnificationTerm Object -> UnificationTerm Object
 simplifyPattern (UnificationTerm pStub) =
     let pat =
             project
-            $ term
+            $ ExpandedPattern.term
             $ evalSimplifier
             $ do
                 simplifiedPatterns <-

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -46,7 +46,7 @@ import qualified Kore.Predicate.Predicate as Predicate
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, Predicated(..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( bottom )
+                 ( Predicated(..), bottom )
 import qualified Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -306,7 +306,7 @@ andSimplifySuccess message term1 term2 resultTerm subst predicate proof =
 
     subst'' = subst'
         { substitution =
-            sortBy (compare `on` fst) (substitution subst')
+            sortBy (compare `on` fst) (ExpandedPattern.substitution subst')
         }
 
 


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

This has the potential to simplify a lot of code in `Simplification`. `ExpandedPattern` is now a pattern synonym, and all code works, so there's no rush to refactor.

