### PR TITLE
Jenkins script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-/.build/*
-
-!/.build/k
-
+/.build/
+!/.build/k/
 
 *.cache
 *.class

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -243,6 +243,7 @@ language_extensions:
   - DeriveGeneric
   - DeriveTraversable
   - DuplicateRecordFields
+  - EmptyCase
   - ExistentialQuantification
   - FlexibleContexts
   - FlexibleInstances
@@ -265,4 +266,3 @@ language_extensions:
   - TypeSynonymInstances
   - UndecidableInstances
   - ViewPatterns
-

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-kore:
 test-k:
 	$(MAKE) -C src/main/k/working test-k
 
-jenkins: all test docs
+jenkins: check all test docs
 
 distclean: clean
 	cd $(K_SUBMODULE) \

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,6 @@ clean: clean-submodules
 	stack clean
 	find -name '*.tix' -exec rm -f '{}' \;
 	$(MAKE) -C src/main/k/working clean
+
+check:
+	./scripts/git-rebased-on.sh master --linear

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean: clean-submodules
 
 check:
 	./scripts/git-assert-clean.sh
-	./scripts/git-rebased-on.sh master --linear
+	./scripts/git-rebased-on.sh origin/master --linear
 	if ! command -v stylish-haskell; then \
 		stack build stylish-haskell; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,16 @@
-# Settings
-# --------
+include include.mk
 
-BUILD_DIR:=$(CURDIR)/.build
-K_SUBMODULE:=$(BUILD_DIR)/k
-export K_BIN=$(K_SUBMODULE)/k-distribution/target/release/k/bin/
-
-.PHONY: all clean deps k-deps distclean clean-submodules kore-exec
+.PHONY: all test test-kore test-k distclean clean clean-submodules
 
 all: kore-exec
 
-test: kore-test k-test
+test: test-kore test-k
 
-kore-test:
-	stack test --pedantic
+test-kore:
+	$(STACK) test $(STACK_TEST_OPTS)
 
-k-test: kore-exec k-deps
-	$(MAKE) -C src/main/k/working k-test
-
-kore-exec:
-	stack build kore:exe:kore-exec
-
-deps: k-deps
+test-k:
+	$(MAKE) -C src/main/k/working test-k
 
 distclean: clean
 	cd $(K_SUBMODULE) \
@@ -30,18 +20,6 @@ distclean: clean
 clean: clean-submodules
 	stack clean
 	$(MAKE) -C src/main/k/working clean
-	rm -rf $(BUILD_DIR)/bin
 
 clean-submodules:
-	rm -rf $(K_SUBMODULE)/make.timestamp
-
-
-k-deps: $(K_SUBMODULE)/make.timestamp
-
-$(K_SUBMODULE)/make.timestamp:
-	@echo "== submodule: $@"
-	git submodule update --init -- $(K_SUBMODULE)
-	cd $(K_SUBMODULE) \
-		&& mvn package -q -DskipTests -U
-	touch $(K_SUBMODULE)/make.timestamp
-
+	rm -rf $(K_TIMESTAMP)

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,8 @@ clean: clean-submodules
 
 check:
 	./scripts/git-assert-clean.sh
-	export PATH=$(STACK_LOCAL_INSTALL_ROOT)/bin:$$PATH
 	if ! command -v stylish-haskell; then \
-		stack build stylish-haskell; \
+		stack install stylish-haskell; \
 	fi
 	./scripts/check-stylish-haskell.sh \
 		src/main/haskell/kore/app \

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,5 @@ distclean: clean
 
 clean: clean-submodules
 	stack clean
+	find -name '*.tix' -exec rm -f '{}' \;
 	$(MAKE) -C src/main/k/working clean

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,12 @@ clean: clean-submodules
 	$(MAKE) -C src/main/k/working clean
 
 check:
+	./scripts/git-assert-clean.sh
 	./scripts/git-rebased-on.sh master --linear
+	if ! command -v stylish-haskell; then \
+		stack build stylish-haskell; \
+	fi
+	./scripts/check-stylish-haskell.sh \
+		src/main/haskell/kore/app \
+		src/main/haskell/kore/src \
+		src/main/haskell/kore/test

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,35 @@
 include include.mk
 
-.PHONY: all test test-kore test-k distclean clean clean-submodules
+jenkins: STACK_OPTS += --test --bench --coverage
+export STACK_OPTS
 
-all: kore-exec
+.PHONY: all docs haddock jenkins kore test test-kore test-k distclean clean clean-submodules
+
+kore:
+	stack build $(STACK_BUILD_OPTS)
+
+docs: haddock
+
+haddock:
+	stack haddock --no-haddock-deps $(STACK_HADDOCK_OPTS)
+	if [ -n "$$BUILD_NUMBER" ]; then \
+		cp -r $$(stack path --local-doc-root) haskell_documentation; \
+	fi
+
+all: kore
 
 test: test-kore test-k
 
 test-kore:
-	$(STACK) test $(STACK_TEST_OPTS)
+	stack test $(STACK_TEST_OPTS)
+	if [ -n "$$BUILD_NUMBER" ]; then \
+		cp -r $$(stack path --local-hpc-root) coverage_report; \
+	fi
 
 test-k:
 	$(MAKE) -C src/main/k/working test-k
+
+jenkins: all test docs
 
 distclean: clean
 	cd $(K_SUBMODULE) \
@@ -20,6 +39,3 @@ distclean: clean
 clean: clean-submodules
 	stack clean
 	$(MAKE) -C src/main/k/working clean
-
-clean-submodules:
-	rm -rf $(K_TIMESTAMP)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ clean: clean-submodules
 
 check:
 	./scripts/git-assert-clean.sh
+	export PATH=$(STACK_LOCAL_INSTALL_ROOT)/bin:$$PATH
 	if ! command -v stylish-haskell; then \
 		stack build stylish-haskell; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ clean: clean-submodules
 
 check:
 	./scripts/git-assert-clean.sh
-	./scripts/git-rebased-on.sh origin/master --linear
 	if ! command -v stylish-haskell; then \
 		stack build stylish-haskell; \
 	fi

--- a/include.mk
+++ b/include.mk
@@ -19,9 +19,10 @@ endif
 
 STACK_LOCAL_INSTALL_ROOT != stack path --local-install-root
 KORE_EXEC ?= $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
+KORE_EXEC_OPTS ?=
 
 KOMPILE_OPTS ?= --backend haskell
-KRUN_OPTS ?= --haskell-backend-command $(KORE_EXEC)
+KRUN_OPTS ?= --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
 
 KOMPILE_TARGETS := $(KOMPILE)
 KRUN_TARGETS := $(KRUN) $(KORE_EXEC)

--- a/include.mk
+++ b/include.mk
@@ -32,7 +32,7 @@ FORCE:
 
 $(K_SUBMODULE): FORCE
 	if [ ! -d $(K_SUBMODULE) ]; then git submodule update --init -- $(K_SUBMODULE); fi
-	cd $(K_SUBMODULE) && touch -d `git log --format=format:%cI -n 1` .
+	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cd -n 1) .
 
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec

--- a/include.mk
+++ b/include.mk
@@ -32,7 +32,9 @@ KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
 FORCE:
 
 $(K_SUBMODULE): FORCE
-	if [ ! -a $(K_SUBMODULE)/pom.xml ]; then git submodule update --init -- $(K_SUBMODULE); fi
+	if test ! -f $(K_SUBMODULE)/pom.xml; then \
+		git submodule update --init -- $(K_SUBMODULE); \
+	fi
 	cd $(K_SUBMODULE) && touch -d "$$(git log --format=format:%cD -n 1)" .
 
 $(KORE_EXEC): FORCE

--- a/include.mk
+++ b/include.mk
@@ -1,0 +1,40 @@
+# Settings
+
+TOP ?= $(shell git rev-parse --show-toplevel)
+
+BUILD_DIR := $(TOP)/.build
+K_SUBMODULE := $(BUILD_DIR)/k
+K_BIN := $(K_SUBMODULE)/k-distribution/target/release/k/bin
+KOMPILE := $(K_BIN)/kompile
+KRUN := $(K_BIN)/krun
+
+STACK_LOCAL_INSTALL_ROOT != stack path --local-install-root
+KORE_EXEC ?= $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
+
+KOMPILE_OPTS ?= --backend haskell
+KRUN_OPTS ?= --haskell-backend-command $(KORE_EXEC)
+
+KOMPILE_TARGETS := $(KOMPILE)
+KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
+
+STACK ?= stack
+STACK_OPTS ?= --test --bench --pedantic
+STACK_BUILD_OPTS ?= $(STACK_OPTS) --no-run-tests --no-run-benchmarks
+STACK_TEST_OPTS ?= $(STACK_OPTS) --no-run-benchmarks
+
+# Targets
+
+FORCE:
+
+$(K_SUBMODULE): FORCE
+	if [ ! -d $(K_SUBMODULE) ]; then git submodule update --init -- $(K_SUBMODULE); fi
+	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cI -n 1) .
+
+$(KORE_EXEC): FORCE
+	$(STACK) build $(STACK_BUILD_OPTS) kore:exe:kore-exec
+
+$(KOMPILE): $(K_SUBMODULE)
+	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U
+
+$(KRUN): $(K_SUBMODULE)
+	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U

--- a/include.mk
+++ b/include.mk
@@ -32,7 +32,7 @@ FORCE:
 
 $(K_SUBMODULE): FORCE
 	if [ ! -d $(K_SUBMODULE) ]; then git submodule update --init -- $(K_SUBMODULE); fi
-	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cI -n 1) .
+	cd $(K_SUBMODULE) && touch -d `git log --format=format:%cI -n 1` .
 
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec

--- a/include.mk
+++ b/include.mk
@@ -32,8 +32,8 @@ KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
 FORCE:
 
 $(K_SUBMODULE): FORCE
-	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cd -n 1) .
 	if [ ! -a $(K_SUBMODULE)/pom.xml ]; then git submodule update --init -- $(K_SUBMODULE); fi
+	cd $(K_SUBMODULE) && touch -d "$$(git log --format=format:%cD -n 1)" .
 
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec

--- a/include.mk
+++ b/include.mk
@@ -8,6 +8,15 @@ K_BIN := $(K_SUBMODULE)/k-distribution/target/release/k/bin
 KOMPILE := $(K_BIN)/kompile
 KRUN := $(K_BIN)/krun
 
+STACK_OPTS ?= --pedantic
+STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
+STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
+STACK_TEST_OPTS = $(STACK_OPTS) --no-run-benchmarks
+
+ifdef BUILD_NUMBER
+STACK_TEST_OPTS += --ta --xml=test-results.xml
+endif
+
 STACK_LOCAL_INSTALL_ROOT != stack path --local-install-root
 KORE_EXEC ?= $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
 
@@ -16,11 +25,6 @@ KRUN_OPTS ?= --haskell-backend-command $(KORE_EXEC)
 
 KOMPILE_TARGETS := $(KOMPILE)
 KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
-
-STACK ?= stack
-STACK_OPTS ?= --test --bench --pedantic
-STACK_BUILD_OPTS ?= $(STACK_OPTS) --no-run-tests --no-run-benchmarks
-STACK_TEST_OPTS ?= $(STACK_OPTS) --no-run-benchmarks
 
 # Targets
 
@@ -31,7 +35,7 @@ $(K_SUBMODULE): FORCE
 	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cI -n 1) .
 
 $(KORE_EXEC): FORCE
-	$(STACK) build $(STACK_BUILD_OPTS) kore:exe:kore-exec
+	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec
 
 $(KOMPILE): $(K_SUBMODULE)
 	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U

--- a/include.mk
+++ b/include.mk
@@ -32,8 +32,8 @@ KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
 FORCE:
 
 $(K_SUBMODULE): FORCE
-	if [ ! -d $(K_SUBMODULE) ]; then git submodule update --init -- $(K_SUBMODULE); fi
 	cd $(K_SUBMODULE) && touch -d $$(git log --format=format:%cd -n 1) .
+	if [ ! -a $(K_SUBMODULE)/pom.xml ]; then git submodule update --init -- $(K_SUBMODULE); fi
 
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec

--- a/scripts/check-stylish-haskell.sh
+++ b/scripts/check-stylish-haskell.sh
@@ -3,5 +3,5 @@
 set -e
 
 find "$@" \( -name '*.hs' -o -name '*.hs-boot' \) \
-    -execdir stylish-haskell -i '{}' \; \
+    -exec stylish-haskell -i '{}' \; \
     && $(dirname "$0")/git-assert-clean.sh

--- a/scripts/check-stylish-haskell.sh
+++ b/scripts/check-stylish-haskell.sh
@@ -2,5 +2,6 @@
 
 set -e
 
-find "$@" \( -name '*.hs' -o -name '*.hs-boot' \) -exec stylish-haskell -i '{}' \;
-$(dirname "$0")/git-assert-clean.sh
+find "$@" \( -name '*.hs' -o -name '*.hs-boot' \) \
+    -execdir stylish-haskell -i '{}' \; \
+    && $(dirname "$0")/git-assert-clean.sh

--- a/scripts/check-stylish-haskell.sh
+++ b/scripts/check-stylish-haskell.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+find "$@" \( -name '*.hs' -o -name '*.hs-boot' \) -exec stylish-haskell -i '{}' \;
+$(dirname "$0")/git-assert-clean.sh

--- a/scripts/git-assert-clean.sh
+++ b/scripts/git-assert-clean.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ ! $(git status --porcelain | wc -l) -eq 0 ]; then
+    echo "Found dirty files:"
+    git status --porcelain
+    exit 1
+fi

--- a/scripts/git-rebased-on.sh
+++ b/scripts/git-rebased-on.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+merge_branch="$1" ; shift
+[[ -z "$1" ]] || { linear="$1" ; shift ; }
+
+# check "ahead of master"
+common_hash="$(git rev-parse "$merge_branch")"
+merge_base_hash="$(git merge-base "$merge_branch" 'HEAD')"
+
+if [[ "$common_hash" != "$merge_base_hash" ]]; then
+    echo "HEAD not based on '$merge_branch'" >&2
+    exit 1
+fi
+
+[[ ! -z "$linear" ]] || exit 0
+
+# check linear history
+for rev in $(git rev-list HEAD "^$merge_branch"); do
+    if git rev-parse "$rev^"'2' &>/dev/null; then
+        echo "Merge commit found: $rev" >&2
+        exit 1
+    fi
+done

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -11,7 +11,8 @@ import Data.String
        ( fromString )
 import Data.Text.Prettyprint.Doc as Doc
 import Data.Text.Prettyprint.Doc.Render.String
-import Data.Void ( Void )
+import Data.Void
+       ( Void )
 
 import           Data.Functor.Impredicative
 import           Kore.AST.Common

--- a/src/main/haskell/kore/src/Kore/SMT/Config.hs
+++ b/src/main/haskell/kore/src/Kore/SMT/Config.hs
@@ -1,7 +1,7 @@
 module Kore.SMT.Config
 ( SMTTimeOut(..)
 )
-where 
+where
 
 
 newtype SMTTimeOut = SMTTimeOut Integer

--- a/src/main/haskell/kore/src/Kore/SMT/SMT.hs
+++ b/src/main/haskell/kore/src/Kore/SMT/SMT.hs
@@ -25,7 +25,7 @@ import           Control.Monad.State
 import           Data.Default
 import qualified Data.Map as Map
 import           Data.Proxy
-import           Text.Megaparsec 
+import           Text.Megaparsec
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
@@ -33,9 +33,9 @@ import           Kore.ASTUtils.SmartConstructors
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.Attribute.Parser
                  ( ParseAttributes (..) )
+import qualified Kore.Builtin.Bool as Bool
 import           Kore.Builtin.Hook
-import qualified Kore.Builtin.Bool as Bool 
-import qualified Kore.Builtin.Int as Int 
+import qualified Kore.Builtin.Int as Int
 import           Kore.IndexedModule.MetadataTools
 import qualified Kore.Predicate.Predicate as KorePredicate
 import           Kore.SMT.Config
@@ -232,7 +232,7 @@ patternToSMT sloppy p =
         goIntLiteral pat@(DV_ sort (BuiltinDomainPattern (StringLiteral_ str))) hookName
          | (getHookString $ getSortHook sort) == hookName
             = let parsed = runParser Int.parse "" str
-              in 
+              in
               case parsed of
                 Right i -> return $ literal i
                 Left _ -> throwError $ ExpectedDVPattern pat
@@ -245,7 +245,7 @@ patternToSMT sloppy p =
         goBoolLiteral pat@(DV_ sort (BuiltinDomainPattern (StringLiteral_ str))) hookName
          | (getHookString $ getSortHook sort) == hookName
             = let parsed = runParser Bool.parse "" str
-              in 
+              in
               case parsed of
                 Right i -> return $ literal i
                 Left _ -> throwError $ ExpectedDVPattern pat

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -11,8 +11,8 @@ module Kore.Step.Condition.Evaluator
     ( evaluate
     ) where
 
+import Control.Monad.Reader
 import Data.Reflection
-import           Control.Monad.Reader
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -74,7 +74,7 @@ data Predicated level variable child = Predicated
 instance Functor (Predicated level variable) where
     fmap f (Predicated a p s) = Predicated (f a) p s
 
--- `<*>` does not do normalization for now. 
+-- `<*>` does not do normalization for now.
 -- Don't use it until we figure that out.
 
 instance

--- a/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
@@ -38,7 +38,6 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate )
-import           Kore.Step.Simplification.Data
 import           Kore.Step.ExpandedPattern
                  ( substitutionToPredicate )
 import           Kore.Step.PatternAttributes
@@ -49,6 +48,7 @@ import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( PredicateSubstitution (..), top )
 import qualified Kore.Step.Simplification.Ceil as Ceil
                  ( makeEvaluateTerm )
+import           Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.Equals as Equals
                  ( makeEvaluateTermsToPredicateSubstitution )
 import           Kore.Step.StepperAttributes

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs-boot
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs-boot
@@ -1,24 +1,24 @@
 module Kore.Step.Substitution where
 
-import Kore.AST.MetaOrObject
-import Kore.Variables.Fresh
-       ( FreshVariable )
-import Kore.AST.Common
-       ( SortedVariable )
 import Control.Monad.Counter
        ( MonadCounter )
-import Kore.Substitution.Class
-       ( Hashable )
+import Kore.AST.Common
+       ( SortedVariable )
+import Kore.AST.MetaOrObject
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools )
-import Kore.Step.StepperAttributes
-       ( StepperAttributes )
 import Kore.Predicate.Predicate
        ( Predicate )
-import Kore.Unification.Data
-       ( UnificationSubstitution, UnificationProof )
 import Kore.Step.ExpandedPattern
        ( PredicateSubstitution )
+import Kore.Step.StepperAttributes
+       ( StepperAttributes )
+import Kore.Substitution.Class
+       ( Hashable )
+import Kore.Unification.Data
+       ( UnificationProof, UnificationSubstitution )
+import Kore.Variables.Fresh
+       ( FreshVariable )
 
 mergePredicatesAndSubstitutions
     :: ( Show (variable level)

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -39,9 +39,9 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Predicate.Predicate as Predicate
                  ( isFalse, makeAndPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern, PredicateSubstitution(..))
+                 ( ExpandedPattern, PredicateSubstitution (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( Predicated (..), bottom, top, )
+                 ( Predicated (..), bottom, top )
 import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( PredicateSubstitution (..), top )
 import           Kore.Step.StepperAttributes

--- a/src/main/haskell/kore/test/Test/Kore/SMT/SMT.hs
+++ b/src/main/haskell/kore/test/Test/Kore/SMT/SMT.hs
@@ -15,8 +15,8 @@ import Kore.ASTUtils.SmartPatterns
 import Kore.IndexedModule.IndexedModule
 import Kore.IndexedModule.MetadataTools
 import Kore.Proof.Dummy
-import Kore.SMT.SMT
 import Kore.SMT.Config
+import Kore.SMT.SMT
 
 
 import Test.Kore.Builtin.Bool
@@ -58,9 +58,9 @@ mul a b = App_ mulSymbol  [a, b]
 div   a b = App_ tdivSymbol [a, b]
 
 run :: CommonPurePattern Object -> Property
-run prop = 
-  (give tools $ unsafeTryRefutePattern (SMTTimeOut 1000) prop) 
-  === 
+run prop =
+  (give tools $ unsafeTryRefutePattern (SMTTimeOut 1000) prop)
+  ===
   Just False
 
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -24,7 +24,7 @@ import Kore.Predicate.Predicate
        ( Predicate, makeEqualsPredicate, makeFalsePredicate,
        makeTruePredicate )
 import Kore.Step.ExpandedPattern as ExpandedPattern
-       ( Predicated(..), allVariables, mapVariables, toMLPattern )
+       ( Predicated (..), allVariables, mapVariables, toMLPattern )
 
 import Test.Kore.Comparators ()
 import Test.Tasty.HUnit.Extensions

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
@@ -26,7 +26,6 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeCeilPredicate, makeEqualsPredicate,
                  makeTruePredicate )
-import           Kore.Step.Simplification.Data
 import           Kore.Step.Function.Matcher
                  ( matchAsUnification )
 import           Kore.Step.PredicateSubstitution
@@ -34,15 +33,16 @@ import           Kore.Step.PredicateSubstitution
                  PredicateSubstitution (PredicateSubstitution) )
 import qualified Kore.Step.PredicateSubstitution as PredicateSubstitution
                  ( PredicateSubstitution (..), bottom, top )
+import           Kore.Step.Simplification.Data
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 
+import           Kore.SMT.Config
 import           Test.Kore.Comparators ()
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
                  ( makeMetadataTools, makeSymbolOrAliasSorts )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
-import           Kore.SMT.Config
 
 test_matcherEqualHeads :: [TestTree]
 test_matcherEqualHeads = give mockSymbolOrAliasSorts

--- a/src/main/k/working/Makefile
+++ b/src/main/k/working/Makefile
@@ -1,4 +1,4 @@
-TOPTARGETS := all clean test k-test
+TOPTARGETS := all clean test test-k
 
 SUBDIRS := $(wildcard */.)
 

--- a/src/main/k/working/function-evaluation-demo/Makefile
+++ b/src/main/k/working/function-evaluation-demo/Makefile
@@ -1,32 +1,34 @@
-KORE_EXEC?="stack exec kore-exec --"
-KOMPILE?=$(K_BIN)kompile
-KRUN?=$(K_BIN)krun --haskell-backend-command $(KORE_EXEC)
+TOP != git rev-parse --show-toplevel
+include $(TOP)/include.mk
 
-demo-kompiled/definition.kore: demo.k
-	$(KOMPILE) demo.k --backend haskell --syntax-module DEMO
+KOMPILED := demo-kompiled
+DEFINITION := $(KOMPILED)/definition.kore
 
-%.demo.kore: %.demo demo-kompiled/definition.kore
-	$(KRUN) $< --dry-run
+$(DEFINITION): demo.k $(KOMPILE_TARGETS)
+	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module DEMO
 
-%.output: %.demo demo-kompiled/definition.kore
-	$(KRUN) $< --output-file $@
+%.imp.kore: %.demo $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.krun: %.demo demo-kompiled/definition.kore
-	$(KRUN) $<
+%.output: %.demo $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --output-file $@
+
+%.krun: %.demo $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
-	diff $< $<.golden
+	diff -u $<.golden $<
 
 %.output.golden: %.output
 	mv $< $<.golden
 
 test: tests/Nat.test tests/NatList.test tests/Truth.test
 
-k-test: test
+test-k: test
 
 golden: tests/Nat.output.golden tests/NatList.output.golden tests/Truth.output.golden
 
 clean:
-	rm -rf demo-kompiled tests/*.demo.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
 
-.PHONY: k-test test golden clean %.test %.krun
+.PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-concrete-heat-cool/Makefile
+++ b/src/main/k/working/imp-concrete-heat-cool/Makefile
@@ -1,32 +1,34 @@
-KORE_EXEC?="stack exec kore-exec --"
-KOMPILE?=$(K_BIN)kompile
-KRUN?=$(K_BIN)krun --haskell-backend-command $(KORE_EXEC)
+TOP != git rev-parse --show-toplevel
+include $(TOP)/include.mk
 
-imp-kompiled/definition.kore: imp.k
-	$(KOMPILE) imp.k --backend haskell --syntax-module IMP
+KOMPILED := imp-kompiled
+DEFINITION := $(KOMPILED)/definition.kore
 
-%.imp.kore: %.imp imp-kompiled/definition.kore
-	$(KRUN) $< --dry-run
+$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.output: %.imp imp-kompiled/definition.kore
-	$(KRUN) $< --output-file $@
+%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.krun: %.imp imp-kompiled/definition.kore
-	$(KRUN) $<
+%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --output-file $@
+
+%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
-	diff $< $<.golden
+	diff -u $<.golden $<
 
 %.output.golden: %.output
 	mv $< $<.golden
 
 test: tests/sum.test tests/primes.test tests/collatz.test
 
-k-test: tests/sum.test
+test-k: tests/sum.test
 
 golden: tests/sum.output.golden tests/primes.output.golden tests/collatz.output.golden
 
 clean:
-	rm -rf imp-kompiled tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
 
-.PHONY: k-test test golden clean %.test %.krun
+.PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-monosorted/Makefile
+++ b/src/main/k/working/imp-monosorted/Makefile
@@ -1,32 +1,34 @@
-KORE_EXEC?="stack exec kore-exec --"
-KOMPILE?=$(K_BIN)kompile
-KRUN?=$(K_BIN)krun --haskell-backend-command $(KORE_EXEC)
+TOP != git rev-parse --show-toplevel
+include $(TOP)/include.mk
 
-imp-kompiled/definition.kore: imp.k
-	$(KOMPILE) imp.k --backend haskell --syntax-module IMP
+KOMPILED := imp-kompiled
+DEFINITION := $(KOMPILED)/definition.kore
 
-%.imp.kore: %.imp imp-kompiled/definition.kore
-	$(KRUN) $< --dry-run
+$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.output: %.imp imp-kompiled/definition.kore
-	$(KRUN) $< --output-file $@
+%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.krun: %.imp imp-kompiled/definition.kore
-	$(KRUN) $<
+%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $< --output-file $@
+
+%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
-	diff $< $<.golden
+	diff -u $<.golden $<
 
 %.output.golden: %.output
 	mv $< $<.golden
 
 test: tests/sum.test tests/primes.test tests/collatz.test
 
-k-test: tests/sum.test
+test-k: tests/sum.test
 
 golden: tests/sum.output.golden tests/primes.output.golden tests/collatz.output.golden
 
 clean:
-	rm -rf imp-kompiled tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
 
-.PHONY: k-test test golden clean %.test %.krun
+.PHONY: test-k test golden clean %.test %.krun


### PR DESCRIPTION
Including the Jenkins script in the repository allows us to track changes in
Git. Contributors may also run the script to check their code before making a
pull request.

This will also enforce the condition, mentioned in the Coding Standards document, that the Git history be linear.

Once merged, I would change the Jenkins configuration to call `scripts/jenkins.sh`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

