### PR TITLE
Unify builtin Maps

### DIFF
--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -1079,16 +1079,21 @@ deriving instance
     ( Eq child
     , Eq (variable level)
     ) => Eq (Pattern level variable child)
+
 deriving instance
     ( Show child
     , Show (variable level)
     ) => Show (Pattern level variable child)
+
 deriving instance
     ( Ord child
     , Ord (variable level)
     ) => Ord (Pattern level variable child)
+
 deriving instance Functor (Pattern level variable)
+
 deriving instance Foldable (Pattern level variable)
+
 deriving instance Traversable (Pattern level variable)
 
 data SortedPattern level variable child = SortedPattern

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -46,6 +46,7 @@ module Kore.Builtin.Builtin
     , runParser
     , appliedFunction
     , lookupSymbol
+    , isSymbol
     , expectNormalConcreteTerm
     , getAttemptedFunction
     ) where
@@ -671,6 +672,18 @@ lookupSymbol builtinName indexedModule
         { symbolOrAliasConstructor
         , symbolOrAliasParams = []
         }
+
+{- | Is the given symbol hooked to the named builtin?
+ -}
+isSymbol
+    :: String  -- ^ Builtin symbol
+    -> MetadataTools Object Hook
+    -> SymbolOrAlias Object  -- ^ Kore symbol
+    -> Bool
+isSymbol builtinName MetadataTools { symAttributes } sym =
+    case getHook (symAttributes sym) of
+        Just hook -> hook == builtinName
+        Nothing -> False
 
 {- | Ensure that a 'PureMLPattern' is a concrete, normalized term.
 

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -27,7 +27,6 @@ import qualified Data.Map as Map
 import           Kore.AST.Common
                  ( Application (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-                 ( Meta, Object )
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -79,10 +78,9 @@ builtinFunctions =
 evalKEq
     ::  ( FreshVariable variable
         , Hashable variable
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
         , SortedVariable variable
-        , Show (variable Object)
+        , ShowMetaOrObject variable
         )
     => Bool
     -> Bool

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -29,6 +29,7 @@ module Kore.Builtin.Map
     , lookupSymbolElement
     , lookupSymbolConcat
     , lookupSymbolInKeys
+    , isSymbolConcat
     ) where
 
 import qualified Control.Monad as Monad
@@ -48,9 +49,13 @@ import qualified Kore.AST.PureML as Kore
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
+import           Kore.Builtin.Hook
+                 ( Hook )
 import qualified Kore.Error as Kore
 import           Kore.IndexedModule.IndexedModule
                  ( KoreIndexedModule )
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
@@ -353,3 +358,8 @@ lookupSymbolInKeys
     :: KoreIndexedModule attrs
     -> Either (Kore.Error e) (Kore.SymbolOrAlias Object)
 lookupSymbolInKeys = Builtin.lookupSymbol "MAP.in_keys"
+
+{- | Check if the given symbol is hooked to @MAP.concat@.
+ -}
+isSymbolConcat :: MetadataTools Object Hook -> Kore.SymbolOrAlias Object -> Bool
+isSymbolConcat = Builtin.isSymbol "MAP.concat"

--- a/src/main/haskell/kore/src/Kore/IndexedModule/MetadataTools.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/MetadataTools.hs
@@ -39,6 +39,7 @@ data MetadataTools level attributes = MetadataTools
     {- ^ @isSubsortOf a b@ is true if sort @a@ is a subsort of sort @b@,
        including when @a@ equals @b@. -}
     }
+  deriving Functor
 
 type SymbolOrAliasSorts level = SymbolOrAlias level -> ApplicationSorts level
 

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -188,10 +188,10 @@ stepWithAxiom
         , Hashable variable
         , MetaOrObject level
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
         , SortedVariable variable
         , Show (variable level)
+        , ShowMetaOrObject variable
         )
     => MetadataTools level StepperAttributes
     -> ExpandedPattern.ExpandedPattern level variable

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -18,7 +18,6 @@ module Kore.Step.Function.Data
 import Kore.AST.Common
        ( Application, PureMLPattern, SortedVariable, Variable )
 import Kore.AST.MetaOrObject
-       ( Meta, MetaOrObject, Object )
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools )
 import Kore.Step.OrOfExpandedPattern
@@ -57,10 +56,10 @@ newtype ApplicationFunctionEvaluator level=
             , Hashable variable
             , MetaOrObject level
             , Ord (variable level)
-            , Ord (variable Meta)
-            , Ord (variable Object)
+            , OrdMetaOrObject variable
             , SortedVariable variable
             , Show (variable level)
+            , ShowMetaOrObject variable
             )
         => MetadataTools level StepperAttributes
         -> PureMLPatternSimplifier level variable

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -59,8 +59,8 @@ evaluateApplication
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -198,9 +198,8 @@ mergeWithConditionAndSubstitution
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -20,7 +20,6 @@ import           Kore.AST.Common
                  ( Application (..), Pattern (..), PureMLPattern,
                  SortedVariable )
 import           Kore.AST.MetaOrObject
-                 ( Meta, MetaOrObject, Object )
 import           Kore.AST.PureML
                  ( asPurePattern )
 import           Kore.IndexedModule.MetadataTools
@@ -64,10 +63,10 @@ axiomFunctionEvaluator
         , Hashable variable
         , MetaOrObject level
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
         , SortedVariable variable
         , Show (variable level)
+        , ShowMetaOrObject variable
         )
     => AxiomPattern level
     -- ^ Axiom defining the current function.
@@ -132,8 +131,8 @@ reevaluateFunctions
         , SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -183,8 +182,8 @@ evaluatePredicate
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/ExpandedPattern.hs
@@ -46,8 +46,8 @@ mergeWithPredicateSubstitution
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         , Given (MetadataTools level StepperAttributes)
@@ -96,8 +96,8 @@ mergeWithEvaluatedCondition
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Merging/OrOfExpandedPattern.hs
@@ -42,8 +42,8 @@ mergeWithPredicateSubstitution
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
@@ -81,8 +81,8 @@ simplify
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -110,8 +110,8 @@ simplifyEvaluated
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -152,8 +152,8 @@ makeEvaluate
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -177,8 +177,8 @@ makeEvaluateNonBool
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -229,9 +229,9 @@ makeTermAnd
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         )
     => MetadataTools level StepperAttributes

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -21,6 +21,8 @@ import Data.Functor.Foldable
        ( project )
 import Data.Reflection
        ( give )
+import Prelude hiding
+       ( concat )
 
 import           Data.Result
 import           Kore.AST.Common
@@ -30,9 +32,7 @@ import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartConstructors
                  ( mkAnd, mkApp, mkBottom, mkTop )
 import           Kore.ASTUtils.SmartPatterns
-                 ( pattern App_, pattern Bottom_, pattern CharLiteral_,
-                 pattern DV_, pattern StringLiteral_, pattern Top_,
-                 pattern Var_ )
+import qualified Kore.Builtin.Map as Builtin.Map
 import           Kore.IndexedModule.MetadataTools
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
                  ( MetadataTools (..) )
@@ -76,9 +76,9 @@ termEquals
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -105,9 +105,9 @@ termEqualsAnd
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -126,9 +126,9 @@ termEqualsAndChild
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -160,9 +160,9 @@ maybeTermEquals
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -211,9 +211,9 @@ termUnification
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -239,9 +239,9 @@ termAnd
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -269,9 +269,9 @@ maybeTermAnd
     ::  ( MetaOrObject level
         , Hashable variable
         , FreshVariable variable
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
         , SortedVariable variable
         , MonadCounter m
@@ -296,6 +296,7 @@ maybeTermAnd =
         , liftET domainValueAndEqualsAssumesDifferent
         , liftET stringLiteralAndEqualsAssumesDifferent
         , liftET charLiteralAndEqualsAssumesDifferent
+        , Builtin.Map.unify
         , lift functionAnd
         ]
   where
@@ -345,7 +346,7 @@ addToolsArg
 addToolsArg = pure
 
 toExpanded
-    :: 
+    ::
     ( MetaOrObject level
     , SortedVariable variable
     , Show (variable level)
@@ -577,9 +578,9 @@ equalInjectiveHeadsAndEquals
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
@@ -5,7 +5,7 @@ import Control.Monad.Counter
 import Kore.AST.Common
        ( PureMLPattern, SortedVariable )
 import Kore.AST.MetaOrObject
-       ( Meta, MetaOrObject, Object )
+       ( MetaOrObject, OrdMetaOrObject, ShowMetaOrObject )
 import Kore.IndexedModule.MetadataTools
        ( MetadataTools )
 import Kore.Step.ExpandedPattern
@@ -24,9 +24,9 @@ termAnd
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )
@@ -40,9 +40,9 @@ termUnification
         , Hashable variable
         , FreshVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , SortedVariable variable
         , MonadCounter m
         )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -71,8 +71,8 @@ simplify
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -116,8 +116,8 @@ makeAndEvaluateApplications
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -150,8 +150,8 @@ evaluateApplicationFunction
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -187,8 +187,8 @@ makeExpandedApplication
         , Ord (variable level)
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
@@ -133,8 +133,8 @@ simplify
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -158,8 +158,8 @@ simplifyEvaluated
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -194,8 +194,8 @@ makeEvaluate
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -291,8 +291,8 @@ makeEvaluateTermsAssumesNoBottom
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -328,8 +328,8 @@ makeEvaluateTermsAssumesNoBottomMaybe
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )
@@ -371,8 +371,8 @@ makeEvaluateTermsToPredicateSubstitution
         , SortedVariable variable
         , Show (variable level)
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , FreshVariable variable
         , Hashable variable
         )

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs
@@ -61,10 +61,10 @@ the correct condition.
 mergeSubstitutions
     :: ( MetaOrObject level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
-       , SortedVariable variable
        , Show (variable level)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
+       , SortedVariable variable
        , Hashable variable
        , FreshVariable variable
        , MonadCounter m
@@ -85,9 +85,10 @@ mergeSubstitutions tools first second =
 mergeAndNormalizeSubstitutions
     ::  ( MetaOrObject level
         , Ord (variable level)
-        , OrdMetaOrObject variable
-        , SortedVariable variable
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , SortedVariable variable
         , FreshVariable variable
         , MonadCounter m
         , Hashable variable
@@ -107,9 +108,10 @@ mergeAndNormalizeSubstitutions tools first second =
 normalizeSubstitutionAfterMerge
     ::  ( MetaOrObject level
         , Ord (variable level)
-        , OrdMetaOrObject variable
-        , SortedVariable variable
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , SortedVariable variable
         , FreshVariable variable
         , MonadCounter m
         , Hashable variable
@@ -165,8 +167,8 @@ mergePredicatesAndSubstitutions
        , SortedVariable variable
        , MetaOrObject level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
        , FreshVariable variable
        , MonadCounter m
        , Hashable variable
@@ -217,11 +219,11 @@ mergePredicatesAndSubstitutions tools predicates substitutions = do
 
 mergeSubstitutionWithPredicate
     :: ( Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
-       , SortedVariable variable
-       , MetaOrObject level
        , Show (variable level)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
+       , MetaOrObject level
+       , SortedVariable variable
        , Hashable variable
        , FreshVariable variable
        , MonadCounter m

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs-boot
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs-boot
@@ -25,8 +25,8 @@ mergePredicatesAndSubstitutions
        , SortedVariable variable
        , MetaOrObject level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
        , FreshVariable variable
        , MonadCounter m
        , Hashable variable

--- a/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
@@ -24,7 +24,6 @@ import Data.Reflection
 import           Kore.AST.Common
                  ( PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-                 ( Meta, MetaOrObject, Object )
 import           Kore.AST.MLPatterns
                  ( getPatternResultSort )
 import           Kore.IndexedModule.MetadataTools
@@ -62,12 +61,12 @@ import           Kore.Variables.Fresh
 unificationProcedure
     ::  ( SortedVariable variable
         , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , MetaOrObject level
         , Hashable variable
         , FreshVariable variable
-        , Show (variable level)
         , MonadCounter m
         )
     => MetadataTools level StepperAttributes

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -100,11 +100,11 @@ simplifyAnds
      . ( MetaOrObject level
        , Eq level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
-       , SortedVariable variable
        , Show (variable level)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
        , Hashable variable
+       , SortedVariable variable
        , FreshVariable variable
        , MonadCounter m
        )
@@ -171,10 +171,10 @@ solveGroupedSubstitution
     :: ( MetaOrObject level
        , Eq level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
-       , SortedVariable variable
        , Show (variable level)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
+       , SortedVariable variable
        , Hashable variable
        , FreshVariable variable
        , MonadCounter m
@@ -211,10 +211,10 @@ normalizeSubstitutionDuplication
     :: ( MetaOrObject level
        , Eq level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
-       , SortedVariable variable
        , Show (variable level)
+       , OrdMetaOrObject variable
+       , ShowMetaOrObject variable
+       , SortedVariable variable
        , Hashable variable
        , FreshVariable variable
        , MonadCounter m

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -493,10 +493,77 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                 (Mock.functionalConstr20 plain1OfA plain1OfB)
             )
         )
+    , testCase "builtin Map domain"
+        (do
+            assertEqualWithExplanation "concrete Map, same keys"
+                (Just Predicated
+                    { term = Mock.builtinMap [(Mock.aConcrete, Mock.b)]
+                    , predicate = makeTruePredicate
+                    , substitution = [(Mock.x, Mock.b)]
+                    }
+                )
+                (unify
+                    mockMetadataTools
+                    (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
+                    (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
+                )
+            assertEqualWithExplanation "concrete Map, different keys"
+                (Just ExpandedPattern.bottom)
+                (unify
+                    mockMetadataTools
+                    (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
+                    (Mock.builtinMap [(Mock.bConcrete, mkVar Mock.x)])
+                )
+            assertEqualWithExplanation "concrete Map with framed Map"
+                (Just Predicated
+                    { term =
+                        Mock.concatMap
+                            (Mock.builtinMap [(Mock.aConcrete, fOfA)])
+                            (Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        [ (Mock.m, Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                        , (Mock.x, fOfA)
+                        ]
+                    }
+                )
+                (unify
+                    mockMetadataTools
+                    (Mock.builtinMap [(Mock.aConcrete, fOfA), (Mock.bConcrete, fOfB)])
+                    (Mock.concatMap
+                        (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
+                        (mkVar Mock.m)
+                    )
+                )
+            assertEqualWithExplanation "framed Map with concrete Map"
+                (Just Predicated
+                    { term =
+                        Mock.concatMap
+                            (Mock.builtinMap [(Mock.aConcrete, fOfA)])
+                            (Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        [ (Mock.m, Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                        , (Mock.x, fOfA)
+                        ]
+                    }
+                )
+                (unify
+                    mockMetadataTools
+                    (Mock.concatMap
+                        (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
+                        (mkVar Mock.m)
+                    )
+                    (Mock.builtinMap [(Mock.aConcrete, fOfA), (Mock.bConcrete, fOfB)])
+                )
+        )
     ]
 
 fOfA :: CommonPurePattern Object
 fOfA = give mockSymbolOrAliasSorts $ Mock.f Mock.a
+
+fOfB :: CommonPurePattern Object
+fOfB = give mockSymbolOrAliasSorts $ Mock.f Mock.b
 
 gOfA :: CommonPurePattern Object
 gOfA = give mockSymbolOrAliasSorts $ Mock.g Mock.a

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
@@ -31,10 +31,10 @@ import           Kore.Step.Simplification.DomainValue
                  ( simplify )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 
-import Test.Kore.Comparators ()
-import Test.Tasty.HUnit.Extensions
+import           Test.Kore.Comparators ()
+import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
+import           Test.Tasty.HUnit.Extensions
 
 test_domainValueSimplification :: [TestTree]
 test_domainValueSimplification =


### PR DESCRIPTION
As discussed in the standup meeting on Tue 9 Oct 2018, there are three main cases:

1. both maps concrete,
2. one concrete map, one framed map
3. both maps framed

This pull request addresses the first two, which are at least enough for concrete execution.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

