### PR TITLE
Generalize stepper variables.

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -44,7 +44,7 @@ import           Kore.AST.MetaOrObject
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Builtin as Builtin
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern )
+                 ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 
 {- | Builtin name of the @Bool@ sort.
@@ -113,7 +113,7 @@ parse = (Parsec.<|>) true false
 asPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Bool  -- ^ builtin value to render
-    -> Kore.CommonPurePattern Object
+    -> Kore.PureMLPattern Object variable
 asPattern resultSort result =
     Kore.DV_ resultSort
         $ Kore.BuiltinDomainPattern
@@ -126,7 +126,7 @@ asMetaPattern False = Kore.StringLiteral_ "false"
 asExpandedPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Bool  -- ^ builtin value to render
-    -> CommonExpandedPattern Object
+    -> ExpandedPattern Object variable
 asExpandedPattern resultSort =
     ExpandedPattern.fromPurePattern . asPattern resultSort
 

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -62,7 +62,7 @@ import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern )
+                 ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
                  ( AttemptedFunction (..) )
@@ -170,7 +170,7 @@ expectBuiltinDomainInt
     :: Monad m
     => String  -- ^ Context for error message
     -> Kore.PureMLPattern Object variable  -- ^ Operand pattern
-    -> ExceptT (AttemptedFunction Object Kore.Variable) m Integer
+    -> ExceptT (AttemptedFunction Object variable) m Integer
 expectBuiltinDomainInt ctx =
     \case
         Kore.DV_ _ domain ->
@@ -195,7 +195,7 @@ expectBuiltinDomainInt ctx =
 asPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
-    -> Kore.CommonPurePattern Object
+    -> Kore.PureMLPattern Object variable
 asPattern resultSort result =
     fromConcretePurePattern (asConcretePattern resultSort result)
 
@@ -225,14 +225,14 @@ asMetaPattern result = Kore.StringLiteral_ $ show result
 asExpandedPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
-    -> CommonExpandedPattern Object
+    -> ExpandedPattern Object variable
 asExpandedPattern resultSort =
     ExpandedPattern.fromPurePattern . asPattern resultSort
 
 asPartialExpandedPattern
     :: Kore.Sort Object  -- ^ resulting sort
     -> Maybe Integer  -- ^ builtin value to render
-    -> CommonExpandedPattern Object
+    -> ExpandedPattern Object variable
 asPartialExpandedPattern resultSort =
     maybe ExpandedPattern.bottom (asExpandedPattern resultSort)
 

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -25,9 +25,9 @@ import           Data.Map
 import qualified Data.Map as Map
 
 import           Kore.AST.Common
-                 ( Application (..), PureMLPattern, Variable (..) )
+                 ( Application (..), PureMLPattern, SortedVariable )
 import           Kore.AST.MetaOrObject
-                 ( Object )
+                 ( Meta, Object )
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -43,6 +43,10 @@ import           Kore.Step.Simplification.Equals
                  ( makeEvaluate )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
+import           Kore.Substitution.Class
+                 ( Hashable )
+import           Kore.Variables.Fresh
+                 ( FreshVariable )
 
 {- | Verify that hooked symbol declarations are well-formed.
 
@@ -73,13 +77,20 @@ builtinFunctions =
     ]
 
 evalKEq
-    :: Bool
+    ::  ( FreshVariable variable
+        , Hashable variable
+        , Ord (variable Meta)
+        , Ord (variable Object)
+        , SortedVariable variable
+        , Show (variable Object)
+        )
+    => Bool
     -> Bool
     -> MetadataTools.MetadataTools Object StepperAttributes
-    -> PureMLPatternSimplifier Object Variable
-    -> Application Object (PureMLPattern Object Variable)
+    -> PureMLPatternSimplifier Object variable
+    -> Application Object (PureMLPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object Variable
+        ( AttemptedFunction Object variable
         , SimplificationProof Object
         )
 evalKEq true false tools _ pat =

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -52,7 +52,7 @@ import qualified Kore.Error as Kore
 import           Kore.IndexedModule.IndexedModule
                  ( KoreIndexedModule )
 import           Kore.Step.ExpandedPattern
-                 ( CommonExpandedPattern )
+                 ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
                  ( AttemptedFunction (..) )
@@ -111,8 +111,8 @@ symbolVerifiers =
     anySort :: Builtin.SortVerifier
     anySort = const $ const $ Right ()
 
-type Builtin =
-    Map (Kore.ConcretePurePattern Object) (Kore.CommonPurePattern Object)
+type Builtin variable =
+    Map (Kore.ConcretePurePattern Object) (Kore.PureMLPattern Object variable)
 
 {- | Abort function evaluation if the argument is not a Map domain value.
 
@@ -124,8 +124,8 @@ type Builtin =
 expectBuiltinDomainMap
     :: Monad m
     => String  -- ^ Context for error message
-    -> Kore.CommonPurePattern Object  -- ^ Operand pattern
-    -> ExceptT (AttemptedFunction Object Kore.Variable) m Builtin
+    -> Kore.PureMLPattern Object variable  -- ^ Operand pattern
+    -> ExceptT (AttemptedFunction Object variable) m (Builtin variable)
 expectBuiltinDomainMap ctx _map =
     do
         case _map of
@@ -141,8 +141,8 @@ expectBuiltinDomainMap ctx _map =
 returnMap
     :: Monad m
     => Kore.Sort Object
-    -> Builtin
-    -> m (AttemptedFunction Object Kore.Variable)
+    -> Builtin variable
+    -> m (AttemptedFunction Object variable)
 returnMap resultSort map' =
     Builtin.appliedFunction
         $ ExpandedPattern.fromPurePattern
@@ -277,7 +277,9 @@ asPattern
     :: KoreIndexedModule attrs
     -- ^ indexed module where pattern would appear
     -> Kore.Sort Object
-    -> Either (Kore.Error e) (Builtin -> Kore.CommonPurePattern Object)
+    -> Either
+        (Kore.Error e)
+        (Builtin variable -> Kore.PureMLPattern Object variable)
 asPattern indexedModule _
   = do
     symbolUnit <- lookupSymbolUnit indexedModule
@@ -301,7 +303,9 @@ asExpandedPattern
     :: KoreIndexedModule attrs
     -- ^ dictionary of Map constructor symbols
     -> Kore.Sort Object
-    -> Either (Kore.Error e) (Builtin -> CommonExpandedPattern Object)
+    -> Either
+        (Kore.Error e)
+        (Builtin variable -> ExpandedPattern Object variable)
 asExpandedPattern symbols resultSort =
     asExpandedPattern0 <$> asPattern symbols resultSort
   where

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -69,7 +69,7 @@ evaluateApplication
     -- such as their sorts, whether they are constructors or hooked.
     -> PureMLPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> PredicateSubstitution level variable
     -- ^ Aggregated children predicate and substitution.

--- a/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
@@ -34,8 +34,7 @@ import Kore.Step.AxiomPatterns
        ( AxiomPattern (..), QualifiedAxiomPattern (..),
        koreSentenceToAxiomPattern )
 import Kore.Step.Function.Data
-       ( ApplicationFunctionEvaluator (..),
-       CommonApplicationFunctionEvaluator )
+       ( ApplicationFunctionEvaluator (..) )
 import Kore.Step.Function.UserDefined
        ( axiomFunctionEvaluator )
 import Kore.Step.StepperAttributes
@@ -43,13 +42,13 @@ import Kore.Step.StepperAttributes
 
 {-|Given a 'MetaOrObject' @level@ and a 'KoreIndexedModule', @extractEvaluators@
 creates a registry mapping function symbol identifiers to their
-corresponding 'CommonApplicationFunctionEvaluator's.
+corresponding 'ApplicationFunctionEvaluator's.
 -}
 extractEvaluators
     :: MetaOrObject level
     => level
     -> KoreIndexedModule StepperAttributes
-    -> Map.Map (Id level) [CommonApplicationFunctionEvaluator level]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
 extractEvaluators level indexedModule =
     Map.fromList (map extractPrefix groupedEvaluators)
   where
@@ -68,10 +67,10 @@ extractEvaluators level indexedModule =
             )
 
 axiomToIdEvaluatorPair
-    :: MetaOrObject level
+    ::  ( MetaOrObject level )
     => level
     -> SentenceAxiom UnifiedSortVariable UnifiedPattern Variable
-    -> Maybe (Id level, CommonApplicationFunctionEvaluator level)
+    -> Maybe (Id level, ApplicationFunctionEvaluator level)
 axiomToIdEvaluatorPair
     level
     axiom

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -17,8 +17,8 @@ import Control.Monad.Except
 import Data.Reflection
 
 import           Kore.AST.Common
-                 ( Application (..), CommonPurePattern, Pattern (..),
-                 PureMLPattern, SortedVariable )
+                 ( Application (..), Pattern (..), PureMLPattern,
+                 SortedVariable )
 import           Kore.AST.MetaOrObject
                  ( Meta, MetaOrObject, Object )
 import           Kore.AST.PureML
@@ -39,15 +39,13 @@ import           Kore.Step.ExpandedPattern
                  ( PredicateSubstitution (PredicateSubstitution) )
 import           Kore.Step.Function.Data as AttemptedFunction
                  ( AttemptedFunction (..) )
-import           Kore.Step.Function.Data
-                 ( CommonAttemptedFunction )
 import qualified Kore.Step.Merging.OrOfExpandedPattern as OrOfExpandedPattern
                  ( mergeWithPredicateSubstitution )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
                  ( make, traverseWithPairs )
 import           Kore.Step.Simplification.Data
-                 ( CommonPureMLPatternSimplifier, PureMLPatternSimplifier (..),
-                 SimplificationProof (..), Simplifier )
+                 ( PureMLPatternSimplifier (..), SimplificationProof (..),
+                 Simplifier )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import           Kore.Step.Substitution
@@ -62,17 +60,25 @@ evaluating the function, it tries to re-evaluate all functions on the result.
 The function is assumed to be defined through an axiom.
 -}
 axiomFunctionEvaluator
-    ::  ( MetaOrObject level)
+    ::  ( FreshVariable variable
+        , Hashable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , Ord (variable Meta)
+        , Ord (variable Object)
+        , SortedVariable variable
+        , Show (variable level)
+        )
     => AxiomPattern level
     -- ^ Axiom defining the current function.
     -> MetadataTools level StepperAttributes
     -- ^ Tools for finding additional information about patterns
     -- such as their sorts, whether they are constructors or hooked.
-    -> CommonPureMLPatternSimplifier level
+    -> PureMLPatternSimplifier level variable
     -- ^ Evaluates functions in patterns
-    -> Application level (CommonPurePattern level)
+    -> Application level (PureMLPattern level variable)
     -- ^ The function on which to evaluate the current function.
-    -> Simplifier (CommonAttemptedFunction level, SimplificationProof level)
+    -> Simplifier (AttemptedFunction level variable, SimplificationProof level)
 axiomFunctionEvaluator
     axiom
     tools

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -79,7 +79,7 @@ simplify
     => MetadataTools level StepperAttributes
     -> PureMLPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> Application level (OrOfExpandedPattern level variable)
     -> Simplifier
@@ -124,7 +124,7 @@ makeAndEvaluateApplications
     => MetadataTools level StepperAttributes
     -> PureMLPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> SymbolOrAlias level
     -> [ExpandedPattern level variable]
@@ -158,7 +158,7 @@ evaluateApplicationFunction
     => MetadataTools level StepperAttributes
     -> PureMLPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> ExpandedApplication level variable
     -- ^ The pattern to be evaluated

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -101,7 +101,7 @@ simplify
         , Hashable variable
         )
     => MetadataTools level StepperAttributes
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> PureMLPattern level variable
     -> Simplifier
@@ -132,7 +132,7 @@ simplifyToOr
         , Hashable variable
         )
     => MetadataTools level StepperAttributes
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> PureMLPattern level variable
     -> Simplifier
@@ -167,7 +167,7 @@ simplifyInternal
         )
     => MetadataTools level StepperAttributes
     -> PureMLPatternSimplifier level variable
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> Pattern level variable (PureMLPattern level variable)
     -> Simplifier

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Simplifier.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Simplifier.hs
@@ -44,7 +44,7 @@ create
         , Hashable variable
         )
     => MetadataTools level StepperAttributes
-    -> Map.Map (Id level) [ApplicationFunctionEvaluator level variable]
+    -> Map.Map (Id level) [ApplicationFunctionEvaluator level]
     -- ^ Map from symbol IDs to defined functions
     -> PureMLPatternSimplifier level variable
 create

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -36,6 +36,8 @@ import Data.Semigroup
 import Numeric.Natural
        ( Natural )
 
+import Kore.AST.Common
+       ( Variable )
 import Kore.AST.MetaOrObject
        ( MetaOrObject )
 import Kore.IndexedModule.MetadataTools
@@ -94,9 +96,9 @@ transitionRule
     -> CommonPureMLPatternSimplifier level
     -- ^ Evaluates functions in patterns
     -> Prim (AxiomPattern level)
-    -> (CommonExpandedPattern level, StepProof level)
+    -> (CommonExpandedPattern level, StepProof Variable level)
     -- ^ Configuration being rewritten and its accompanying proof
-    -> Simplifier [(CommonExpandedPattern level, StepProof level)]
+    -> Simplifier [(CommonExpandedPattern level, StepProof Variable level)]
 transitionRule tools simplifier =
     \case
         Simplify -> transitionSimplify

--- a/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
@@ -24,6 +24,10 @@ import Kore.AST.MetaOrObject
 {- | A 'FreshVariable' can be freshened in a 'MonadCounter'.
 -}
 class FreshVariable var where
+    {-|Given an existing Variable, generate a fresh one.
+    -}
+    freshVariableFromVariable
+        :: MetaOrObject level => Variable level -> Natural -> var level
     {-|Given an existing variable, generate a fresh one of
     the same kind.
     -}
@@ -52,6 +56,7 @@ freshVariablePrefix :: String
 freshVariablePrefix = "var_"
 
 instance FreshVariable Variable where
+    freshVariableFromVariable = freshVariableWith
     freshVariableWith var n =
         var
             { variableName = Id

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/List.hs
@@ -165,11 +165,11 @@ unit_simplify =
         assertEqual "Expected simplified List" expected actual
 
 -- | Specialize 'List.asPattern' to the builtin sort 'listSort'.
-asPattern :: List.Builtin -> CommonPurePattern Object
+asPattern :: List.Builtin Variable -> CommonPurePattern Object
 Right asPattern = List.asPattern indexedModule listSort
 
 -- | Specialize 'List.asPattern' to the builtin sort 'listSort'.
-asExpandedPattern :: List.Builtin -> CommonExpandedPattern Object
+asExpandedPattern :: List.Builtin Variable -> CommonExpandedPattern Object
 Right asExpandedPattern = List.asExpandedPattern indexedModule listSort
 
 -- | A sort to hook to the builtin @LIST.List@.

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
@@ -318,11 +318,11 @@ asSymbolicPattern result =
     applyConcat map1 map2 = App_ symbolConcat [map1, map2]
 
 -- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
-asPattern :: Map.Builtin -> CommonPurePattern Object
+asPattern :: Map.Builtin Variable -> CommonPurePattern Object
 Right asPattern = Map.asPattern indexedModule mapSort
 
 -- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
-asExpandedPattern :: Map.Builtin -> CommonExpandedPattern Object
+asExpandedPattern :: Map.Builtin Variable -> CommonExpandedPattern Object
 Right asExpandedPattern = Map.asExpandedPattern indexedModule mapSort
 
 -- | A sort to hook to the builtin @MAP.Map@.

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -17,7 +17,7 @@ import           Kore.Proof.Functional
 import           Kore.Step.BaseStep
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( ExpandedPattern, Predicated(..) )
+                 ( ExpandedPattern, Predicated (..) )
 import           Kore.Step.ExpandedPattern as PredicateSubstitution
                  ( PredicateSubstitution (..) )
 import           Kore.Step.Function.Data as AttemptedFunction
@@ -173,15 +173,21 @@ instance
     printWithExplanation = show
 
 instance
-    (Eq level, Show level) =>
-    SumEqualWithExplanation (StepProof level)
+    ( Eq level, Show level
+    , Eq (variable level), Show (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => SumEqualWithExplanation (StepProof variable level)
   where
     sumConstructorPair (StepProof a1) (StepProof a2) =
         SumConstructorSameWithArguments (EqWrap "StepProofCombined" a1 a2)
 
 instance
-    (Eq level, Show level) =>
-    SumEqualWithExplanation (StepProofAtom level)
+    ( Eq level, Show level
+    , Eq (variable level), Show (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => SumEqualWithExplanation (StepProofAtom variable level)
   where
     sumConstructorPair (StepProofUnification a1) (StepProofUnification a2) =
         SumConstructorSameWithArguments (EqWrap "StepProofUnification" a1 a2)
@@ -207,11 +213,23 @@ instance
         SumConstructorDifferent
             (printWithExplanation a1) (printWithExplanation a2)
 
-instance (Eq level, Show level) => EqualWithExplanation (StepProofAtom level) where
+instance
+    ( Eq level, Show level
+    , Eq (variable level), Show (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => EqualWithExplanation (StepProofAtom variable level)
+  where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
 
-instance (Eq level, Show level) => EqualWithExplanation (StepProof level) where
+instance
+    ( Eq level, Show level
+    , Eq (variable level), Show (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => EqualWithExplanation (StepProof variable level)
+  where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
 
@@ -710,7 +728,9 @@ instance
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
 
-instance StructEqualWithExplanation (VariableRenaming level)
+instance
+    (EqualWithExplanation (variable level), Show (variable level))
+    => StructEqualWithExplanation (VariableRenaming level variable)
   where
     structFieldsWithNames
         expected@(VariableRenaming _ _)
@@ -726,12 +746,17 @@ instance StructEqualWithExplanation (VariableRenaming level)
         ]
     structConstructorName _ = "VariableRenaming"
 
-instance EqualWithExplanation (VariableRenaming level)
+instance
+    (EqualWithExplanation (variable level), Show (variable level))
+    => EqualWithExplanation (VariableRenaming level variable)
   where
     compareWithExplanation = structCompareWithExplanation
     printWithExplanation = show
 
-instance SumEqualWithExplanation (StepperVariable level) where
+instance
+    (EqualWithExplanation (variable level), Show (variable level))
+    => SumEqualWithExplanation (StepperVariable variable level)
+  where
     sumConstructorPair (AxiomVariable a1) (AxiomVariable a2) =
         SumConstructorSameWithArguments (EqWrap "AxiomVariable" a1 a2)
     sumConstructorPair a1@(AxiomVariable _) a2 =
@@ -744,7 +769,9 @@ instance SumEqualWithExplanation (StepperVariable level) where
         SumConstructorDifferent
             (printWithExplanation a1) (printWithExplanation a2)
 
-instance EqualWithExplanation (StepperVariable level)
+instance
+    (EqualWithExplanation (variable level), Show (variable level))
+    => EqualWithExplanation (StepperVariable variable level)
   where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show

--- a/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
@@ -16,8 +16,8 @@ import Data.Reflection
 
 import Kore.AST.Common
        ( Application (..), AstLocation (..), Id (..),
-       Pattern (ApplicationPattern, StringLiteralPattern), SymbolOrAlias (..),
-       Variable, StringLiteral (..) )
+       Pattern (ApplicationPattern, StringLiteralPattern), StringLiteral (..),
+       SymbolOrAlias (..), Variable )
 import Kore.AST.MetaOrObject
 import Kore.AST.PureML
 import Kore.AST.PureToKore
@@ -35,15 +35,15 @@ import Kore.MetaML.AST
 import Kore.Predicate.Predicate
        ( CommonPredicate, makeEqualsPredicate, makeTruePredicate )
 import Kore.Step.BaseStep
-import Kore.Step.Simplification.Data
 import Kore.Step.Error
 import Kore.Step.ExpandedPattern as ExpandedPattern
        ( Predicated (..), bottom )
 import Kore.Step.ExpandedPattern
        ( CommonExpandedPattern )
+import Kore.Step.Simplification.Data
 import Kore.Step.StepperAttributes
 import Kore.Unification.Unifier
-       ( UnificationProof (..), UnificationError (..)  )
+       ( UnificationError (..), UnificationProof (..) )
 
 import Test.Kore.Comparators ()
 import Test.Tasty.HUnit.Extensions
@@ -928,7 +928,9 @@ test_baseStep =
     var_0 = metaVariable "#var_0" AstLocationTest
     variableRenaming
         :: MetaSort sort
-        => MetaVariable sort -> MetaVariable sort -> VariableRenaming Meta
+        => MetaVariable sort
+        -> MetaVariable sort
+        -> VariableRenaming Meta Variable
     variableRenaming from to =
         VariableRenaming
             { variableRenamingOriginal = AxiomVariable (asMetaVariable from)
@@ -1127,7 +1129,7 @@ runStep
     -> AxiomPattern level
     -> Either
         (StepError level Variable)
-        (CommonExpandedPattern level, StepProof level)
+        (CommonExpandedPattern level, StepProof Variable level)
 runStep metadataTools configuration axiom =
     first evalSimplifier
     . evalSimplifier

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
@@ -36,7 +36,7 @@ import           Kore.Step.ExpandedPattern
                  ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( CommonApplicationFunctionEvaluator )
+                 ( ApplicationFunctionEvaluator )
 import           Kore.Step.Function.Registry
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Simplification.Data
@@ -218,7 +218,7 @@ testId name =
         }
 
 testEvaluators
-    :: Map.Map (Id Object) [CommonApplicationFunctionEvaluator Object]
+    :: Map.Map (Id Object) [ApplicationFunctionEvaluator Object]
 testEvaluators = extractEvaluators Object testIndexedModule
 
 testMetadataTools :: MetadataTools Object StepperAttributes

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -31,7 +31,7 @@ import           Kore.Predicate.Predicate
                  ( makeTruePredicate )
 import           Kore.Step.BaseStep
 import           Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( CommonExpandedPattern, ExpandedPattern, Predicated(..) )
+                 ( CommonExpandedPattern, ExpandedPattern, Predicated (..) )
 import           Kore.Step.Simplification.Data
                  ( SimplificationProof (..), evalSimplifier )
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
@@ -75,7 +75,7 @@ rewriteImplies =
         , axiomPatternAttributes = def
         }
 
-expectTwoAxioms :: [(ExpandedPattern Meta Variable, StepProof Meta)]
+expectTwoAxioms :: [(ExpandedPattern Meta Variable, StepProof Variable Meta)]
 expectTwoAxioms =
     [
         ( Predicated
@@ -108,7 +108,7 @@ expectTwoAxioms =
         )
     ]
 
-actualTwoAxioms :: [(CommonExpandedPattern Meta, StepProof Meta)]
+actualTwoAxioms :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 actualTwoAxioms =
     runStep
         mockMetadataTools
@@ -134,10 +134,10 @@ initialFailSimple =
         , substitution = []
         }
 
-expectFailSimple :: [(CommonExpandedPattern Meta, StepProof Meta)]
+expectFailSimple :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 expectFailSimple = [ (initialFailSimple, mempty) ]
 
-actualFailSimple :: [(CommonExpandedPattern Meta, StepProof Meta)]
+actualFailSimple :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 actualFailSimple =
     runStep
         mockMetadataTools
@@ -166,10 +166,10 @@ initialFailCycle =
         , substitution = []
         }
 
-expectFailCycle :: [(CommonExpandedPattern Meta, StepProof Meta)]
+expectFailCycle :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 expectFailCycle = [ (initialFailCycle, mempty) ]
 
-actualFailCycle :: [(CommonExpandedPattern Meta, StepProof Meta)]
+actualFailCycle :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 actualFailCycle =
     runStep
         mockMetadataTools
@@ -196,7 +196,7 @@ initialIdentity =
         , substitution = []
         }
 
-expectIdentity :: [(CommonExpandedPattern Meta, StepProof Meta)]
+expectIdentity :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 expectIdentity =
     [
         ( initialIdentity
@@ -208,7 +208,7 @@ expectIdentity =
         )
     ]
 
-actualIdentity :: [(CommonExpandedPattern Meta, StepProof Meta)]
+actualIdentity :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
 actualIdentity =
     runStep
         mockMetadataTools
@@ -288,7 +288,7 @@ axiomsSimpleStrategy =
         }
     ]
 
-expectOneStep :: (ExpandedPattern Meta Variable, StepProof Meta)
+expectOneStep :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
 expectOneStep =
     ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
@@ -304,7 +304,7 @@ expectOneStep =
         )
     )
 
-actualOneStep :: (CommonExpandedPattern Meta, StepProof Meta)
+actualOneStep :: (CommonExpandedPattern Meta, StepProof Variable Meta)
 actualOneStep =
     runSteps
         mockMetadataTools
@@ -324,7 +324,7 @@ actualOneStep =
             }
         ]
 
-expectTwoSteps :: (ExpandedPattern Meta Variable, StepProof Meta)
+expectTwoSteps :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
 expectTwoSteps =
     ( Predicated
         { term = asPureMetaPattern (metaH (v1 PatternSort))
@@ -341,7 +341,7 @@ expectTwoSteps =
         ]
     )
 
-actualTwoSteps :: (CommonExpandedPattern Meta, StepProof Meta)
+actualTwoSteps :: (CommonExpandedPattern Meta, StepProof Variable Meta)
 actualTwoSteps =
     runSteps
         mockMetadataTools
@@ -354,7 +354,7 @@ actualTwoSteps =
         axiomsSimpleStrategy
 
 
-expectZeroStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta)
+expectZeroStepLimit :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
 expectZeroStepLimit =
         ( Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
@@ -364,7 +364,7 @@ expectZeroStepLimit =
         , mempty
         )
 
-actualZeroStepLimit :: (CommonExpandedPattern Meta, StepProof Meta)
+actualZeroStepLimit :: (CommonExpandedPattern Meta, StepProof Variable Meta)
 actualZeroStepLimit =
     runSteps
         mockMetadataTools
@@ -376,7 +376,7 @@ actualZeroStepLimit =
             }
         axiomsSimpleStrategy
 
-expectStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta)
+expectStepLimit :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
 expectStepLimit =
     ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
@@ -390,7 +390,7 @@ expectStepLimit =
         ]
     )
 
-actualStepLimit :: (CommonExpandedPattern Meta, StepProof Meta)
+actualStepLimit :: (CommonExpandedPattern Meta, StepProof Variable Meta)
 actualStepLimit =
     runSteps
         mockMetadataTools
@@ -513,7 +513,7 @@ runStep
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
     -> [AxiomPattern level]
-    -> [(CommonExpandedPattern level, StepProof level)]
+    -> [(CommonExpandedPattern level, StepProof Variable level)]
 runStep metadataTools configuration axioms =
     pickStuck
         $ evalSimplifier
@@ -533,7 +533,7 @@ runSteps
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
     -> [AxiomPattern level]
-    -> (CommonExpandedPattern level, StepProof level)
+    -> (CommonExpandedPattern level, StepProof Variable level)
 runSteps metadataTools stepLimit configuration axioms =
     pickLongest
         $ evalSimplifier


### PR DESCRIPTION
Why this change is needed:

Our stepping works like this:
1. Wrap axiom variables and pattern variables in `StepperVariables`
2. Unify the pattern with the axiom LHS and get a substitution+predicate
3. Apply the substitution to the axiom RHS and the (axiom predicate + all other predicates)
4. Check that the substitution removed all axiom variables
5. Unwrap the remaining ones
6. Simplify the predicate and the RHS

So, with the current code, simplification works on variables.

However, in order to support map unification, in particular, in order to support using a variable (that gets resolved in another place) as the key we want to change the second step to (small lies to keep things simple)
2.a. Unify the pattern with the LHS and get a substitution + predicate.
2.b. Apply the substitution to the predicate and simplify, getting a new substitution + predicate.
2.c. Repeat 2.b. until it stabilizes
2.d. Concatenate all substitutions mentioned at 2.b.

At point 2.b. we need the substitution to work with `StepperVariable`s, so we need to make a lot of the code work with `StepperVariable`s. In particular, the simplification code calls `stepWithAxiom`, which must also work with `StepperVariable`, and needs to be able to wrap them in a second level of `StepperVariable`, and so on.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

