### PR TITLE
Kore.Builtin.Map.unify: Commute arguments of MAP.concat

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -492,21 +492,27 @@ unify
         :: PureMLPattern level variable
         -> PureMLPattern level variable
         -> Result (m (expanded, proof))
+
     unify0
-        (DV_ sort' (BuiltinDomainMap map1))
-        (DV_ _     (BuiltinDomainMap map2))
+        (DV_ resultSort (BuiltinDomainMap map1))
+        (DV_ _          (BuiltinDomainMap map2))
       =
-        unifyConcrete sort' map1 map2
+        unifyConcrete resultSort map1 map2
+
     unify0
-        (DV_ sort' (BuiltinDomainMap map1))
-        (App_ concat'
-            [ DV_ _ (BuiltinDomainMap map2)
-            , x@(Var_ _)
-            ]
-        )
-        | isSymbolConcat hookTools concat' =
-            unifyFramed1 sort' map1 concat' map2 x
+        (DV_ resultSort (BuiltinDomainMap map1))
+        (App_ concat2 args2)
+      | isSymbolConcat hookTools concat2 =
+        -- Accept the arguments of concat in either order.
+        case args2 of
+            [ DV_ _ (BuiltinDomainMap map2), x@(Var_ _) ] ->
+                unifyFramed1 resultSort map1 concat2 map2 x
+            [ x@(Var_ _), DV_ _ (BuiltinDomainMap map2) ] ->
+                unifyFramed1 resultSort map1 concat2 map2 x
+            _ -> empty
+
     unify0 app_@(App_ _ _) dv_@(DV_ _ _) = unify0 dv_ app_
+
     unify0 _ _ = empty
 
     -- | Unify two concrete maps.

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -535,6 +535,27 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                         (mkVar Mock.m)
                     )
                 )
+            assertEqualWithExplanation "concrete Map with framed Map"
+                (Just Predicated
+                    { term =
+                        Mock.concatMap
+                            (Mock.builtinMap [(Mock.aConcrete, fOfA)])
+                            (Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        [ (Mock.m, Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                        , (Mock.x, fOfA)
+                        ]
+                    }
+                )
+                (unify
+                    mockMetadataTools
+                    (Mock.builtinMap [(Mock.aConcrete, fOfA), (Mock.bConcrete, fOfB)])
+                    (Mock.concatMap
+                        (mkVar Mock.m)
+                        (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
+                    )
+                )
             assertEqualWithExplanation "framed Map with concrete Map"
                 (Just Predicated
                     { term =
@@ -553,6 +574,27 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
                     (Mock.concatMap
                         (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
                         (mkVar Mock.m)
+                    )
+                    (Mock.builtinMap [(Mock.aConcrete, fOfA), (Mock.bConcrete, fOfB)])
+                )
+            assertEqualWithExplanation "framed Map with concrete Map"
+                (Just Predicated
+                    { term =
+                        Mock.concatMap
+                            (Mock.builtinMap [(Mock.aConcrete, fOfA)])
+                            (Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        [ (Mock.m, Mock.builtinMap [(Mock.bConcrete, fOfB)])
+                        , (Mock.x, fOfA)
+                        ]
+                    }
+                )
+                (unify
+                    mockMetadataTools
+                    (Mock.concatMap
+                        (mkVar Mock.m)
+                        (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
                     )
                     (Mock.builtinMap [(Mock.aConcrete, fOfA), (Mock.bConcrete, fOfB)])
                 )


### PR DESCRIPTION
The commutativity of MAP.concat must be observed so that we can unify
user-defined rules with framing variables, where the user may concatenate the
concrete map and the framing variable in either order.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

