### PR TITLE
Makefile: Add `stylish` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-kore:
 test-k:
 	$(MAKE) -C src/main/k/working test-k
 
-jenkins: check all test docs
+jenkins: distclean check all test docs
 
 distclean: clean
 	cd $(K_SUBMODULE) \

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ test-k:
 jenkins: distclean check all test docs
 
 distclean: clean
-	cd $(K_SUBMODULE) \
-		&& mvn clean -q
+	if test -f $(K_SUBMODULE)/pom.xml; then \
+		cd $(K_SUBMODULE) && mvn clean -q; \
+	fi
 	git submodule deinit --force -- ./
 
 clean: clean-submodules

--- a/include.mk
+++ b/include.mk
@@ -8,6 +8,8 @@ K_BIN := $(K_SUBMODULE)/k-distribution/target/release/k/bin
 KOMPILE := $(K_BIN)/kompile
 KRUN := $(K_BIN)/krun
 
+HS_TOP := $(TOP)/src/main/haskell/kore
+HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test
 STACK_OPTS ?= --pedantic
 STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks

--- a/scripts/check-stylish-haskell.sh
+++ b/scripts/check-stylish-haskell.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-find "$@" \( -name '*.hs' -o -name '*.hs-boot' \) \
-    -exec stylish-haskell -i '{}' \; \
-    && $(dirname "$0")/git-assert-clean.sh


### PR DESCRIPTION
The `stylish` target runs `stylish-haskell` on every Haskell source file in the
repository. The `check` target now uses the `stylish` target in its
style-conformance test. The `check` target now suggests solutions to the errors
it detects.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

