### PR TITLE
Kore.Variables.Free: Replace `pureFreeVariables` with `freePureVariables`

### DIFF
--- a/src/main/haskell/kore/src/Kore/ASTHelpers.hs
+++ b/src/main/haskell/kore/src/Kore/ASTHelpers.hs
@@ -22,8 +22,6 @@ import           Data.Foldable
 import           Data.Functor.Foldable
                  ( Fix (..) )
 import qualified Data.Map as Map
-import           Data.Proxy
-                 ( Proxy (..) )
 import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
@@ -116,7 +114,7 @@ quantifyFreeVariables s p =
     foldl'
         (wrapAndQuantify s)
         p
-        (checkUnique (pureFreeVariables (Proxy :: Proxy level) p))
+        (checkUnique (freePureVariables p))
 
 wrapAndQuantify
     :: Sort level

--- a/src/main/haskell/kore/src/Kore/MetaML/AST.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/AST.hs
@@ -27,7 +27,6 @@ import Kore.AST.MetaOrObject
 import Kore.AST.PureML
 import Kore.AST.Sentence
 import Kore.Variables.Free
-       ( pureFreeVariables )
 
 {-|'MetaMLPattern' corresponds to "fixed point" representations
 of the 'Pattern' class where the level is fixed to 'Meta'.
@@ -69,7 +68,7 @@ type MetaPatternStub = PatternStub Meta Variable CommonMetaPattern
 
 -- |'metaFreeVariables' collects the free variables of a 'CommonMetaPattern'.
 metaFreeVariables :: CommonMetaPattern -> Set (Variable Meta)
-metaFreeVariables = pureFreeVariables (toProxy Meta)
+metaFreeVariables = freePureVariables
 
 nilSortListHead :: SymbolOrAlias Meta
 nilSortListHead = groundHead "#nilSortList" AstLocationImplicit

--- a/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
+++ b/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
@@ -41,8 +41,6 @@ module Kore.Predicate.Predicate
 
 import Data.List
        ( foldl', nub )
-import Data.Proxy
-       ( Proxy (..) )
 import Data.Reflection
        ( Given )
 import Data.Set
@@ -61,7 +59,7 @@ import Kore.ASTUtils.SmartPatterns
 import Kore.IndexedModule.MetadataTools
        ( SymbolOrAliasSorts )
 import Kore.Variables.Free
-       ( pureAllVariables, pureFreeVariables )
+       ( freePureVariables, pureAllVariables )
 
 {-| 'PredicateProof' is a placeholder for a proof showing that a Predicate
 evaluation was correct.
@@ -386,14 +384,10 @@ allVariables = pureAllVariables . unwrapPredicate
 {- | Extract the set of free variables from a @Predicate@.
 -}
 freeVariables
-    :: ( MetaOrObject level
-       , Show (variable Object)
-       , Show (variable Meta)
-       , Ord (variable Object)
-       , Ord (variable Meta))
+    :: (MetaOrObject level , Ord (variable level))
     => Predicate level variable
     -> Set (variable level)
-freeVariables = pureFreeVariables Proxy . unwrapPredicate
+freeVariables = freePureVariables . unwrapPredicate
 
 {- | 'substitutionToPredicate' transforms a substitution in a predicate.
 
@@ -427,4 +421,3 @@ singleSubstitutionToPredicate
     -> Predicate level variable
 singleSubstitutionToPredicate (var, patt) =
     makeEqualsPredicate (mkVar var) patt
-

--- a/src/main/haskell/kore/src/Kore/Step/PredicateSubstitution.hs
+++ b/src/main/haskell/kore/src/Kore/Step/PredicateSubstitution.hs
@@ -99,14 +99,11 @@ toPredicate PredicateSubstitution { predicate, substitution } =
 
 freeVariables
     :: ( MetaOrObject level
-       , Show (variable Object)
-       , Show (variable Meta)
-       , Ord (variable Object)
-       , Ord (variable Meta)
+       , Ord (variable level)
+       , Show (variable level)
        , Given (SymbolOrAliasSorts level)
        , SortedVariable variable
-       , Eq (variable level)
-       , Show (variable level))
+       )
     => PredicateSubstitution level variable
     -> Set.Set (variable level)
 freeVariables = Predicate.freeVariables . toPredicate

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
@@ -13,8 +13,6 @@ module Kore.Step.Simplification.Exists
     ) where
 
 import qualified Control.Arrow as Arrow
-import           Data.Proxy
-                 ( Proxy (..) )
 import           Data.Reflection
                  ( Given )
 import qualified Data.Set as Set
@@ -51,7 +49,7 @@ import qualified Kore.Substitution.List as ListSubstitution
 import           Kore.Unification.Unifier
                  ( UnificationSubstitution )
 import           Kore.Variables.Free
-                 ( pureFreeVariables )
+                 ( freePureVariables )
 import           Kore.Variables.Fresh
 
 -- TODO: Move Exists up in the other simplifiers or something similar. Note
@@ -211,15 +209,9 @@ makeEvaluateNoFreeVarInSubstitution
     (OrOfExpandedPattern.make [simplifiedPattern], SimplificationProof)
   where
     termHasVariable =
-        variable
-            `Set.member`
-            pureFreeVariables (Proxy :: Proxy level) term
+        Set.member variable (freePureVariables term)
     predicateHasVariable =
-        variable
-            `Set.member`
-            pureFreeVariables
-                (Proxy :: Proxy level)
-                (unwrapPredicate predicate)
+        Set.member variable (freePureVariables $ unwrapPredicate predicate)
     simplifiedPattern = case (termHasVariable, predicateHasVariable) of
         (False, False) -> patt
         (False, True) ->

--- a/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-|
 Module      : Kore.Unification.SubstitutionNormalization
 Description : Normalization for substitutions resulting from unification, so


### PR DESCRIPTION
The new function `freePureVariables` is a simple traversal down the tree,
tracing the bound variables and recording those that occur free.

Note: The implementation is slightly different than I outlined in the associated Trello card, but it is morally the same.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

