### PR TITLE
Ensure that branch is rebased onto master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,19 @@ clean: clean-submodules
 	$(MAKE) -C src/main/k/working clean
 
 check:
-	if ! ./scripts/git-assert-clean.sh; then \
+	if ! ./scripts/git-assert-clean.sh; \
+	then \
 		echo >&2 "Please commit your changes!"; \
 		exit 1; \
 	fi
+	if ! ./scripts/git-rebased-on.sh "$$(git rev-parse origin/master)" --linear; \
+	then \
+		echo >&2 "Please rebase your branch onto ‘master’!"; \
+		exit 1; \
+	fi
 	$(MAKE) stylish
-	if ! ./scripts/git-assert-clean.sh; then \
+	if ! ./scripts/git-assert-clean.sh; \
+	then \
 		echo >&2 "Please run ‘make stylish’ to fix style errors!"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
When I updated the Jenkins builder a few days ago, I also wanted to check that pull request history is linear on top of master, i.e. rebased and not merged. At that time the check was failing, but I did not understand why!

This pull request reinstates the linear-history check. This pull request will fail to build (at least the first time) until I change the Jenkins configuration. That change is backwards-compatible.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

