### PR TITLE
Kore.Step.BaseStep.StepProof: Add explicit kind signatures

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -93,7 +93,7 @@ data StepperConfiguration level = StepperConfiguration
 
 {- | 'StepProof' is the proof for an execution step or steps.
  -}
-newtype StepProof level variable =
+newtype StepProof (level :: *) (variable :: * -> *) =
     StepProof { getStepProof :: Seq (StepProofAtom level variable) }
   deriving (Eq, Show)
 
@@ -107,7 +107,7 @@ instance Monoid (StepProof level variable) where
 stepProof :: StepProofAtom level variable -> StepProof level variable
 stepProof atom = StepProof (Seq.singleton atom)
 
-simplificationProof :: SimplificationProof level -> StepProof variable level
+simplificationProof :: SimplificationProof level -> StepProof level variable
 simplificationProof = stepProof . StepProofSimplification
 
 {- | The smallest unit of a 'StepProof'.
@@ -116,7 +116,7 @@ simplificationProof = stepProof . StepProofSimplification
   variable renaming, and simplification.
 
  -}
-data StepProofAtom variable level
+data StepProofAtom (level :: *) (variable :: * -> *)
     = StepProofUnification !(UnificationProof level variable)
     -- ^ Proof for a unification that happened during the step.
     | StepProofVariableRenamings [VariableRenaming level variable]
@@ -235,7 +235,7 @@ stepWithAxiom'
         (Simplifier (StepError level variable))
         Simplifier
             ( ExpandedPattern.ExpandedPattern level variable
-            , StepProof variable level
+            , StepProof level variable
             )
 stepWithAxiom'
     tools
@@ -454,7 +454,7 @@ stepWithAxiom
         (Simplifier (StepError level variable))
         Simplifier
             ( ExpandedPattern.ExpandedPattern level variable
-            , StepProof variable level
+            , StepProof level variable
             )
 stepWithAxiom tools =
     stepWithAxiom'

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -98,9 +98,9 @@ transitionRule
     -> CommonPureMLPatternSimplifier level
     -- ^ Evaluates functions in patterns
     -> Prim (AxiomPattern level)
-    -> (CommonExpandedPattern level, StepProof Variable level)
+    -> (CommonExpandedPattern level, StepProof level Variable)
     -- ^ Configuration being rewritten and its accompanying proof
-    -> Simplifier [(CommonExpandedPattern level, StepProof Variable level)]
+    -> Simplifier [(CommonExpandedPattern level, StepProof level Variable)]
 transitionRule tools substitutionSimplifier simplifier =
     \case
         Simplify -> transitionSimplify

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -177,7 +177,7 @@ instance
     , Eq (variable level), Show (variable level)
     , EqualWithExplanation (variable level)
     )
-    => SumEqualWithExplanation (StepProof variable level)
+    => SumEqualWithExplanation (StepProof level variable)
   where
     sumConstructorPair (StepProof a1) (StepProof a2) =
         SumConstructorSameWithArguments (EqWrap "StepProofCombined" a1 a2)
@@ -187,7 +187,7 @@ instance
     , Eq (variable level), Show (variable level)
     , EqualWithExplanation (variable level)
     )
-    => SumEqualWithExplanation (StepProofAtom variable level)
+    => SumEqualWithExplanation (StepProofAtom level variable)
   where
     sumConstructorPair (StepProofUnification a1) (StepProofUnification a2) =
         SumConstructorSameWithArguments (EqWrap "StepProofUnification" a1 a2)
@@ -218,7 +218,7 @@ instance
     , Eq (variable level), Show (variable level)
     , EqualWithExplanation (variable level)
     )
-    => EqualWithExplanation (StepProofAtom variable level)
+    => EqualWithExplanation (StepProofAtom level variable)
   where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show
@@ -228,7 +228,7 @@ instance
     , Eq (variable level), Show (variable level)
     , EqualWithExplanation (variable level)
     )
-    => EqualWithExplanation (StepProof variable level)
+    => EqualWithExplanation (StepProof level variable)
   where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show

--- a/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
@@ -1132,7 +1132,7 @@ runStep
     -> AxiomPattern level
     -> Either
         (StepError level Variable)
-        (CommonExpandedPattern level, StepProof Variable level)
+        (CommonExpandedPattern level, StepProof level Variable)
 runStep metadataTools configuration axiom =
     first evalSimplifier
     . evalSimplifier

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -76,7 +76,7 @@ rewriteImplies =
         , axiomPatternAttributes = def
         }
 
-expectTwoAxioms :: [(ExpandedPattern Meta Variable, StepProof Variable Meta)]
+expectTwoAxioms :: [(ExpandedPattern Meta Variable, StepProof Meta Variable)]
 expectTwoAxioms =
     [
         ( Predicated
@@ -109,7 +109,7 @@ expectTwoAxioms =
         )
     ]
 
-actualTwoAxioms :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+actualTwoAxioms :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 actualTwoAxioms =
     runStep
         mockMetadataTools
@@ -135,10 +135,10 @@ initialFailSimple =
         , substitution = []
         }
 
-expectFailSimple :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+expectFailSimple :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 expectFailSimple = [ (initialFailSimple, mempty) ]
 
-actualFailSimple :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+actualFailSimple :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 actualFailSimple =
     runStep
         mockMetadataTools
@@ -167,10 +167,10 @@ initialFailCycle =
         , substitution = []
         }
 
-expectFailCycle :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+expectFailCycle :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 expectFailCycle = [ (initialFailCycle, mempty) ]
 
-actualFailCycle :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+actualFailCycle :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 actualFailCycle =
     runStep
         mockMetadataTools
@@ -197,7 +197,7 @@ initialIdentity =
         , substitution = []
         }
 
-expectIdentity :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+expectIdentity :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 expectIdentity =
     [
         ( initialIdentity
@@ -209,7 +209,7 @@ expectIdentity =
         )
     ]
 
-actualIdentity :: [(CommonExpandedPattern Meta, StepProof Variable Meta)]
+actualIdentity :: [(CommonExpandedPattern Meta, StepProof Meta Variable)]
 actualIdentity =
     runStep
         mockMetadataTools
@@ -289,7 +289,7 @@ axiomsSimpleStrategy =
         }
     ]
 
-expectOneStep :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
+expectOneStep :: (ExpandedPattern Meta Variable, StepProof Meta Variable)
 expectOneStep =
     ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
@@ -305,7 +305,7 @@ expectOneStep =
         )
     )
 
-actualOneStep :: (CommonExpandedPattern Meta, StepProof Variable Meta)
+actualOneStep :: (CommonExpandedPattern Meta, StepProof Meta Variable)
 actualOneStep =
     runSteps
         mockMetadataTools
@@ -325,7 +325,7 @@ actualOneStep =
             }
         ]
 
-expectTwoSteps :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
+expectTwoSteps :: (ExpandedPattern Meta Variable, StepProof Meta Variable)
 expectTwoSteps =
     ( Predicated
         { term = asPureMetaPattern (metaH (v1 PatternSort))
@@ -342,7 +342,7 @@ expectTwoSteps =
         ]
     )
 
-actualTwoSteps :: (CommonExpandedPattern Meta, StepProof Variable Meta)
+actualTwoSteps :: (CommonExpandedPattern Meta, StepProof Meta Variable)
 actualTwoSteps =
     runSteps
         mockMetadataTools
@@ -355,7 +355,7 @@ actualTwoSteps =
         axiomsSimpleStrategy
 
 
-expectZeroStepLimit :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
+expectZeroStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta Variable)
 expectZeroStepLimit =
         ( Predicated
             { term = asPureMetaPattern (metaF (v1 PatternSort))
@@ -365,7 +365,7 @@ expectZeroStepLimit =
         , mempty
         )
 
-actualZeroStepLimit :: (CommonExpandedPattern Meta, StepProof Variable Meta)
+actualZeroStepLimit :: (CommonExpandedPattern Meta, StepProof Meta Variable)
 actualZeroStepLimit =
     runSteps
         mockMetadataTools
@@ -377,7 +377,7 @@ actualZeroStepLimit =
             }
         axiomsSimpleStrategy
 
-expectStepLimit :: (ExpandedPattern Meta Variable, StepProof Variable Meta)
+expectStepLimit :: (ExpandedPattern Meta Variable, StepProof Meta Variable)
 expectStepLimit =
     ( Predicated
         { term = asPureMetaPattern (metaG (v1 PatternSort))
@@ -391,7 +391,7 @@ expectStepLimit =
         ]
     )
 
-actualStepLimit :: (CommonExpandedPattern Meta, StepProof Variable Meta)
+actualStepLimit :: (CommonExpandedPattern Meta, StepProof Meta Variable)
 actualStepLimit =
     runSteps
         mockMetadataTools
@@ -514,7 +514,7 @@ runStep
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
     -> [AxiomPattern level]
-    -> [(CommonExpandedPattern level, StepProof Variable level)]
+    -> [(CommonExpandedPattern level, StepProof level Variable)]
 runStep metadataTools configuration axioms =
     pickStuck
         $ evalSimplifier
@@ -538,7 +538,7 @@ runSteps
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
     -> [AxiomPattern level]
-    -> (CommonExpandedPattern level, StepProof Variable level)
+    -> (CommonExpandedPattern level, StepProof level Variable)
 runSteps metadataTools stepLimit configuration axioms =
     pickLongest
         $ evalSimplifier


### PR DESCRIPTION
Without explicit kind signatures, the type parameters to StepProof were being
swapped in some places.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

