### PR TITLE
Don't use Make 4 short-hand notation

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -20,7 +20,7 @@ ifdef BUILD_NUMBER
 STACK_TEST_OPTS += --ta --xml=test-results.xml
 endif
 
-STACK_LOCAL_INSTALL_ROOT != stack path --local-install-root
+STACK_LOCAL_INSTALL_ROOT := $(shell stack path --local-install-root)
 KORE_EXEC ?= $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
 KORE_EXEC_OPTS ?=
 

--- a/src/main/k/working/function-evaluation-demo/Makefile
+++ b/src/main/k/working/function-evaluation-demo/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := demo-kompiled

--- a/src/main/k/working/imp-concrete-heat-cool/Makefile
+++ b/src/main/k/working/imp-concrete-heat-cool/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := imp-kompiled

--- a/src/main/k/working/imp-concrete-state/Makefile
+++ b/src/main/k/working/imp-concrete-state/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := imp-kompiled

--- a/src/main/k/working/imp-monosorted/Makefile
+++ b/src/main/k/working/imp-monosorted/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := imp-kompiled

--- a/src/main/k/working/tests/strict/Makefile
+++ b/src/main/k/working/tests/strict/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := strict-kompiled


### PR DESCRIPTION
Make 4 introduces some short-hand notation for the `$(shell ...)`
command. Unfortunately, the default Make on macOS is Make 3, which does not
recognize the notation.

@virgil-serbanuta Could you double-check that this works for you?

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

