### PR TITLE
Makefile: Be strict about `find` invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ distclean: clean
 
 clean: clean-submodules
 	stack clean
-	find -name '*.tix' -exec rm -f '{}' \;
+	find . -name '*.tix' -exec rm -f '{}' \;
 	$(MAKE) -C src/main/k/working clean
 
 check:


### PR DESCRIPTION
`find` expects its first argument to be a search path. GNU Find allows the
search path to be omitted, in which case it is implied to be `.`. macOS Find
does not allow the search path to be omitted.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

