### PR TITLE
Invoke kompile and krun without nailgun

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -5,9 +5,14 @@ TOP ?= $(shell git rev-parse --show-toplevel)
 BUILD_DIR := $(TOP)/.build
 K_SUBMODULE := $(BUILD_DIR)/k
 K_TIMESTAMP := $(TOP)/.git/modules/deps/k/logs/HEAD
-K_BIN := $(K_SUBMODULE)/k-distribution/target/release/k/bin
-KOMPILE := $(K_BIN)/kompile
-KRUN := $(K_BIN)/krun
+K_PACKAGE := $(K_SUBMODULE)/k-distribution/target/release/k
+K_BIN := $(K_PACKAGE)/bin
+K_LIB := $(K_PACKAGE)/lib
+
+JAVA_CLASSPATH := '$(K_LIB)/java/*'
+JAVA := java -ea -cp $(JAVA_CLASSPATH)
+KOMPILE := $(JAVA) org.kframework.main.Main -kompile
+KRUN := $(JAVA) org.kframework.main.Main -krun
 
 HS_TOP := $(TOP)/src/main/haskell/kore
 HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test
@@ -27,8 +32,8 @@ KORE_EXEC_OPTS ?=
 KOMPILE_OPTS ?= --backend haskell
 KRUN_OPTS ?= --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
 
-KOMPILE_TARGETS := $(KOMPILE)
-KRUN_TARGETS := $(KRUN) $(KORE_EXEC)
+KOMPILE_TARGETS := $(K_BIN)/kompile
+KRUN_TARGETS := $(K_BIN)/krun $(KORE_EXEC)
 
 # Targets
 
@@ -44,8 +49,8 @@ $(K_TIMESTAMP): $(K_SUBMODULE)
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec
 
-$(KOMPILE): $(K_TIMESTAMP)
+$(K_BIN)/kompile: $(K_TIMESTAMP)
 	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U
 
-$(KRUN): $(K_TIMESTAMP)
+$(K_BIN)/krun: $(K_TIMESTAMP)
 	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U

--- a/include.mk
+++ b/include.mk
@@ -4,11 +4,14 @@ TOP ?= $(shell git rev-parse --show-toplevel)
 
 BUILD_DIR := $(TOP)/.build
 K_SUBMODULE := $(BUILD_DIR)/k
-K_TIMESTAMP := $(TOP)/.git/modules/deps/k/logs/HEAD
+# The K submodule reflog is used as a source timestamp.
+K_SRC := $(TOP)/.git/modules/deps/k/logs/HEAD
 K_PACKAGE := $(K_SUBMODULE)/k-distribution/target/release/k
 K_BIN := $(K_PACKAGE)/bin
 K_LIB := $(K_PACKAGE)/lib
 
+# The kernel JAR is used as a build timestamp.
+K := $(K_LIB)/java/kernel-1.0-SNAPSHOT.jar
 JAVA_CLASSPATH := '$(K_LIB)/java/*'
 JAVA := java -ea -cp $(JAVA_CLASSPATH)
 KOMPILE := $(JAVA) org.kframework.main.Main -kompile
@@ -32,9 +35,6 @@ KORE_EXEC_OPTS ?=
 KOMPILE_OPTS ?= --backend haskell
 KRUN_OPTS ?= --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
 
-KOMPILE_TARGETS := $(K_BIN)/kompile
-KRUN_TARGETS := $(K_BIN)/krun $(KORE_EXEC)
-
 # Targets
 
 FORCE:
@@ -44,13 +44,10 @@ $(K_SUBMODULE): FORCE
 		git submodule update --init -- $(K_SUBMODULE); \
 	fi
 
-$(K_TIMESTAMP): $(K_SUBMODULE)
+$(K_SRC): $(K_SUBMODULE)
 
 $(KORE_EXEC): FORCE
 	stack build $(STACK_BUILD_OPTS) kore:exe:kore-exec
 
-$(K_BIN)/kompile: $(K_TIMESTAMP)
-	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U
-
-$(K_BIN)/krun: $(K_TIMESTAMP)
+$(K): $(K_SRC)
 	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U

--- a/src/main/k/working/function-evaluation-demo/Makefile
+++ b/src/main/k/working/function-evaluation-demo/Makefile
@@ -4,16 +4,16 @@ include $(TOP)/include.mk
 KOMPILED := demo-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): demo.k $(KOMPILE_TARGETS)
+$(DEFINITION): demo.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module DEMO
 
-%.imp.kore: %.demo $(DEFINITION) $(KRUN_TARGETS)
+%.imp.kore: %.demo $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.demo $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.demo $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.demo $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.demo $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/imp-concrete-heat-cool/Makefile
+++ b/src/main/k/working/imp-concrete-heat-cool/Makefile
@@ -4,16 +4,16 @@ include $(TOP)/include.mk
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+$(DEFINITION): imp.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.imp.kore: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/imp-concrete-state/Makefile
+++ b/src/main/k/working/imp-concrete-state/Makefile
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): imp.k $(KOMPILE_TARGETS)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.imp.kore: %.imp $(DEFINITION) $(K)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/imp-monosorted/Makefile
+++ b/src/main/k/working/imp-monosorted/Makefile
@@ -4,16 +4,16 @@ include $(TOP)/include.mk
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+$(DEFINITION): imp.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.imp.kore: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/tests/strict/Makefile
+++ b/src/main/k/working/tests/strict/Makefile
@@ -4,16 +4,16 @@ include $(TOP)/include.mk
 KOMPILED := strict-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): strict.k $(KOMPILE_TARGETS)
+$(DEFINITION): strict.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module STRICT
 
-%.strict.kore: %.strict $(DEFINITION) $(KRUN_TARGETS)
+%.strict.kore: %.strict $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.strict $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.strict $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.strict $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.strict $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output


### PR DESCRIPTION
Running K through nailgun causes problems when multiple builds using multiple
versions of K want to run on the same Jenkins instance.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

