### PR TITLE
Make list unification return ExpandedPattern.bottom instead of Failure

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/List.hs
@@ -365,7 +365,8 @@ unify
     simplifyChild
     (DV_ dvSort (BuiltinDomainList list1))
     (DV_ _    (BuiltinDomainList list2))
-  | Seq.length list1 /= Seq.length list2 = Failure
+  | Seq.length list1 /= Seq.length list2 =
+        return $ return $ (ExpandedPattern.bottom, SimplificationProof)
   | otherwise = give symbolOrAliasSorts $ do
       unifiedList <- sequence $ Seq.zipWith simplifyChild list1 list2
       return $ do
@@ -382,7 +383,8 @@ unify
     simplifyChild
     (App_ symConcat [DV_ _ (BuiltinDomainList list1), (Var_ v)])
     (DV_ dvSort (BuiltinDomainList list2))
-  | Seq.length list1 > Seq.length list2 = Failure
+  | Seq.length list1 > Seq.length list2 =
+        return $ return $ (ExpandedPattern.bottom, SimplificationProof)
   | isSymbolConcat (StepperAttributes.hook <$> tools) symConcat
   = give symbolOrAliasSorts $
     let list2' = Seq.take (Seq.length list1) list2

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -648,7 +648,7 @@ test_andTermsSimplification = give mockSymbolOrAliasSorts
             let term7 = Mock.builtinList [Mock.a, Mock.a]
             let term8 = Mock.builtinList [Mock.a]
             assertEqualWithExplanation "different lengths"
-                ( Nothing
+                ( Just ExpandedPattern.bottom
                 )
                 ( unify
                     mockMetadataTools


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

