### PR TITLE
LTS Haskell 12.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ target
 !docs/hash-symbol.pdf
 *.fdb_latexmk
 *.fls
+*.tix
 *.toc
 .stack-work
 .*.swp

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.14
+resolver: lts-12.16
 
 nix:
   packages:


### PR DESCRIPTION
Among various package updates, LTS Haskell updates to GHC 8.4.4 with various bugfixes.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

