### PR TITLE
Fix Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,4 @@ stylish:
 	fi
 	find $(HS_SOURCE_DIRS) \
 		\( -name '*.hs' -o -name '*.hs-boot' \) \
-		-exec stylish-haskell -i '{}' \;
+		-print0 | xargs -0L1 stylish-haskell -i

--- a/include.mk
+++ b/include.mk
@@ -14,8 +14,8 @@ K_LIB := $(K_PACKAGE)/lib
 K := $(K_LIB)/java/kernel-1.0-SNAPSHOT.jar
 JAVA_CLASSPATH := '$(K_LIB)/java/*'
 JAVA := java -ea -cp $(JAVA_CLASSPATH)
-KOMPILE := $(JAVA) org.kframework.main.Main -kompile
-KRUN := $(JAVA) org.kframework.main.Main -krun
+KOMPILE := $(K_BIN)/kompile
+KRUN := $(K_BIN)/krun
 
 HS_TOP := $(TOP)/src/main/haskell/kore
 HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test
@@ -51,3 +51,4 @@ $(KORE_EXEC): FORCE
 
 $(K): $(K_SRC)
 	cd $(K_SUBMODULE) && mvn package -q -DskipTests -U
+	rm -f $(K_BIN)/ng

--- a/src/main/haskell/kore/src/Kore/MetaML/Unlift.hs
+++ b/src/main/haskell/kore/src/Kore/MetaML/Unlift.hs
@@ -13,9 +13,9 @@ for all MetaML constructs up to patterns.
 -}
 module Kore.MetaML.Unlift ( UnliftableFromMetaML (..) ) where
 
-import Control.Applicative
-import Data.Functor.Foldable
-import Data.Maybe
+import           Control.Applicative
+import           Data.Functor.Foldable
+import           Data.Maybe
 import qualified Data.Text as Text
 
 import Kore.AST.Common
@@ -53,12 +53,13 @@ parseObjectId input location =
 unliftObjectId :: Id Meta -> Maybe (Id Object)
 unliftObjectId
     Id
-        { getId = Text.unpack -> '#' : oid
+        { getId = mid
         , idLocation = location
         }
   =
-    parseObjectId oid location
-unliftObjectId _  = Nothing
+    case Text.unpack mid of
+        '#' : oid -> parseObjectId oid location
+        _ -> Nothing
 
 instance UnliftableFromMetaML (Id Object) where
     unliftFromMeta (Fix (StringLiteralPattern (StringLiteral str))) =

--- a/src/main/k/in-progress/tests/collections/list/list-unify-any-elem/Makefile
+++ b/src/main/k/in-progress/tests/collections/list/list-unify-any-elem/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-any-elem-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-any-elem.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-any-elem
 
-%.list-unify-any-elem.kore: %.list-unify-any-elem $(DEFINITION) $(KORE_EXEC)
+%.list-unify-any-elem.kore: %.list-unify-any-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-any-elem $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-any-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-any-elem $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-any-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): list-unify-any-elem.k $(K)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/list/list-unify-first-elem/Makefile
+++ b/src/main/k/in-progress/tests/collections/list/list-unify-first-elem/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-first-elem-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-first-elem.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-first-elem
 
-%.list-unify-first-elem.kore: %.list-unify-first-elem $(DEFINITION) $(KORE_EXEC)
+%.list-unify-first-elem.kore: %.list-unify-first-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-first-elem $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-first-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-first-elem $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-first-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): list-unify-first-elem.k $(K)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/list/list-unify-framing-variable-left/Makefile
+++ b/src/main/k/in-progress/tests/collections/list/list-unify-framing-variable-left/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-framing-variable-left-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-framing-variable-left.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-framing-variable-left
 
-%.list-unify-framing-variable-left.kore: %.list-unify-framing-variable-left $(DEFINITION) $(KORE_EXEC)
+%.list-unify-framing-variable-left.kore: %.list-unify-framing-variable-left $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-framing-variable-left $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-framing-variable-left $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-framing-variable-left $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-framing-variable-left $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): list-unify-framing-variable-left.k $(K)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/list/list-unify-framing-variable-right/Makefile
+++ b/src/main/k/in-progress/tests/collections/list/list-unify-framing-variable-right/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-framing-variable-right-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-framing-variable-right.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-framing-variable-right
 
-%.list-unify-framing-variable-right.kore: %.list-unify-framing-variable-right $(DEFINITION) $(KORE_EXEC)
+%.list-unify-framing-variable-right.kore: %.list-unify-framing-variable-right $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-framing-variable-right $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-framing-variable-right $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-framing-variable-right $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-framing-variable-right $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): list-unify-framing-variable-right.k $(K)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/list/list-unify-last-elem/Makefile
+++ b/src/main/k/in-progress/tests/collections/list/list-unify-last-elem/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-last-elem-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-last-elem.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-last-elem
 
-%.list-unify-last-elem.kore: %.list-unify-last-elem $(DEFINITION) $(KORE_EXEC)
+%.list-unify-last-elem.kore: %.list-unify-last-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-last-elem $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-last-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-last-elem $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-last-elem $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): list-unify-last-elem.k $(K)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/map/map-unify-framing-variable/Makefile
+++ b/src/main/k/in-progress/tests/collections/map/map-unify-framing-variable/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := map-unify-framing-variable-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): map-unify-framing-variable.k $(KOMPILE_TARGETS)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module map-unify-framing-variable
 
-%.map-unify-framing-variable.kore: %.map-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.map-unify-framing-variable.kore: %.map-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.map-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.map-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.map-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.map-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): map-unify-framing-variable.k $(KOMPILE_TARGETS)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/in-progress/tests/collections/set/set-unify-framing-variable/Makefile
+++ b/src/main/k/in-progress/tests/collections/set/set-unify-framing-variable/Makefile
@@ -1,19 +1,19 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := set-unify-framing-variable-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): set-unify-framing-variable.k $(KOMPILE_TARGETS)
+$(DEFINITION): set-unify-framing-variable.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module set-unify-framing-variable
 
-%.set-unify-framing-variable.kore: %.set-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.set-unify-framing-variable.kore: %.set-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.set-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.set-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.set-unify-framing-variable $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.set-unify-framing-variable $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -22,9 +22,9 @@ $(DEFINITION): set-unify-framing-variable.k $(KOMPILE_TARGETS)
 %.output.golden: %.output
 	mv $< $<.golden
 
-test: tests/1.test tests/2.test tests/3.test 
+test: tests/1.test tests/2.test tests/3.test
 
-test-k: tests/1.test tests/2.test tests/3.test 
+test-k: tests/1.test tests/2.test tests/3.test
 
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 

--- a/src/main/k/working/imp-map/Makefile
+++ b/src/main/k/working/imp-map/Makefile
@@ -1,19 +1,19 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+$(DEFINITION): imp.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.imp.kore: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.imp $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.imp $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/search/Makefile
+++ b/src/main/k/working/search/Makefile
@@ -1,52 +1,52 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := search-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): search.k $(KOMPILE_TARGETS)
+$(DEFINITION): search.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module SEARCH
 
-%.search.kore: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.search.kore: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.star.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.star.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all
 
-%.plus.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.plus.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps
 
-%.one.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.one.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step
 
-%.final.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.final.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.star.unreachable.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.star.unreachable.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all --pattern '<k> unreachable </k>'
 
-%.plus.unreachable.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.plus.unreachable.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps --pattern '<k> unreachable </k>'
 
-%.one.unreachable.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.one.unreachable.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step --pattern '<k> unreachable </k>'
 
-%.final.unreachable.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.final.unreachable.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final --pattern '<k> unreachable </k>'
 
-%.star.initial.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.star.initial.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all --pattern '<k> initial </k>'
 
-%.plus.initial.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.plus.initial.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps --pattern '<k> initial </k>'
 
-%.one.initial.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.one.initial.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step --pattern '<k> initial </k>'
 
-%.final.initial.output: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.final.initial.output: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final --pattern '<k> initial </k>'
 
-%.krun: %.search $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.search $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/tests/collections/list-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-concrete/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := list-unify-concrete-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): list-unify-concrete.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-concrete
 
-%.list-unify-concrete.kore: %.list-unify-concrete $(DEFINITION) $(KORE_EXEC)
+%.list-unify-concrete.kore: %.list-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.list-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.list-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.list-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/tests/collections/map-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/map-unify-concrete/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := map-unify-concrete-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): map-unify-concrete.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module map-unify-concrete
 
-%.map-unify-concrete.kore: %.map-unify-concrete $(DEFINITION) $(KORE_EXEC)
+%.map-unify-concrete.kore: %.map-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.map-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.map-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.map-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.map-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output

--- a/src/main/k/working/tests/collections/set-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/set-unify-concrete/Makefile
@@ -1,4 +1,4 @@
-TOP != git rev-parse --show-toplevel
+TOP := $(shell git rev-parse --show-toplevel)
 include $(TOP)/include.mk
 
 KOMPILED := set-unify-concrete-kompiled
@@ -7,13 +7,13 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): set-unify-concrete.k $(K)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module set-unify-concrete
 
-%.set-unify-concrete.kore: %.set-unify-concrete $(DEFINITION) $(KORE_EXEC)
+%.set-unify-concrete.kore: %.set-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.set-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.output: %.set-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.set-unify-concrete $(DEFINITION) $(KRUN_TARGETS)
+%.krun: %.set-unify-concrete $(DEFINITION) $(K) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output


### PR DESCRIPTION
This pull request fixes various stale Makefiles after #303.

The `stylish` Makefile target is updated so that it fails if a Haskell source file cannot be parsed. A parse error due to ViewPatterns is fixed.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

