### PR TITLE
Kore.Step.OrOfExpandedPattern.merge: Use idempotency property

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -446,9 +446,9 @@ parseString parser lit =
   See also: 'ExpandedPattern'
  -}
 appliedFunction
-    :: Monad m
-    => ExpandedPattern Object variable
-    -> m (AttemptedFunction Object variable)
+    :: (Monad m, Ord (variable level), level ~ Object)
+    => ExpandedPattern level variable
+    -> m (AttemptedFunction level variable)
 appliedFunction epat =
     (return . Applied . OrOfExpandedPattern.make) [epat]
 
@@ -483,11 +483,12 @@ unaryOperator
     get :: DomainValue Object (BuiltinDomain child) -> a
     get = runParser (Text.unpack ctx) . parseDomainValue parser
     unaryOperator0
-        :: MetadataTools Object StepperAttributes
-        -> PureMLPatternSimplifier Object variable
-        -> Sort Object
-        -> [PureMLPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        :: (Ord (variable level), level ~ Object)
+        => MetadataTools level StepperAttributes
+        -> PureMLPatternSimplifier level variable
+        -> Sort level
+        -> [PureMLPattern level variable]
+        -> Simplifier (AttemptedFunction level variable)
     unaryOperator0 _ _ resultSort children =
         case Functor.Foldable.project <$> children of
             [DomainValuePattern a] -> do
@@ -529,11 +530,12 @@ binaryOperator
     get :: DomainValue Object (BuiltinDomain child) -> a
     get = runParser (Text.unpack ctx) . parseDomainValue parser
     binaryOperator0
-        :: MetadataTools Object StepperAttributes
-        -> PureMLPatternSimplifier Object variable
-        -> Sort Object
-        -> [PureMLPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        :: (Ord (variable level), level ~ Object)
+        => MetadataTools level StepperAttributes
+        -> PureMLPatternSimplifier level variable
+        -> Sort level
+        -> [PureMLPattern level variable]
+        -> Simplifier (AttemptedFunction level variable)
     binaryOperator0 _ _ resultSort children =
         case Functor.Foldable.project <$> children of
             [DomainValuePattern a, DomainValuePattern b] -> do
@@ -575,11 +577,12 @@ ternaryOperator
     get :: DomainValue Object (BuiltinDomain child) -> a
     get = runParser (Text.unpack ctx) . parseDomainValue parser
     ternaryOperator0
-        :: MetadataTools Object StepperAttributes
-        -> PureMLPatternSimplifier Object variable
-        -> Sort Object
-        -> [PureMLPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        :: (Ord (variable level), level ~ Object)
+        => MetadataTools level StepperAttributes
+        -> PureMLPatternSimplifier level variable
+        -> Sort level
+        -> [PureMLPattern level variable]
+        -> Simplifier (AttemptedFunction level variable)
     ternaryOperator0 _ _ resultSort children =
         case Functor.Foldable.project <$> children of
             [DomainValuePattern a, DomainValuePattern b, DomainValuePattern c] -> do

--- a/src/main/haskell/kore/src/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/List.hs
@@ -145,7 +145,7 @@ expectBuiltinDomainList ctx =
             empty
 
 returnList
-    :: Monad m
+    :: (Monad m, Ord (variable Object))
     => Kore.Sort Object
     -> (Builtin variable)
     -> m (AttemptedFunction Object variable)
@@ -170,7 +170,8 @@ evalGet =
   where
     ctx = "LIST.get"
     evalGet0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Kore.Sort Object
         -> [Kore.PureMLPattern Object variable]
@@ -216,7 +217,8 @@ evalConcat =
   where
     ctx = "LIST.concat"
     evalConcat0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Kore.Sort Object
         -> [Kore.PureMLPattern Object variable]

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -162,7 +162,7 @@ expectBuiltinDomainMap ctx _map =
                 empty
 
 returnMap
-    :: Monad m
+    :: (Monad m, Ord (variable Object))
     => Kore.Sort Object
     -> Builtin variable
     -> m (AttemptedFunction Object variable)
@@ -177,7 +177,8 @@ evalLookup =
   where
     ctx = "MAP.lookup"
     evalLookup0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Sort Object
         -> [PureMLPattern Object variable]
@@ -223,7 +224,8 @@ evalConcat =
   where
     ctx = "MAP.concat"
     evalConcat0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Sort Object
         -> [PureMLPattern Object variable]

--- a/src/main/haskell/kore/src/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Set.hs
@@ -165,7 +165,7 @@ expectBuiltinDomainSet ctx tools _set =
                 empty
 
 returnSet
-    :: Monad m
+    :: (Monad m, Ord (variable Object))
     => Kore.Sort Object
     -> Builtin
     -> m (AttemptedFunction Object variable)
@@ -193,7 +193,8 @@ evalIn =
     Builtin.functionEvaluator evalIn0
   where
     evalIn0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Kore.Sort Object
         -> [Kore.PureMLPattern Object variable]
@@ -228,7 +229,8 @@ evalConcat =
   where
     ctx = "SET.concat"
     evalConcat0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Kore.Sort Object
         -> [Kore.PureMLPattern Object variable]
@@ -267,7 +269,8 @@ evalDifference =
   where
     ctx = "SET.difference"
     evalDifference0
-        :: MetadataTools Object StepperAttributes
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
         -> PureMLPatternSimplifier Object variable
         -> Kore.Sort Object
         -> [Kore.PureMLPattern Object variable]

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -93,7 +93,7 @@ notApplicableFunctionEvaluator = pure (NotApplicable, SimplificationProof)
 
 -- |Yields a pure 'Simplifier' which produces a given 'PureMLPattern'
 purePatternFunctionEvaluator
-    :: (MetaOrObject level)
+    :: (MetaOrObject level, Ord (variable level))
     => PureMLPattern level variable
     -> Simplifier (AttemptedFunction level variable, SimplificationProof level')
 purePatternFunctionEvaluator p =

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -166,7 +166,7 @@ evaluateApplication
 -- move the recursive simplification call from UserDefined.hs here.
 
 evaluateSortInjection
-    :: (MetaOrObject level)
+    :: (MetaOrObject level, Ord (variable level))
     => MetadataTools level StepperAttributes
     -> OrOfExpandedPattern level variable
     -> Application level (PureMLPattern level variable)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Bottom.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Bottom.hs
@@ -13,6 +13,7 @@ module Kore.Step.Simplification.Bottom
 
 import           Kore.AST.Common
                  ( Bottom (..) )
+import           Kore.AST.MetaOrObject
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -23,7 +24,8 @@ import           Kore.Step.Simplification.Data
 {-| simplifies a Bottom pattern, which means returning an always-false or.
 -}
 simplify
-    :: Bottom level child
+    :: (MetaOrObject level, Ord (variable level))
+    => Bottom level child
     -> ( OrOfExpandedPattern level variable
        , SimplificationProof level
        )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/CharLiteral.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/CharLiteral.hs
@@ -31,7 +31,8 @@ import           Kore.Step.Simplification.Data
 an or containing a term made of that literal.
 -}
 simplify
-    :: CharLiteral
+    :: Ord (variable Meta)
+    => CharLiteral
     -> ( OrOfExpandedPattern Meta variable
        , SimplificationProof Meta
        )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/DomainValue.hs
@@ -33,7 +33,7 @@ import           Kore.Step.Simplification.Data
 an or containing a term made of that value.
 -}
 simplify
-    :: ( Eq (variable Object), Show (variable Object)
+    :: ( Ord (variable Object), Show (variable Object)
        , SortedVariable variable
        )
     => MetadataTools Object attrs

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/StringLiteral.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/StringLiteral.hs
@@ -31,7 +31,8 @@ import           Kore.Step.Simplification.Data
 an or containing a term made of that literal.
 -}
 simplify
-    :: StringLiteral
+    :: Ord (variable Meta)
+    => StringLiteral
     -> ( OrOfExpandedPattern Meta variable
        , SimplificationProof Meta
        )

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Top.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Top.hs
@@ -26,7 +26,7 @@ import           Kore.Step.Simplification.Data
 {-| simplifies a Top pattern, which means returning an always-true or.
 -}
 simplify
-    :: MetaOrObject level
+    :: (MetaOrObject level, Ord (variable level))
     => Top level child
     -> ( OrOfExpandedPattern level variable
        , SimplificationProof level

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Variable.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Variable.hs
@@ -31,7 +31,7 @@ import           Kore.Step.Simplification.Data
 an or containing a term made of that variable.
 -}
 simplify
-    :: MetaOrObject level
+    :: (MetaOrObject level, Ord (variable level))
     => variable level
     -> ( OrOfExpandedPattern level variable
        , SimplificationProof level

--- a/src/main/haskell/kore/test/Test/Kore.hs
+++ b/src/main/haskell/kore/test/Test/Kore.hs
@@ -294,6 +294,9 @@ patternGen childGen x =
         , VariablePattern <$> variableGen x
         ]
 
+purePatternGen :: MetaOrObject level => level -> Gen (CommonPurePattern level)
+purePatternGen level = embed <$> patternGen (purePatternGen level) level
+
 korePatternGen :: Gen CommonKorePattern
 korePatternGen = sized (\n ->
     if n<=0

--- a/src/main/haskell/kore/test/Test/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/OrOfExpandedPattern.hs
@@ -1,0 +1,42 @@
+module Test.Kore.Step.OrOfExpandedPattern where
+
+import Test.Tasty.QuickCheck
+
+import Kore.AST.MetaOrObject
+import Kore.Predicate.Predicate
+import Kore.Step.ExpandedPattern
+import Kore.Step.OrOfExpandedPattern
+
+import Test.Kore
+
+expandedPatternGen
+    :: MetaOrObject level
+    => level
+    -> Gen (CommonExpandedPattern level)
+expandedPatternGen level = do
+    term <- purePatternGen level
+    return Predicated { term, predicate = makeTruePredicate, substitution = [] }
+
+orOfExpandedPatternGen
+    :: MetaOrObject level
+    => level
+    -> Gen (CommonOrOfExpandedPattern level)
+orOfExpandedPatternGen level =
+    filterOr . MultiOr <$> listOf (expandedPatternGen level)
+
+-- | Check that 'merge' preserves the @\\or@-idempotency condition.
+prop_mergeIdemOr :: Gen Property
+prop_mergeIdemOr = do
+    ors <- orOfExpandedPatternGen Object
+    return (merge ors ors === ors)
+
+prop_makeIdemOr :: Gen Property
+prop_makeIdemOr = do
+    pat <- expandedPatternGen Object
+    return (make [pat, pat] === make [pat])
+
+prop_flattenIdemOr :: Gen Property
+prop_flattenIdemOr = do
+    ors <- orOfExpandedPatternGen Object
+    let nested = MultiOr [ors, ors]
+    return (flatten nested === ors)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -426,7 +426,8 @@ test_applicationSimplification = give mockSymbolOrAliasSorts
             mockSymbolOrAliasSorts attributesMapping headTypeMapping []
 
 makeApplication
-    :: SymbolOrAlias level
+    :: (MetaOrObject level, Ord (variable level))
+    => SymbolOrAlias level
     -> [[ExpandedPattern level variable]]
     -> Application level (OrOfExpandedPattern level variable)
 makeApplication symbol patterns =

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -330,7 +330,8 @@ test_ceilSimplification = give mockSymbolOrAliasSorts
             Mock.subsorts
 
 makeCeil
-    :: [ExpandedPattern Object variable]
+    :: Ord (variable Object)
+    => [ExpandedPattern Object variable]
     -> Ceil Object (OrOfExpandedPattern Object variable)
 makeCeil patterns =
     Ceil

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -271,14 +271,15 @@ test_existsSimplification = give mockSymbolOrAliasSorts
             Mock.subsorts
 
 makeExists
-    :: variable Object
+    :: Ord (variable Object)
+    => variable Object
     -> [ExpandedPattern Object variable]
     -> Exists Object variable (OrOfExpandedPattern Object variable)
 makeExists variable patterns =
     Exists
         { existsSort = testSort
-        , existsVariable  = variable
-        , existsChild       = OrOfExpandedPattern.make patterns
+        , existsVariable = variable
+        , existsChild = OrOfExpandedPattern.make patterns
         }
 
 testSort :: Sort Object

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Floor.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Floor.hs
@@ -194,7 +194,8 @@ test_floorSimplification =
     mockSymbolOrAliasSorts = Mock.makeSymbolOrAliasSorts symbolOrAliasSortsMapping
 
 makeFloor
-    :: [ExpandedPattern Object variable]
+    :: Ord (variable Object)
+    => [ExpandedPattern Object variable]
     -> Floor Object (OrOfExpandedPattern Object variable)
 makeFloor patterns =
     Floor

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Forall.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Forall.hs
@@ -246,7 +246,8 @@ test_forallSimplification = give mockSymbolOrAliasSorts
     mockSymbolOrAliasSorts = Mock.makeSymbolOrAliasSorts Mock.symbolOrAliasSortsMapping
 
 makeForall
-    :: variable Object
+    :: Ord (variable Object)
+    => variable Object
     -> [ExpandedPattern Object variable]
     -> Forall Object variable (OrOfExpandedPattern Object variable)
 makeForall variable patterns =
@@ -281,4 +282,3 @@ makeEvaluate
     -> CommonExpandedPattern level
 makeEvaluate variable child =
     fst $ Forall.makeEvaluate variable child
-

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
@@ -22,7 +22,7 @@ import           Kore.Step.Simplification.Data
                  Simplifier )
 
 mockSimplifier
-    :: (MetaOrObject level, Eq level, Eq (variable level))
+    :: (MetaOrObject level, Eq level, Ord (variable level))
     =>  [   ( PureMLPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)
             )
@@ -38,7 +38,7 @@ mockSimplifier values =
         )
 
 mockPredicateSimplifier
-    :: (MetaOrObject level, Eq level, Eq (variable level))
+    :: (MetaOrObject level, Eq level, Ord (variable level))
     =>  [   ( PureMLPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)
             )
@@ -57,7 +57,7 @@ mockPredicateSimplifier values =
         )
 
 mockSimplifierHelper
-    ::  (MetaOrObject level, Eq level, Eq (variable level))
+    ::  (MetaOrObject level, Eq level, Ord (variable level))
     =>  (PureMLPattern level variable -> ExpandedPattern level variable)
     ->  [   ( PureMLPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)


### PR DESCRIPTION
`merge` takes advantage of the idempotency property of disjunction to eliminate
identical patterns from disjunctions. Only patterns that are syntactically
identical are de-duplicated. (Simplification should eventually rewrite
semantically-equivalent patterns into syntactically identical ones.)

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

