### PR TITLE
Add KEQUAL.ite and STRING.lt builtins

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -318,6 +318,35 @@ argument is not positive.
         [hook{}("INT.log2")]
 ~~~
 
+## STRING
+
+Depends on `BOOL`.
+
+### STRING.String
+
+The builtin String sort:
+
+~~~
+    hooked-sort String{}
+        [hook{}("STRING.String")]
+~~~
+
+Valid domain values are strings.
+
+~~~
+    \dv{String{}}("string")
+~~~
+
+### STRING.lt
+
+Comparison: is the first argument less than the second?
+
+~~~
+    hooked-symbol lt{}(String{}, String{}) : Bool{}
+        [hook{}("STRING.lt")]
+~~~
+
+
 ## MAP
 
 Depends on `BOOL`.
@@ -501,4 +530,38 @@ Is the element a member of the given set?
 ~~~
     hooked-symbol in{}(Elem{}, Set{}) : Bool{}
         [hook{}("SET.in")]
+~~~
+
+## KEQUAL
+
+Depends on `BOOL`.
+
+The sorts on which equality is tested are referred to as `Item`.
+
+### KEQUAL.eq
+
+Comparison: is the first argument equal to the second?
+
+~~~
+    hooked-symbol eq{}(Item{}, Item{}) : Bool{}
+        [hook{}("KEQUAL.eq")]
+~~~
+
+
+### KEQUAL.neq
+
+Comparison: is the first argument inequal to the second?
+
+~~~
+    hooked-symbol neq{}(Item{}, Item{}) : Bool{}
+        [hook{}("KEQUAL.neq")]
+~~~
+
+### KEQUAL.ite
+
+If-then-else: if condition then something, else something else.
+
+~~~
+    hooked-symbol neq{}(Bool{}, Item{}, Item{}) : Item{}
+        [hook{}("KEQUAL.ite")]
 ~~~

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -53,6 +53,7 @@ import qualified Kore.Builtin.KEqual as KEqual
 import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.Map as Map
 import qualified Kore.Builtin.Set as Set
+import qualified Kore.Builtin.String as String
 import           Kore.Error
 import           Kore.IndexedModule.IndexedModule
                  ( IndexedModule (..), KoreIndexedModule )
@@ -79,6 +80,7 @@ koreVerifiers =
         <> List.sortDeclVerifiers
         <> Map.sortDeclVerifiers
         <> Set.sortDeclVerifiers
+        <> String.sortDeclVerifiers
     , symbolVerifiers =
            Bool.symbolVerifiers
         <> Int.symbolVerifiers
@@ -86,9 +88,11 @@ koreVerifiers =
         <> Map.symbolVerifiers
         <> KEqual.symbolVerifiers
         <> Set.symbolVerifiers
+        <> String.symbolVerifiers
     , patternVerifier =
            Bool.patternVerifier
         <> Int.patternVerifier
+        <> String.patternVerifier
     }
 
 {- | Construct an evaluation context for Kore builtin functions.
@@ -114,6 +118,7 @@ koreEvaluators = evaluators builtins
             , List.builtinFunctions
             , Map.builtinFunctions
             , Set.builtinFunctions
+            , String.builtinFunctions
             ]
 
 {- | Construct an evaluation context for the given builtin functions.

--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -1,0 +1,196 @@
+{- |
+Module      : Kore.Builtin.String
+Description : Built-in string sort
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : vladimir.ciobanu@runtimeverification.com
+Stability   : experimental
+Portability : portable
+
+This module is intended to be imported qualified, to avoid collision with other
+builtin modules.
+
+@
+    import qualified Kore.Builtin.String as String
+@
+ -}
+
+module Kore.Builtin.String
+    ( sort
+    , assertSort
+    , sortDeclVerifiers
+    , symbolVerifiers
+    , patternVerifier
+    , builtinFunctions
+    , expectBuiltinDomainString
+    , asMetaPattern
+    , asPattern
+    , asConcretePattern
+    , asExpandedPattern
+    , asPartialExpandedPattern
+    , parse
+    ) where
+
+import           Control.Applicative
+                 ( Alternative (..) )
+import           Control.Error
+                 ( MaybeT )
+import           Control.Monad
+                 ( void )
+import qualified Data.Functor.Foldable as Functor.Foldable
+import qualified Data.HashMap.Strict as HashMap
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Text
+                 ( Text )
+import qualified Text.Megaparsec as Parsec
+import qualified Text.Megaparsec.Char as Parsec
+
+import qualified Kore.AST.Common as Kore
+import           Kore.AST.MetaOrObject
+                 ( Meta, Object )
+import           Kore.AST.PureML
+                 ( fromConcretePurePattern )
+import qualified Kore.ASTUtils.SmartPatterns as Kore
+import qualified Kore.Builtin.Bool as Bool
+import qualified Kore.Builtin.Builtin as Builtin
+import           Kore.Step.ExpandedPattern
+                 ( ExpandedPattern )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+
+
+{- | Builtin name of the @String@ sort.
+ -}
+sort :: Text
+sort = "STRING.String"
+
+
+{- | Verify that the sort is hooked to the builtin @String@ sort.
+
+  See also: 'sort', 'Builtin.verifySort'
+
+ -}
+assertSort :: Builtin.SortVerifier
+assertSort findSort = Builtin.verifySort findSort sort
+
+{- | Verify that hooked sort declarations are well-formed.
+
+  See also: 'Builtin.verifySortDecl'
+
+ -}
+sortDeclVerifiers :: Builtin.SortDeclVerifiers
+sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
+
+{- | Verify that hooked symbol declarations are well-formed.
+
+  See also: 'Builtin.verifySymbol'
+
+ -}
+symbolVerifiers :: Builtin.SymbolVerifiers
+symbolVerifiers =
+    HashMap.fromList
+    [
+        ("STRING.lt", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    ]
+
+{- | Verify that domain value patterns are well-formed.
+ -}
+patternVerifier :: Builtin.PatternVerifier
+patternVerifier =
+    Builtin.verifyDomainValue sort
+    (void . Builtin.parseDomainValue parse)
+
+{- | Parse a string literal.
+ -}
+parse :: Builtin.Parser String
+parse = Parsec.many Parsec.anyChar
+
+{- | Abort function evaluation if the argument is not a String domain value.
+
+    If the operand pattern is not a domain value, the function is simply
+    'NotApplicable'. If the operand is a domain value, but not represented
+    by a 'BuiltinDomainMap', it is a bug.
+
+ -}
+expectBuiltinDomainString
+    :: Monad m
+    => String  -- ^ Context for error message
+    -> Kore.PureMLPattern Object variable  -- ^ Operand pattern
+    -> MaybeT m String
+expectBuiltinDomainString ctx =
+    \case
+        Kore.DV_ _ domain ->
+            case domain of
+                Kore.BuiltinDomainPattern (Kore.StringLiteral_ lit) ->
+                    (return . Builtin.runParser ctx)
+                        (Builtin.parseString parse lit)
+                _ ->
+                    Builtin.verifierBug
+                        (ctx ++ ": Domain value argument is not a string")
+        _ ->
+            empty
+
+{- | Render an 'String' as a domain value pattern of the given sort.
+
+  The result sort should be hooked to the builtin @String@ sort, but this is not
+  checked.
+
+  See also: 'sort'
+
+ -}
+asPattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> String  -- ^ builtin value to render
+    -> Kore.PureMLPattern Object variable
+asPattern resultSort result =
+    fromConcretePurePattern (asConcretePattern resultSort result)
+
+{- | Render a 'String' as a concrete domain value pattern of the given sort.
+
+  The result sort should be hooked to the builtin @String@ sort, but this is not
+  checked.
+
+  See also: 'sort'
+
+ -}
+asConcretePattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> String  -- ^ builtin value to render
+    -> Kore.ConcretePurePattern Object
+asConcretePattern domainValueSort result =
+    (Functor.Foldable.embed . Kore.DomainValuePattern)
+        Kore.DomainValue
+            { domainValueSort
+            , domainValueChild =
+                Kore.BuiltinDomainPattern $ asMetaPattern result
+            }
+
+asMetaPattern :: String -> Kore.CommonPurePattern Meta
+asMetaPattern result = Kore.StringLiteral_ $ result
+
+asExpandedPattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> String  -- ^ builtin value to render
+    -> ExpandedPattern Object variable
+asExpandedPattern resultSort =
+    ExpandedPattern.fromPurePattern . asPattern resultSort
+
+asPartialExpandedPattern
+    :: Kore.Sort Object  -- ^ resulting sort
+    -> Maybe String  -- ^ builtin value to render
+    -> ExpandedPattern Object variable
+asPartialExpandedPattern resultSort =
+    maybe ExpandedPattern.bottom (asExpandedPattern resultSort)
+
+{- | Implement builtin function evaluation.
+ -}
+builtinFunctions :: Map Text Builtin.Function
+builtinFunctions =
+    Map.fromList
+    [
+        comparator "STRING.lt" (<)
+    ]
+  where
+    comparator name op =
+        (name, Builtin.binaryOperator parse Bool.asExpandedPattern name op)

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/String.hs
@@ -1,0 +1,176 @@
+module Test.Kore.Builtin.String where
+
+import Test.QuickCheck
+       ( Property, (===) )
+
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Proxy
+                 ( Proxy (..) )
+import           Data.Text
+                 ( Text )
+
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+import           Kore.AST.Sentence
+import           Kore.ASTUtils.SmartPatterns
+import           Kore.ASTVerifier.DefinitionVerifier
+import           Kore.Attribute.Parser
+                 ( ParseAttributes (..) )
+import qualified Kore.Builtin as Builtin
+import           Kore.Builtin.Hook
+                 ( hookAttribute )
+import qualified Kore.Builtin.String as String
+import qualified Kore.Error
+import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.MetadataTools
+import           Kore.Step.ExpandedPattern
+import           Kore.Step.Simplification.Data
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
+
+import           Test.Kore
+                 ( testId )
+import qualified Test.Kore.Builtin.Bool as Test.Bool
+import           Test.Kore.Builtin.Builtin
+import qualified Test.Kore.Step.MockSimplifiers as Mock
+
+-- | Test a comparison operator hooked to the given symbol
+propComparison
+    :: (String -> String -> Bool)
+    -- ^ implementation
+    -> SymbolOrAlias Object
+    -- ^ symbol
+    -> (String -> String -> Property)
+propComparison impl symb a b =
+    let pat = App_ symb (asPattern <$> [a, b])
+    in Test.Bool.asExpandedPattern (impl a b) === evaluate pat
+
+prop_lt :: String -> String -> Property
+prop_lt = propComparison (<) ltSymbol
+
+ltSymbol :: SymbolOrAlias Object
+ltSymbol = builtinSymbol "ltString"
+
+-- | Another name for asPattern.
+stringLiteral :: String -> CommonPurePattern Object
+stringLiteral = asPattern
+
+-- | Specialize 'String.asPattern' to the builtin sort 'stringSort'.
+asPattern :: String -> CommonPurePattern Object
+asPattern = String.asPattern stringSort
+
+-- | Specialize 'String.asConcretePattern' to the builtin sort 'stringSort'.
+asConcretePattern :: String -> ConcretePurePattern Object
+asConcretePattern = String.asConcretePattern stringSort
+
+-- | Specialize 'String.asExpandedPattern' to the builtin sort 'stringSort'.
+asExpandedPattern :: String -> CommonExpandedPattern Object
+asExpandedPattern = String.asExpandedPattern stringSort
+
+-- | Specialize 'String.asPartialPattern' to the builtin sort 'stringSort'.
+asPartialExpandedPattern :: Maybe String -> CommonExpandedPattern Object
+asPartialExpandedPattern = String.asPartialExpandedPattern stringSort
+
+-- | A sort to hook to the builtin @STRING.String@.
+stringSort :: Sort Object
+stringSort =
+    SortActualSort SortActual
+        { sortActualName = testId "String"
+        , sortActualSorts = []
+        }
+
+-- | Declare 'stringSort' in a Kore module.
+stringSortDecl :: KoreSentence
+stringSortDecl =
+    (asSentence . SentenceHookedSort) (SentenceSort
+        { sentenceSortName =
+            let SortActualSort SortActual { sortActualName } = stringSort
+            in sortActualName
+        , sentenceSortParameters = []
+        , sentenceSortAttributes = Attributes [ hookAttribute "STRING.String" ]
+        }
+        :: KoreSentenceSort Object)
+
+-- | Make an unparameterized builtin symbol with the given name.
+builtinSymbol :: Text -> SymbolOrAlias Object
+builtinSymbol name =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = testId name
+        , symbolOrAliasParams = []
+        }
+
+{- | Declare a hooked symbol with two arguments.
+
+  The arguments have sort 'stringSort' and the result is 'Test.Bool.boolSort'.
+
+  -}
+comparisonSymbolDecl :: String -> SymbolOrAlias Object -> KoreSentence
+comparisonSymbolDecl builtinName symbol =
+    hookedSymbolDecl
+        builtinName
+        symbol
+        Test.Bool.boolSort
+        [stringSort, stringSort]
+
+importBool :: KoreSentence
+importBool =
+    asSentence
+        (SentenceImport
+            { sentenceImportModuleName = Test.Bool.boolModuleName
+            , sentenceImportAttributes = Attributes []
+            }
+            :: KoreSentenceImport
+        )
+
+stringModuleName :: ModuleName
+stringModuleName = ModuleName "STRING"
+
+{- | Declare the @STRING@ builtins.
+ -}
+stringModule :: KoreModule
+stringModule =
+    Module
+        { moduleName = stringModuleName
+        , moduleAttributes = Attributes []
+        , moduleSentences =
+            [ importBool
+            , stringSortDecl
+            , comparisonSymbolDecl "STRING.lt" ltSymbol
+            ]
+        }
+
+evaluate :: CommonPurePattern Object -> CommonExpandedPattern Object
+evaluate pat =
+    fst $ evalSimplifier
+    $ Pattern.simplify tools (Mock.substitutionSimplifier tools) evaluators pat
+  where
+    tools = extractMetadataTools indexedModule
+
+stringDefinition :: KoreDefinition
+stringDefinition =
+    Definition
+        { definitionAttributes = Attributes []
+        , definitionModules = [ Test.Bool.boolModule, stringModule ]
+        }
+
+indexedModules :: Map ModuleName (KoreIndexedModule StepperAttributes)
+indexedModules = verify stringDefinition
+
+indexedModule :: KoreIndexedModule StepperAttributes
+Just indexedModule = Map.lookup stringModuleName indexedModules
+
+evaluators :: Map (Id Object) [Builtin.Function]
+evaluators = Builtin.evaluators String.builtinFunctions indexedModule
+
+verify
+    :: ParseAttributes a
+    => KoreDefinition
+    -> Map ModuleName (KoreIndexedModule a)
+verify defn =
+    either (error . Kore.Error.printError) id
+        (verifyAndIndexDefinition attrVerify Builtin.koreVerifiers defn)
+  where
+    attrVerify = defaultAttributesVerification Proxy


### PR DESCRIPTION
I only added `STRING.lt` since this seems to be the only required builtin by `evm-semantics`, at least for now.

It is odd that strings are not between `"`. Should add a card to investigate whether this is a problem in the frontend or here.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

