### PR TITLE
Concrete execution as a library

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -18,7 +18,7 @@ KOMPILE := $(K_BIN)/kompile
 KRUN := $(K_BIN)/krun
 
 HS_TOP := $(TOP)/src/main/haskell/kore
-HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test
+HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test $(HS_TOP)/bench
 STACK_OPTS ?= --pedantic
 STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks

--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -349,12 +349,12 @@ mainWithOptions
         searchParameters <-
             case koreSearchOptions of
                 Nothing -> return Nothing
-                Just KoreSearchOptions { searchFileName , bound, searchType } ->
+                Just KoreSearchOptions { searchFileName, bound, searchType } ->
                     do
                         searchPattern <-
                             mainParseSearchPattern indexedModule searchFileName
                         let searchConfig = Search.Config { bound, searchType }
-                        (return . Just) (searchPattern , searchConfig)
+                        (return . Just) (searchPattern, searchConfig)
         finalPattern <-
             clockSomethingIO "Executing"
             $ SMT.runSMT smtConfig

--- a/src/main/haskell/kore/bench/exec/Main.hs
+++ b/src/main/haskell/kore/bench/exec/Main.hs
@@ -5,8 +5,8 @@ import Criterion.Main
 import qualified Control.Lens as Lens
 import           Data.Function
                  ( (&) )
-import Data.Limit
-       ( Limit (Unlimited) )
+import           Data.Limit
+                 ( Limit (Unlimited) )
 import qualified Data.Map as Map
 
 import           Kore.AST.MetaOrObject

--- a/src/main/haskell/kore/src/Kore/Attribute/Constructor.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Constructor.hs
@@ -11,8 +11,12 @@ module Kore.Attribute.Constructor
     , constructorId, constructorSymbol, constructorAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Monad as Monad
 import           Data.Default
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Kore
@@ -23,7 +27,7 @@ import qualified Kore.Attribute.Parser as Parser
 
 -- | @Constructor@ represents the @constructor@ attribute for symbols.
 newtype Constructor = Constructor { isConstructor :: Bool }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Constructor where
     (<>) (Constructor a) (Constructor b) = Constructor (a || b)
@@ -33,6 +37,8 @@ instance Monoid Constructor where
 
 instance Default Constructor where
     def = mempty
+
+instance NFData Constructor
 
 -- | Kore identifier representing the @constructor@ attribute symbol.
 constructorId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Attribute/Function.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Function.hs
@@ -11,8 +11,12 @@ module Kore.Attribute.Function
     , functionId, functionSymbol, functionAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Monad as Monad
 import           Data.Default
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Kore
@@ -23,7 +27,7 @@ import qualified Kore.Attribute.Parser as Parser
 
 -- | @Function@ represents the @function@ attribute for symbols.
 newtype Function = Function { isDeclaredFunction :: Bool }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Function where
     (<>) (Function a) (Function b) = Function (a || b)
@@ -33,6 +37,8 @@ instance Monoid Function where
 
 instance Default Function where
     def = mempty
+
+instance NFData Function
 
 -- | Kore identifier representing the @function@ attribute symbol.
 functionId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Attribute/Functional.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Functional.hs
@@ -11,8 +11,12 @@ module Kore.Attribute.Functional
     , functionalId, functionalSymbol, functionalAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Monad as Monad
 import           Data.Default
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Kore
@@ -24,7 +28,7 @@ import qualified Kore.Attribute.Parser as Parser
 {- | @Functional@ represents the @functional@ attribute for symbols.
  -}
 newtype Functional = Functional { isDeclaredFunctional :: Bool }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Functional where
     (<>) (Functional a) (Functional b) = Functional (a || b)
@@ -34,6 +38,8 @@ instance Monoid Functional where
 
 instance Default Functional where
     def = mempty
+
+instance NFData Functional
 
 -- | Kore identifier representing the @functional@ attribute symbol.
 functionalId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Attribute/Hook.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Hook.hs
@@ -12,6 +12,8 @@ module Kore.Attribute.Hook
     , getHookAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData (..) )
 import qualified Control.Monad as Monad
 import           Data.Default
                  ( Default (..) )
@@ -53,6 +55,8 @@ instance Default Hook where
     def = emptyHook
 
 instance Hashable Hook
+
+instance NFData Hook
 
 {- | Kore identifier representing a @hook@ attribute symbol.
  -}

--- a/src/main/haskell/kore/src/Kore/Attribute/Injective.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Injective.hs
@@ -11,8 +11,12 @@ module Kore.Attribute.Injective
     , injectiveId, injectiveSymbol, injectiveAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Monad as Monad
 import           Data.Default
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Kore
@@ -24,7 +28,7 @@ import qualified Kore.Attribute.Parser as Parser
 {- | @Injective@ represents the @injective@ attribute for symbols.
  -}
 newtype Injective = Injective { isDeclaredInjective :: Bool }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Injective where
     (<>) (Injective a) (Injective b) = Injective (a || b)
@@ -34,6 +38,8 @@ instance Monoid Injective where
 
 instance Default Injective where
     def = mempty
+
+instance NFData Injective
 
 -- | Kore identifier representing the @injective@ attribute symbol.
 injectiveId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Attribute/Smtlib.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Smtlib.hs
@@ -12,12 +12,16 @@ module Kore.Attribute.Smtlib
     , applySExpr
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Error as Error
 import qualified Control.Monad as Monad
 import           Data.Default
 import           Data.Maybe
                  ( fromMaybe, isNothing )
 import qualified Data.Text as Text
+import           GHC.Generics
+                 ( Generic )
 import           SimpleSMT
 
 import           Kore.AST.Common
@@ -46,7 +50,7 @@ valid SMT-LIB S-expressions.
 
  -}
 newtype Smtlib = Smtlib { getSmtlib :: Maybe SExpr }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Default Smtlib where
     def = Smtlib Nothing
@@ -63,6 +67,8 @@ instance ParseAttributes Smtlib where
       where
         withApplication = Parser.withApplication smtlibId
         failDuplicate = Parser.failDuplicate smtlibId
+
+instance NFData Smtlib
 
 -- | Kore identifier representing the @smtlib@ attribute symbol.
 smtlibId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Attribute/SortInjection.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/SortInjection.hs
@@ -11,8 +11,12 @@ module Kore.Attribute.SortInjection
     , sortInjectionId, sortInjectionSymbol, sortInjectionAttribute
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Monad as Monad
 import           Data.Default
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Kore
@@ -23,7 +27,7 @@ import qualified Kore.Attribute.Parser as Parser
 
 -- | @SortInjection@ represents the @sortInjection@ attribute for symbols.
 newtype SortInjection = SortInjection { isSortInjection :: Bool }
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup SortInjection where
     (<>) (SortInjection a) (SortInjection b) = SortInjection (a || b)
@@ -33,6 +37,8 @@ instance Monoid SortInjection where
 
 instance Default SortInjection where
     def = mempty
+
+instance NFData SortInjection
 
 -- | Kore identifier representing the @sortInjection@ attribute symbol.
 sortInjectionId :: Id Object

--- a/src/main/haskell/kore/src/Kore/Exec.hs
+++ b/src/main/haskell/kore/src/Kore/Exec.hs
@@ -1,0 +1,262 @@
+module Kore.Exec
+    ( exec
+    , search
+    ) where
+
+import qualified Control.Arrow as Arrow
+import qualified Data.Map.Merge.Strict as Map
+import qualified Data.Map.Strict as Map
+import           Data.Reflection
+                 ( give )
+import           Data.These
+                 ( These (..) )
+
+import           Data.Limit
+                 ( Limit (..) )
+import qualified Data.Limit as Limit
+import           Kore.AST.Common
+import           Kore.AST.MetaOrObject
+                 ( Meta, Object (..), asUnified )
+import qualified Kore.Builtin as Builtin
+import           Kore.IndexedModule.IndexedModule
+                 ( KoreIndexedModule )
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools (..), extractMetadataTools )
+
+import           Kore.Predicate.Predicate
+                 ( pattern PredicateTrue, makeMultipleOrPredicate,
+                 makeTruePredicate, unwrapPredicate )
+import           Kore.Step.AxiomPatterns
+                 ( AxiomPattern (..), extractRewriteAxioms )
+import           Kore.Step.BaseStep
+                 ( StepProof )
+import           Kore.Step.ExpandedPattern
+                 ( CommonExpandedPattern, Predicated (..) )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+import qualified Kore.Step.ExpandedPattern as Predicated
+import           Kore.Step.Function.Registry
+                 ( axiomPatternsToEvaluators, extractFunctionAxioms )
+import           Kore.Step.OrOfExpandedPattern
+                 ( OrOfExpandedPattern )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+import           Kore.Step.Search
+                 ( searchTree )
+import qualified Kore.Step.Search as Search
+import           Kore.Step.Simplification.Data
+                 ( PredicateSubstitutionSimplifier (..),
+                 PureMLPatternSimplifier, SimplificationProof (..),
+                 Simplifier )
+import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
+import qualified Kore.Step.Simplification.PredicateSubstitution as PredicateSubstitution
+import qualified Kore.Step.Simplification.Simplifier as Simplifier
+                 ( create )
+import           Kore.Step.Step
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes (..) )
+import           Kore.Step.Strategy
+                 ( Tree )
+import           Kore.Substitution.Class
+                 ( Hashable, substitute )
+import qualified Kore.Substitution.List as ListSubstitution
+import           Kore.Variables.Fresh
+                 ( FreshVariable )
+
+exec
+    :: KoreIndexedModule StepperAttributes
+    -> CommonPurePattern Object
+    -> Limit Natural
+    -> ([AxiomPattern Object] -> Strategy (Prim (AxiomPattern Object)))
+    -> Simplifier (CommonPurePattern Object)
+exec indexedModule purePattern stepLimit strategy =
+    helper indexedModule purePattern stepLimit strategy execute
+  where
+    execute
+        :: MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object Variable
+        -> PredicateSubstitutionSimplifier Object Simplifier
+        -> Tree (CommonExpandedPattern Object, StepProof Object Variable)
+        -> Simplifier (CommonPurePattern Object)
+    execute metadataTools _ _ executionTree =
+        give (symbolOrAliasSorts metadataTools) $ do
+            let (finalConfig, _) = pickLongest executionTree
+            return (ExpandedPattern.toMLPattern finalConfig)
+
+search
+    :: KoreIndexedModule StepperAttributes
+    -> CommonPurePattern Object
+    -> Limit Natural
+    -> ([AxiomPattern Object] -> Strategy (Prim (AxiomPattern Object)))
+    -> CommonExpandedPattern Object
+    -> Search.Config
+    -> Simplifier (CommonPurePattern Object)
+search
+    indexedModule
+    purePattern
+    stepLimit
+    strategy
+    searchPattern
+    searchConfig
+  =
+    helper indexedModule purePattern stepLimit strategy execute
+  where
+    execute metadataTools simplifier substitutionSimplifier executionTree = do
+        let
+            match target (config, _proof) =
+                Search.matchWith
+                    metadataTools
+                    substitutionSimplifier
+                    simplifier
+                    target
+                    config
+        solutions <- searchTree searchConfig (match searchPattern) executionTree
+        let
+            orPredicate =
+                give (symbolOrAliasSorts metadataTools)
+                $ makeMultipleOrPredicate
+                $ fmap Predicated.toPredicate solutions
+        return (unwrapPredicate orPredicate)
+
+helper
+    :: KoreIndexedModule StepperAttributes
+    -> CommonPurePattern Object
+    -> Limit Natural
+    -> ([AxiomPattern Object] -> Strategy (Prim (AxiomPattern Object)))
+    -> (MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object Variable
+        -> PredicateSubstitutionSimplifier Object Simplifier
+        -> Tree (CommonExpandedPattern Object, StepProof Object Variable)
+        -> Simplifier a)
+    -> Simplifier a
+helper indexedModule purePattern stepLimit strategy execute = do
+    let
+        metadataTools = extractMetadataTools indexedModule
+    axiomsAndSimplifiers <-
+        makeAxiomsAndSimplifiers indexedModule metadataTools
+    let
+        (rewriteAxioms, simplifier, substitutionSimplifier) =
+            axiomsAndSimplifiers
+        runStrategy' pat =
+            runStrategy
+                (transitionRule metadataTools substitutionSimplifier simplifier)
+                (Limit.replicate stepLimit (strategy rewriteAxioms))
+                (pat, mempty)
+        expandedPattern = makeExpandedPattern purePattern
+    simplifiedPatterns <-
+        ExpandedPattern.simplify
+            metadataTools substitutionSimplifier simplifier expandedPattern
+    let
+        initialPattern =
+            case OrOfExpandedPattern.extractPatterns (fst simplifiedPatterns) of
+                [] -> ExpandedPattern.bottom
+                (config : _) -> config
+    executionTree <- runStrategy' initialPattern
+    execute metadataTools simplifier substitutionSimplifier executionTree
+
+makeExpandedPattern
+    :: CommonPurePattern Object
+    -> CommonExpandedPattern Object
+makeExpandedPattern pat =
+    Predicated
+    { term = pat
+    , predicate = makeTruePredicate
+    , substitution = []
+    }
+
+preSimplify
+    ::  (  CommonPurePattern Object
+        -> Simplifier
+            (OrOfExpandedPattern Object Variable, SimplificationProof Object)
+        )
+    -> AxiomPattern Object
+    -> Simplifier (AxiomPattern Object)
+preSimplify simplifier
+    AxiomPattern
+    { axiomPatternLeft = lhs
+    , axiomPatternRight = rhs
+    , axiomPatternRequires = requires
+    , axiomPatternAttributes = atts
+    }
+  = do
+    (simplifiedOrLhs, _proof) <- simplifier lhs
+    let
+        [Predicated {term, predicate = PredicateTrue, substitution}] =
+            OrOfExpandedPattern.extractPatterns simplifiedOrLhs
+        listSubst =
+            ListSubstitution.fromList
+                (map (Arrow.first asUnified) substitution)
+    newLhs <- substitute term listSubst
+    newRhs <- substitute rhs listSubst
+    newRequires <- traverse (`substitute` listSubst) requires
+    return AxiomPattern
+        { axiomPatternLeft = newLhs
+        , axiomPatternRight = newRhs
+        , axiomPatternRequires = newRequires
+        , axiomPatternAttributes = atts
+        }
+
+makeAxiomsAndSimplifiers
+    :: KoreIndexedModule StepperAttributes
+    -> MetadataTools Object StepperAttributes
+    -> Simplifier
+        ( [AxiomPattern Object]
+        , PureMLPatternSimplifier Object Variable
+        , PredicateSubstitutionSimplifier Object Simplifier
+        )
+makeAxiomsAndSimplifiers indexedModule tools =
+    do
+        functionAxioms <-
+            simplifyFunctionAxioms
+                (extractFunctionAxioms Object indexedModule)
+        rewriteAxioms <-
+            simplifyRewriteAxioms
+                (extractRewriteAxioms Object indexedModule)
+        let
+            functionEvaluators =
+                axiomPatternsToEvaluators functionAxioms
+            functionRegistry =
+                Map.merge
+                    (Map.mapMissing (const This))
+                    (Map.mapMissing (const That))
+                    (Map.zipWithMatched (const These))
+                    -- builtin functions
+                    (Builtin.koreEvaluators indexedModule)
+                    -- user-defined functions
+                    functionEvaluators
+            simplifier
+                ::  ( SortedVariable variable
+                    , Ord (variable Meta)
+                    , Ord (variable Object)
+                    , Show (variable Meta)
+                    , Show (variable Object)
+                    , FreshVariable variable
+                    , Hashable variable
+                    )
+                => PureMLPatternSimplifier Object variable
+            simplifier = Simplifier.create tools functionRegistry
+            substitutionSimplifier
+                :: PredicateSubstitutionSimplifier Object Simplifier
+            substitutionSimplifier =
+                PredicateSubstitution.create tools simplifier
+        return (rewriteAxioms, simplifier, substitutionSimplifier)
+  where
+    simplifyFunctionAxioms = mapM (mapM (preSimplify emptyPatternSimplifier))
+    simplifyRewriteAxioms = mapM (preSimplify emptyPatternSimplifier)
+    emptySimplifier
+        ::  ( SortedVariable variable
+            , Ord (variable Meta)
+            , Ord (variable Object)
+            , Show (variable Meta)
+            , Show (variable Object)
+            , FreshVariable variable
+            , Hashable variable
+            )
+        => PureMLPatternSimplifier Object variable
+    emptySimplifier = Simplifier.create tools Map.empty
+    emptySubstitutionSimplifier =
+        PredicateSubstitution.create tools emptySimplifier
+    emptyPatternSimplifier =
+        ExpandedPattern.simplify
+            tools
+            emptySubstitutionSimplifier
+            emptySimplifier
+        . makeExpandedPattern

--- a/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -36,6 +36,8 @@ module Kore.IndexedModule.IndexedModule
 
 import           Control.Arrow
                  ( (&&&) )
+import           Control.DeepSeq
+                 ( NFData (..) )
 import           Control.Monad
                  ( foldM )
 import           Control.Monad.State.Strict
@@ -53,6 +55,8 @@ import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
 import qualified Data.Text as Text
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
 import           Kore.AST.Error
@@ -121,6 +125,7 @@ data IndexedModule sortParam pat variable atts =
         -- ^ map from builtin domain (symbol and sort) identifiers to the hooked
         -- identifiers
     }
+    deriving Generic
 
 -- |Convenient notation for retrieving a sentence from a
 -- @(attributes,sentence)@ pair format.
@@ -137,6 +142,8 @@ deriving instance
 
 type KoreIndexedModule =
     IndexedModule UnifiedSortVariable UnifiedPattern Variable
+
+instance NFData a => NFData (KoreIndexedModule a)
 
 indexedModuleRawSentences  :: KoreIndexedModule atts -> [KoreSentence]
 indexedModuleRawSentences im =

--- a/src/main/haskell/kore/src/Kore/Step/Search.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Search.hs
@@ -8,7 +8,7 @@ Maintainer  : traian.serbanuta@runtimeverification.com
 module Kore.Step.Search
     ( Config (..)
     , SearchType (..)
-    , search
+    , searchTree
     , matchWith
     ) where
 
@@ -60,7 +60,7 @@ import           Kore.Variables.Fresh
 
 {-| Which configurations are considered for matching?
 
-See also: 'search'
+See also: 'searchTree'
 
  -}
 data SearchType
@@ -91,21 +91,21 @@ The matching criterion returns a substitution which takes its argument to the
 search goal (see 'matchWith'). The 'searchType' is used to restrict which states
 may be considered for matching.
 
-@search@ returns a list of substitutions which take the initial configuration to
-the goal defined by the matching criterion. The number of solutions returned is
-limited by 'bound'.
+@searchTree@ returns a list of substitutions which take the initial
+configuration to the goal defined by the matching criterion. The number of
+solutions returned is limited by 'bound'.
 
 See also: 'Kore.Step.Strategy.runStrategy', 'matchWith'
 
 -}
-search
+searchTree
     :: Config  -- ^ Search options
     -> (config -> MaybeT Simplifier substitution)
         -- ^ Matching criterion
     -> Tree config
         -- ^ Execution tree
     -> Simplifier [substitution]
-search Config { searchType, bound } match executionTree = do
+searchTree Config { searchType, bound } match executionTree = do
     let selectedConfigs = pick executionTree
     matches <- catMaybes <$> traverse (runMaybeT . match) selectedConfigs
     return (Limit.takeWithin bound matches)

--- a/src/main/haskell/kore/src/Kore/Step/StepperAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/StepperAttributes.hs
@@ -42,6 +42,8 @@ module Kore.Step.StepperAttributes
     , isTotal_, isTotal
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Lens as Lens hiding
                  ( makeLenses )
 import qualified Control.Lens.TH.Rules as Lens
@@ -50,6 +52,8 @@ import           Control.Monad
 import           Data.Default
 import           Data.Reflection
                  ( Given, given )
+import           GHC.Generics
+                 ( Generic )
 
 import Kore.AST.Common
        ( SymbolOrAlias )
@@ -90,9 +94,11 @@ data StepperAttributes =
       -- ^ The builtin sort or symbol hooked to a sort or symbol
     , smtlib        :: !Smtlib
     }
-  deriving (Eq, Show)
+  deriving (Generic, Eq, Show)
 
 Lens.makeLenses ''StepperAttributes
+
+instance NFData StepperAttributes
 
 instance ParseAttributes StepperAttributes where
     parseAttribute attr =

--- a/src/main/haskell/kore/src/SimpleSMT.hs
+++ b/src/main/haskell/kore/src/SimpleSMT.hs
@@ -140,6 +140,8 @@ import           Control.Applicative
                  ( Alternative (..) )
 import           Control.Concurrent
                  ( forkIO )
+import           Control.DeepSeq
+                 ( NFData )
 import qualified Control.Exception as X
 import           Control.Monad
                  ( forever, when )
@@ -166,6 +168,8 @@ import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.IO as Text.Lazy
 import           Data.Void
                  ( Void )
+import           GHC.Generics
+                 ( Generic )
 import           Numeric
                  ( readHex, showFFloat, showHex )
 import           Prelude hiding
@@ -204,7 +208,9 @@ data Value =  Bool  !Bool           -- ^ Boolean value
 data SExpr
     = Atom !Text
     | List ![SExpr]
-    deriving (Eq, Ord, Show)
+    deriving (Generic, Eq, Ord, Show)
+
+instance NFData SExpr
 
 -- | Stream an S-expression into 'Builder'.
 buildSExpr :: SExpr -> Builder

--- a/src/main/haskell/kore/test/Test/Kore/Exec.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Exec.hs
@@ -1,0 +1,291 @@
+module Test.Kore.Exec
+    ( test_exec
+    , test_search
+    ) where
+
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+
+import           Control.Applicative
+                 ( liftA2 )
+import           Data.Functor.Foldable
+                 ( Fix (..) )
+import           Data.Limit
+                 ( Limit (Unlimited) )
+import qualified Data.Map as Map
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
+import           Data.Text
+                 ( Text )
+
+import           Kore.AST.Common
+import           Kore.AST.Kore
+import           Kore.AST.MetaOrObject
+import           Kore.AST.Sentence
+import           Kore.ASTVerifier.DefinitionVerifier
+                 ( AttributesVerification (DoNotVerifyAttributes),
+                 verifyAndIndexDefinition )
+import qualified Kore.Builtin as Builtin
+import           Kore.IndexedModule.IndexedModule
+                 ( KoreIndexedModule )
+import           Kore.Predicate.Predicate
+                 ( makeTruePredicate )
+import           Kore.Step.ExpandedPattern
+                 ( CommonExpandedPattern, Predicated (..) )
+import           Kore.Step.Search
+                 ( SearchType (..) )
+import qualified Kore.Step.Search as Search
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
+import           Kore.Step.Step
+                 ( allAxioms, anyAxiom )
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes (..) )
+
+import Kore.Exec
+
+test_exec :: TestTree
+test_exec = testCase "exec" $ actual @=? expected
+  where
+    actual = evalSimplifier $ exec
+        indexedModule
+        inputPattern
+        Unlimited
+        anyAxiom
+    indexedModule = indexedMyModule $ Module
+        { moduleName = ModuleName "MY-MODULE"
+        , moduleSentences =
+            [ asSentence $ mySortDecl
+            , asSentence $ constructorDecl "a"
+            , asSentence $ constructorDecl "b"
+            , asSentence $ constructorDecl "c"
+            , asSentence $ constructorDecl "d"
+            , asSentence $ functionalAxiom "a"
+            , asSentence $ functionalAxiom "b"
+            , asSentence $ functionalAxiom "c"
+            , asSentence $ functionalAxiom "d"
+            , asSentence $ rewritesAxiom "a" "b"
+            , asSentence $ rewritesAxiom "b" "c"
+            , asSentence $ rewritesAxiom "c" "d"
+            ]
+        , moduleAttributes = Attributes []
+        }
+    inputPattern = Fix $ applyToNoArgs "b"
+    expected = Fix $ applyToNoArgs "d"
+
+test_search :: TestTree
+test_search =
+    testGroup
+        "search"
+        [ makeTestCase searchType | searchType <- [ ONE, STAR, PLUS, FINAL] ]
+  where
+    makeTestCase searchType =
+        testCase
+            (show searchType)
+            (actual searchType @=? expected searchType)
+    actual searchType =
+        let
+            simplifier = search
+                indexedModule
+                inputPattern
+                Unlimited
+                allAxioms
+                searchPattern
+                Search.Config { bound = Unlimited, searchType }
+            Just results = extractSearchResults $ evalSimplifier simplifier
+        in  results
+    indexedModule = indexedMyModule $ Module
+        { moduleName = ModuleName "MY-MODULE"
+        , moduleSentences =
+            [ asSentence $ mySortDecl
+            , asSentence $ constructorDecl "a"
+            , asSentence $ constructorDecl "b"
+            , asSentence $ constructorDecl "c"
+            , asSentence $ constructorDecl "d"
+            , asSentence $ constructorDecl "e"
+            , asSentence $ functionalAxiom "a"
+            , asSentence $ functionalAxiom "b"
+            , asSentence $ functionalAxiom "c"
+            , asSentence $ functionalAxiom "d"
+            , asSentence $ functionalAxiom "e"
+            , asSentence $ rewritesAxiom "a" "b"
+            , asSentence $ rewritesAxiom "a" "c"
+            , asSentence $ rewritesAxiom "c" "d"
+            , asSentence $ rewritesAxiom "e" "a"
+            ]
+        , moduleAttributes = Attributes []
+        }
+    inputPattern = Fix $ applyToNoArgs "a"
+    expected =
+        let
+            a = Fix $ applyToNoArgs "a"
+            b = Fix $ applyToNoArgs "b"
+            c = Fix $ applyToNoArgs "c"
+            d = Fix $ applyToNoArgs "d"
+        in
+            \case
+                ONE -> Set.fromList [b, c]
+                STAR -> Set.fromList [a, b, c, d]
+                PLUS -> Set.fromList [b, c, d]
+                FINAL -> Set.fromList [b, d]
+
+-- | V:MySort{}
+searchVar :: CommonPurePattern Object
+searchVar = Fix $ VariablePattern Variable
+    { variableName = Id "V" AstLocationTest
+    , variableSort = mySort
+    }
+
+-- |
+--  \and{MySort{}}(
+--      V:MySort{},
+--      \top{MySort{}}())
+searchPattern :: CommonExpandedPattern Object
+searchPattern = Predicated
+    { term = searchVar
+    , predicate = makeTruePredicate
+    , substitution = []
+    }
+
+-- | Turn a disjunction of "v = ???" into Just a set of the ???. If the input is
+-- not a disjunction of "v = ???", return Nothing.
+extractSearchResults
+    :: CommonPurePattern Object -> Maybe (Set (CommonPurePattern Object))
+extractSearchResults =
+    \case
+        Fix (EqualsPattern equals)
+            | equalsOperandSort equals == mySort
+                && equalsResultSort equals == predicateSort
+                && equalsFirst equals == searchVar
+            -> Just $ Set.singleton $ equalsSecond equals
+        Fix (OrPattern Or { orSort, orFirst, orSecond })
+            | orSort == predicateSort
+            -> liftA2
+                Set.union
+                (extractSearchResults orFirst)
+                (extractSearchResults orSecond)
+        _ -> Nothing
+  where
+    predicateSort = SortActualSort SortActual
+        { sortActualName = "PREDICATE"
+        , sortActualSorts = []
+        }
+
+indexedMyModule :: KoreModule -> KoreIndexedModule StepperAttributes
+indexedMyModule module_ = indexedModule
+  where
+    Just indexedModule = Map.lookup (ModuleName "MY-MODULE") indexedModules
+    Right indexedModules = verifyAndIndexDefinition
+        DoNotVerifyAttributes
+        Builtin.koreVerifiers
+        definition
+    definition = Definition
+        { definitionAttributes = Attributes []
+        , definitionModules = [module_]
+        }
+
+mySortName :: Id Object
+mySortName = Id "MySort" AstLocationTest
+
+mySort :: Sort Object
+mySort = SortActualSort SortActual
+    { sortActualName = mySortName
+    , sortActualSorts = []
+    }
+
+-- | sort MySort{} []
+mySortDecl :: KoreSentenceSort Object
+mySortDecl = SentenceSort
+    { sentenceSortName = mySortName
+    , sentenceSortParameters = []
+    , sentenceSortAttributes = Attributes []
+    }
+
+-- | symbol name{}() : MySort{} [functional{}(), constructor{}()]
+constructorDecl :: Text -> KoreSentenceSymbol Object
+constructorDecl name = SentenceSymbol
+    { sentenceSymbolSymbol =
+        Symbol
+            { symbolConstructor = Id name AstLocationTest
+            , symbolParams = []
+            }
+    , sentenceSymbolSorts = []
+    , sentenceSymbolResultSort = mySort
+    , sentenceSymbolAttributes = Attributes
+        [ asObjectKorePattern $ applyToNoArgs "functional"
+        , asObjectKorePattern $ applyToNoArgs "constructor"
+        ]
+    }
+
+-- |
+--  axiom{R}
+--      \exists{R}(
+--          V:MySort{},
+--          \equals{MySort{}, R}(
+--              V:MySort{},
+--              a{}()))
+--  [functional{}()]
+functionalAxiom :: Text -> KoreSentenceAxiom
+functionalAxiom name = SentenceAxiom
+    { sentenceAxiomParameters = [UnifiedObject r]
+    , sentenceAxiomPattern =
+        asObjectKorePattern $ ExistsPattern Exists
+            { existsSort = SortVariableSort r
+            , existsVariable = v
+            , existsChild =
+                asObjectKorePattern $ EqualsPattern Equals
+                    { equalsOperandSort = mySort
+                    , equalsResultSort = SortVariableSort r
+                    , equalsFirst = asObjectKorePattern $ VariablePattern v
+                    , equalsSecond = asObjectKorePattern $ applyToNoArgs name
+                    }
+            }
+    , sentenceAxiomAttributes =
+        Attributes [asObjectKorePattern $ applyToNoArgs "functional"]
+    }
+  where
+    v = Variable
+        { variableName = Id "V" AstLocationTest
+        , variableSort = mySort
+        }
+    r = SortVariable $ Id "R" AstLocationTest
+
+-- |
+--  axiom{}
+--      \and{MySort{}}(
+--          \top{MySort{}}(),
+--          \and{MySort{}}(),
+--              \top{MySort{}}(),
+--              \rewrites{MySort{}}(
+--                  lhsName{}(),
+--                  rhsName{}())))
+--  []
+rewritesAxiom :: Text -> Text -> KoreSentenceAxiom
+rewritesAxiom lhsName rhsName = SentenceAxiom
+    { sentenceAxiomParameters = []
+    , sentenceAxiomPattern = asObjectKorePattern $ AndPattern And
+        { andSort = mySort
+        , andFirst = asObjectKorePattern $ TopPattern $ Top mySort
+        , andSecond = asObjectKorePattern $ AndPattern And
+            { andSort = mySort
+            , andFirst = asObjectKorePattern $ TopPattern $ Top mySort
+            , andSecond = asObjectKorePattern $ RewritesPattern Rewrites
+                { rewritesSort = mySort
+                , rewritesFirst = asObjectKorePattern $ applyToNoArgs lhsName
+                , rewritesSecond = asObjectKorePattern $ applyToNoArgs rhsName
+                }
+            }
+        }
+    , sentenceAxiomAttributes = Attributes []
+    }
+
+applyToNoArgs :: Text -> Pattern level variable child
+applyToNoArgs name = ApplicationPattern Application
+    { applicationSymbolOrAlias = SymbolOrAlias
+        { symbolOrAliasConstructor = Id name AstLocationTest
+        , symbolOrAliasParams = []
+        }
+    , applicationChildren = []
+    }

--- a/src/main/haskell/kore/test/Test/Tasty/HUnit/Extensions.hs
+++ b/src/main/haskell/kore/test/Test/Tasty/HUnit/Extensions.hs
@@ -14,6 +14,9 @@ import           Data.List
                  ( intercalate, isInfixOf )
 import           Data.Sequence
                  ( Seq )
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
 
 assertEqualWithPrinter
     :: (Eq a, HasCallStack)
@@ -266,6 +269,12 @@ instance EqualWithExplanation a => EqualWithExplanation (Seq a) where
         compareWithExplanation (Foldable.toList expected) (Foldable.toList actual)
 
     printWithExplanation = printWithExplanation . Foldable.toList
+
+instance EqualWithExplanation a => EqualWithExplanation (Set a) where
+    compareWithExplanation expected actual =
+        compareWithExplanation (Set.toList expected) (Set.toList actual)
+
+    printWithExplanation = printWithExplanation . Set.toList
 
 instance (Show (thing (Fix thing)), Show1 thing, EqualWithExplanation (thing (Fix thing)))
     => WrapperEqualWithExplanation (Fix thing)


### PR DESCRIPTION
Before I write tests, I would just like to make sure I am on the right track with the way the `exec` function in `src/Kore/Exec.hs` works. Is this the right way to expose concrete execution?

I pushed some of `app/exec/Main.hs` down into `src/Kore/Exec.hs` so that we can expose concrete execution as a library call. Then the concrete execution benchmarks don't have to shell out to krun which in turn shells out to kore-exec.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

