### PR TITLE
Added a few STRING and INT builtins needed for evm

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -225,6 +225,17 @@ The result is `bottom{}()` if the second argument is zero.
         [hook{}("INT.tmod")]
 ~~~
 
+### INT.emod
+
+Remainder of the first argument divided by the second (using the euclidean
+algorithm).
+The result is `bottom{}()` if the second argument is zero.
+
+~~~
+    hooked-symbol emod{}(Int{}, Int{}) : Int{}
+        [hook{}("INT.emod")]
+~~~
+
 ### INT.and
 
 Bitwise and of the arguments.
@@ -346,6 +357,64 @@ Comparison: is the first argument less than the second?
         [hook{}("STRING.lt")]
 ~~~
 
+### STRING.concat
+
+Concatenate two strings.
+
+~~~
+    hooked-symbol concat{}(String{}, String{}) : String{}
+        [hook{}("STRING.concat")]
+~~~
+
+### STRING.string2int
+
+Convert a base10 string to its integer value.
+
+~~~
+    hooked-symbol string2int{}(String{}) : Int{}
+        [hook{}("STRING.string2int")]
+~~~
+
+### STRING.string2base
+
+Takes a string and a base and converts the string from `base` to its integer
+value.
+Currently only works for base 8, 10, and 16.
+
+~~~
+    hooked-symbol string2base{}(String{}, Int{}) : Int{}
+        [hook{}("STRING.string2base")]
+~~~
+
+### STRING.substr
+
+Substr takes a string and two indices (start and end) and returns the substring
+that starts at index `start` and ends at index `end`.
+
+~~~
+    hooked-symbol substr{}(String{}, Int{}, Int{}) : String{}
+        [hook{}("STRING.substr")]
+~~~
+
+### STRING.length
+
+Calculates the length of a string.
+
+~~~
+    hooked-symbol length{}(String{}): Int{}
+        [hook{}("STRING.length")]
+~~~
+
+### STRING.find
+
+Takes a string, a substring and an index and searches for `substring` in
+the `string`, starting at `index`, returning the resulting index, or `-1` if it
+is not found.
+
+~~~
+    hooked-symbol find{}(String{}, String{}, Int{}): Int{}
+        [hook{}("STRING.find")]
+~~~
 
 ## MAP
 

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -271,7 +271,7 @@ builtinFunctions =
 
       -- TODO (thomas.tuegel): Implement division.
     , ("INT.ediv", Builtin.notImplemented)
-    , ("INT.emod", Builtin.notImplemented)
+    , partialBinaryOperator "INT.emod" emod
     , partialBinaryOperator "INT.tdiv" tdiv
     , partialBinaryOperator "INT.tmod" tmod
 
@@ -307,6 +307,10 @@ builtinFunctions =
     tmod n d
         | d == 0 = Nothing
         | otherwise = Just (rem n d)
+    emod a b
+        | b == 0 = Nothing
+        | b < 0  = Just (rem a b)
+        | otherwise = Just (mod a b)
     pow b e
         | e < 0 = Nothing
         | otherwise = Just (b ^ e)

--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -39,11 +39,17 @@ import           Control.Monad
                  ( void )
 import qualified Data.Functor.Foldable as Functor.Foldable
 import qualified Data.HashMap.Strict as HashMap
+import           Data.List
+                 ( findIndex, isPrefixOf, tails )
 import           Data.Map
                  ( Map )
 import qualified Data.Map as Map
+import           Data.Maybe
+                 ( listToMaybe )
 import           Data.Text
                  ( Text )
+import           Numeric
+                 ( readDec, readHex, readOct, readSigned )
 import qualified Text.Megaparsec as Parsec
 import qualified Text.Megaparsec.Char as Parsec
 
@@ -55,10 +61,18 @@ import           Kore.AST.PureML
 import qualified Kore.ASTUtils.SmartPatterns as Kore
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
+import qualified Kore.Builtin.Int as Int
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools (..) )
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-
+import           Kore.Step.Function.Data
+                 ( AttemptedFunction (..) )
+import           Kore.Step.Simplification.Data
+                 ( PureMLPatternSimplifier, Simplifier )
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
 
 {- | Builtin name of the @String@ sort.
  -}
@@ -90,8 +104,33 @@ sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
     HashMap.fromList
-    [
-        ("STRING.lt", Builtin.verifySymbol Bool.assertSort [assertSort, assertSort])
+    [   ( ltKeyT
+        , Builtin.verifySymbol Bool.assertSort [assertSort, assertSort]
+        )
+    ,   ( plusKeyT
+        , Builtin.verifySymbol assertSort [assertSort, assertSort]
+        )
+    ,   ( substrKeyT
+        , Builtin.verifySymbol
+            assertSort
+            [assertSort, Int.assertSort, Int.assertSort]
+        )
+    ,   ( lengthKeyT
+        , Builtin.verifySymbol Int.assertSort [assertSort]
+        )
+    ,   ( findKeyT
+        , Builtin.verifySymbol
+            Int.assertSort
+            [assertSort, assertSort, Int.assertSort]
+        )
+    ,   ( string2BaseKeyT
+        , Builtin.verifySymbol
+            Int.assertSort
+            [assertSort, Int.assertSort]
+        )
+    ,   ( string2IntKeyT
+        , Builtin.verifySymbol Int.assertSort [assertSort]
+        )
     ]
 
 {- | Verify that domain value patterns are well-formed.
@@ -183,14 +222,179 @@ asPartialExpandedPattern
 asPartialExpandedPattern resultSort =
     maybe ExpandedPattern.bottom (asExpandedPattern resultSort)
 
+ltKeyT :: Text
+ltKeyT = "STRING.lt"
+
+plusKeyT :: Text
+plusKeyT = "STRING.concat"
+
+string2IntKeyT :: Text
+string2IntKeyT = "STRING.string2int"
+
+substrKey :: String
+substrKey = "STRING.substr"
+substrKeyT :: Text
+substrKeyT = "STRING.substr"
+
+lengthKey :: String
+lengthKey = "STRING.length"
+lengthKeyT :: Text
+lengthKeyT = "STRING.length"
+
+findKey :: String
+findKey = "STRING.find"
+findKeyT :: Text
+findKeyT = "STRING.find"
+
+string2BaseKey :: String
+string2BaseKey = "STRING.string2base"
+string2BaseKeyT :: Text
+string2BaseKeyT = "STRING.string2base"
+
+evalSubstr :: Builtin.Function
+evalSubstr = Builtin.functionEvaluator evalSubstr0
+  where
+    substr :: Int -> Int -> String -> String
+    substr startIndex endIndex =
+        take (endIndex - startIndex) . drop startIndex
+    evalSubstr0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object variable
+        -> Kore.Sort Object
+        -> [Kore.PureMLPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalSubstr0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let (_str, _start, _end) =
+                    case arguments of
+                        [_str, _start, _end] -> (_str, _start, _end)
+                        _                    -> Builtin.wrongArity substrKey
+            _str   <- expectBuiltinDomainString substrKey _str
+            _start <- fromInteger <$> Int.expectBuiltinDomainInt substrKey _start
+            _end   <- fromInteger <$> Int.expectBuiltinDomainInt substrKey _end
+            Builtin.appliedFunction
+                . asExpandedPattern resultSort
+                $ substr _start _end _str
+
+evalLength :: Builtin.Function
+evalLength = Builtin.functionEvaluator evalLength0
+  where
+    evalLength0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object variable
+        -> Kore.Sort Object
+        -> [Kore.PureMLPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalLength0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let _str =
+                    case arguments of
+                        [_str] -> _str
+                        _      -> Builtin.wrongArity lengthKey
+            _str <- expectBuiltinDomainString lengthKey _str
+            Builtin.appliedFunction
+                . Int.asExpandedPattern resultSort
+                . toInteger
+                $ length _str
+
+evalFind :: Builtin.Function
+evalFind = Builtin.functionEvaluator evalFind0
+  where
+    maybeNotFound :: Maybe Int -> Integer
+    maybeNotFound = maybe (-1) toInteger
+
+    evalFind0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object variable
+        -> Kore.Sort Object
+        -> [Kore.PureMLPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalFind0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let (_str, _substr, _idx) =
+                    case arguments of
+                        [_str, _substr, _idx] -> (_str, _substr, _idx)
+                        _                     -> Builtin.wrongArity findKey
+            _str <- expectBuiltinDomainString findKey _str
+            _substr <- expectBuiltinDomainString findKey _substr
+            _idx <- fromInteger <$> Int.expectBuiltinDomainInt substrKey _idx
+            Builtin.appliedFunction
+                . Int.asExpandedPattern resultSort
+                . maybeNotFound
+                $ findIndex (isPrefixOf _substr) (tails . drop _idx $ _str)
+
+evalString2Base :: Builtin.Function
+evalString2Base = Builtin.functionEvaluator evalString2Base0
+  where
+    evalString2Base0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object variable
+        -> Kore.Sort Object
+        -> [Kore.PureMLPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalString2Base0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let (_str, _base) =
+                    case arguments of
+                        [_str, _base] -> (_str, _base)
+                        _             -> Builtin.wrongArity findKey
+            _str  <- expectBuiltinDomainString string2BaseKey _str
+            _base <- Int.expectBuiltinDomainInt string2BaseKey _base
+            readN <- case _base of
+                8  -> pure . readSigned $ readOct
+                10 -> pure . readSigned $ readDec
+                16 -> pure . readSigned $ readHex
+                _  -> pure $ const empty
+            case fmap fst . listToMaybe $ readN _str of
+                Nothing     -> Builtin.appliedFunction ExpandedPattern.bottom
+                Just result ->
+                    Builtin.appliedFunction
+                        . Int.asExpandedPattern resultSort
+                        $ result
+
+evalString2Int :: Builtin.Function
+evalString2Int = Builtin.functionEvaluator evalString2Int0
+  where
+    evalString2Int0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> PureMLPatternSimplifier Object variable
+        -> Kore.Sort Object
+        -> [Kore.PureMLPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalString2Int0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let _str =
+                    case arguments of
+                        [_str] -> _str
+                        _      -> Builtin.wrongArity findKey
+            _str <- expectBuiltinDomainString findKey _str
+            Builtin.appliedFunction
+                . maybe
+                    ExpandedPattern.bottom
+                    (Int.asExpandedPattern resultSort)
+                . fmap fst . listToMaybe . readSigned readDec
+                $ _str
+
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
     Map.fromList
-    [
-        comparator "STRING.lt" (<)
+    [ comparator ltKeyT (<)
+    , binaryOperator plusKeyT (++)
+    , (substrKeyT, evalSubstr)
+    , (lengthKeyT, evalLength)
+    , (findKeyT, evalFind)
+    , (string2BaseKeyT, evalString2Base)
+    , (string2IntKeyT, evalString2Int)
     ]
   where
     comparator name op =
         (name, Builtin.binaryOperator parse Bool.asExpandedPattern name op)
+    binaryOperator name op =
+        (name, Builtin.binaryOperator parse asExpandedPattern name op)

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -5,7 +5,13 @@ module Test.Kore.Builtin.Builtin
     , mkPair
     , importKoreModule
     , substitutionSimplifier
+    , testSymbol
     ) where
+
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
 
 import           Kore.AST.Common
 import           Kore.AST.MetaOrObject
@@ -19,7 +25,7 @@ import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import qualified Kore.Predicate.Predicate as Predicate
 import           Kore.Step.ExpandedPattern
-                 ( Predicated (..) )
+                 ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.PredicateSubstitution as PredicateSubstitution
@@ -176,4 +182,24 @@ substitutionSimplifier tools =
                     , SimplificationProof
                     )
             )
+        )
+
+-- | 'testSymbol' is useful for writing unit tests for symbols.
+testSymbol
+    :: (CommonPurePattern Object -> CommonExpandedPattern Object)
+    -- ^ evaluator function for the builtin
+    -> String
+    -- ^ test name
+    -> SymbolOrAlias Object
+    -- ^ symbol being tested
+    -> [CommonPurePattern Object]
+    -- ^ arguments for symbol
+    -> CommonExpandedPattern Object
+    -- ^ expected result
+    -> TestTree
+testSymbol evaluate title symbol args expected =
+    testCase title
+        (assertEqual ""
+            expected
+            (evaluate $ App_ symbol args)
         )

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Int.hs
@@ -4,6 +4,8 @@ module Test.Kore.Builtin.Int where
 
 import Test.QuickCheck
        ( Property, (===) )
+import Test.Tasty
+       ( TestTree )
 
 import           Data.Bits
                  ( complement, shift, xor, (.&.), (.|.) )
@@ -292,6 +294,38 @@ powmodSymbol = builtinSymbol "powmodInt"
 log2Symbol :: SymbolOrAlias Object
 log2Symbol = builtinSymbol "log2Int"
 
+emodSymbol :: SymbolOrAlias Object
+emodSymbol = builtinSymbol "emodInt"
+
+test_emod :: [TestTree]
+test_emod =
+    [ testInt
+        "emod normal"
+        emodSymbol
+        (asPattern <$> [193, 12])
+        (asExpandedPattern 1)
+    , testInt
+        "emod negative lhs"
+        emodSymbol
+        (asPattern <$> [-193, 12])
+        (asExpandedPattern 11)
+    , testInt
+        "emod negative rhs"
+        emodSymbol
+        (asPattern <$> [193, -12])
+        (asExpandedPattern 1)
+    , testInt
+        "emod both negative"
+        emodSymbol
+        (asPattern <$> [-193, -12])
+        (asExpandedPattern (-1))
+    , testInt
+        "emod bottom"
+        emodSymbol
+        (asPattern <$> [193, 0])
+        bottom
+    ]
+
 -- | Another name for asPattern.
 intLiteral :: Integer -> CommonPurePattern Object
 intLiteral = asPattern
@@ -413,6 +447,7 @@ intModule =
             , unarySymbolDecl "INT.abs" absSymbol
             , binarySymbolDecl "INT.tdiv" tdivSymbol
             , binarySymbolDecl "INT.tmod" tmodSymbol
+            , binarySymbolDecl "INT.emod" emodSymbol
             , binarySymbolDecl "INT.and" andSymbol
             , binarySymbolDecl "INT.or" orSymbol
             , binarySymbolDecl "INT.xor" xorSymbol
@@ -457,3 +492,11 @@ verify defn =
         (verifyAndIndexDefinition attrVerify Builtin.koreVerifiers defn)
   where
     attrVerify = defaultAttributesVerification Proxy
+
+testInt
+    :: String
+    -> SymbolOrAlias Object
+    -> [CommonPurePattern Object]
+    -> CommonExpandedPattern Object
+    -> TestTree
+testInt = testSymbol evaluate


### PR DESCRIPTION
Added an implementation for `INT.emod` and a few `STRING.` new builtins:
- `concat`
- `length`
- `find`
- `substr`
- `string2base`
- `string2int`

Updated docs. Added tests. I did not add quickcheck properties since they did not seem to add any real value.

Note that I added these builtins since these are required by `evm-semantics`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

