### PR TITLE
Recover parsed Attributes

### DIFF
--- a/src/main/haskell/kore/src/Kore/AST/Sentence.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Sentence.hs
@@ -24,6 +24,7 @@ module Kore.AST.Sentence where
 
 import           Control.DeepSeq
                  ( NFData (..) )
+import           Data.Default
 import           Data.Functor.Classes
 import           Data.Functor.Foldable
 import           Data.Text
@@ -48,6 +49,9 @@ newtype Attributes =
   deriving (Eq, Generic, Show)
 
 instance NFData Attributes
+
+instance Default Attributes where
+    def = Attributes []
 
 {-|'SentenceAlias' corresponds to the @object-alias-declaration@ and
 @meta-alias-declaration@ syntactic categories from the Semantics of K,

--- a/src/main/haskell/kore/src/Kore/Attribute/Parser.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Parser.hs
@@ -81,7 +81,10 @@ import           Kore.Error
 import qualified Kore.Error
 
 -- | Run the parser from the @ParseAttributes@ instance.
-parseAttributes :: ParseAttributes atts => Attributes -> Either (Error ParseError) atts
+parseAttributes
+    :: ParseAttributes atts
+    => Attributes
+    -> Either (Error ParseError) atts
 parseAttributes = runParser attributesParser
 
 {- | Run the parser from the @ParseAttributes@ instance

--- a/src/main/haskell/kore/test/Test/Kore/Attribute/Parser.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Attribute/Parser.hs
@@ -31,7 +31,9 @@ test_runParser =
         attrs =
             Kore.Attributes [ Kore.asKorePattern metaPattern ]
           where
-            metaPattern = Kore.StringLiteralPattern (Kore.StringLiteral "meta-pattern")
+            metaPattern =
+                Kore.StringLiteralPattern
+                    (Kore.StringLiteral "meta-pattern")
       in
         testCase "Rejects meta-level attribute patterns"
             (equiv attrs expect actual)
@@ -44,7 +46,9 @@ test_runParser =
             (equiv attrs expect actual)
     , let
         expect = pure [[], []]
-        actual = map arguments . Foldable.toList <$> someAttributesWithName "key"
+        actual =
+            map arguments . Foldable.toList
+                <$> someAttributesWithName "key"
         attrs = multipleAttrs
       in
         testCase "Accepts multiple occurrences of the same attribute"

--- a/src/main/haskell/kore/test/Test/Kore/Attribute/Parser.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Attribute/Parser.hs
@@ -49,6 +49,13 @@ test_runParser =
       in
         testCase "Accepts multiple occurrences of the same attribute"
             (equiv attrs expect actual)
+    ,   let
+            expect = return multipleAttrs
+            actual = attributesParser
+            attrs = multipleAttrs
+        in
+            testCase "Reconstructs parsed attributes"
+                (equiv attrs expect actual)
     ]
   where
     reject = Kore.Error.koreFail "Expected object-level application pattern"


### PR DESCRIPTION
This pull request adds an `instance ParseAttributes Attributes` to recover the list of `Attributes` after indexing a module.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

