### PR TITLE
LTS Haskell 12.21

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.16
+resolver: lts-12.21
 
 nix:
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,11 +45,7 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-  - sbv-7.10
-  - simple-smt-0.9.3
-  - crackNum-2.2
-  - FloatingHex-0.4
+# extra-deps:
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
This pull request removes some unused extra dependencies and updates the Stack resolver to LTS Haskell 12.21.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

