### PR TITLE
Added --depth to kprove for the haskell backend.

### DIFF
--- a/src/main/haskell/kore/Makefile
+++ b/src/main/haskell/kore/Makefile
@@ -32,7 +32,7 @@ pedantic:
 	$(stack) build --haddock --no-haddock-deps --coverage --bench --no-run-benchmarks --test --no-run-tests --pedantic
 
 ghcid:
-	$(stack) exec -- ghcid -c "stack ghci $(package) --test --ghci-options='-Wall -Wincomplete-uni-patterns -fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-exec"
+	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --ghci-options='-fobject-code -fno-warn-unused-do-bind' --main-is $(package):kore-exec"
 
 # TODO(Vladimir): remove 'hyperlink-source' when we upgrade from lts-12.10 (8.4.3)
 hoogle-gen:

--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -446,8 +446,9 @@ mainWithOptions
                         (\pat -> (ExitFailure 1, pat))
                         (\_ -> (ExitSuccess, Pattern.mkTop))
                     <$> prove
-                        indexedModule
-                        specIndexedModule
+                            stepLimit
+                            indexedModule
+                            specIndexedModule
         let
             finalExternalPattern =
                 either (error . printError) id

--- a/src/main/haskell/kore/src/Kore/Exec.hs
+++ b/src/main/haskell/kore/src/Kore/Exec.hs
@@ -325,12 +325,13 @@ emptyPatternSimplifier tools =
 
 -- | Proving a spec given as a module containing rules to be proven
 prove
-    :: KoreIndexedModule StepperAttributes
+    :: Limit Natural
+    -> KoreIndexedModule StepperAttributes
     -- ^ The main module
     -> KoreIndexedModule StepperAttributes
     -- ^ The spec module
     -> Simplifier (Either (CommonStepPattern Object) ())
-prove definitionModule specModule = do
+prove limit definitionModule specModule = do
     let
         tools = extractMetadataTools definitionModule
         symbolOrAlias = symbolOrAliasSorts tools
@@ -360,5 +361,5 @@ prove definitionModule specModule = do
             result
 
   where
-    makeClaim claim = (claim, Unlimited)
+    makeClaim claim = (claim, limit)
 


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

