### PR TITLE
Turn on extra warnings

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -151,9 +151,7 @@ parseKoreSearchOptions =
             "Search type (selects potential solutions)"
             (map (\s -> (show s, s)) [ ONE, FINAL, STAR, PLUS ])
 
-    parseSum
-        :: Eq value
-        => String -> String -> String -> [(String,value)] -> Parser value
+    parseSum :: String -> String -> String -> [(String,value)] -> Parser value
     parseSum metaName longName helpMsg options =
         option readSum
             (  metavar metaName

--- a/src/main/haskell/kore/src/Data/Graph/TopologicalSort.hs
+++ b/src/main/haskell/kore/src/Data/Graph/TopologicalSort.hs
@@ -27,7 +27,7 @@ nodes.
 Returns an error for graphs that have cycles.
 -}
 topologicalSort
-    :: (Ord node, Show node)
+    :: Ord node
     => Map.Map node [node]
     -> Either (ToplogicalSortCycles node) [node]
 topologicalSort edges =

--- a/src/main/haskell/kore/src/Kore/AST/Builders.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Builders.hs
@@ -296,7 +296,6 @@ ceilS_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => Sort level
@@ -310,7 +309,6 @@ ceil_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => CommonPurePatternStub level domain ()
@@ -323,7 +321,6 @@ floorS_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => Sort level
@@ -337,7 +334,6 @@ floor_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => CommonPurePatternStub level domain ()
@@ -347,7 +343,7 @@ floor_ = floorM_ Nothing
 -- |Builds a 'PatternStub' representing 'Exists' given a variable and an
 -- operand 'PatternStub'.
 exists_
-    :: (Functor domain, MetaOrObject level)
+    :: Functor domain
     => Variable level
     -> CommonPurePatternStub level domain ()
     -> CommonPurePatternStub level domain ()
@@ -517,7 +513,6 @@ parameterizedAxiom_
         , Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => [SortVariable level]
@@ -547,7 +542,6 @@ axiom_
         , Functor domain
         , MetaOrObject level
         , child ~ CommonPurePattern level domain ()
-        , Show child
         , Show (Pattern level domain Variable child)
         )
     => CommonPurePatternStub level domain ()

--- a/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
+++ b/src/main/haskell/kore/src/Kore/AST/BuildersImpl.hs
@@ -7,6 +7,10 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX
 -}
+
+-- TODO (thomas.tuegel): Fix withSort to eliminate this:
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 module Kore.AST.BuildersImpl where
 
 import           Control.Comonad.Trans.Cofree
@@ -45,8 +49,6 @@ provided sort otherwise.
 -}
 fillCheckSort
     ::  ( Functor domain
-        , Show level
-        , Show (variable level)
         , Show (Pattern level domain variable child)
         , child ~ PurePattern level domain variable ()
         )
@@ -169,7 +171,6 @@ unarySortedPattern
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ PurePattern level domain variable ()
-        , Show child
         , Show (Pattern level domain variable child)
         )
     =>  (  ResultSort level
@@ -318,7 +319,6 @@ equalsM_ s =
 inM_
     ::  ( Functor domain
         , MetaOrObject level
-        , Show (variable level)
         , Show (PurePattern level domain variable ())
         )
     => Maybe (Sort level)
@@ -345,7 +345,6 @@ ceilM_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ PurePattern level domain variable ()
-        , Show child
         , Show (Pattern level domain variable child)
         )
     => Maybe (Sort level)
@@ -369,7 +368,6 @@ floorM_
     ::  ( Functor domain
         , MetaOrObject level
         , child ~ PurePattern level domain variable ()
-        , Show child
         , Show (Pattern level domain variable child)
         )
     => Maybe (Sort level)

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -28,8 +28,9 @@ module Kore.AST.Common where
 import           Control.DeepSeq
                  ( NFData (..) )
 import           Data.Deriving
-                 ( deriveEq1, deriveOrd1, deriveShow1, makeLiftCompare,
-                 makeLiftEq, makeLiftShowsPrec )
+                 ( makeLiftCompare, makeLiftEq, makeLiftShowsPrec )
+import           Data.Function
+                 ( on )
 import           Data.Functor.Classes
 import           Data.Functor.Const
                  ( Const )
@@ -47,7 +48,6 @@ import           Data.Void
 import           GHC.Generics
                  ( Generic )
 
-import Data.Functor.Foldable.Orphans ()
 import Kore.AST.MetaOrObject
 
 {-| 'FileLocation' represents a position in a source file.
@@ -412,11 +412,27 @@ data And level child = And
     , andFirst  :: !child
     , andSecond :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''And
-deriveOrd1 ''And
-deriveShow1 ''And
+$(return [])
+
+instance Eq1 (And level) where
+    liftEq = $(makeLiftEq ''And)
+
+instance Ord1 (And level) where
+    liftCompare = $(makeLiftCompare ''And)
+
+instance Show1 (And level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''And)
+
+instance Eq child => Eq (And level child) where
+    (==) = eq1
+
+instance Ord child => Ord (And level child) where
+    compare = compare1
+
+instance Show child => Show (And level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (And level child)
 
@@ -435,11 +451,27 @@ data Application level child = Application
     { applicationSymbolOrAlias :: !(SymbolOrAlias level)
     , applicationChildren      :: ![child]
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Application
-deriveOrd1 ''Application
-deriveShow1 ''Application
+$(return [])
+
+instance Eq1 (Application level) where
+    liftEq = $(makeLiftEq ''Application)
+
+instance Ord1 (Application level) where
+    liftCompare = $(makeLiftCompare ''Application)
+
+instance Show1 (Application level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Application)
+
+instance Eq child => Eq (Application level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Application level child) where
+    compare = compare1
+
+instance Show child => Show (Application level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Application level child)
 
@@ -456,12 +488,25 @@ versions of symbol declarations. It should verify 'MetaOrObject level'.
 
 This represents the ⌈BottomPattern⌉ Matching Logic construct.
 -}
-newtype Bottom level child = Bottom { bottomSort :: Sort level}
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+newtype Bottom level child = Bottom { bottomSort :: Sort level }
+    deriving (Functor, Foldable, Show, Traversable, Generic)
 
-deriveEq1 ''Bottom
-deriveOrd1 ''Bottom
-deriveShow1 ''Bottom
+$(return [])
+
+instance Eq1 (Bottom level) where
+    liftEq = $(makeLiftEq ''Bottom)
+
+instance Ord1 (Bottom level) where
+    liftCompare = $(makeLiftCompare ''Bottom)
+
+instance Show1 (Bottom level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Bottom)
+
+instance Eq (Bottom level child) where
+    (==) = on (==) bottomSort
+
+instance Ord (Bottom level child) where
+    compare = on compare bottomSort
 
 instance Hashable (Bottom level child)
 
@@ -485,11 +530,27 @@ data Ceil level child = Ceil
     , ceilResultSort  :: !(Sort level)
     , ceilChild       :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Ceil
-deriveOrd1 ''Ceil
-deriveShow1 ''Ceil
+$(return [])
+
+instance Eq1 (Ceil level) where
+    liftEq = $(makeLiftEq ''Ceil)
+
+instance Ord1 (Ceil level) where
+    liftCompare = $(makeLiftCompare ''Ceil)
+
+instance Show1 (Ceil level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Ceil)
+
+instance Eq child => Eq (Ceil level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Ceil level child) where
+    compare = compare1
+
+instance Show child => Show (Ceil level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Ceil level child)
 
@@ -514,11 +575,27 @@ data DomainValue level domain child = DomainValue
     { domainValueSort  :: !(Sort level)
     , domainValueChild :: !(domain child)
     }
-    deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
+    deriving (Foldable, Functor, Generic, Traversable)
 
-deriveEq1 ''DomainValue
-deriveOrd1 ''DomainValue
-deriveShow1 ''DomainValue
+$(return [])
+
+instance Eq1 domain => Eq1 (DomainValue level domain) where
+    liftEq = $(makeLiftEq ''DomainValue)
+
+instance Ord1 domain => Ord1 (DomainValue level domain) where
+    liftCompare = $(makeLiftCompare ''DomainValue)
+
+instance Show1 domain => Show1 (DomainValue level domain) where
+    liftShowsPrec = $(makeLiftShowsPrec ''DomainValue)
+
+instance (Eq1 domain, Eq child) => Eq (DomainValue level domain child) where
+    (==) = eq1
+
+instance (Ord1 domain, Ord child) => Ord (DomainValue level domain child) where
+    compare = compare1
+
+instance (Show1 dom, Show child) => Show (DomainValue lvl dom child) where
+    showsPrec = showsPrec1
 
 instance Hashable (domain child) => Hashable (DomainValue level domain child)
 
@@ -543,11 +620,27 @@ data Equals level child = Equals
     , equalsFirst       :: !child
     , equalsSecond      :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Equals
-deriveOrd1 ''Equals
-deriveShow1 ''Equals
+$(return [])
+
+instance Eq1 (Equals level) where
+    liftEq = $(makeLiftEq ''Equals)
+
+instance Ord1 (Equals level) where
+    liftCompare = $(makeLiftCompare ''Equals)
+
+instance Show1 (Equals level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Equals)
+
+instance Eq child => Eq (Equals level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Equals level child) where
+    compare = compare1
+
+instance Show child => Show (Equals level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Equals level child)
 
@@ -569,31 +662,31 @@ data Exists level v child = Exists
     , existsVariable :: !(v level)
     , existsChild    :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-instance (Ord (Sort level), Ord (v level)) => Ord1 (Exists level v) where
-    liftCompare liftedCompare a b =
-        (existsSort a `compare` existsSort b)
-        <> (existsVariable a `compare` existsVariable b)
-        <> (existsChild a) `liftedCompare` (existsChild b)
+$(return [])
 
-instance (Eq (Sort level), Eq (v level)) => Eq1 (Exists level v) where
-    liftEq liftedEq a b =
-        (existsSort a == existsSort b)
-        && (existsVariable a == existsVariable b)
-        && liftedEq (existsChild a) (existsChild b)
+instance Eq (var lvl) => Eq1 (Exists lvl var) where
+    liftEq = $(makeLiftEq ''Exists)
 
-instance (Show (Sort level), Show (v level)) => Show1 (Exists level v) where
-    liftShowsPrec liftedShowsPrec _ _ e =
-        showString "Exists { "
-        . showString "existsSort = " . shows (existsSort e)
-        . showString ", existsVariable = " . shows (existsVariable e)
-        . showString ", existsChild = " . liftedShowsPrec 0 (existsChild e)
-        . showString " }"
+instance Ord (var lvl) => Ord1 (Exists lvl var) where
+    liftCompare = $(makeLiftCompare ''Exists)
 
-instance (Hashable child, Hashable (v level)) => Hashable (Exists level v child)
+instance Show (var lvl) => Show1 (Exists lvl var) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Exists)
 
-instance (NFData child, NFData (var level)) => NFData (Exists level var child)
+instance (Eq child, Eq (var lvl)) => Eq (Exists lvl var child) where
+    (==) = eq1
+
+instance (Ord child, Ord (var lvl)) => Ord (Exists lvl var child) where
+    compare = compare1
+
+instance (Show child, Show (var lvl)) => Show (Exists lvl var child) where
+    showsPrec = showsPrec1
+
+instance (Hashable child, Hashable (var lvl)) => Hashable (Exists lvl var child)
+
+instance (NFData child, NFData (var lvl)) => NFData (Exists lvl var child)
 
 {-|'Floor' corresponds to the @\floor@ branches of the @object-pattern@ and
 @meta-pattern@ syntactic categories from the Semantics of K,
@@ -613,11 +706,27 @@ data Floor level child = Floor
     , floorResultSort  :: !(Sort level)
     , floorChild       :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Floor
-deriveOrd1 ''Floor
-deriveShow1 ''Floor
+$(return [])
+
+instance Eq1 (Floor level) where
+    liftEq = $(makeLiftEq ''Floor)
+
+instance Ord1 (Floor level) where
+    liftCompare = $(makeLiftCompare ''Floor)
+
+instance Show1 (Floor level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Floor)
+
+instance Eq child => Eq (Floor level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Floor level child) where
+    compare = compare1
+
+instance Show child => Show (Floor level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Floor level child)
 
@@ -639,31 +748,31 @@ data Forall level v child = Forall
     , forallVariable :: !(v level)
     , forallChild    :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-instance (Ord (Sort level), Ord (v level)) => Ord1 (Forall level v) where
-    liftCompare liftedCompare a b =
-        (forallSort a `compare` forallSort b)
-        <> (forallVariable a `compare` forallVariable b)
-        <> (forallChild a) `liftedCompare` (forallChild b)
+$(return [])
 
-instance (Eq (Sort level), Eq (v level)) => Eq1 (Forall level v) where
-    liftEq liftedEq a b =
-        (forallSort a == forallSort b)
-        && (forallVariable a == forallVariable b)
-        && liftedEq (forallChild a) (forallChild b)
+instance Eq (var lvl) => Eq1 (Forall lvl var) where
+    liftEq = $(makeLiftEq ''Forall)
 
-instance (Show (Sort level), Show (v level)) => Show1 (Forall level v) where
-    liftShowsPrec liftedShowsPrec _ _ e =
-        showString "Forall { "
-        . showString "forallSort = " . shows (forallSort e)
-        . showString ", forallVariable = " . shows (forallVariable e)
-        . showString ", forallChild = " . liftedShowsPrec 0 (forallChild e)
-        . showString " }"
+instance Ord (var lvl) => Ord1 (Forall lvl var) where
+    liftCompare = $(makeLiftCompare ''Forall)
 
-instance (Hashable child, Hashable (v level)) => Hashable (Forall level v child)
+instance Show (var lvl) => Show1 (Forall lvl var) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Forall)
 
-instance (NFData child, NFData (v level)) => NFData (Forall level v child)
+instance (Eq child, Eq (var lvl)) => Eq (Forall lvl var child) where
+    (==) = eq1
+
+instance (Ord child, Ord (var lvl)) => Ord (Forall lvl var child) where
+    compare = compare1
+
+instance (Show child, Show (var lvl)) => Show (Forall lvl var child) where
+    showsPrec = showsPrec1
+
+instance (Hashable child, Hashable (var lvl)) => Hashable (Forall lvl var child)
+
+instance (NFData child, NFData (var lvl)) => NFData (Forall lvl var child)
 
 {-|'Iff' corresponds to the @\iff@ branches of the @object-pattern@ and
 @meta-pattern@ syntactic categories from the Semantics of K,
@@ -681,11 +790,27 @@ data Iff level child = Iff
     , iffFirst  :: !child
     , iffSecond :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Iff
-deriveOrd1 ''Iff
-deriveShow1 ''Iff
+$(return [])
+
+instance Eq1 (Iff level) where
+    liftEq = $(makeLiftEq ''Iff)
+
+instance Ord1 (Iff level) where
+    liftCompare = $(makeLiftCompare ''Iff)
+
+instance Show1 (Iff level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Iff)
+
+instance Eq child => Eq (Iff level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Iff level child) where
+    compare = compare1
+
+instance Show child => Show (Iff level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Iff level child)
 
@@ -707,11 +832,27 @@ data Implies level child = Implies
     , impliesFirst  :: !child
     , impliesSecond :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Implies
-deriveOrd1 ''Implies
-deriveShow1 ''Implies
+$(return [])
+
+instance Eq1 (Implies level) where
+    liftEq = $(makeLiftEq ''Implies)
+
+instance Ord1 (Implies level) where
+    liftCompare = $(makeLiftCompare ''Implies)
+
+instance Show1 (Implies level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Implies)
+
+instance Eq child => Eq (Implies level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Implies level child) where
+    compare = compare1
+
+instance Show child => Show (Implies level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Implies level child)
 
@@ -739,16 +880,31 @@ data In level child = In
     , inContainedChild  :: !child
     , inContainingChild :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''In
-deriveOrd1 ''In
-deriveShow1 ''In
+$(return [])
+
+instance Eq1 (In level) where
+    liftEq = $(makeLiftEq ''In)
+
+instance Ord1 (In level) where
+    liftCompare = $(makeLiftCompare ''In)
+
+instance Show1 (In level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''In)
+
+instance Eq child => Eq (In level child) where
+    (==) = eq1
+
+instance Ord child => Ord (In level child) where
+    compare = compare1
+
+instance Show child => Show (In level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (In level child)
 
 instance NFData child => NFData (In level child)
-
 
 {-|'Next' corresponds to the @\next@ branch of the @object-pattern@
 syntactic category from the Semantics of K, Section 9.1.4 (Patterns).
@@ -765,11 +921,27 @@ data Next level child = Next
     { nextSort  :: !(Sort level)
     , nextChild :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Next
-deriveOrd1 ''Next
-deriveShow1 ''Next
+$(return [])
+
+instance Eq1 (Next level) where
+    liftEq = $(makeLiftEq ''Next)
+
+instance Ord1 (Next level) where
+    liftCompare = $(makeLiftCompare ''Next)
+
+instance Show1 (Next level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Next)
+
+instance Eq child => Eq (Next level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Next level child) where
+    compare = compare1
+
+instance Show child => Show (Next level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Next level child)
 
@@ -790,11 +962,27 @@ data Not level child = Not
     { notSort  :: !(Sort level)
     , notChild :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Not
-deriveOrd1 ''Not
-deriveShow1 ''Not
+$(return [])
+
+instance Eq1 (Not level) where
+    liftEq = $(makeLiftEq ''Not)
+
+instance Ord1 (Not level) where
+    liftCompare = $(makeLiftCompare ''Not)
+
+instance Show1 (Not level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Not)
+
+instance Eq child => Eq (Not level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Not level child) where
+    compare = compare1
+
+instance Show child => Show (Not level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Not level child)
 
@@ -816,11 +1004,27 @@ data Or level child = Or
     , orFirst  :: !child
     , orSecond :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Or
-deriveOrd1 ''Or
-deriveShow1 ''Or
+$(return [])
+
+instance Eq1 (Or level) where
+    liftEq = $(makeLiftEq ''Or)
+
+instance Ord1 (Or level) where
+    liftCompare = $(makeLiftCompare ''Or)
+
+instance Show1 (Or level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Or)
+
+instance Eq child => Eq (Or level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Or level child) where
+    compare = compare1
+
+instance Show child => Show (Or level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Or level child)
 
@@ -843,11 +1047,27 @@ data Rewrites level child = Rewrites
     , rewritesFirst  :: !child
     , rewritesSecond :: !child
     }
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Traversable, Generic)
 
-deriveEq1 ''Rewrites
-deriveOrd1 ''Rewrites
-deriveShow1 ''Rewrites
+$(return [])
+
+instance Eq1 (Rewrites level) where
+    liftEq = $(makeLiftEq ''Rewrites)
+
+instance Ord1 (Rewrites level) where
+    liftCompare = $(makeLiftCompare ''Rewrites)
+
+instance Show1 (Rewrites level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Rewrites)
+
+instance Eq child => Eq (Rewrites level child) where
+    (==) = eq1
+
+instance Ord child => Ord (Rewrites level child) where
+    compare = compare1
+
+instance Show child => Show (Rewrites level child) where
+    showsPrec = showsPrec1
 
 instance Hashable child => Hashable (Rewrites level child)
 
@@ -865,11 +1085,24 @@ versions of symbol declarations. It should verify 'MetaOrObject level'.
 This represents the ⌈TopPattern⌉ Matching Logic construct.
 -}
 newtype Top level child = Top { topSort :: Sort level}
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving (Functor, Foldable, Show, Traversable, Generic)
 
-deriveEq1 ''Top
-deriveOrd1 ''Top
-deriveShow1 ''Top
+$(return [])
+
+instance Eq1 (Top level) where
+    liftEq = $(makeLiftEq ''Top)
+
+instance Ord1 (Top level) where
+    liftCompare = $(makeLiftCompare ''Top)
+
+instance Show1 (Top level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''Top)
+
+instance Eq (Top level child) where
+    (==) = on (==) topSort
+
+instance Ord (Top level child) where
+    compare = on compare topSort
 
 instance Hashable (Top level child)
 
@@ -1023,19 +1256,19 @@ instance
 deriving instance
     ( Eq child
     , Eq (variable level)
-    , Eq (domain child)
+    , Eq1 domain
     ) => Eq (Pattern level domain variable child)
 
 deriving instance
     ( Show child
     , Show (variable level)
-    , Show (domain child)
+    , Show1 domain
     ) => Show (Pattern level domain variable child)
 
 deriving instance
     ( Ord child
     , Ord (variable level)
-    , Ord (domain child)
+    , Ord1 domain
     ) => Ord (Pattern level domain variable child)
 
 deriving instance Functor domain => Functor (Pattern level domain variable)

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -1168,8 +1168,7 @@ $(return [])
 {- dummy top-level splice to make ''Pattern available for lifting -}
 
 instance
-    ( Ord level
-    , Ord (variable level)
+    ( Ord (variable level)
     , Ord1 domain
     ) =>
     Ord1 (Pattern level domain variable)
@@ -1177,8 +1176,7 @@ instance
     liftCompare = $(makeLiftCompare ''Pattern)
 
 instance
-    ( Eq level
-    , Eq (variable level)
+    ( Eq (variable level)
     , Eq1 domain
     ) =>
     Eq1 (Pattern level domain variable)

--- a/src/main/haskell/kore/src/Kore/AST/Kore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Kore.hs
@@ -241,8 +241,7 @@ instance
 deriving instance
     ( Show annotation
     , ShowMetaOrObject variable
-    , Show (domain child)
-    , child ~ Cofree (UnifiedPattern domain variable) annotation
+    , Show1 domain
     ) =>
     Show (KorePattern domain variable annotation)
 

--- a/src/main/haskell/kore/src/Kore/AST/Pure.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Pure.hs
@@ -117,7 +117,7 @@ instance
 deriving instance
     ( Show annotation
     , Show (variable level)
-    , Show (domain child)
+    , Show1 domain
     , child ~ Cofree (Pattern level domain variable) annotation
     ) =>
     Show (PurePattern level domain variable annotation)

--- a/src/main/haskell/kore/src/Kore/AST/PureToKore.hs
+++ b/src/main/haskell/kore/src/Kore/AST/PureToKore.hs
@@ -56,9 +56,7 @@ patternKoreToPure level =
     Recursive.fold (extractPurePattern $ isMetaOrObject $ toProxy level)
 
 extractPurePattern
-    ::  ( MetaOrObject level
-        , result ~ Either (Error a) (CommonPurePattern level Domain.Builtin ())
-        )
+    :: result ~ Either (Error a) (CommonPurePattern level Domain.Builtin ())
     => IsMetaOrObject level
     -> Base CommonKorePattern result
     -> result

--- a/src/main/haskell/kore/src/Kore/AST/Sentence.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Sentence.hs
@@ -341,11 +341,7 @@ deriving instance
 
 instance
     ( NFData (SentenceAlias level pat domain variable)
-    , NFData (SentenceSymbol level pat domain variable)
-    , NFData (SentenceImport pat domain variable)
     , NFData (SentenceAxiom param pat domain variable)
-    , NFData (SentenceSort level pat domain variable)
-    , NFData (SentenceHook level pat domain variable)
     ) =>
     NFData (Sentence level param pat domain variable)
   where
@@ -683,9 +679,7 @@ type PureSentence level domain =
     Sentence level (SortVariable level) (PurePattern level) domain Variable
 
 instance
-    ( MetaOrObject level
-    , sortParam ~ SortVariable level
-    ) =>
+    sortParam ~ SortVariable level =>
     AsSentence
         (Sentence level sortParam (PurePattern level) domain variable)
         (SentenceAlias level (PurePattern level) domain variable)
@@ -693,9 +687,7 @@ instance
     asSentence = SentenceAliasSentence
 
 instance
-    ( MetaOrObject level
-    , sortParam ~ SortVariable level
-    ) =>
+    sortParam ~ SortVariable level =>
     AsSentence
         (Sentence level sortParam (PurePattern level) domain variable)
         (SentenceSymbol level (PurePattern level) domain variable)
@@ -723,9 +715,7 @@ instance
     asSentence = SentenceAxiomSentence
 
 instance
-    ( MetaOrObject level
-    , sortParam ~ SortVariable level
-    ) =>
+    sortParam ~ SortVariable level =>
     AsSentence
         (Sentence level sortParam (PurePattern level) domain variable)
         (SentenceSort level (PurePattern level) domain variable)

--- a/src/main/haskell/kore/src/Kore/ASTHelpers.hs
+++ b/src/main/haskell/kore/src/Kore/ASTHelpers.hs
@@ -107,7 +107,7 @@ pairVariablesToSorts variables sorts
 It assumes that the pattern has the provided sort.
 -}
 quantifyFreeVariables
-    :: (Foldable domain, Functor domain, MetaOrObject level)
+    :: (Foldable domain, Functor domain)
     => Sort level
     -> CommonPurePattern level domain ()
     -> CommonPurePattern level domain ()

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -320,7 +320,7 @@ instance
 instance PrettyPrint a => PrettyPrint (Const a b) where
     prettyPrint flags (Const a) = writeOneFieldStruct flags "Const" a
 
-instance PrettyPrint child => PrettyPrint (Domain.Builtin child) where
+instance PrettyPrint (Domain.Builtin child) where
     prettyPrint flags =
         \case
             Domain.BuiltinPattern str ->
@@ -329,9 +329,8 @@ instance PrettyPrint child => PrettyPrint (Domain.Builtin child) where
             _ -> Builtin.notImplementedInternal
 
 instance
-    ( MetaOrObject level
-    , PrettyPrint child
-    , PrettyPrint (domain child)
+    ( PrettyPrint (domain child)
+    , MetaOrObject level
     ) => PrettyPrint (DomainValue level domain child) where
     prettyPrint _ p@(DomainValue _ _) =
         writeStructure
@@ -575,9 +574,7 @@ instance
                 writeOneFieldStruct flags "UnifiedObjectPattern" object
 
 instance
-    ( PrettyPrint ann
-    , PrettyPrint child
-    , PrettyPrint (domain child)
+    ( PrettyPrint child
     , child ~ Cofree (UnifiedPattern domain var) ann
     ) =>
     PrettyPrint (KorePattern domain var ann)
@@ -587,12 +584,11 @@ instance
             [ writeFieldOneLine "getKorePattern" getKorePattern korePattern ]
 
 instance
-    ( MetaOrObject level
-    , Functor domain
-    , PrettyPrint child
-    , PrettyPrint annotation
-    , PrettyPrint (domain child)
-    , child ~ Cofree (Pattern level domain variable) annotation
+    ( PrettyPrint annotation
+    , PrettyPrint (variable level)
+    , PrettyPrint
+        (domain (CofreeT (Pattern level domain variable) Identity annotation))
+    , MetaOrObject level
     ) =>
     PrettyPrint (PurePattern level domain variable annotation)
   where
@@ -628,9 +624,8 @@ instance
             ]
 
 instance
-    ( MetaOrObject level
-    , PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (SentenceSymbol level pat domain variable)
+    MetaOrObject level =>
+    PrettyPrint (SentenceSymbol level pat domain variable)
   where
     prettyPrint _ sa@(SentenceSymbol _ _ _ _) =
         writeStructure
@@ -644,8 +639,7 @@ instance
             ]
 
 instance
-    (PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (SentenceImport pat domain variable)
+    PrettyPrint (SentenceImport pat domain variable)
   where
     prettyPrint _ sa@(SentenceImport _ _) =
         writeStructure
@@ -673,9 +667,8 @@ instance
             ]
 
 instance
-    ( MetaOrObject level
-    , PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (SentenceSort level pat domain variable)
+    MetaOrObject level =>
+    PrettyPrint (SentenceSort level pat domain variable)
   where
     prettyPrint _ sa@(SentenceSort _ _ _) =
         writeStructure
@@ -688,9 +681,8 @@ instance
             ]
 
 instance
-    ( MetaOrObject level
-    , PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (SentenceHook level pat domain variable)
+    MetaOrObject level =>
+    PrettyPrint (SentenceHook level pat domain variable)
   where
     prettyPrint flags (SentenceHookedSymbol s)   =
         writeOneFieldStruct flags "SentenceHookedSymbol" s
@@ -736,10 +728,8 @@ instance
         writeOneFieldStruct flags "ObjectSentence" s
 
 instance
-    (PrettyPrint (sentence sortParam pat domain variable)
-    , PrettyPrint sortParam
-    , PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (Module sentence sortParam pat domain variable)
+    PrettyPrint (sentence sortParam pat domain variable) =>
+    PrettyPrint (Module sentence sortParam pat domain variable)
   where
     prettyPrint _ m@(Module _ _ _) =
         writeStructure
@@ -750,10 +740,8 @@ instance
             ]
 
 instance
-    (PrettyPrint (sentence sortParam pat domain variable)
-    , PrettyPrint sortParam
-    , PrettyPrint (pat domain variable ())
-    ) => PrettyPrint (Definition sentence sortParam pat domain variable)
+    PrettyPrint (sentence sortParam pat domain variable) =>
+    PrettyPrint (Definition sentence sortParam pat domain variable)
   where
     prettyPrint _ d@(Definition _ _) =
         writeStructure

--- a/src/main/haskell/kore/src/Kore/ASTUtils/AlphaCompare.hs
+++ b/src/main/haskell/kore/src/Kore/ASTUtils/AlphaCompare.hs
@@ -38,12 +38,7 @@ import qualified Kore.Domain.Builtin as Domain
 -- lowest index if there are multiple occurences of `elem`.
 
 alphaEq
-    ::  ( MetaOrObject level
-        , Eq (var level)
-        , Ord (var level)
-        , EqMetaOrObject var
-        , OrdMetaOrObject var
-        )
+    :: Ord (var level)
     => PurePattern level Domain.Builtin var ()
     -> PurePattern level Domain.Builtin var ()
     -> Bool
@@ -56,9 +51,7 @@ alphaEq e1' e2' = Reader.runReader (alphaEqWorker e1' e2') ([], [])
     project = Cofree.tailF . Recursive.project
 
     alphaEqWorker
-        ::  ( Eq (var level)
-            , Ord (var level)
-            )
+        :: Ord (var level)
         => PurePattern level Domain.Builtin var ()
         -> PurePattern level Domain.Builtin var ()
         -> Reader ([var level], [var level]) Bool

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -141,8 +141,7 @@ verifyAndIndexDefinitionWithBase
             (map (\m -> (moduleName m, m)) (definitionModules definition))
 
 defaultAttributesVerification
-    :: ParseAttributes atts
-    => Proxy atts
+    :: Proxy atts
     -> AttributesVerification atts
 defaultAttributesVerification = VerifyAttributes
 

--- a/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/src/main/haskell/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -443,8 +443,7 @@ verifyBinder
     binderSort = getBinderPatternSort binder
 
 verifyVariableUsage
-    :: (MetaOrObject level)
-    => Variable level
+    :: Variable level
     -> KoreIndexedModule atts
     -> VerifyHelpers level
     -> Set.Set UnifiedSortVariable
@@ -519,8 +518,7 @@ verifyVariableDeclarationUsing declaredSortVariables f v =
         (variableSort v)
 
 findVariableDeclaration
-    :: (MetaOrObject level)
-    => Id level
+    :: Id level
     -> VerifyHelpers level
     -> Either (Error VerifyError) (Variable level)
 findVariableDeclaration variableId verifyHelpers =

--- a/src/main/haskell/kore/src/Kore/Building/Patterns.hs
+++ b/src/main/haskell/kore/src/Kore/Building/Patterns.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans -Wno-redundant-constraints #-}
 {-|
 Module      : Kore.Building.Patterns
 Description : Builders for the standard Kore patterns, without 'Application'.

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -151,12 +151,7 @@ evalKEq true false tools substitutionSimplifier _ pat =
         ep2 = ExpandedPattern.fromPurePattern t2
 
 evalKIte
-    ::  forall variable
-    .   ( FreshVariable variable
-        , OrdMetaOrObject variable
-        , SortedVariable variable
-        , ShowMetaOrObject variable
-        )
+    :: forall variable. OrdMetaOrObject variable
     => MetadataTools.MetadataTools Object StepperAttributes
     -> PredicateSubstitutionSimplifier Object Simplifier
     -> StepPatternSimplifier Object variable

--- a/src/main/haskell/kore/src/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/List.hs
@@ -362,15 +362,12 @@ isSymbolElement = Builtin.isSymbol "LIST.element"
     reject the definition.
  -}
 unifyEquals
-    :: forall level variable m p expanded proof.
-        ( OrdMetaOrObject variable
-        , ShowMetaOrObject variable
-        , Ord (variable level)
+    ::  forall level variable m p expanded proof.
+        ( Ord (variable level)
         , Show (variable level)
         , SortedVariable variable
         , MonadCounter m
         , MetaOrObject level
-        , FreshVariable variable
         , p ~ StepPattern level variable
         , expanded ~ ExpandedPattern level variable
         , proof ~ SimplificationProof level

--- a/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/src/main/haskell/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -130,7 +130,7 @@ getIndexedSentence = snd
 
 deriving instance
     ( Show1 (pat dom var)
-    , Show (dom child)
+    , Show1 dom
     , Show (pat dom var ())
     , Show sortParam
     , ShowMetaOrObject var

--- a/src/main/haskell/kore/src/Kore/OnePath/Verification.hs
+++ b/src/main/haskell/kore/src/Kore/OnePath/Verification.hs
@@ -115,9 +115,8 @@ Things to note when implementing your own:
 2. You can return an infinite list.
 -}
 defaultStrategy
-    :: forall level
-    .   (MetaOrObject level)
-    => [Claim level]
+    ::  forall level.
+        [Claim level]
     -- The claims that we wnt to prove
     -> [Axiom level]
     -> CommonStepPattern level
@@ -190,4 +189,3 @@ verifyClaim
         StrategyPattern.RewritePattern p : _ -> throwE p
         StrategyPattern.Stuck p : _ -> throwE p
         StrategyPattern.Bottom : _ -> error "Unexpected bottom pattern."
-

--- a/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Parser/ParserImpl.hs
@@ -137,8 +137,7 @@ Relevant BNF definitions:
 @
 -}
 validateMetaSort
-    :: MetaOrObject level
-    => Id level     -- ^ The sort name
+    :: Id level     -- ^ The sort name
     -> [Sort level] -- ^ The sort arguments
     -> Parser ()
 validateMetaSort identifier [] =

--- a/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
+++ b/src/main/haskell/kore/src/Kore/Predicate/Predicate.hs
@@ -297,10 +297,9 @@ makeInPredicate first second =
 predicate.
 -}
 makeCeilPredicate
-    ::  ( MetaOrObject level
-        , Given (SymbolOrAliasSorts level)
+    ::  ( Given (SymbolOrAliasSorts level)
         , SortedVariable variable
-        , Show (variable level))
+        )
     => StepPattern level variable
     -> Predicate level variable
 makeCeilPredicate patt =
@@ -310,10 +309,9 @@ makeCeilPredicate patt =
 predicate.
 -}
 makeFloorPredicate
-    ::  ( MetaOrObject level
-        , Given (SymbolOrAliasSorts level)
+    ::  ( Given (SymbolOrAliasSorts level)
         , SortedVariable variable
-        , Show (variable level))
+        )
     => StepPattern level variable
     -> Predicate level variable
 makeFloorPredicate patt =
@@ -351,17 +349,13 @@ makeForallPredicate v (GenericPredicate p) =
 
 {-| 'makeTruePredicate' produces a predicate wrapping a 'top'.
 -}
-makeTruePredicate
-    ::  (MetaOrObject level)
-    => Predicate level variable
+makeTruePredicate :: Predicate level variable
 makeTruePredicate =
     GenericPredicate mkTop
 
 {-| 'makeFalsePredicate' produces a predicate wrapping a 'bottom'.
 -}
-makeFalsePredicate
-    ::  (MetaOrObject level)
-    => Predicate level variable
+makeFalsePredicate :: Predicate level variable
 makeFalsePredicate =
     GenericPredicate mkBottom
 
@@ -434,7 +428,7 @@ allVariables = pureAllVariables . unwrapPredicate
 {- | Extract the set of free variables from a @Predicate@.
 -}
 freeVariables
-    :: (MetaOrObject level , Ord (variable level))
+    :: Ord (variable level)
     => Predicate level variable
     -> Set (variable level)
 freeVariables = freePureVariables . unwrapPredicate

--- a/src/main/haskell/kore/src/Kore/Proof/Dummy.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Dummy.hs
@@ -8,20 +8,7 @@ Stability   : experimental
 Portability : portable
 -}
 
-{-# LANGUAGE AllowAmbiguousTypes       #-}
-{-# LANGUAGE ConstraintKinds           #-}
-{-# LANGUAGE DeriveFoldable            #-}
-{-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE DeriveTraversable         #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FunctionalDependencies    #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE PatternSynonyms           #-}
-{-# LANGUAGE Rank2Types                #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
 module Kore.Proof.Dummy where
 
@@ -38,17 +25,17 @@ import Kore.IndexedModule.MetadataTools
 
 import Kore.ASTUtils.SmartConstructors
 
-var :: MetaOrObject level => Text -> Variable level
+var :: Text -> Variable level
 var x = x `varS` defaultSort
 
-sym :: MetaOrObject level => Text -> SymbolOrAlias level
+sym :: Text -> SymbolOrAlias level
 sym x = x `symS` []
 
-var_ :: MetaOrObject level => Text -> Text -> Variable level
+var_ :: Text -> Text -> Variable level
 var_ x s =
   Variable (noLocationId x) (mkSort s)
 
-defaultSort :: MetaOrObject level => Sort level
+defaultSort :: Sort level
 defaultSort = mkSort "*"
 
 
@@ -58,8 +45,7 @@ dummyEnvironment
   -> r
 dummyEnvironment = give (dummySymbolOrAliasSorts @Object)
 
-dummySymbolOrAliasSorts
-    :: MetaOrObject level => SymbolOrAliasSorts level
+dummySymbolOrAliasSorts :: SymbolOrAliasSorts level
 dummySymbolOrAliasSorts = const ApplicationSorts
     { applicationSortsOperands = []
     , applicationSortsResult = defaultSort

--- a/src/main/haskell/kore/src/Kore/Proof/Unification.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Unification.hs
@@ -105,10 +105,7 @@ instance Hashable UnificationError
 
 -- | Returns False if the eq x = t fails the occurs check,
 -- i.e. returns False iff x appears in t.
-occursCheck
-    :: Given (SymbolOrAliasSorts Object)
-    => Proof
-    -> Bool
+occursCheck :: Proof -> Bool
 occursCheck eq = case getConclusion eq of
     Equals_ _ _ (Var_ v) rhs -> not $ S.member v (freeVars rhs)
     _                        -> impossible
@@ -139,6 +136,3 @@ flipEqn eq = case getConclusion eq of
       provablySubstitute eq [0] (useRule $ EqualityIntro a)
       -- i.e. substitute a=b in the first position of a=a to get b=a
     _ -> impossible
-
-
-

--- a/src/main/haskell/kore/src/Kore/Proof/Util.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Util.hs
@@ -200,24 +200,16 @@ provablySubstitute eq path pat = case getConclusion eq of
         )
     _ -> impossible
 
-eqSymmetry
-    :: Given (SymbolOrAliasSorts Object)
-    => Proof
-    -> Proof
+eqSymmetry :: Proof -> Proof
 eqSymmetry = undefined
 
-eqTransitivity
-    :: Given (SymbolOrAliasSorts Object)
-    => Proof
-    -> Proof
-    -> Proof
+eqTransitivity :: Proof -> Proof -> Proof
 eqTransitivity = undefined
 
 --------------------------------------------------------------------------------
 
 generateVarList
-    :: Given (SymbolOrAliasSorts Object)
-    => [Sort Object]
+    :: [Sort Object]
     -> Text
     -> ([Variable Object], [Term])
 generateVarList sorts name =

--- a/src/main/haskell/kore/src/Kore/Proof/Value.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Value.hs
@@ -19,7 +19,8 @@ module Kore.Proof.Value
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
 import           Data.Deriving
-                 ( deriveEq1, deriveOrd1, deriveShow1 )
+                 ( makeLiftCompare, makeLiftEq, makeLiftShowsPrec )
+import           Data.Functor.Classes
 import           Data.Functor.Foldable
                  ( Fix (..) )
 import qualified Data.Functor.Foldable as Recursive
@@ -55,9 +56,16 @@ deriving instance Functor (ValueF level)
 deriving instance Foldable (ValueF level)
 deriving instance Traversable (ValueF level)
 
-deriveEq1 ''ValueF
-deriveOrd1 ''ValueF
-deriveShow1 ''ValueF
+$(return [])
+
+instance Eq1 (ValueF level) where
+    liftEq = $(makeLiftEq ''ValueF)
+
+instance Ord1 (ValueF level) where
+    liftCompare = $(makeLiftCompare ''ValueF)
+
+instance Show1 (ValueF level) where
+    liftShowsPrec = $(makeLiftShowsPrec ''ValueF)
 
 type Value level = Fix (ValueF level)
 

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -294,12 +294,7 @@ stepWithRuleForUnifier
 
         -- Remap unification and substitution errors into 'StepError'.
         normalizeUnificationOrSubstitutionError
-            ::  ( FreshVariable variable
-                , MetaOrObject level
-                , Ord (variable level)
-                , Show (variable level)
-                )
-            => Set.Set (StepperVariable variable level)
+            :: Set.Set (StepperVariable variable level)
             -> ExceptT
                 (UnificationOrSubstitutionError
                     level
@@ -500,13 +495,8 @@ stepWithRuleForUnifier
     -- | Unwrap 'StepperVariable's so that errors are not expressed in terms of
     -- internally-defined variables.
     stepperVariableToVariableForError
-        :: forall a
-        .   ( FreshVariable variable
-            , MetaOrObject level
-            , Ord (variable level)
-            , Show (variable level)
-            )
-        => Set.Set (StepperVariable variable level)
+        ::  forall a.
+            Set.Set (StepperVariable variable level)
         -> ExceptT (StepError level (StepperVariable variable)) Simplifier a
         -> ExceptT (StepError level variable) Simplifier a
     stepperVariableToVariableForError existingVars = mapExceptT mapper
@@ -835,9 +825,7 @@ configurationVariableToCommon (AxiomVariable a) =
 configurationVariableToCommon (ConfigurationVariable v) = v
 
 replacePatternVariables
-    ::  ( MetaOrObject level
-        , Ord (variable level)
-        )
+    :: Ord (variable level)
     => Map.Map (StepperVariable variable level) (StepperVariable variable level)
     -> StepPattern level (StepperVariable variable)
     -> StepPattern level (StepperVariable variable)
@@ -884,8 +872,7 @@ addAxiomVariablesAsConfig
                 vars
 
 removeAxiomVariables
-    :: MetaOrObject level
-    => Substitution level (StepperVariable variable)
+    :: Substitution level (StepperVariable variable)
     -> Substitution level (StepperVariable variable)
 removeAxiomVariables =
     Substitution.wrap

--- a/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -70,7 +70,6 @@ evaluate
     ::  forall level variable .
         ( MetaOrObject level
         , SortedVariable variable
-        , Eq (variable level)
         , Ord (variable level)
         , Show (variable level)
         , Given (MetadataTools level StepperAttributes)
@@ -139,8 +138,6 @@ refutePredicate
        ( Given (MetadataTools level StepperAttributes)
        , MetaOrObject level
        , Ord (variable level)
-       , Show (variable level)
-       , SortedVariable variable
        , MonadSMT m
        )
     => Predicate level variable
@@ -355,7 +352,7 @@ translatePattern sort =
 
 type Translator p = MaybeT (StateT (Map p SExpr) (CounterT SMT))
 
-runTranslator :: Ord p => Translator p a -> MaybeT SMT a
+runTranslator :: Translator p a -> MaybeT SMT a
 runTranslator = Morph.hoist (evalCounterT . flip evalStateT Map.empty)
 
 translateUninterpreted

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -236,7 +236,7 @@ toMLPattern
 {-|'bottom' is an expanded pattern that has a bottom condition and that
 should become Bottom when transformed to a ML pattern.
 -}
-bottom :: MetaOrObject level => ExpandedPattern level variable
+bottom :: ExpandedPattern level variable
 bottom =
     Predicated
         { term      = mkBottom
@@ -247,7 +247,7 @@ bottom =
 {-|'top' is an expanded pattern that has a top condition and that
 should become Top when transformed to a ML pattern.
 -}
-top :: MetaOrObject level => ExpandedPattern level variable
+top :: ExpandedPattern level variable
 top =
     Predicated
         { term      = mkTop
@@ -284,10 +284,7 @@ isBottom _ = False
   See also: 'makeTruePredicate', 'pure'
 
  -}
-fromPurePattern
-    :: MetaOrObject level
-    => StepPattern level variable
-    -> ExpandedPattern level variable
+fromPurePattern :: StepPattern level variable -> ExpandedPattern level variable
 fromPurePattern term =
     case term of
         Bottom_ _ -> bottom
@@ -298,10 +295,10 @@ fromPurePattern term =
                 , substitution = mempty
                 }
 
-topPredicate :: MetaOrObject level => PredicateSubstitution level variable
+topPredicate :: PredicateSubstitution level variable
 topPredicate = top $> ()
 
-bottomPredicate :: MetaOrObject level => PredicateSubstitution level variable
+bottomPredicate :: PredicateSubstitution level variable
 bottomPredicate = bottom $> ()
 
 {- | Transform a predicate and substitution into a predicate only.

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -59,8 +59,6 @@ evaluateApplication
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
         , FreshVariable variable
-        , Show (variable Meta)
-        , Show (variable Object)
         )
     => MetadataTools level StepperAttributes
     -- ^ Tools for finding additional information about patterns

--- a/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Matcher.hs
@@ -482,16 +482,12 @@ matchNonVarToPattern tools substitutionSimplifier first second
                 }
 
 checkVariableEscape
-    :: ( MetaOrObject level
-        , Show (variable Object)
-        , Show (variable Meta)
-        , Ord (variable Object)
-        , Ord (variable Meta)
+    ::  ( MetaOrObject level
         , Given (SymbolOrAliasSorts level)
         , SortedVariable variable
-        , Eq (variable level)
         , Ord (variable level)
-        , Show (variable level))
+        , Show (variable level)
+        )
     => [variable level]
     -> PredicateSubstitution level variable
     -> PredicateSubstitution level variable

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -117,8 +117,7 @@ ruleFunctionEvaluator
             (stepperConfiguration app)
             rule
     stepperConfiguration
-        :: MetaOrObject level
-        => Application level (StepPattern level variable)
+        :: Application level (StepPattern level variable)
         -> ExpandedPattern level variable
     stepperConfiguration app' =
         Predicated

--- a/src/main/haskell/kore/src/Kore/Step/RecursiveAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/RecursiveAttributes.hs
@@ -15,7 +15,6 @@ module Kore.Step.RecursiveAttributes
     ) where
 
 
-import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartPatterns
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
@@ -25,9 +24,8 @@ import           Kore.Step.Pattern
 import           Kore.Step.StepperAttributes
 
 recursivelyCheckHeadProperty
-    :: forall level variable .
-       (MetaOrObject level)
-    => (StepperAttributes -> Bool)
+    ::  forall level variable .
+        (StepperAttributes -> Bool)
     -> MetadataTools level StepperAttributes
     -> StepPattern level variable
     -> Bool
@@ -42,9 +40,8 @@ recursivelyCheckHeadProperty prop tools = go
     go _ = False
 
 isFunctionalPattern, isFunctionPattern, isTotalPattern
-    :: forall level variable .
-       (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    ::  forall level variable.
+        MetadataTools level StepperAttributes
     -> StepPattern level variable
     -> Bool
 --TODO(traiansf): we assume below that the pattern does not contain

--- a/src/main/haskell/kore/src/Kore/Step/Search.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Search.hs
@@ -116,11 +116,10 @@ searchGraph Config { searchType, bound } match executionGraph = do
 matchWith
     ::  ( MetaOrObject level
         , SortedVariable variable
-        , Eq (variable level)
         , FreshVariable variable
         , Ord (variable level)
-        , OrdMetaOrObject variable
         , Show (variable level)
+        , OrdMetaOrObject variable
         , ShowMetaOrObject variable
         )
     => MetadataTools level StepperAttributes

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -285,9 +285,7 @@ maybeTermAnd
 maybeTermAnd = maybeTransformTerm andFunctions
 
 andFunctions
-    ::  ( Eq (variable level)
-        , Eq (variable Meta)
-        , FreshVariable variable
+    ::  ( FreshVariable variable
         , MetaOrObject level
         , MonadCounter m
         , Ord (variable level)
@@ -313,9 +311,7 @@ andFunctions =
     forAnd f = f SimplificationType.And
 
 equalsFunctions
-    ::  ( Eq (variable level)
-        , Eq (variable Meta)
-        , FreshVariable variable
+    ::  ( FreshVariable variable
         , MetaOrObject level
         , MonadCounter m
         , Ord (variable level)
@@ -341,9 +337,7 @@ equalsFunctions =
     forEquals f = f SimplificationType.Equals
 
 andEqualsFunctions
-    ::  ( Eq (variable level)
-        , Eq (variable Meta)
-        , FreshVariable variable
+    ::  ( FreshVariable variable
         , MetaOrObject level
         , MonadCounter m
         , Ord (variable level)
@@ -423,15 +417,7 @@ type TermTransformationOld level variable m =
     -> MaybeT m (ExpandedPattern level variable , SimplificationProof level)
 
 maybeTransformTerm
-    ::  ( MetaOrObject level
-        , FreshVariable variable
-        , Ord (variable level)
-        , Ord (variable Meta)
-        , Ord (variable Object)
-        , Show (variable level)
-        , SortedVariable variable
-        , MonadCounter m
-        )
+    :: MonadCounter m
     => [TermTransformationOld level variable m]
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
@@ -464,13 +450,7 @@ addToolsArg
 addToolsArg = pure
 
 toExpanded
-    ::
-    ( MetaOrObject level
-    , SortedVariable variable
-    , Show (variable level)
-    , Eq (variable level)
-    )
-    =>   (  MetadataTools level StepperAttributes
+    ::  (  MetadataTools level StepperAttributes
         -> StepPattern level variable
         -> StepPattern level variable
         -> Maybe (StepPattern level variable, SimplificationProof level)
@@ -552,10 +532,7 @@ boolAnd first second =
 
 -- | Unify two identical ('==') patterns.
 equalAndEquals
-    ::  ( Eq (variable level)
-        , Eq (variable Object)
-        , MetaOrObject level
-        )
+    :: (Eq (variable level), MetaOrObject level)
     => StepPattern level variable
     -> StepPattern level variable
     -> Maybe (StepPattern level variable, SimplificationProof level)
@@ -773,11 +750,7 @@ when @src1@ is a subsort of @src2@.
 
  -}
 sortInjectionAndEqualsAssumesDifferentHeads
-    ::  forall level variable m .
-        ( Eq (variable Object)
-        , MetaOrObject level
-        , MonadCounter m
-        )
+    :: forall level variable m. MonadCounter m
     => MetadataTools level StepperAttributes
     -> TermSimplifier level variable m
     -> StepPattern level variable
@@ -917,10 +890,7 @@ returns @\\bottom@.
 -- TODO (virgil): This implementation is provisional, we're not sure yet if sort
 -- injection should always clash with constructors. We should clarify this.
 constructorSortInjectionAndEquals
-    ::  ( Eq (variable Object)
-        , MetaOrObject level
-        )
-    => MetadataTools level StepperAttributes
+    :: MetadataTools level StepperAttributes
     -> StepPattern level variable
     -> StepPattern level variable
     -> Maybe (StepPattern level variable, SimplificationProof level)
@@ -948,10 +918,7 @@ to be different; therefore their conjunction is @\\bottom@.
 
  -}
 constructorAndEqualsAssumesDifferentHeads
-    ::  ( Eq (variable Object)
-        , MetaOrObject level
-        )
-    => MetadataTools level StepperAttributes
+    :: MetadataTools level StepperAttributes
     -> StepPattern level variable
     -> StepPattern level variable
     -> Maybe (StepPattern level variable, SimplificationProof level)
@@ -974,10 +941,7 @@ sort with constructors.
 
 -}
 domainValueAndConstructorErrors
-    :: ( Eq (variable Object)
-       , MetaOrObject level
-       )
-    => MetadataTools level StepperAttributes
+    :: MetadataTools level StepperAttributes
     -> StepPattern level variable
     -> StepPattern level variable
     -> Maybe (StepPattern level variable, SimplificationProof level)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -66,8 +66,6 @@ simplify
     ::  ( MetaOrObject level
         , SortedVariable variable
         , Show (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
         , Ord (variable level)
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
@@ -114,8 +112,6 @@ makeAndEvaluateApplications
     ::  ( MetaOrObject level
         , SortedVariable variable
         , Show (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
         , Ord (variable level)
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
@@ -154,8 +150,6 @@ makeAndEvaluateSymbolApplications
     ::  ( MetaOrObject level
         , SortedVariable variable
         , Show (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
         , Ord (variable level)
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
@@ -191,8 +185,6 @@ evaluateApplicationFunction
     ::  ( MetaOrObject level
         , SortedVariable variable
         , Show (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
         , Ord (variable level)
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
@@ -229,7 +221,6 @@ makeExpandedApplication
         , Kore.AST.Common.SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
-        , Ord (variable level)
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
         , FreshVariable variable

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Exists.hs
@@ -192,10 +192,6 @@ makeEvaluateNoFreeVarInSubstitution
         , Given (SymbolOrAliasSorts level)
         , Show (variable level)
         , Ord (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
-        , Ord (variable Meta)
-        , Ord (variable Object)
         )
     => variable level
     -> ExpandedPattern level variable
@@ -244,14 +240,7 @@ makeEvaluateNoFreeVarInSubstitution
 
 substituteTermPredicate
     ::  ( MetaOrObject level
-        , SortedVariable variable
-        , Given (SymbolOrAliasSorts level)
-        , Show (variable level)
-        , Ord (variable level)
-        , Show (variable Meta)
-        , Show (variable Object)
-        , Ord (variable Meta)
-        , Ord (variable Object)
+        , OrdMetaOrObject variable
         , FreshVariable variable
         )
     => StepPattern level variable

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Next.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Next.hs
@@ -42,8 +42,7 @@ child.
 Right now this does not do any actual simplification.
 -}
 simplify
-    ::  ( MetaOrObject Object
-        , SortedVariable variable
+    ::  ( SortedVariable variable
         , Given (SymbolOrAliasSorts Object)
         , Show (variable Object)
         , Ord (variable Object)
@@ -58,8 +57,7 @@ simplify
     simplifyEvaluated child
 
 simplifyEvaluated
-    ::  ( MetaOrObject Object
-        , SortedVariable variable
+    ::  ( SortedVariable variable
         , Given (SymbolOrAliasSorts Object)
         , Show (variable Object)
         , Ord (variable Object)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Not.hs
@@ -138,7 +138,6 @@ makeTermNot
         , SortedVariable variable
         , Given (SymbolOrAliasSorts level)
         , Show (variable level)
-        , Ord (variable level)
         )
     => StepPattern level variable
     -> StepPattern level variable

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Predicate.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Predicate.hs
@@ -11,7 +11,6 @@ module Kore.Step.Simplification.Predicate
     ( simplifyPartial
     ) where
 
-import           Kore.AST.MetaOrObject
 import           Kore.ASTUtils.SmartPatterns
                  ( pattern Top_ )
 import           Kore.Predicate.Predicate
@@ -31,9 +30,7 @@ without trying to reapply the substitution on the predicate.
 TODO(virgil): Make this fully simplify.
 -}
 simplifyPartial
-    ::  ( MetaOrObject level
-        , Show (variable level)
-        )
+    :: Show (variable level)
     => PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -> Predicate level variable

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -42,8 +42,7 @@ Right now this does not do any actual simplification.
 TODO(virgil): Should I even bother to simplify Rewrites? Maybe to implies+next?
 -}
 simplify
-    ::  ( MetaOrObject Object
-        , SortedVariable variable
+    ::  ( SortedVariable variable
         , Given (SymbolOrAliasSorts Object)
         , Show (variable Object)
         , Ord (variable Object)
@@ -61,8 +60,7 @@ simplify
     simplifyEvaluatedRewrites first second
 
 simplifyEvaluatedRewrites
-    ::  ( MetaOrObject Object
-        , SortedVariable variable
+    ::  ( SortedVariable variable
         , Given (SymbolOrAliasSorts Object)
         , Show (variable Object)
         , Ord (variable Object)
@@ -76,8 +74,7 @@ simplifyEvaluatedRewrites first second =
         (OrOfExpandedPattern.toExpandedPattern second)
 
 makeEvaluateRewrites
-    ::  ( MetaOrObject Object
-        , SortedVariable variable
+    ::  ( SortedVariable variable
         , Given (SymbolOrAliasSorts Object)
         , Show (variable Object)
         , Ord (variable Object)

--- a/src/main/haskell/kore/src/Kore/Step/Strategy.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Strategy.hs
@@ -380,7 +380,7 @@ See also: 'pickLongest', 'pickFinal', 'pickOne', 'pickStar', 'pickPlus'
  -}
 
 runStrategy
-    :: forall m prim config . (Monad m, Show config, Hashable config)
+    :: forall m prim config . (Monad m, Hashable config)
     => (prim -> config -> m [config])
     -- ^ Primitive strategy rule
     -> [Strategy prim]

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs
@@ -59,7 +59,6 @@ import           Kore.Variables.Fresh
 normalize
     :: forall level variable m .
         ( level ~ Object
-        , Monad m
         , MonadCounter m
         , MetaOrObject level
         , FreshVariable variable

--- a/src/main/haskell/kore/src/Kore/Substitution/Class.hs
+++ b/src/main/haskell/kore/src/Kore/Substitution/Class.hs
@@ -84,7 +84,6 @@ substitute
         , SubstitutionClass subst (Unified var) (f ann)
         , MonadCounter m
         , Traversable dom
-        , Traversable (pat dom var)
         , OrdMetaOrObject var
         , FreshVariable var
         , Corecursive (f ann)

--- a/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -128,8 +128,8 @@ normalizeSubstitution tools substitution =
         normalizeSortedSubstitution'
 
 checkCircularVariableDependency
-    :: (MetaOrObject level, Eq (variable level))
-    =>  MetadataTools level StepperAttributes
+    :: Eq (variable level)
+    => MetadataTools level StepperAttributes
     -> [(variable level, StepPattern level variable)]
     -> [variable level]
     -> Either (SubstitutionError level variable) ()
@@ -142,8 +142,7 @@ checkCircularVariableDependency tools substitution vars =
         vars
 
 checkThatApplicationUsesConstructors
-    :: (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    :: MetadataTools level StepperAttributes
     -> checkError
     -> Maybe (StepPattern level variable)
     -> Either checkError ()
@@ -158,8 +157,7 @@ checkThatApplicationUsesConstructors _ _ Nothing =
     error "This should not be reachable"
 
 checkApplicationConstructor
-    :: (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    :: MetadataTools level StepperAttributes
     -> checkError
     -> Base (StepPattern level variable) ()
     -> Either checkError ()
@@ -216,9 +214,7 @@ normalizeSortedSubstitution
                 ((asUnified var, substitutedVarPattern) : substitution)
 
 extractVariables
-    ::  ( MetaOrObject level
-        , Ord (variable level)
-        )
+    :: Ord (variable level)
     => [(variable level, StepPattern level variable)]
     -> Set (variable level)
 extractVariables unification =
@@ -232,9 +228,7 @@ extractVariables unification =
     pattern.
  -}
 getDependencies
-    ::  ( MetaOrObject level
-        , Ord (variable level)
-        )
+    :: Ord (variable level)
     => Set (variable level)  -- ^ interesting variables
     -> variable level  -- ^ substitution variable
     -> StepPattern level variable  -- ^ substitution pattern

--- a/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/UnifierImpl.hs
@@ -96,7 +96,6 @@ simplifyCombinedItems =
 simplifyAnds
     ::  forall level variable m unifier.
         ( MetaOrObject level
-        , Eq level
         , Ord (variable level)
         , Show (variable level)
         , OrdMetaOrObject variable
@@ -175,7 +174,6 @@ groupSubstitutionByVariable =
 -- then recursively reducing that to finally get x = t /\ subst
 solveGroupedSubstitution
     :: ( MetaOrObject level
-       , Eq level
        , Ord (variable level)
        , Show (variable level)
        , OrdMetaOrObject variable
@@ -220,7 +218,6 @@ solveGroupedSubstitution tools substitutionSimplifier var patterns = do
 normalizeSubstitutionDuplication
     :: forall variable level m
     .   ( MetaOrObject level
-        , Eq level
         , Ord (variable level)
         , Show (variable level)
         , OrdMetaOrObject variable
@@ -286,10 +283,7 @@ normalizeSubstitutionDuplication tools substitutionSimplifier subst =
 
 mergePredicateSubstitutionList
     :: ( MetaOrObject level
-       , Eq level
        , Ord (variable level)
-       , Ord (variable Meta)
-       , Ord (variable Object)
        , SortedVariable variable
        , Show (variable level)
        )

--- a/src/main/haskell/kore/src/Kore/Unparser.hs
+++ b/src/main/haskell/kore/src/Kore/Unparser.hs
@@ -148,9 +148,7 @@ instance
 instance Unparse Void where
     unparse = \case {}
 
-instance
-    Unparse child => Unparse (Domain.Builtin child)
-  where
+instance Unparse (Domain.Builtin child) where
     unparse =
         \case
             Domain.BuiltinPattern child -> unparse child
@@ -422,9 +420,6 @@ instance Unparse UnifiedSortVariable where
             UnifiedObject sv -> unparse sv
 
 instance
-    ( Unparse (SentenceSort level pat domain variable)
-    , Unparse (SentenceSymbol level pat domain variable)
-    ) =>
     Unparse (SentenceHook level pat domain variable)
   where
     unparse =
@@ -433,11 +428,11 @@ instance
             SentenceHookedSymbol a -> "hooked-" <> unparse a
 
 instance
-    ( Unparse (SentenceAlias level pat domain variable)
-    , Unparse (SentenceSymbol level pat domain variable)
-    , Unparse (SentenceImport pat domain variable)
-    , Unparse (SentenceAxiom sortParam pat domain variable)
-    , Unparse (SentenceSort level pat domain variable)
+    ( Unparse sortParam
+    , Unparse child
+    , Unparse (domain child)
+    , Unparse (variable level)
+    , child ~ pat domain variable ()
     ) =>
     Unparse (Sentence level sortParam pat domain variable)
   where

--- a/src/main/haskell/kore/src/Kore/Variables/Free.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Free.hs
@@ -73,7 +73,6 @@ freePureVariables root =
 freeVariables
     ::  forall patternHead patternType annotation domain variable.
         ( UnifiedPatternInterface patternHead
-        , Functor (patternHead domain variable)
         , Foldable domain
         , OrdMetaOrObject variable
         , Recursive patternType
@@ -123,7 +122,6 @@ freeVariables root =
 allVariables
     ::  forall patternHead patternType annotation domain variable.
         ( UnifiedPatternInterface patternHead
-        , Functor (patternHead domain variable)
         , Foldable domain
         , OrdMetaOrObject variable
         , Recursive patternType

--- a/src/main/haskell/kore/src/Logic/Matching/Pattern.hs
+++ b/src/main/haskell/kore/src/Logic/Matching/Pattern.hs
@@ -121,7 +121,7 @@ wfPatSort (WFPattern (Fix p)) = patternSort p
 
 -- | Check the sorts of one layer of a pattern,
 -- requiring that the subterms are already known to be well-formed
-checkSorts1 :: (IsSignature sig, Eq (Sort sig))
+checkSorts1 :: IsSignature sig
             => SigPatternF sig var (WFPattern sig var)
             -> Maybe (WFPattern sig var)
 checkSorts1 pat = if patOk then Just (WFPattern (Fix (coerce pat))) else Nothing
@@ -136,7 +136,7 @@ checkSorts1 pat = if patOk then Just (WFPattern (Fix (coerce pat))) else Nothing
     childrenSame = all (==patternSort pat) (fmap wfPatSort pat)
 
 -- | Check if a pattern is well-sorted
-checkSorts :: (IsSignature sig, Eq (Sort sig))
+checkSorts :: IsSignature sig
            => SigPattern sig var
            -> Maybe (WFPattern sig var)
 checkSorts pat = cata (sequenceA >=> checkSorts1) pat
@@ -170,7 +170,7 @@ instance FromPattern (Pattern sort label var) sort label var where
 
 instance ToPattern (WFPattern sig var) (Sort sig) (Label sig) var where
     toPattern (WFPattern p) = coerce p
-instance (IsSignature sig, Eq (Sort sig)) =>
+instance IsSignature sig =>
     FromPattern (Maybe (WFPattern sig var)) (Sort sig) (Label sig) var
   where
     fromPattern = sequenceA >=> checkSorts1

--- a/src/main/haskell/kore/test/Test/Kore/ASTUtils.hs
+++ b/src/main/haskell/kore/test/Test/Kore/ASTUtils.hs
@@ -146,7 +146,7 @@ sortAgreement2 = dummyEnvironment $
         (mkEquals (Var_ $ var_ "foo" "X") (Var_ $ var_ "bar" "X"))
         (Var_ $ var_ "y" "Y")
 
-varX :: (Given (SymbolOrAliasSorts Object)) => CommonStepPattern Object
+varX :: CommonStepPattern Object
 varX = mkVar $ var_ "x" "X"
 
 sortAgreementManySimplePatterns
@@ -231,21 +231,18 @@ testGetSetIdentity size = dummyEnvironment $ testGroup "getSetIdent" $ do
   pat <- generatePatterns size
   return $ testCase "" $ substitutionGetSetIdentity a b pat
 
-var :: MetaOrObject level => Text -> Variable level
+var :: Text -> Variable level
 var x =
   Variable (noLocationId x) (mkSort "S")
 
-var_ :: MetaOrObject level => Text -> Text -> Variable level
+var_ :: Text -> Text -> Variable level
 var_ x s =
   Variable (noLocationId x) (mkSort s)
 
-dummyEnvironment
-  :: forall r . MetaOrObject Object
-  => (Given (SymbolOrAliasSorts Object) => r)
-  -> r
+dummyEnvironment :: (Given (SymbolOrAliasSorts Object) => r) -> r
 dummyEnvironment = give (dummySymbolOrAliasSorts @Object)
 
-dummySymbolOrAliasSorts :: MetaOrObject level => SymbolOrAliasSorts level
+dummySymbolOrAliasSorts :: SymbolOrAliasSorts level
 dummySymbolOrAliasSorts = const ApplicationSorts
     { applicationSortsOperands = []
     , applicationSortsResult   = mkSort "S"

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -15,6 +15,7 @@ import Control.Applicative
        ( Alternative (..) )
 import Control.Comonad.Trans.Cofree
        ( CofreeF (..), CofreeT (..) )
+import Data.Functor.Classes
 import Data.Functor.Identity
        ( Identity (..) )
 import Numeric.Natural
@@ -22,7 +23,6 @@ import Numeric.Natural
 
 import           Kore.AST.Kore
 import           Kore.AST.Pure
-import qualified Kore.Domain.Builtin as Domain
 import           Kore.OnePath.Step
                  ( StrategyPattern )
 import           Kore.OnePath.Step as StrategyPattern
@@ -65,8 +65,8 @@ instance
     , Eq child
     , Eq level
     , Show child
-    , Eq (domain child)
-    , Show (domain child)
+    , Eq1 domain
+    , Show1 domain
     , EqualWithExplanation (variable level)
     , Eq (variable level)
     , Show (variable level)
@@ -199,8 +199,8 @@ instance
     , Show child
     , EqualWithExplanation (variable level)
     , Show (variable level)
-    , Show (domain child)
-    , Eq (domain child)
+    , Show1 domain
+    , Eq1 domain
     ) => EqualWithExplanation (Pattern level domain variable child)
   where
     compareWithExplanation = sumCompareWithExplanation
@@ -208,9 +208,8 @@ instance
 
 instance
     ( Show (PurePattern level domain variable annotation)
-    , Show
-        (domain (CofreeT (Pattern level domain variable) Identity annotation))
-    , Eq (domain (CofreeT (Pattern level domain variable) Identity annotation))
+    , Show1 domain
+    , Eq1 domain
     , Show (variable level)
     , Eq (variable level)
     , EqualWithExplanation (variable level)
@@ -226,9 +225,8 @@ instance
 
 instance
     ( Show (PurePattern level domain variable annotation)
-    , Show
-        (domain (CofreeT (Pattern level domain variable) Identity annotation))
-    , Eq (domain (CofreeT (Pattern level domain variable) Identity annotation))
+    , Show1 domain
+    , Eq1 domain
     , Show (variable level)
     , Eq (variable level)
     , EqualWithExplanation (variable level)
@@ -248,9 +246,8 @@ instance
 
 instance
     ( Show (KorePattern domain variable annotation)
-    , Show
-        (domain (CofreeT (UnifiedPattern domain variable) Identity annotation))
-    , Eq (domain (CofreeT (UnifiedPattern domain variable) Identity annotation))
+    , Show1 domain
+    , Eq1 domain
     , Show annotation
     , Eq annotation
     , EqualWithExplanation annotation
@@ -266,16 +263,12 @@ instance
 
 instance
     ( Show (KorePattern domain variable annotation)
-    , Show
-        (domain (CofreeT (UnifiedPattern domain variable) Identity annotation))
-    , Eq (domain (CofreeT (UnifiedPattern domain variable) Identity annotation))
-    , Show annotation
-    , Eq annotation
+    , Eq1 domain, Show1 domain
+    , Eq annotation, Show annotation
     , EqualWithExplanation annotation
     , EqualWithExplanation (variable Meta)
     , EqualWithExplanation (variable Object)
-    , OrdMetaOrObject variable
-    , ShowMetaOrObject variable
+    , OrdMetaOrObject variable, ShowMetaOrObject variable
     ) =>
     WrapperEqualWithExplanation (KorePattern domain variable annotation)
   where
@@ -478,7 +471,7 @@ instance (EqualWithExplanation child, Show child)
     printWithExplanation = show
 
 instance
-    (Eq child, Show child, Eq (domain child), Show (domain child)) =>
+    (Eq child, Show child, Eq1 domain, Show1 domain) =>
     EqualWithExplanation (DomainValue level domain child)
   where
     compareWithExplanation = rawCompareWithExplanation
@@ -1067,8 +1060,9 @@ instance
     printWithExplanation = show
 
 instance
-    ( EqualWithExplanation (PurePattern level Domain.Builtin variable ())
-    , Show level, Show (variable level)
+    ( EqualWithExplanation (variable level)
+    , Eq level, Show level
+    , Eq (variable level), Show (variable level)
     )
     => EqualWithExplanation (Predicate level variable)
   where
@@ -1178,8 +1172,8 @@ instance
     , EqualWithExplanation (variable Meta)
     , EqualWithExplanation (variable Object)
     , EqualWithExplanation child
-    , Show (domain child)
-    , Eq (domain child)
+    , Show1 domain
+    , Eq1 domain
     )
     => EqualWithExplanation (UnifiedPattern domain variable child)
   where
@@ -1192,8 +1186,8 @@ instance
     , EqualWithExplanation (variable Object)
     , EqualWithExplanation (variable Meta)
     , EqualWithExplanation child
-    , Show (domain child)
-    , Eq (domain child)
+    , Show1 domain
+    , Eq1 domain
     )
     => SumEqualWithExplanation (UnifiedPattern domain variable child)
   where

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -438,9 +438,7 @@ instance (Show child, EqualWithExplanation child)
     compareWithExplanation = structCompareWithExplanation
     printWithExplanation = show
 
-instance (EqualWithExplanation child, Eq child, Show child)
-    => EqualWithExplanation (Bottom level child)
-  where
+instance EqualWithExplanation (Bottom level child) where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 
@@ -645,19 +643,21 @@ instance
     compareWithExplanation = structCompareWithExplanation
     printWithExplanation = show
 
-instance (EqualWithExplanation child, Eq child, Show child)
+instance (Eq child, Show child)
     => EqualWithExplanation (Implies level child)
   where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
+
 instance
-    (EqualWithExplanation child, Eq child, Show child)
+    (Eq child, Show child)
     => EqualWithExplanation (In level child)
   where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
+
 instance
-    (EqualWithExplanation child, Eq child, Show child)
+    (Eq child, Show child)
     => EqualWithExplanation (Next level child)
   where
     compareWithExplanation = rawCompareWithExplanation
@@ -716,7 +716,7 @@ instance
     printWithExplanation = show
 
 instance
-    (EqualWithExplanation child, Eq child, Show child)
+    (Eq child, Show child)
     => EqualWithExplanation (Rewrites level child)
   where
     compareWithExplanation = rawCompareWithExplanation
@@ -729,10 +729,8 @@ instance EqualWithExplanation CharLiteral
   where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
-instance
-    (EqualWithExplanation child, Eq child, Show child)
-    => EqualWithExplanation (Top level child)
-  where
+
+instance EqualWithExplanation (Top level child) where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 
@@ -1061,7 +1059,7 @@ instance
 
 instance
     ( EqualWithExplanation (variable level)
-    , Eq level, Show level
+    , Eq level
     , Eq (variable level), Show (variable level)
     )
     => EqualWithExplanation (Predicate level variable)
@@ -1201,9 +1199,7 @@ instance
             (printWithExplanation p2)
 
 instance
-    ( EqualWithExplanation (a Meta)
-    , EqualWithExplanation (a Object)
-    , Show (a Meta)
+    ( Show (a Meta)
     , Show (a Object)
     , SumEqualWithExplanation (Unified a)
     )

--- a/src/main/haskell/kore/test/Test/Kore/MetaML/Lift.hs
+++ b/src/main/haskell/kore/test/Test/Kore/MetaML/Lift.hs
@@ -866,7 +866,6 @@ testLiftUnlift
     :: ( LiftableToMetaML a
        , UnliftableFromMetaML a
        , Eq a
-       , Show a
        , PrettyPrint a
        , HasCallStack
        )

--- a/src/main/haskell/kore/test/Test/Kore/OnePath/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/OnePath/Step.hs
@@ -336,8 +336,7 @@ test_onePathStrategy = give symbolOrAliasSorts
 
 
 simpleRewrite
-    :: MetaOrObject level
-    => CommonStepPattern level
+    :: CommonStepPattern level
     -> CommonStepPattern level
     -> RewriteRule level
 simpleRewrite left right =

--- a/src/main/haskell/kore/test/Test/Kore/OnePath/Verification.hs
+++ b/src/main/haskell/kore/test/Test/Kore/OnePath/Verification.hs
@@ -299,24 +299,21 @@ test_onePathVerification = give symbolOrAliasSorts
             Mock.subsorts
 
 simpleAxiom
-    :: MetaOrObject level
-    => CommonStepPattern level
+    :: CommonStepPattern level
     -> CommonStepPattern level
     -> OnePath.Axiom level
 simpleAxiom left right =
     OnePath.Axiom $ simpleRewrite left right
 
 simpleClaim
-    :: MetaOrObject level
-    => CommonStepPattern level
+    :: CommonStepPattern level
     -> CommonStepPattern level
     -> OnePath.Claim level
 simpleClaim left right =
     OnePath.Claim $ simpleRewrite left right
 
 simpleRewrite
-    :: MetaOrObject level
-    => CommonStepPattern level
+    :: CommonStepPattern level
     -> CommonStepPattern level
     -> RewriteRule level
 simpleRewrite left right =

--- a/src/main/haskell/kore/test/Test/Kore/Predicate/Predicate.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Predicate/Predicate.hs
@@ -362,9 +362,8 @@ test_predicate = give mockSymbolOrAliasSorts
 
 makePredicateYieldsWrapPredicate
     ::  ( Given (SymbolOrAliasSorts level)
-        , Eq level
-        , Show level
-        , MetaOrObject level)
+        , MetaOrObject level
+        )
     => String -> CommonStepPattern level -> IO ()
 makePredicateYieldsWrapPredicate msg p =
     assertEqual msg

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -433,8 +433,7 @@ evaluate metadataTools functionIdToEvaluator patt =
     substitutionSimplifier =
         PredicateSubstitution.create metadataTools patternSimplifier
     patternSimplifier
-        ::  ( MetaOrObject level
-            , SortedVariable variable
+        ::  ( SortedVariable variable
             , Ord (variable level)
             , Show (variable level)
             , Ord (variable Meta)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
@@ -9,7 +9,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Control.DeepSeq
-       ( NFData, deepseq )
+       ( deepseq )
 import Control.Exception
        ( ErrorCall (..), catch )
 import Control.Monad.Except
@@ -763,9 +763,7 @@ mockMetaMetadataTools =
 
 match
     :: forall level .
-        ( MetaOrObject level
-        , NFData (CommonPredicateSubstitution level)
-        )
+        MetaOrObject level
     => MetadataTools level StepperAttributes
     -> CommonStepPattern level
     -> CommonStepPattern level

--- a/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -22,8 +22,6 @@ module Test.Kore.Step.MockSymbols where
 -}
 
 import qualified Data.Map.Strict as Map
-import           Data.Reflection
-                 ( Given )
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 
@@ -40,7 +38,7 @@ import           Kore.Attribute.Hook
                  ( Hook (..) )
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.MetadataTools
-                 ( HeadType, SymbolOrAliasSorts )
+                 ( HeadType )
 import qualified Kore.IndexedModule.MetadataTools as HeadType
                  ( HeadType (..) )
 import           Kore.Step.Pattern
@@ -448,302 +446,248 @@ z = Variable (testId "z") testSort
 m :: Variable Object
 m = Variable (testId "m") mapSort
 
-a   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+a   :: StepPattern Object variable
 a = mkApp aSymbol []
 
-aConcrete :: Given (SymbolOrAliasSorts Object) => ConcreteStepPattern Object
+aConcrete :: ConcreteStepPattern Object
 aConcrete = let Just r = asConcretePurePattern a in r
 
 aSort0
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 aSort0 = mkApp aSort0Symbol []
 
 aSort1
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 aSort1 = mkApp aSort1Symbol []
 
 aSubsort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 aSubsort = mkApp aSubsortSymbol []
 
 aSubSubsort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 aSubSubsort = mkApp aSubSubsortSymbol []
 
 aOtherSort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 aOtherSort = mkApp aOtherSortSymbol []
 
-b   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+b   :: StepPattern Object variable
 b = mkApp bSymbol []
 
-bConcrete :: Given (SymbolOrAliasSorts Object) => ConcreteStepPattern Object
+bConcrete :: ConcreteStepPattern Object
 bConcrete = let Just r = asConcretePurePattern b in r
 
 bSort0
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 bSort0 = mkApp bSort0Symbol []
 
-c   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+c   :: StepPattern Object variable
 c = mkApp cSymbol []
 
-d   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+d   :: StepPattern Object variable
 d = mkApp dSymbol []
 
-e   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+e   :: StepPattern Object variable
 e = mkApp eSymbol []
 
-f   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable -> StepPattern Object variable
+f   :: StepPattern Object variable -> StepPattern Object variable
 f arg = mkApp fSymbol [arg]
 
-g   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable -> StepPattern Object variable
+g   :: StepPattern Object variable -> StepPattern Object variable
 g arg = mkApp gSymbol [arg]
 
-h   :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable -> StepPattern Object variable
+h   :: StepPattern Object variable -> StepPattern Object variable
 h arg = mkApp hSymbol [arg]
 
-cf  :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+cf  :: StepPattern Object variable
 cf = mkApp cfSymbol []
 
 cfSort0
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 cfSort0 = mkApp cfSort0Symbol []
 
 cfSort1
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 cfSort1 = mkApp cfSort1Symbol []
 
-cg  :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+cg  :: StepPattern Object variable
 cg = mkApp cgSymbol []
 
 cgSort0
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 cgSort0 = mkApp cgSort0Symbol []
 
-ch  :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+ch  :: StepPattern Object variable
 ch = mkApp chSymbol []
 
 plain00
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 plain00 = mkApp plain00Symbol []
 
 plain00Sort0
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 plain00Sort0 = mkApp plain00Sort0Symbol []
 
 plain00Subsort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 plain00Subsort = mkApp plain00SubsortSymbol []
 
 plain00SubSubsort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 plain00SubSubsort = mkApp plain00SubSubsortSymbol []
 
 plain10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable -> StepPattern Object variable
+    :: StepPattern Object variable -> StepPattern Object variable
 plain10 arg = mkApp plain10Symbol [arg]
 
 plain11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable -> StepPattern Object variable
+    :: StepPattern Object variable -> StepPattern Object variable
 plain11 arg = mkApp plain11Symbol [arg]
 
 plain20
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 plain20 arg1 arg2 = mkApp plain20Symbol [arg1, arg2]
 
 constr10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 constr10 arg = mkApp constr10Symbol [arg]
 
 constr11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 constr11 arg = mkApp constr11Symbol [arg]
 
 constr20
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 constr20 arg1 arg2 = mkApp constr20Symbol [arg1, arg2]
 
 function20MapTest
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 function20MapTest arg1 arg2 = mkApp function20MapTestSymbol [arg1, arg2]
 
 functional00
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 functional00 = mkApp functional00Symbol []
 
 functional01
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 functional01 = mkApp functional01Symbol []
 
 functional10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 functional10 arg = mkApp functional10Symbol [arg]
 
 functional11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 functional11 arg = mkApp functional11Symbol [arg]
 
 functional20
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 functional20 arg1 arg2 = mkApp functional20Symbol [arg1, arg2]
 
 functional00SubSubSort
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
 functional00SubSubSort = mkApp functional00SubSubSortSymbol []
 
 functionalConstr10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 functionalConstr10 arg = mkApp functionalConstr10Symbol [arg]
 
 functionalConstr11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 functionalConstr11 arg = mkApp functionalConstr11Symbol [arg]
 
 functionalConstr20
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 functionalConstr20 arg1 arg2 = mkApp functionalConstr20Symbol [arg1, arg2]
 
 functionalTopConstr20
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 functionalTopConstr20 arg1 arg2 = mkApp functionalTopConstr20Symbol [arg1, arg2]
 
 functionalTopConstr21
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 functionalTopConstr21 arg1 arg2 = mkApp functionalTopConstr21Symbol [arg1, arg2]
 
 injective10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 injective10 arg = mkApp injective10Symbol [arg]
 
 injective11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 injective11 arg = mkApp injective11Symbol [arg]
 
 sortInjection10
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjection10 arg = mkApp sortInjection10Symbol [arg]
 
 sortInjection11
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjection11 arg = mkApp sortInjection11Symbol [arg]
 
 sortInjection0ToTop
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjection0ToTop arg = mkApp sortInjection0ToTopSymbol [arg]
 
 sortInjectionSubToTop
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjectionSubToTop arg = mkApp sortInjectionSubToTopSymbol [arg]
 
 sortInjectionSubSubToTop
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjectionSubSubToTop arg = mkApp sortInjectionSubSubToTopSymbol [arg]
 
 sortInjectionSubSubToSub
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjectionSubSubToSub arg = mkApp sortInjectionSubSubToSubSymbol [arg]
 
 sortInjectionOtherToTop
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
 sortInjectionOtherToTop arg = mkApp sortInjectionOtherToTopSymbol [arg]
 
 concatMap
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 concatMap m1 m2 = mkApp concatMapSymbol [m1, m2]
 
 elementMap
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 elementMap m1 m2 = mkApp elementMapSymbol [m1, m2]
 
 concatList
-    :: Given (SymbolOrAliasSorts Object)
-    => StepPattern Object variable
+    :: StepPattern Object variable
     -> StepPattern Object variable
     -> StepPattern Object variable
 concatList l1 l2 = mkApp concatListSymbol [l1, l2]

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -468,7 +468,7 @@ mockMetadataTools =
         Mock.headTypeMapping
         Mock.subsorts
 
-testSort :: forall level. MetaOrObject level => Sort level
+testSort :: Sort level
 testSort =
     case mkBottom :: CommonStepPattern level of
         Bottom_ sort -> sort

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
@@ -45,8 +45,7 @@ test_charLiteralSimplification =
     ]
 
 evaluate
-    ::  ( MetaOrObject Meta)
-    => CharLiteral
+    :: CharLiteral
     -> CommonOrOfExpandedPattern Meta
 evaluate charLiteral =
     case simplify charLiteral of

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
@@ -110,8 +110,7 @@ mockMetadataTools =
     Mock.makeMetadataTools mockSymbolOrAliasSorts [] [] []
 
 evaluate
-    :: (MetaOrObject Object)
-    => MetadataTools Object attrs
+    :: MetadataTools Object attrs
     -> DomainValue Object Domain.Builtin (CommonOrOfExpandedPattern Object)
     -> CommonOrOfExpandedPattern Object
 evaluate tools domainValue =

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -706,8 +706,7 @@ assertTermEqualsGeneric tools expectPure first second =
             actualPure
   where
     termToExpandedPattern
-        :: MetaOrObject level
-        => CommonStepPattern level
+        :: CommonStepPattern level
         -> CommonExpandedPattern level
     termToExpandedPattern (Bottom_ _) =
         Predicated.bottom
@@ -718,8 +717,7 @@ assertTermEqualsGeneric tools expectPure first second =
             , substitution = mempty
             }
     predSubstToExpandedPattern
-        :: MetaOrObject level
-        => CommonPredicateSubstitution level
+        :: CommonPredicateSubstitution level
         -> CommonExpandedPattern level
     predSubstToExpandedPattern
         Predicated {predicate = PredicateFalse}

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
@@ -44,10 +44,7 @@ test_stringLiteralSimplification =
         )
     ]
 
-evaluate
-    ::  ( MetaOrObject Meta)
-    => StringLiteral
-    -> CommonOrOfExpandedPattern Meta
+evaluate :: StringLiteral -> CommonOrOfExpandedPattern Meta
 evaluate stringLiteral =
     case simplify stringLiteral of
         (result, _proof) -> result

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplifier.hs
@@ -20,7 +20,7 @@ import           Kore.Step.Simplification.Data
                  Simplifier, StepPatternSimplifier (..) )
 
 mockSimplifier
-    :: (MetaOrObject level, Eq level, Ord (variable level))
+    :: (MetaOrObject level, Ord (variable level))
     =>  [   ( StepPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)
             )
@@ -39,7 +39,7 @@ mockSimplifier values =
         )
 
 mockPredicateSimplifier
-    :: (MetaOrObject level, Eq level, Ord (variable level))
+    :: (MetaOrObject level, Ord (variable level))
     =>  [   ( StepPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)
             )
@@ -58,7 +58,7 @@ mockPredicateSimplifier values =
         )
 
 mockSimplifierHelper
-    ::  (MetaOrObject level, Eq level, Ord (variable level))
+    ::  (MetaOrObject level, Ord (variable level))
     =>  (StepPattern level variable -> ExpandedPattern level variable)
     ->  [   ( StepPattern level variable
             , ([ExpandedPattern level variable], SimplificationProof level)

--- a/src/main/haskell/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
@@ -176,7 +176,7 @@ runNormalizeSubstitution substitution =
     . runExceptT
     $ normalizeSubstitution mockMetadataTools (Substitution.wrap substitution)
 
-mockSymbolOrAliasSorts :: MetaOrObject level => SymbolOrAliasSorts level
+mockSymbolOrAliasSorts :: SymbolOrAliasSorts level
 mockSymbolOrAliasSorts = const ApplicationSorts
     { applicationSortsOperands = []
     , applicationSortsResult   =
@@ -184,7 +184,7 @@ mockSymbolOrAliasSorts = const ApplicationSorts
             { getSortVariable = noLocationId "S" }
     }
 
-mockMetadataTools :: MetaOrObject level => MetadataTools level StepperAttributes
+mockMetadataTools :: MetadataTools level StepperAttributes
 mockMetadataTools = MetadataTools
     { symAttributes = const Mock.functionalAttributes
     , symbolOrAliasType = const HeadType.Symbol

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/Kore/ProofAssistant.hs
@@ -1,5 +1,5 @@
  -- to avoid warnings that constraints (AsAst CommonKorePattern p) can be simplified
-{-# OPTIONS_GHC -fno-warn-simplifiable-class-constraints #-}
+{-# OPTIONS_GHC -fno-warn-simplifiable-class-constraints -Wno-redundant-constraints #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 

--- a/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne/Pattern.hs
+++ b/src/main/haskell/kore/test/Test/Logic/Matching/Rules/OnePlusOne/Pattern.hs
@@ -117,9 +117,10 @@ wfPatSort (WFPattern (Fix p)) = patternSort p
 
 -- | Check the sorts of one layer of a pattern,
 -- requiring that the subterms are already known to be well-formed
-checkSorts1 :: (IsSignature sig, Eq (Sort sig))
-            => SigPatternF sig var (WFPattern sig var)
-            -> Maybe (WFPattern sig var)
+checkSorts1
+    :: IsSignature sig
+    => SigPatternF sig var (WFPattern sig var)
+    -> Maybe (WFPattern sig var)
 checkSorts1 pat = if patOk then Just (WFPattern (Fix (coerce pat))) else Nothing
   where
     patOk = case pat of
@@ -132,9 +133,7 @@ checkSorts1 pat = if patOk then Just (WFPattern (Fix (coerce pat))) else Nothing
     childrenSame = all (==patternSort pat) (fmap wfPatSort pat)
 
 -- | Check if a pattern is well-sorted
-checkSorts :: (IsSignature sig, Eq (Sort sig))
-           => SigPattern sig var
-           -> Maybe (WFPattern sig var)
+checkSorts :: IsSignature sig => SigPattern sig var -> Maybe (WFPattern sig var)
 checkSorts pat = cata (sequenceA >=> checkSorts1) pat
 
 {- | Check if all the raw sorts and labels in a pattern are
@@ -166,10 +165,12 @@ instance FromPattern (Pattern sort label var) sort label var where
 
 instance ToPattern (WFPattern sig var) (Sort sig) (Label sig) var where
     toPattern (WFPattern p) = coerce p
-instance (IsSignature sig, Eq (Sort sig)) =>
+
+instance IsSignature sig =>
     FromPattern (Maybe (WFPattern sig var)) (Sort sig) (Label sig) var
   where
     fromPattern = sequenceA >=> checkSorts1
+
 instance (Applicative f) => FromPattern (f (Pattern sort label var)) sort label var where
     fromPattern p = Fix <$> sequenceA p
 

--- a/src/main/haskell/kore/test/Test/SMT.hs
+++ b/src/main/haskell/kore/test/Test/SMT.hs
@@ -42,8 +42,7 @@ testPropertyWithSolver name propt =
     withSolver (testProperty name . propertyWithSolver propt)
 
 testCaseWithSolver
-    :: HasCallStack
-    => TestName
+    :: TestName
     -> (MVar Solver -> Assertion)
     -> TestTree
 testCaseWithSolver name within =

--- a/src/main/haskell/kore/test/Test/Tasty/HUnit/Extensions.hs
+++ b/src/main/haskell/kore/test/Test/Tasty/HUnit/Extensions.hs
@@ -236,8 +236,7 @@ instance EqualWithExplanation a => EqualWithExplanation [a]
             Left _     -> Nothing
             Right errs -> Just ("[" ++ intercalate ", " errs ++ "]")
       where
-        compareUnequalListWithExplanation
-            :: EqualWithExplanation a => [a] -> [a] -> Either () [String]
+        compareUnequalListWithExplanation :: [a] -> [a] -> Either () [String]
         compareUnequalListWithExplanation [] []                = Left ()
         compareUnequalListWithExplanation (expect : es) [] =
             Right

--- a/stack.yaml
+++ b/stack.yaml
@@ -70,3 +70,10 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+ghc-options:
+  "$locals": >
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wredundant-constraints


### PR DESCRIPTION
Turn on more warnings:

- `-Wcompat`, forward-compatibility warnings
- `-Wincomplete-record-updates`, warnings for record updates that may be partial
- `-Wredundant-constraints`, warnings for redundant type class constraints

To enable `-Wredundant-constraints`, I had to remove many redundant constraints. I disabled the warning for a few little-used modules that had a tangled web of redundant constraints.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

