### PR TITLE
Kore.Builtin.Error: Move notImplementedInternal here

### DIFF
--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -20,7 +20,7 @@ import qualified Kore.Annotation.Null as Annotation
 import           Kore.AST.Kore
 import           Kore.AST.Pure
 import           Kore.AST.Sentence
-import qualified Kore.Builtin as Builtin
+import qualified Kore.Builtin.Error as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.Parser.CString
                  ( escapeCString )

--- a/src/main/haskell/kore/src/Kore/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin.hs
@@ -26,8 +26,6 @@ module Kore.Builtin
     , asPattern
     , externalizePattern
     , asMetaPattern
-    -- * Errors
-    , notImplementedInternal
     ) where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
@@ -39,8 +37,6 @@ import           Data.Semigroup
                  ( (<>) )
 import           Data.Text
                  ( Text )
-import           GHC.Stack
-                 ( HasCallStack )
 
 import           Kore.AST.Pure
 import           Kore.ASTUtils.SmartPatterns
@@ -48,6 +44,8 @@ import           Kore.Attribute.Hook
                  ( Hook (..) )
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Builtin as Builtin
+import           Kore.Builtin.Error
+                 ( notImplementedInternal )
 import qualified Kore.Builtin.Int as Int
 import qualified Kore.Builtin.KEqual as KEqual
 import qualified Kore.Builtin.List as List
@@ -226,8 +224,3 @@ asMetaPattern =
         Domain.BuiltinMap _ -> notImplementedInternal
         Domain.BuiltinList _ -> notImplementedInternal
         Domain.BuiltinSet _ -> notImplementedInternal
-
-{- | Throw an error for operations not implemented for internal domain values.
- -}
-notImplementedInternal :: HasCallStack => a
-notImplementedInternal = error "Not implemented for internal domain values"

--- a/src/main/haskell/kore/src/Kore/Builtin/Error.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Error.hs
@@ -12,6 +12,7 @@ pattern verifier has admitted an invalid builtin domain expression.
 module Kore.Builtin.Error
     ( verifierBug
     , wrongArity
+    , notImplementedInternal
     ) where
 
 import GHC.Stack
@@ -35,3 +36,8 @@ verifierBug msg =
  -}
 wrongArity :: HasCallStack => String -> a
 wrongArity ctx = verifierBug (ctx ++ ": Wrong number of arguments")
+
+{- | Throw an error for operations not implemented for internal domain values.
+ -}
+notImplementedInternal :: HasCallStack => a
+notImplementedInternal = error "Not implemented for internal domain values"

--- a/src/main/haskell/kore/src/Kore/Unparser.hs
+++ b/src/main/haskell/kore/src/Kore/Unparser.hs
@@ -28,7 +28,7 @@ import           Data.Void
 import           Kore.AST.Kore
 import           Kore.AST.Pure
 import           Kore.AST.Sentence
-import qualified Kore.Builtin as Builtin
+import qualified Kore.Builtin.Error as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Domain.External as Domain
 import           Kore.Parser.CString


### PR DESCRIPTION
Move `notImplementedInternal` from `Kore.Builtin` to `Kore.Builtin.Error` to
break cycles involving `Kore.Unparser`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

