### PR TITLE
implement STRING.chr builtin

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Bool.hs
@@ -146,8 +146,8 @@ builtinFunctions =
     , ("BOOL.eq", binaryOperator "BOOL.eq" (==))
     , ("BOOL.not", unaryOperator "BOOL.not" not)
     , ("BOOL.implies", binaryOperator "BOOL.implies" implies)
-    , ("BOOL.andThen", Builtin.notImplemented)
-    , ("BOOL.orElse", Builtin.notImplemented)
+--    , ("BOOL.andThen", Builtin.notImplemented)
+--    , ("BOOL.orElse", Builtin.notImplemented)
     ]
   where
     unaryOperator = Builtin.unaryOperator parse asExpandedPattern

--- a/src/main/haskell/kore/src/Kore/Builtin/Int.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Int.hs
@@ -240,15 +240,15 @@ builtinFunctions =
     Map.fromList
     [
       -- TODO (thomas.tuegel): Implement bit ranges.
-      ("INT.bitRange", Builtin.notImplemented)
-    , ("INT.signExtendBitRange", Builtin.notImplemented)
+--      ("INT.bitRange", Builtin.notImplemented)
+--    , ("INT.signExtendBitRange", Builtin.notImplemented)
 
       -- TODO (thomas.tuegel): Add MonadRandom to evaluation context to
       -- implement rand and srand.
-    , ("INT.rand", Builtin.notImplemented)
-    , ("INT.srand", Builtin.notImplemented)
+--    , ("INT.rand", Builtin.notImplemented)
+--    , ("INT.srand", Builtin.notImplemented)
 
-    , comparator "INT.gt" (>)
+      comparator "INT.gt" (>)
     , comparator "INT.ge" (>=)
     , comparator "INT.eq" (==)
     , comparator "INT.le" (<=)
@@ -266,7 +266,7 @@ builtinFunctions =
     , unaryOperator "INT.abs" abs
 
       -- TODO (thomas.tuegel): Implement division.
-    , ("INT.ediv", Builtin.notImplemented)
+--    , ("INT.ediv", Builtin.notImplemented)
     , partialBinaryOperator "INT.emod" emod
     , partialBinaryOperator "INT.tdiv" tdiv
     , partialBinaryOperator "INT.tmod" tmod

--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -37,6 +37,8 @@ import           Control.Error
                  ( MaybeT )
 import           Control.Monad
                  ( void )
+import           Data.Char
+                 ( chr )
 import qualified Data.HashMap.Strict as HashMap
 import           Data.List
                  ( findIndex, isPrefixOf, tails )
@@ -404,7 +406,7 @@ evalChr = Builtin.functionEvaluator evalChr0
             _n <- Int.expectBuiltinInt chrKey _n
             Builtin.appliedFunction
                 . asExpandedPattern resultSort
-                $ [ toEnum (fromIntegral _n) ] 
+                $ [ chr (fromIntegral _n) ]
 
 {- | Implement builtin function evaluation.
  -}

--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -250,6 +250,11 @@ string2BaseKey = "STRING.string2base"
 string2BaseKeyT :: Text
 string2BaseKeyT = "STRING.string2base"
 
+chrKey :: String
+chrKey = "STRING.chr"
+chrKeyT :: Text
+chrKeyT = "STRING.chr"
+
 evalSubstr :: Builtin.Function
 evalSubstr = Builtin.functionEvaluator evalSubstr0
   where
@@ -380,6 +385,27 @@ evalString2Int = Builtin.functionEvaluator evalString2Int0
                 . fmap fst . listToMaybe . readSigned readDec
                 $ _str
 
+evalChr :: Builtin.Function
+evalChr = Builtin.functionEvaluator evalChr0
+    where
+    evalChr0
+        :: Ord (variable Object)
+        => MetadataTools Object StepperAttributes
+        -> StepPatternSimplifier Object variable
+        -> Sort Object
+        -> [StepPattern Object variable]
+        -> Simplifier (AttemptedFunction Object variable)
+    evalChr0 _ _ resultSort arguments =
+        Builtin.getAttemptedFunction $ do
+            let _n =
+                    case arguments of
+                        [_n] -> _n
+                        _    -> Builtin.wrongArity lengthKey
+            _n <- Int.expectBuiltinInt chrKey _n
+            Builtin.appliedFunction
+                . asExpandedPattern resultSort
+                $ [ toEnum (fromIntegral _n) ] 
+
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
@@ -392,6 +418,7 @@ builtinFunctions =
     , (findKeyT, evalFind)
     , (string2BaseKeyT, evalString2Base)
     , (string2IntKeyT, evalString2Int)
+    , (chrKeyT, evalChr)
     ]
   where
     comparator name op =

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -46,7 +46,7 @@ import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier, SimplificationProof (..),
                  Simplifier, StepPatternSimplifier (..) )
 import           Kore.Step.StepperAttributes
-                 ( StepperAttributes, isSortInjection_ )
+                 ( StepperAttributes (..), isSortInjection_, isHooked_ )
 import           Kore.Variables.Fresh
 
 {-| 'evaluateApplication' - evaluates functions on an application pattern.
@@ -90,6 +90,13 @@ evaluateApplication
         Nothing
           | give tools isSortInjection_ appHead ->
             evaluateSortInjection tools unchangedOr app
+          | give tools isHooked_ appHead && not(null symbolIdToEvaluator) ->
+            error
+                (   "Attempting to evaluate unimplemented hooked operation"
+                ++ (show $ hook (symAttributes tools appHead))
+                ++ "\nSymbol: "
+                ++  show appHead
+                )
           | otherwise ->
             return unchanged
         Just builtinOrAxiomEvaluators ->

--- a/src/main/haskell/kore/src/Kore/Step/StepperAttributes.hs
+++ b/src/main/haskell/kore/src/Kore/Step/StepperAttributes.hs
@@ -37,6 +37,7 @@ module Kore.Step.StepperAttributes
     -- * Hooked symbols
     , lensHook, Hook (..)
     , hookAttribute
+    , isHooked_, isHooked
     -- * SMT symbols
     , smtlib, Smtlib (..)
     , smtlibAttribute
@@ -52,6 +53,8 @@ import qualified Control.Lens.TH.Rules as Lens
 import           Control.Monad
                  ( (>=>) )
 import           Data.Default
+import           Data.Maybe
+                 ( isJust )
 import           Data.Reflection
                  ( Given, given )
 import           GHC.Generics
@@ -275,3 +278,30 @@ isNonSimplifiable = do
     Constructor isConstructor' <- constructor
     SortInjection isSortInjection' <- sortInjection
     return (isSortInjection' || isConstructor')
+
+{- | Is the symbol hooked?
+
+A symbol is hooked if it is given the @hook@ attribute.
+
+See also: 'isHooked', 'hookAttribute'
+
+ -}
+isHooked_
+    :: Given (MetadataTools level StepperAttributes)
+    => SymbolOrAlias level
+    -> Bool
+isHooked_ = isHooked . symAttributes given
+
+{- | Is the symbol injective?
+
+A symbol is injective if it is given the @injective@ attribute, the
+@constructor@ attribute, or the @sortInjection@ attribute.
+
+See also: 'injectiveAttribute', 'constructorAttribute', 'sortInjectionAttribute'
+
+ -}
+isHooked :: StepperAttributes -> Bool
+isHooked = do
+    Hook hook' <- hook
+    return (isJust hook')
+


### PR DESCRIPTION
Implements the `STRING.chr` builtin. 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

