### PR TITLE
Select GHC options for RTS performance

### DIFF
--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -102,22 +102,16 @@ executables:
     source-dirs:
       - app/parser
       - app/share
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
-    - kore
+      - kore
 
   kore-exec:
     main: Main.hs
     source-dirs:
       - app/exec
       - app/share
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
 
@@ -126,10 +120,7 @@ executables:
     source-dirs:
       - app/format
       - app/share
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
 
@@ -138,6 +129,7 @@ executables:
     source-dirs:
       - app/prover
       - app/share
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
 
@@ -146,10 +138,7 @@ tests:
     main: Driver.hs
     source-dirs:
       - test
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
       - call-stack
@@ -174,10 +163,7 @@ benchmarks:
     source-dirs:
       - bench/parser
       - test
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
       - criterion
@@ -192,10 +178,7 @@ benchmarks:
     source-dirs:
       - bench/exec
       - test
-    ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
       - criterion


### PR DESCRIPTION
By default, we have been setting `+RTS -N -RTS`, which causes the GHC runtime
system (RTS) to spawn one thread per logical processor for the parallel garbage
collector. Having a large number of GC threads contending for memory bandwidth
is not efficient because the default allocation size is small (1 megabyte). The
default allocation size is increased to 32 megabytes (`-A32M`) to make better
use of the parallel garbage collector. An upper bound is placed so that there
will be no more than 8 GC threads (`-qn8`) to ensure that the number of threads
is appropriate to the new default allocation size.

This improves performance relative to the number of processors. On my laptop (4 cores) the improvement is a modest 15%, but performance improves on my desktop (16 cores) by 30%.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

