### PR TITLE
Unification returns an 'Or'

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -264,7 +264,7 @@ notImplemented :: Function
 notImplemented =
     ApplicationFunctionEvaluator notImplemented0
   where
-    notImplemented0 _ _ _ _ = pure (NotApplicable, SimplificationProof)
+    notImplemented0 _ _ _ _ = pure [(NotApplicable, SimplificationProof)]
 
 {- | Verify a builtin sort declaration.
 
@@ -630,9 +630,10 @@ functionEvaluator impl =
         -> StepPatternSimplifier Object variable
         -> Application Object (StepPattern Object variable)
         -> Simplifier
-            ( AttemptedFunction Object variable
-            , SimplificationProof Object
-            )
+            [   ( AttemptedFunction Object variable
+                , SimplificationProof Object
+                )
+            ]
     evaluator
         tools
         _
@@ -642,10 +643,9 @@ functionEvaluator impl =
                 (MetadataTools.getResultSort tools -> resultSort)
             , applicationChildren
             }
-      =
-        do
-            attempt <- impl tools simplifier resultSort applicationChildren
-            return (attempt, SimplificationProof)
+      = do
+        attempt <- impl tools simplifier resultSort applicationChildren
+        return [(attempt, SimplificationProof)]
 
 {- | Run a parser on a verified domain value.
 

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -127,9 +127,10 @@ evalKEq
     -> StepPatternSimplifier Object variable
     -> Application Object (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
-        , SimplificationProof Object
-        )
+        [   ( AttemptedFunction Object variable
+            , SimplificationProof Object
+            )
+        ]
 evalKEq true false tools substitutionSimplifier _ pat =
     case pat of
         Application
@@ -162,9 +163,10 @@ evalKIte
     -> StepPatternSimplifier Object variable
     -> Application Object (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
-        , SimplificationProof Object
-        )
+        [   ( AttemptedFunction Object variable
+            , SimplificationProof Object
+            )
+        ]
 evalKIte _ _ _ =
     \case
         Application { applicationChildren = [expr, t1, t2] } ->

--- a/src/main/haskell/kore/src/Kore/Exec.hs
+++ b/src/main/haskell/kore/src/Kore/Exec.hs
@@ -142,8 +142,11 @@ search
                     simplifier
                     target
                     config
-        solutions <- searchGraph searchConfig (match searchPattern) executionGraph
+        solutionsLists <-
+            searchGraph searchConfig (match searchPattern) executionGraph
         let
+            solutions =
+                concatMap OrOfExpandedPattern.extractPatterns solutionsLists
             orPredicate =
                 give (symbolOrAliasSorts metadataTools)
                 $ makeMultipleOrPredicate

--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -21,6 +21,7 @@ module Kore.Step.ExpandedPattern
     , isBottom
     , isTop
     , mapVariables
+    , predicateSubstitutionToExpandedPattern
     , substitutionToPredicate
     , toMLPattern
     , top
@@ -327,3 +328,9 @@ freeVariables
     => PredicateSubstitution level variable
     -> Set.Set (variable level)
 freeVariables = Predicate.freeVariables . toPredicate
+
+predicateSubstitutionToExpandedPattern
+    :: MetaOrObject level
+    => PredicateSubstitution level variable
+    -> ExpandedPattern level variable
+predicateSubstitutionToExpandedPattern = fmap (const mkTop)

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -73,9 +73,10 @@ newtype ApplicationFunctionEvaluator level =
         -> StepPatternSimplifier level variable
         -> Application level (StepPattern level variable)
         -> Simplifier
-            ( AttemptedFunction level variable
-            , SimplificationProof level
-            )
+            [   ( AttemptedFunction level variable
+                , SimplificationProof level
+                )
+            ]
         )
 
 {-|Datastructure to combine both a builtin evaluator and axiom-based
@@ -114,16 +115,18 @@ type CommonAttemptedFunction level = AttemptedFunction level Variable
 -- |Yields a pure 'Simplifier' which always returns 'NotApplicable'
 notApplicableFunctionEvaluator
     :: Simplifier
-         (AttemptedFunction level1 variable, SimplificationProof level2)
-notApplicableFunctionEvaluator = pure (NotApplicable, SimplificationProof)
+        [(AttemptedFunction level1 variable, SimplificationProof level2)]
+notApplicableFunctionEvaluator = pure [(NotApplicable, SimplificationProof)]
 
 -- |Yields a pure 'Simplifier' which produces a given 'StepPattern'
 purePatternFunctionEvaluator
     :: (MetaOrObject level, Ord (variable level))
     => StepPattern level variable
-    -> Simplifier (AttemptedFunction level variable, SimplificationProof level')
+    -> Simplifier
+        [(AttemptedFunction level variable, SimplificationProof level)]
 purePatternFunctionEvaluator p =
     pure
-        (Applied (makeFromSinglePurePattern p)
-        , SimplificationProof
-        )
+        [   ( Applied (makeFromSinglePurePattern p)
+            , SimplificationProof
+            )
+        ]

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -11,6 +11,7 @@ Portability : portable
 -}
 module Kore.Step.OrOfExpandedPattern
     ( CommonOrOfExpandedPattern
+    , CommonOrOfPredicateSubstitution
     , MultiOr (..)
     , OrOfExpandedPattern
     , OrOfPredicateSubstitution
@@ -33,11 +34,15 @@ module Kore.Step.OrOfExpandedPattern
     , traverseFlattenWithPairsGeneric
     ) where
 
+import           Control.DeepSeq
+                 ( NFData )
 import           Data.List
                  ( foldl' )
 import           Data.Reflection
                  ( Given )
 import qualified Data.Set as Set
+import           GHC.Generics
+                 ( Generic )
 
 import           Kore.AST.Common
                  ( SortedVariable, Variable )
@@ -60,7 +65,10 @@ import           Kore.TopBottom
 TODO(virgil): Make this a list-like monad, many things would be nicer.
 -}
 newtype MultiOr child = MultiOr [child]
-    deriving (Applicative, Eq, Foldable, Functor, Monad, Show, Traversable)
+  deriving
+    (Applicative, Eq, Foldable, Functor, Generic, Monad, Show, Traversable)
+
+instance NFData child => NFData (MultiOr child)
 
 instance TopBottom child => TopBottom (MultiOr child)
   where
@@ -87,6 +95,13 @@ type OrOfPredicateSubstitution level variable
 'Variable', following the same convention as the other Common* types.
 -}
 type CommonOrOfExpandedPattern level = OrOfExpandedPattern level Variable
+
+{-| 'CommonOrOfOrOfPredicateSubstitution' particularizes
+'OrOfPredicateSubstitution' to 'Variable', following the same convention
+as the other Common* types.
+-}
+type CommonOrOfPredicateSubstitution level =
+    OrOfPredicateSubstitution level Variable
 
 {-| 'OrBool' is an some sort of Bool data type used when evaluating things
 inside an 'MultiOr'.

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -25,7 +25,6 @@ import           Control.Exception
                  ( assert )
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans as Monad.Trans
-import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Functor.Foldable as Recursive
 import           Data.Reflection
                  ( give )
@@ -48,10 +47,13 @@ import           Kore.Predicate.Predicate
                  ( pattern PredicateTrue, makeEqualsPredicate,
                  makeNotPredicate, makeTruePredicate )
 import           Kore.Step.ExpandedPattern
-                 ( ExpandedPattern, PredicateSubstitution, Predicated (..),
-                 erasePredicatedTerm )
+                 ( ExpandedPattern, Predicated (..), erasePredicatedTerm )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( Predicated (..), bottom, fromPurePattern, isBottom )
+import           Kore.Step.OrOfExpandedPattern
+                 ( OrOfPredicateSubstitution )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+                 ( make )
 import           Kore.Step.Pattern
 import           Kore.Step.PatternAttributes
                  ( isConstructorLikeTop )
@@ -108,10 +110,10 @@ termEquals
     -> StepPattern level variable
     -> StepPattern level variable
     -> MaybeT m
-        (PredicateSubstitution level variable, SimplificationProof level)
+        (OrOfPredicateSubstitution level variable, SimplificationProof level)
 termEquals tools substitutionSimplifier first second = do
-    result <- termEqualsAnd tools substitutionSimplifier first second
-    return (Bifunctor.first erasePredicatedTerm result)
+    (result, proof) <- termEqualsAnd tools substitutionSimplifier first second
+    return (OrOfExpandedPattern.make [erasePredicatedTerm result], proof)
 
 termEqualsAnd
     ::  ( MetaOrObject level

--- a/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Procedure.hs
@@ -32,8 +32,12 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate )
 import           Kore.Step.ExpandedPattern
-                 ( PredicateSubstitution, Predicated (..) )
+                 ( Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as Predicated
+import           Kore.Step.OrOfExpandedPattern
+                 ( OrOfPredicateSubstitution )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+                 ( make )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.AndTerms
                  ( termUnification )
@@ -76,12 +80,12 @@ unificationProcedure
         -- TODO: Consider using a false predicate instead of a Left error
         (UnificationOrSubstitutionError level variable)
         m
-        ( PredicateSubstitution level variable
+        ( OrOfPredicateSubstitution level variable
         , UnificationProof level variable
         )
 unificationProcedure tools substitutionSimplifier p1 p2
   | p1Sort /= p2Sort =
-    return (Predicated.bottomPredicate, EmptyUnificationProof)
+    return (OrOfExpandedPattern.make [], EmptyUnificationProof)
   | otherwise = do
     let
         getUnifiedTerm =
@@ -95,17 +99,17 @@ unificationProcedure tools substitutionSimplifier p1 p2
         (pred', _) = Ceil.makeEvaluateTerm tools term
     if Predicated.isBottom pat
         then return
-            ( Predicated.bottomPredicate
-            , EmptyUnificationProof
-            )
+            (OrOfExpandedPattern.make [], EmptyUnificationProof)
         else return
-            ( Predicated
-                { term = ()
-                , predicate =
-                    give symbolOrAliasSorts
-                    $ makeAndPredicate predicate pred'
-                , substitution
-                }
+            ( OrOfExpandedPattern.make
+                [ Predicated
+                    { term = ()
+                    , predicate =
+                        give symbolOrAliasSorts
+                        $ makeAndPredicate predicate pred'
+                    , substitution
+                    }
+                ]
             , EmptyUnificationProof
             )
   where

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -205,13 +205,14 @@ runStep
     -> IO
         (Either
             (StepError Object Variable)
-            (CommonExpandedPattern Object, StepProof Object Variable)
+            [(CommonExpandedPattern Object, StepProof Object Variable)]
         )
 runStep configuration axiom = do
     ioResult <- runStepResult configuration axiom
-    return $ do
-        (StepResult { rewrittenPattern }, proof) <- ioResult
-        return (rewrittenPattern, proof)
+    return (map processResult <$> ioResult)
+  where
+    processResult (StepResult { rewrittenPattern }, proof) =
+        (rewrittenPattern, proof)
 
 runStepResult
     :: CommonExpandedPattern Object
@@ -221,7 +222,7 @@ runStepResult
     -> IO
         (Either
             (StepError Object Variable)
-            (StepResult Object Variable, StepProof Object Variable)
+            [(StepResult Object Variable, StepProof Object Variable)]
         )
 runStepResult configuration axiom =
     (runSMT . evalSimplifier . runExceptT)
@@ -244,14 +245,15 @@ runStepWith
     -> IO
         (Either
             (StepError Object Variable)
-            (CommonExpandedPattern Object, StepProof Object Variable)
+            [(CommonExpandedPattern Object, StepProof Object Variable)]
         )
 runStepWith solver configuration axiom = do
     ioResult <- runStepResultWith
         solver configuration axiom
-    return $ do
-        (StepResult { rewrittenPattern }, proof) <- ioResult
-        return (rewrittenPattern, proof)
+    return (map processResult <$> ioResult)
+  where
+    processResult (StepResult { rewrittenPattern }, proof) =
+        (rewrittenPattern, proof)
 
 runStepResultWith
     :: MVar Solver
@@ -262,7 +264,7 @@ runStepResultWith
     -> IO
         (Either
             (StepError Object Variable)
-            (StepResult Object Variable, StepProof Object Variable)
+            [(StepResult Object Variable, StepProof Object Variable)]
         )
 runStepResultWith solver configuration axiom =
     let smt =

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Map.hs
@@ -442,9 +442,8 @@ test_concretizeKeysAxiom =
             , requires = Predicate.makeTruePredicate
             , attributes = Default.def
             }
-    expected =
-        Right
-            ( Predicated
+    expected = Right
+        [   ( Predicated
                 { term = val
                 , predicate = Predicate.makeTruePredicate
                 , substitution = mempty
@@ -454,6 +453,7 @@ test_concretizeKeysAxiom =
                 , stepProof (StepProofUnification EmptyUnificationProof)
                 ]
             )
+        ]
 
 -- | Specialize 'Map.asPattern' to the builtin sort 'mapSort'.
 asPattern :: Map.Builtin Variable -> CommonStepPattern Object

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Set.hs
@@ -354,9 +354,8 @@ test_concretizeKeysAxiom =
             , requires = Predicate.makeTruePredicate
             , attributes = Default.def
             }
-    expected =
-        Right
-            ( Predicated
+    expected = Right
+        [   ( Predicated
                 { term = symbolicKey
                 , predicate = Predicate.makeTruePredicate
                 , substitution = mempty
@@ -366,6 +365,7 @@ test_concretizeKeysAxiom =
                 , stepProof (StepProofUnification EmptyUnificationProof)
                 ]
             )
+        ]
 
 -- | Specialize 'Set.asPattern' to the builtin sort 'setSort'.
 asPattern :: Set.Builtin -> CommonStepPattern Object

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -412,9 +412,9 @@ mockEvaluator
     -> StepPatternSimplifier level variable
     -> Application level (StepPattern level variable)
     -> Simplifier
-        (AttemptedFunction level variable, SimplificationProof level)
+        [(AttemptedFunction level variable, SimplificationProof level)]
 mockEvaluator evaluation _ _ _ _ =
-    return (evaluation, SimplificationProof)
+    return [(evaluation, SimplificationProof)]
 
 evaluate
     :: forall level . MetaOrObject level

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -128,10 +128,10 @@ test_applicationSimplification = give mockSymbolOrAliasSorts
                     (That
                         [ ApplicationFunctionEvaluator
                             (const $ const $ const $ const $ return
-                                ( AttemptedFunction.Applied
+                                [( AttemptedFunction.Applied
                                     (OrOfExpandedPattern.make [gOfAExpanded])
                                 , SimplificationProof
-                                )
+                                )]
                             )
                         ]
                     )
@@ -221,7 +221,7 @@ test_applicationSimplification = give mockSymbolOrAliasSorts
                                 (const $ const $ const $ const $ do
                                     let zvar = freshVariableFromVariable z 1
                                     return
-                                        ( AttemptedFunction.Applied
+                                        [( AttemptedFunction.Applied
                                             (OrOfExpandedPattern.make
                                                 [ Predicated
                                                     { term = mkApp fSymbol [a]
@@ -236,7 +236,7 @@ test_applicationSimplification = give mockSymbolOrAliasSorts
                                                 ]
                                             )
                                         , SimplificationProof
-                                        )
+                                        )]
                                 )
                             ]
                         )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
@@ -329,18 +329,20 @@ simpleEvaluator
     => [(StepPattern Object variable, StepPattern Object variable)]
     -> Application Object (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
-        , SimplificationProof Object
-        )
-simpleEvaluator [] _ = return (NotApplicable, SimplificationProof)
+        [   ( AttemptedFunction Object variable
+            , SimplificationProof Object
+            )
+        ]
+simpleEvaluator [] _ = return [(NotApplicable, SimplificationProof)]
 simpleEvaluator ((from, to) : ps) app
   | from == embed (mempty :< ApplicationPattern app) =
     return
-        ( Applied
-            (OrOfExpandedPattern.make
-                [Predicated.fromPurePattern to]
+        [   ( Applied
+                (OrOfExpandedPattern.make
+                    [Predicated.fromPurePattern to]
+                )
+            , SimplificationProof
             )
-        , SimplificationProof
-        )
+        ]
   | otherwise =
     simpleEvaluator ps app


### PR DESCRIPTION
The test using "assertTermEqualsMulti" in Equals.hs highlights a bug in the equals simplification.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

