### PR TITLE
STRING.ord should return bottom if the input's length is not 1

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -439,10 +439,13 @@ evalOrd = Builtin.functionEvaluator evalOrd0
                         _    -> Builtin.wrongArity ordKey
             _str <- expectBuiltinString ordKey _str
             Builtin.appliedFunction
-                . maybe crash charToOrdInt
-                $ listToMaybe _str
+                . maybe ExpandedPattern.bottom charToOrdInt
+                $ singletonOrNothing _str
       where
-        crash = Builtin.verifierBug $ ordKey <> " called with string of length != 1"
+        singletonOrNothing :: [a] -> Maybe a
+        singletonOrNothing [x] = Just x
+        singletonOrNothing _ = Nothing
+
         charToOrdInt =
             Int.asExpandedPattern resultSort
             . toInteger

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/String.hs
@@ -132,6 +132,16 @@ test_ord =
         ordStringSymbol
         [asPattern "d"]
         (Test.Int.asExpandedPattern 100)
+    , Test.Int.testInt
+        "STRING.ord('') is bottom"
+        ordStringSymbol
+        [asPattern ""]
+        bottom
+    , Test.Int.testInt
+        "STRING.ord('foo') is bottom"
+        ordStringSymbol
+        [asPattern "foo"]
+        bottom
     ]
 
 test_find :: [TestTree]


### PR DESCRIPTION
I will add integration tests with my next PR ( https://trello.com/c/A1yfIgnB/409-correctly-sanitize-variables-in-exists-and-forall )

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

