### PR TITLE
Check module headers on Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,13 @@ kore:
 docs: haddock
 
 haddock:
-	stack haddock --no-haddock-deps $(STACK_HADDOCK_OPTS)
+	stack haddock --no-haddock-deps $(STACK_HADDOCK_OPTS) 2>&1 | tee haddock.log
+	if grep -B 2 'Module header' haddock.log; then \
+		echo >&2 "Please fix the missing documentation!"; \
+		exit 1; \
+	else \
+		rm haddock.log; \
+	fi
 	if [ -n "$$BUILD_NUMBER" ]; then \
 		cp -r $$(stack path --local-doc-root) haskell_documentation; \
 	fi

--- a/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
+++ b/src/main/haskell/kore/src/Kore/ASTPrettyPrint.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Kore.ASTPrettyPrint
+Description : Pretty-printer for internal representations of Kore
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+-}
+
 module Kore.ASTPrettyPrint
     ( prettyPrintToString
     , PrettyPrint(..)

--- a/src/main/haskell/kore/src/Kore/Domain/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Domain/Builtin.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Kore.Domain.Builtin
+Description : Internal representation of builtin domains
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : thomas.tuegel@runtimeverification.com
+-}
+
 {-# LANGUAGE TemplateHaskell #-}
 
 module Kore.Domain.Builtin where

--- a/src/main/haskell/kore/src/Kore/Domain/External.hs
+++ b/src/main/haskell/kore/src/Kore/Domain/External.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Kore.Domain.External
+Description : Domain values in the concrete syntax of Kore
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : thomas.tuegel@runtimeverification.com
+-}
+
 {-# LANGUAGE TemplateHaskell #-}
 
 module Kore.Domain.External

--- a/src/main/haskell/kore/src/Kore/Step/Error.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Error.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Kore.Step.Error
+Description : Kore step evaluator errors
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+-}
+
 module Kore.Step.Error
     ( StepError (..)
     , mapStepErrorVariables

--- a/src/main/haskell/kore/src/Kore/Step/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Pattern.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Kore.Step.Pattern
+Description : Abstract representation of Kore patterns in the evaluator
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : thomas.tuegel@runtimeverification.com
+-}
+
 module Kore.Step.Pattern
     ( StepPattern
     , CommonStepPattern

--- a/src/main/haskell/kore/src/Text/IndentingPrinter.hs
+++ b/src/main/haskell/kore/src/Text/IndentingPrinter.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Text.IndentingPrinter
+Description : Indentation-aware pretty-printer
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+-}
+
 module Text.IndentingPrinter
     ( PrinterOutput (write, betweenLines, withIndent)
     , printToString


### PR DESCRIPTION
Avoid the scourge of missing module headers!

The `make haddock` target now fails if any modules are missing their Haddock header.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

