### PR TITLE
added [concrete] attribute for Kore rules

### DIFF
--- a/src/main/haskell/kore/src/Kore/AST/Pure.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Pure.hs
@@ -17,6 +17,7 @@ module Kore.AST.Pure
     , traverseVariables
     , mapVariables
     , asConcretePurePattern
+    , isConcrete
     , fromConcretePurePattern
     , castMetaDomainValues
     , castVoidDomainValues
@@ -55,6 +56,7 @@ import           Data.Functor.Identity
                  ( Identity (..) )
 import           Data.Hashable
                  ( Hashable (..) )
+import           Data.Maybe
 import           Data.Text
                  ( Text )
 import           Data.Void
@@ -399,10 +401,16 @@ deciding if the result is @Nothing@ or @Just _@.
 
  -}
 asConcretePurePattern
-    :: forall level domain variable annotation. Traversable domain
+    :: forall level domain variable annotation . Traversable domain
     => PurePattern level domain variable annotation
     -> Maybe (PurePattern level domain Concrete annotation)
 asConcretePurePattern = traverseVariables (\case { _ -> Nothing })
+
+isConcrete
+    :: forall level domain variable annotation . Traversable domain
+    => PurePattern level domain variable annotation
+    -> Bool
+isConcrete = isJust . asConcretePurePattern
 
 {- | Construct a 'PurePattern' from a 'ConcretePurePattern'.
 

--- a/src/main/haskell/kore/src/Kore/Attribute/Axiom/Concrete.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Axiom/Concrete.hs
@@ -18,7 +18,8 @@ import           Data.Default
 import           GHC.Generics
                  ( Generic )
 
-import           Kore.AST.Kore hiding ( Concrete )
+import           Kore.AST.Kore hiding
+                 ( Concrete )
 import           Kore.Attribute.Parser
                  ( ParseAttributes (..) )
 import qualified Kore.Attribute.Parser as Parser

--- a/src/main/haskell/kore/src/Kore/Attribute/Axiom/Concrete.hs
+++ b/src/main/haskell/kore/src/Kore/Attribute/Axiom/Concrete.hs
@@ -1,0 +1,66 @@
+{-|
+Module      : Kore.Attribute.Concrete
+Description : Concrete axiom attribute
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+Maintainer  : phillip.harris@runtimeverification.com
+
+-}
+module Kore.Attribute.Axiom.Concrete
+    ( Concrete (..)
+    , concreteId, concreteSymbol, concreteAttribute
+    ) where
+
+import           Control.DeepSeq
+                 ( NFData )
+import qualified Control.Monad as Monad
+import           Data.Default
+import           GHC.Generics
+                 ( Generic )
+
+import           Kore.AST.Kore hiding ( Concrete )
+import           Kore.Attribute.Parser
+                 ( ParseAttributes (..) )
+import qualified Kore.Attribute.Parser as Parser
+
+{- | @Concrete@ represents the @concrete@ attribute for axioms.
+ -}
+newtype Concrete = Concrete { isConcrete :: Bool }
+    deriving (Eq, Ord, Show, Generic)
+
+instance NFData Concrete
+
+instance Default Concrete where
+    def = Concrete False
+
+-- | Kore identifier representing the @concrete@ attribute symbol.
+concreteId :: Id Object
+concreteId = "concrete"
+
+-- | Kore symbol representing the @concrete@ attribute.
+concreteSymbol :: SymbolOrAlias Object
+concreteSymbol =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = concreteId
+        , symbolOrAliasParams = []
+        }
+
+-- | Kore pattern representing the @concrete@ attribute.
+concreteAttribute :: CommonKorePattern
+concreteAttribute =
+    (asCommonKorePattern . ApplicationPattern)
+        Application
+            { applicationSymbolOrAlias = concreteSymbol
+            , applicationChildren = []
+            }
+
+instance ParseAttributes Concrete where
+    parseAttribute =
+        withApplication $ \params args Concrete { isConcrete } -> do
+            Parser.getZeroParams params
+            Parser.getZeroArguments args
+            Monad.when isConcrete failDuplicate
+            return Concrete { isConcrete = True }
+      where
+        withApplication = Parser.withApplication concreteId
+        failDuplicate = Parser.failDuplicate concreteId

--- a/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
@@ -47,6 +47,7 @@ import           Kore.AST.Kore
 import           Kore.AST.Sentence
 import           Kore.AST.Valid
 import           Kore.Attribute.Assoc
+import qualified Kore.Attribute.Axiom.Concrete as Axiom
 import           Kore.Attribute.Comm
 import           Kore.Attribute.HeatCool
 import           Kore.Attribute.Idem
@@ -79,6 +80,7 @@ data AxiomPatternAttributes =
     -- ^ The axiom is an idempotency axiom.
     , trusted :: !Trusted
     -- ^ The claim is trusted
+    , concrete :: !Axiom.Concrete
     }
     deriving (Eq, Ord, Show, Generic)
 
@@ -96,6 +98,7 @@ instance Default AxiomPatternAttributes where
             , unit = def
             , idem = def
             , trusted = def
+            , concrete = def
             }
 
 instance ParseAttributes AxiomPatternAttributes where
@@ -107,6 +110,7 @@ instance ParseAttributes AxiomPatternAttributes where
         >=> lensUnit (parseAttribute attr)
         >=> lensIdem (parseAttribute attr)
         >=> lensTrusted (parseAttribute attr)
+        >=> lensConcrete (parseAttribute attr)
 
 newtype AxiomPatternError = AxiomPatternError ()
 

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -15,14 +15,18 @@ module Kore.Step.Function.UserDefined
 import Control.Monad.Except
        ( runExceptT )
 
-import           Kore.AST.Pure
+import           Kore.AST.Pure hiding
+                 ( isConcrete )
+import qualified Kore.AST.Pure as Pure
 import           Kore.AST.Valid
+import qualified Kore.Attribute.Axiom.Concrete as Axiom.Concrete
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Predicate.Predicate
                  ( pattern PredicateFalse, makeTruePredicate )
 import           Kore.Step.AxiomPatterns
-                 ( EqualityRule (EqualityRule) )
+                 ( AxiomPatternAttributes (..), EqualityRule (EqualityRule),
+                 RulePattern (..) )
 import           Kore.Step.BaseStep
                  ( StepResult (StepResult), UnificationProcedure (..),
                  stepWithRuleForUnifier )
@@ -44,6 +48,7 @@ import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import           Kore.Unparser
+                 ( Unparse )
 import           Kore.Variables.Fresh
 
 {-| 'ruleFunctionEvaluator' evaluates a user-defined function. After
@@ -82,16 +87,23 @@ ruleFunctionEvaluator
     tools
     substitutionSimplifier
     simplifier
-    app
-  = do
+    app@(_ :< Application _ c)
+    | (Axiom.Concrete.isConcrete $ concrete $ attributes rule)
+        && any (not . Pure.isConcrete) c
+    = notApplicable
+    | otherwise = do
     result <- runExceptT stepResult
     case result of
         Left _ ->
-            return [(AttemptedFunction.NotApplicable, SimplificationProof)]
+            notApplicable
         Right results -> do
             processedResults <- mapM processResult results
             return (concat processedResults)
   where
+
+    notApplicable = return [(AttemptedFunction.NotApplicable, SimplificationProof)]
+
+
     stepResult =
         stepWithRuleForUnifier
             tools

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -103,7 +103,6 @@ ruleFunctionEvaluator
 
     notApplicable = return [(AttemptedFunction.NotApplicable, SimplificationProof)]
 
-
     stepResult =
         stepWithRuleForUnifier
             tools

--- a/src/main/haskell/kore/test/Test/Kore/Attribute/Axiom/Concrete.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Attribute/Axiom/Concrete.hs
@@ -1,0 +1,66 @@
+module Test.Kore.Attribute.Axiom.Concrete where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Kore.AST.Kore hiding
+       ( Concrete )
+import Kore.Attribute.Axiom.Concrete
+
+import Test.Kore.Attribute.Parser
+
+parseConcrete :: Attributes -> Parser Concrete
+parseConcrete = parseAttributes
+
+test_concrete :: TestTree
+test_concrete =
+    testCase "[concrete{}()] :: Concrete"
+        $ expectSuccess Concrete { isConcrete = True }
+        $ parseConcrete $ Attributes [ concreteAttribute ]
+
+test_Attributes :: TestTree
+test_Attributes =
+    testCase "[concrete{}()] :: Attributes"
+        $ expectSuccess attrs $ parseAttributes attrs
+  where
+    attrs = Attributes [ concreteAttribute ]
+
+test_duplicate :: TestTree
+test_duplicate =
+    testCase "[concrete{}(), concrete{}()]"
+        $ expectFailure
+        $ parseConcrete $ Attributes [ concreteAttribute, concreteAttribute ]
+
+test_arguments :: TestTree
+test_arguments =
+    testCase "[concrete{}(\"illegal\")]"
+        $ expectFailure
+        $ parseConcrete $ Attributes [ illegalAttribute ]
+  where
+    illegalAttribute =
+        (asCommonKorePattern . ApplicationPattern)
+            Application
+                { applicationSymbolOrAlias = concreteSymbol
+                , applicationChildren =
+                    [ (asCommonKorePattern . StringLiteralPattern)
+                        (StringLiteral "illegal")
+                    ]
+                }
+
+test_parameters :: TestTree
+test_parameters =
+    testCase "[concrete{illegal}()]"
+        $ expectFailure
+        $ parseConcrete $ Attributes [ illegalAttribute ]
+  where
+    illegalAttribute =
+        (asCommonKorePattern . ApplicationPattern)
+            Application
+                { applicationSymbolOrAlias =
+                    SymbolOrAlias
+                        { symbolOrAliasConstructor = concreteId
+                        , symbolOrAliasParams =
+                            [ SortVariableSort (SortVariable "illegal") ]
+                        }
+                , applicationChildren = []
+                }

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -253,11 +253,11 @@ hSymbol = SymbolOrAlias
     , symbolOrAliasParams = []
     }
 
-metaH :: Functor dom => PurePattern Meta dom variable (Valid Meta)
+metaH :: Functor dom => PurePattern Meta dom variable (Valid (Variable Meta) Meta)
 metaH = asPurePattern $
     valid :< ApplicationPattern (Application hSymbol [])
   where
-    valid = Valid { patternSort = patternMetaSort }
+    valid = Valid { patternSort = patternMetaSort, freeVariables = mempty }
 
 sigmaSymbol :: SymbolOrAlias Meta
 sigmaSymbol = SymbolOrAlias

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -15,6 +15,7 @@ import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 
 import           Kore.AST.Pure
 import           Kore.AST.Valid
+import           Kore.Attribute.Axiom.Concrete
 import           Kore.Implicit.ImplicitSorts
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..) )
@@ -23,7 +24,8 @@ import qualified Kore.IndexedModule.MetadataTools as HeadType
 import           Kore.Predicate.Predicate
                  ( makeFalsePredicate, makeTruePredicate )
 import           Kore.Step.AxiomPatterns
-                 ( EqualityRule (EqualityRule), RulePattern (RulePattern) )
+                 ( AxiomPatternAttributes (..), EqualityRule (EqualityRule),
+                 RulePattern (RulePattern) )
 import           Kore.Step.AxiomPatterns as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.ExpandedPattern as ExpandedPattern
@@ -78,7 +80,42 @@ test_userDefinedFunction =
                 (mockSimplifier [])
                 (metaF (mkVar $ x patternMetaSort))
         assertEqualWithExplanation "f(x) => g(x)" [expect] actual
-
+    , testCase "Cannot apply concrete rule to symbolic pattern" $ do
+        let expect =
+                AttemptedFunction.NotApplicable
+        actual <-
+            evaluateWithAxiom
+                mockMetadataTools
+                (EqualityRule RulePattern
+                    { left =
+                        asApplicationPattern $ metaF (mkVar $ x patternMetaSort)
+                    , right =
+                        asApplicationPattern $ metaG (mkVar $ x patternMetaSort)
+                    , requires = makeTruePredicate
+                    , attributes = def { concrete = Concrete True }
+                    }
+                )
+                (mockSimplifier [])
+                (metaF (mkVar $ x patternMetaSort))
+        assertEqualWithExplanation "f(x) => g(x)" [expect] actual
+    , testCase "Can apply concrete rule to concrete pattern" $ do
+        let expect =
+                AttemptedFunction.NotApplicable
+        actual <-
+            evaluateWithAxiom
+                mockMetadataTools
+                (EqualityRule RulePattern
+                    { left =
+                        asApplicationPattern $ metaF metaH
+                    , right =
+                        asApplicationPattern $ metaG metaH
+                    , requires = makeTruePredicate
+                    , attributes = def { concrete = Concrete True }
+                    }
+                )
+                (mockSimplifier [])
+                (metaF (mkVar $ x patternMetaSort))
+        assertEqualWithExplanation "f(x) => g(x)" [expect] actual
     , testCase "Cannot apply step with unsat axiom pre-condition" $ do
         let expect =
                 AttemptedFunction.Applied (OrOfExpandedPattern.make [])
@@ -209,6 +246,18 @@ metaG p =
   where
     Valid { freeVariables } = extract p
     valid = Valid { patternSort = patternMetaSort, freeVariables }
+
+hSymbol :: SymbolOrAlias Meta
+hSymbol = SymbolOrAlias
+    { symbolOrAliasConstructor = testId "#h"
+    , symbolOrAliasParams = []
+    }
+
+metaH :: Functor dom => PurePattern Meta dom variable (Valid Meta)
+metaH = asPurePattern $
+    valid :< ApplicationPattern (Application hSymbol [])
+  where
+    valid = Valid { patternSort = patternMetaSort }
 
 sigmaSymbol :: SymbolOrAlias Meta
 sigmaSymbol = SymbolOrAlias


### PR DESCRIPTION
Function evaluator now refuses to apply function axioms marked with [concrete] to symbolic patterns (patterns containing a variable somewhere).
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

