### PR TITLE
include.mk: Remove NPROCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,14 @@ test-kore:
 	fi
 
 test-k: all
-	$(MAKE) --directory src/main/k/working test-k -j$(NPROCS)
+	$(MAKE) --directory src/main/k/working test-k
 
 jenkins: clean check all test docs
 
 clean:
 	stack clean
 	find . -name '*.tix' -exec rm -f '{}' \;
-	$(MAKE) --directory src/main/k/working clean -j$(NPROCS)
+	$(MAKE) --directory src/main/k/working clean
 	rm -rf $(BUILD_DIR)
 
 check:

--- a/include.mk
+++ b/include.mk
@@ -2,7 +2,6 @@
 
 TOP ?= $(shell git rev-parse --show-toplevel)
 UPSTREAM_BRANCH := origin/master
-NPROCS := $(shell nproc)
 
 BUILD_DIR := $(TOP)/.build
 K_NIGHTLY := $(BUILD_DIR)/nightly.tar.gz


### PR DESCRIPTION
Program nprocs is not available by default on macOS. Ultimately, we need to
restructure the Makefile so that option -j works correctly, but for now we just
need to get Jenkins running again.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

