### PR TITLE
Parallel integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ src/main/haskell/stack.yaml
 *.prof
 .kprove-*
 .stack-work-haddock
+/coverage_report
+/haskell_documentation
+.stack-work-test

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ src/main/haskell/stack.yaml
 /coverage_report
 /haskell_documentation
 .stack-work-test
+/src/main/haskell/kore/test-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ src/main/haskell/stack.yaml
 .dir-locals.el
 *.prof
 .kprove-*
+.stack-work-haddock

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include include.mk
 
-.PHONY: all clean docs haddock jenkins kore k-frontend stylish \
+.PHONY: all clean docs haddock jenkins kore k-frontend \
         test test-kore test-k
 
 kore:
@@ -82,17 +82,9 @@ check:
 		echo >&2 "Please rebase your branch onto ‘master’!"; \
 		exit 1; \
 	fi
-	$(MAKE) stylish
+	$(TOP)/scripts/stylish.sh
 	if ! ./scripts/git-assert-clean.sh; \
 	then \
-		echo >&2 "Please run ‘make stylish’ to fix style errors!"; \
+		echo >&2 "Please run ‘scripts/stylish.sh’ to fix style errors!"; \
 		exit 1; \
 	fi
-
-stylish:
-	if ! command -v stylish-haskell; then\
-		stack install stylish-haskell; \
-	fi
-	find $(HS_SOURCE_DIRS) \
-		\( -name '*.hs' -o -name '*.hs-boot' \) \
-		-print0 | xargs -0L1 stylish-haskell -i

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,6 @@ coverage_report: $(STACK_LOCAL_HPC_ROOT)
 test-k:
 	$(MAKE) --directory src/main/k/working test-k
 
-jenkins:
-	$(MAKE) clean
-	$(MAKE) check
-	$(MAKE) all
-	$(MAKE) test
-	$(MAKE) docs
-
 clean:
 	$(STACK) clean --full
 	$(STACK_HADDOCK) clean --full

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,12 @@ test-kore:
 test-k: all
 	$(MAKE) --directory src/main/k/working test-k
 
-jenkins: clean check all test docs
+jenkins:
+	$(MAKE) clean
+	$(MAKE) check
+	$(MAKE) all
+	$(MAKE) test
+	$(MAKE) docs
 
 clean:
 	stack clean

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ kore:
 
 k-frontend:
 	mkdir -p $(BUILD_DIR)
-	rm -rf $(K_DIR) $(K_NIGHTLY)
+	rm -rf $(K_DIST) $(K_NIGHTLY)
 	curl --location --output $(K_NIGHTLY) \
 	    $$(curl 'https://api.github.com/repos/kframework/k/releases' | jq --raw-output '.[0].assets[0].browser_download_url')
-	mkdir --parents $(K_DIR)
-	tar --extract --file $(K_NIGHTLY) --strip-components 1 --directory $(K_DIR)
+	mkdir --parents $(K_DIST)
+	tar --extract --file $(K_NIGHTLY) --strip-components 1 --directory $(K_DIST)
 	$(KRUN) --version
 
 docs: haddock

--- a/Makefile
+++ b/Makefile
@@ -70,21 +70,3 @@ clean:
 	rm -rf coverage_report
 	rm -rf $(BUILD_DIR)
 	$(MAKE) --directory src/main/k/working clean
-
-check:
-	if ! ./scripts/git-assert-clean.sh; \
-	then \
-		echo >&2 "Please commit your changes!"; \
-		exit 1; \
-	fi
-	if ! ./scripts/git-rebased-on.sh "$$(git rev-parse $(UPSTREAM_BRANCH))" --linear; \
-	then \
-		echo >&2 "Please rebase your branch onto ‘master’!"; \
-		exit 1; \
-	fi
-	$(TOP)/scripts/stylish.sh
-	if ! ./scripts/git-assert-clean.sh; \
-	then \
-		echo >&2 "Please run ‘scripts/stylish.sh’ to fix style errors!"; \
-		exit 1; \
-	fi

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(STACK_LOCAL_HPC_ROOT):
 coverage_report: $(STACK_LOCAL_HPC_ROOT)
 	cp -r $(STACK_LOCAL_HPC_ROOT) coverage_report
 
-test-k: all
+test-k:
 	$(MAKE) --directory src/main/k/working test-k
 
 jenkins:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 include include.mk
 
-jenkins: STACK_OPTS += --test --bench
-export STACK_OPTS
-
 .PHONY: all clean docs haddock jenkins kore k-frontend stylish \
         test test-kore test-k
 
@@ -45,7 +42,10 @@ test-kore: $(STACK_LOCAL_HPC_ROOT)
 
 $(STACK_LOCAL_HPC_ROOT): STACK := $(STACK_TEST)
 $(STACK_LOCAL_HPC_ROOT):
-	$(STACK) build $(STACK_NO_PROFILE) $(STACK_FAST) $(STACK_COVERAGE) --test --bench --no-run-benchmarks
+	$(STACK) build \
+		$(STACK_NO_PROFILE) $(STACK_FAST) $(STACK_COVERAGE) \
+		--test --bench --no-run-benchmarks \
+		--ta --xml=test-results.xml
 
 coverage_report: $(STACK_LOCAL_HPC_ROOT)
 	cp -r $(STACK_LOCAL_HPC_ROOT) coverage_report
@@ -65,10 +65,11 @@ clean:
 	$(STACK_HADDOCK) clean --full
 	$(STACK_TEST) clean --full
 	find . -name '*.tix' -exec rm -f '{}' \;
+	rm -f src/main/haskell/kore/test-results.xml
 	rm -rf haskell_documentation
 	rm -rf coverage_report
-	$(MAKE) --directory src/main/k/working clean
 	rm -rf $(BUILD_DIR)
+	$(MAKE) --directory src/main/k/working clean
 
 check:
 	if ! ./scripts/git-assert-clean.sh; \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ export STACK_OPTS
 kore:
 	stack build $(STACK_BUILD_OPTS)
 
+kore-exec: $(KORE_EXEC)
+
 k-frontend:
 	mkdir -p $(BUILD_DIR)
 	rm -rf $(K_DIST) $(K_NIGHTLY)

--- a/include.mk
+++ b/include.mk
@@ -19,14 +19,13 @@ KPROVE = $(K_DIST_BIN)/kprove
 HS_TOP = $(TOP)/src/main/haskell/kore
 HS_SOURCE_DIRS = $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test $(HS_TOP)/bench
 STACK_OPTS = --pedantic
-STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
-STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
-STACK_TEST_OPTS = $(STACK_OPTS) --no-run-benchmarks
 STACK_NO_PROFILE = --no-library-profiling --no-executable-profiling
 STACK_FAST = --fast
+STACK_COVERAGE = --coverage
 
 STACK = stack
 STACK_HADDOCK = $(STACK) --work-dir=.stack-work-haddock
+STACK_TEST = $(STACK) --work-dir=.stack-work-test
 
 # These paths are assigned with ?= so they will only be assigned once.
 # Sub-processes will inherit the setting from their parent process.

--- a/include.mk
+++ b/include.mk
@@ -22,14 +22,23 @@ STACK_OPTS = --pedantic
 STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_TEST_OPTS = $(STACK_OPTS) --no-run-benchmarks
+STACK_NO_PROFILE = --no-library-profiling --no-executable-profiling
+STACK_FAST = --fast
+
+STACK = stack
+STACK_LOCAL_INSTALL_ROOT := $(shell $(STACK) path --local-install-root)
+STACK_HADDOCK = $(STACK) --work-dir=.stack-work-haddock
+STACK_LOCAL_DOC_ROOT := $(shell $(STACK_HADDOCK) path --local-doc-root)
 
 ifdef BUILD_NUMBER
 STACK_TEST_OPTS += --ta --xml=test-results.xml --coverage
 endif
 
-STACK_LOCAL_INSTALL_ROOT = $(shell stack path --local-install-root)
 KORE_EXEC = $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
 KORE_EXEC_OPTS =
+
+$(KORE_EXEC):
+	$(STACK) build --pedantic kore:exe:kore-exec
 
 KOMPILE_OPTS = --backend haskell
 KRUN_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"

--- a/include.mk
+++ b/include.mk
@@ -26,9 +26,13 @@ STACK_NO_PROFILE = --no-library-profiling --no-executable-profiling
 STACK_FAST = --fast
 
 STACK = stack
-STACK_LOCAL_INSTALL_ROOT := $(shell $(STACK) path --local-install-root)
 STACK_HADDOCK = $(STACK) --work-dir=.stack-work-haddock
-STACK_LOCAL_DOC_ROOT := $(shell $(STACK_HADDOCK) path --local-doc-root)
+
+# These paths are assigned with ?= so they will only be assigned once.
+# Sub-processes will inherit the setting from their parent process.
+STACK_LOCAL_INSTALL_ROOT ?= $(shell $(STACK) path --local-install-root)
+STACK_LOCAL_DOC_ROOT ?= $(shell $(STACK_HADDOCK) path --local-doc-root)
+STACK_LOCAL_HPC_ROOT ?= $(shell $(STACK_TEST) path --local-hpc-root)
 
 ifdef BUILD_NUMBER
 STACK_TEST_OPTS += --ta --xml=test-results.xml --coverage

--- a/include.mk
+++ b/include.mk
@@ -1,6 +1,6 @@
 # Settings
 
-TOP = $(shell git rev-parse --show-toplevel)
+TOP ?= $(shell git rev-parse --show-toplevel)
 UPSTREAM_BRANCH = origin/master
 
 BUILD_DIR = $(TOP)/.build
@@ -16,9 +16,12 @@ KOMPILE = $(K_DIST_BIN)/kompile
 KRUN = $(K_DIST_BIN)/krun
 KPROVE = $(K_DIST_BIN)/kprove
 
+KOMPILE_OPTS = --backend haskell
+KRUN_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
+KPROVE_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
+
 HS_TOP = $(TOP)/src/main/haskell/kore
 HS_SOURCE_DIRS = $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test $(HS_TOP)/bench
-STACK_OPTS = --pedantic
 STACK_NO_PROFILE = --no-library-profiling --no-executable-profiling
 STACK_FAST = --fast
 STACK_COVERAGE = --coverage
@@ -37,8 +40,4 @@ KORE_EXEC = $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
 KORE_EXEC_OPTS =
 
 $(KORE_EXEC):
-	$(STACK) build --pedantic kore:exe:kore-exec
-
-KOMPILE_OPTS = --backend haskell
-KRUN_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
-KPROVE_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
+	$(STACK) build --pedantic $(STACK_NO_PROFILE) kore:exe:kore-exec

--- a/include.mk
+++ b/include.mk
@@ -33,10 +33,6 @@ STACK_LOCAL_INSTALL_ROOT ?= $(shell $(STACK) path --local-install-root)
 STACK_LOCAL_DOC_ROOT ?= $(shell $(STACK_HADDOCK) path --local-doc-root)
 STACK_LOCAL_HPC_ROOT ?= $(shell $(STACK_TEST) path --local-hpc-root)
 
-ifdef BUILD_NUMBER
-STACK_TEST_OPTS += --ta --xml=test-results.xml --coverage
-endif
-
 KORE_EXEC = $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
 KORE_EXEC_OPTS =
 

--- a/include.mk
+++ b/include.mk
@@ -1,27 +1,24 @@
 # Settings
 
-TOP ?= $(shell git rev-parse --show-toplevel)
-UPSTREAM_BRANCH := origin/master
+TOP = $(shell git rev-parse --show-toplevel)
+UPSTREAM_BRANCH = origin/master
 
-BUILD_DIR := $(TOP)/.build
-K_NIGHTLY := $(BUILD_DIR)/nightly.tar.gz
-K_DIR := $(BUILD_DIR)/k
-# The K submodule reflog is used as a source timestamp.
-K_BIN := $(K_DIR)/bin
-K_LIB := $(K_DIR)/lib
-K_REPO := 'https://github.com/kframework/k'
+BUILD_DIR = $(TOP)/.build
+K_NIGHTLY = $(BUILD_DIR)/nightly.tar.gz
+K_DIST = $(BUILD_DIR)/k
+K_DIST_BIN = $(K_DIST)/bin
+K_DIST_LIB = $(K_DIST)/lib
+K_REPO = 'https://github.com/kframework/k'
 
 # The kernel JAR is used as a build timestamp.
-K := $(K_LIB)/java/kernel-1.0-SNAPSHOT.jar
-JAVA_CLASSPATH := '$(K_LIB)/java/*'
-JAVA := java -ea -cp $(JAVA_CLASSPATH)
-KOMPILE := $(K_BIN)/kompile
-KRUN := $(K_BIN)/krun
-KPROVE := $(K_BIN)/kprove
+K = $(K_DIST_LIB)/java/kernel-1.0-SNAPSHOT.jar
+KOMPILE = $(K_DIST_BIN)/kompile
+KRUN = $(K_DIST_BIN)/krun
+KPROVE = $(K_DIST_BIN)/kprove
 
-HS_TOP := $(TOP)/src/main/haskell/kore
-HS_SOURCE_DIRS := $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test $(HS_TOP)/bench
-STACK_OPTS ?= --pedantic
+HS_TOP = $(TOP)/src/main/haskell/kore
+HS_SOURCE_DIRS = $(HS_TOP)/src $(HS_TOP)/app $(HS_TOP)/test $(HS_TOP)/bench
+STACK_OPTS = --pedantic
 STACK_BUILD_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_HADDOCK_OPTS = $(STACK_OPTS) --no-run-tests --no-run-benchmarks
 STACK_TEST_OPTS = $(STACK_OPTS) --no-run-benchmarks
@@ -30,10 +27,10 @@ ifdef BUILD_NUMBER
 STACK_TEST_OPTS += --ta --xml=test-results.xml --coverage
 endif
 
-STACK_LOCAL_INSTALL_ROOT := $(shell stack path --local-install-root)
-KORE_EXEC ?= $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
-KORE_EXEC_OPTS ?=
+STACK_LOCAL_INSTALL_ROOT = $(shell stack path --local-install-root)
+KORE_EXEC = $(STACK_LOCAL_INSTALL_ROOT)/bin/kore-exec
+KORE_EXEC_OPTS =
 
-KOMPILE_OPTS ?= --backend haskell
-KRUN_OPTS ?= --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
-KPROVE_OPTS ?= --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
+KOMPILE_OPTS = --backend haskell
+KRUN_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"
+KPROVE_OPTS = --haskell-backend-command "$(KORE_EXEC) $(KORE_EXEC_OPTS)"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+export TOP=${TOP:-$(git rev-parse --show-toplevel)}
+UPSTREAM_BRANCH=${UPSTREAM_BRANCH:-origin/master}
+
+if ! $TOP/scripts/git-assert-clean.sh; \
+then \
+  echo >&2 "Please commit your changes!"; \
+  exit 1; \
+fi
+UPSTREAM_REV=$(git rev-parse $UPSTREAM_BRANCH)
+if ! $TOP/scripts/git-rebased-on.sh $UPSTREAM_REV --linear; \
+then \
+  echo >&2 "Please rebase your branch onto ‘$UPSTREAM_BRANCH’!"; \
+  exit 1; \
+fi
+$TOP/scripts/stylish.sh
+if ! $TOP/scripts/git-assert-clean.sh; \
+then \
+  echo >&2 "Please run ‘scripts/stylish.sh’ to fix style errors!"; \
+  exit 1; \
+fi

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+export TOP=${TOP:-$(git rev-parse --show-toplevel)}
+
+export PATH="$(stack path --local-bin)${PATH:+:$PATH}"
+
+if ! command -v stylish-haskell >/dev/null; then
+    stack install stylish-haskell
+fi
+
+$TOP/scripts/check.sh
+
+MAKE="make -O -j --directory $TOP"
+$MAKE clean
+$MAKE k-frontend
+$MAKE coverage_report haskell_documentation test-k

--- a/scripts/stylish.sh
+++ b/scripts/stylish.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export TOP=${TOP:-$(git rev-parse --show-toplevel)}
+
+HS_TOP="$TOP/src/main/haskell/kore"
+HS_SOURCE_DIRS="$HS_TOP/src $HS_TOP/app $HS_TOP/test $HS_TOP/bench"
+
+find $HS_SOURCE_DIRS \
+    \( -name '*.hs' -o -name '*.hs-boot' \) \
+    -print0 | xargs -0L1 stylish-haskell -i

--- a/src/main/k/working/Makefile
+++ b/src/main/k/working/Makefile
@@ -1,9 +1,14 @@
+include $(CURDIR)/include.mk
+
 TOPTARGETS := all clean test test-k golden
+
+.PHONY: $(TOPTARGETS)
 
 SUBDIRS := $(wildcard */.)
 
-$(TOPTARGETS): $(SUBDIRS)
-$(SUBDIRS):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-.PHONY: $(TOPTARGETS) $(SUBDIRS)
+# The subdirectory targets should not run in parallel, due to issues with
+# running multiple concurrent krun processes.
+$(TOPTARGETS):
+	for subdir in $(SUBDIRS); do \
+		$(MAKE) -C "$$subdir" $(MAKECMDGOALS); \
+	done

--- a/src/main/k/working/function-evaluation-demo/Makefile
+++ b/src/main/k/working/function-evaluation-demo/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
-KOMPILED := demo-kompiled
-DEFINITION := $(KOMPILED)/definition.kore
+KOMPILED = demo-kompiled
+DEFINITION = $(KOMPILED)/definition.kore
 
-$(DEFINITION): demo.k $(KOMPILE)
+$(DEFINITION): demo.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module DEMO
 
-%.imp.kore: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.demo $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.demo $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: test
 golden: tests/Nat.output.golden tests/NatList.output.golden tests/Truth.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-concrete-heat-cool/Makefile
+++ b/src/main/k/working/imp-concrete-heat-cool/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-concrete-state/Makefile
+++ b/src/main/k/working/imp-concrete-state/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE_TARGETS)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-map-strict/Makefile
+++ b/src/main/k/working/imp-map-strict/Makefile
@@ -1,22 +1,21 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.imp.kore: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --dry-run
 
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +34,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-map-unify-strict/Makefile
+++ b/src/main/k/working/imp-map-unify-strict/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-map-unify/Makefile
+++ b/src/main/k/working/imp-map-unify/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-map/Makefile
+++ b/src/main/k/working/imp-map/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp-monosorted/Makefile
+++ b/src/main/k/working/imp-monosorted/Makefile
@@ -1,22 +1,18 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -35,6 +31,6 @@ test-k: $(foreach test, $(k_tests), tests/$(test).test)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/imp/Makefile
+++ b/src/main/k/working/imp/Makefile
@@ -1,25 +1,21 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
-KOMPILED := imp-kompiled
-DEFINITION := $(KOMPILED)/definition.kore
+KOMPILED = imp-kompiled
+DEFINITION = $(KOMPILED)/definition.kore
 
-$(DEFINITION): imp.k $(KOMPILE)
+$(DEFINITION): imp.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
-%.kprove: %.k $(DEFINITION) $(KPROVE) $(KORE_EXEC)
+%.kprove: %.k $(DEFINITION) $(KORE_EXEC)
 	$(KPROVE) $(KPROVE_OPTS) -d . -m VERIFICATION $<
 
-%.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final \
 		$(foreach pat, $(wildcard $*.search.pattern), --pattern "$$(cat $(pat))")
 
@@ -54,6 +50,6 @@ test-prove: $(foreach test, $(prove_tests), prove/$(test).kprove)
 golden: $(foreach test, $(all_tests), tests/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) tests/*.imp.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/include.mk
+++ b/src/main/k/working/include.mk
@@ -1,0 +1,5 @@
+ifeq ($(origin TOP), undefined)
+	TOP = $(shell git rev-parse --show-toplevel)
+endif
+
+include $(TOP)/include.mk

--- a/src/main/k/working/search/Makefile
+++ b/src/main/k/working/search/Makefile
@@ -1,52 +1,48 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../include.mk
 
 KOMPILED := search-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): search.k $(KOMPILE)
+$(DEFINITION): search.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module SEARCH
 
-%.search.kore: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.star.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.star.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all
 
-%.plus.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.plus.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps
 
-%.one.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.one.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step
 
-%.final.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.final.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final
 
-%.star.unreachable.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.star.unreachable.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all --pattern '<k> unreachable </k>'
 
-%.plus.unreachable.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.plus.unreachable.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps --pattern '<k> unreachable </k>'
 
-%.one.unreachable.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.one.unreachable.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step --pattern '<k> unreachable </k>'
 
-%.final.unreachable.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.final.unreachable.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final --pattern '<k> unreachable </k>'
 
-%.star.initial.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.star.initial.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-all --pattern '<k> initial </k>'
 
-%.plus.initial.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.plus.initial.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-or-more-steps --pattern '<k> initial </k>'
 
-%.one.initial.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.one.initial.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-one-step --pattern '<k> initial </k>'
 
-%.final.initial.output: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.final.initial.output: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final --pattern '<k> initial </k>'
 
-%.krun: %.search $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.search $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -86,6 +82,6 @@ golden: \
 	tests/initial.final.initial.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.search.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/Makefile
+++ b/src/main/k/working/tests/Makefile
@@ -1,9 +1,14 @@
+include ../include.mk
+
 TOPTARGETS := all clean test test-k golden
+
+.PHONY: $(TOPTARGETS)
 
 SUBDIRS := $(wildcard */.)
 
-$(TOPTARGETS): $(SUBDIRS)
-$(SUBDIRS):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-.PHONY: $(TOPTARGETS) $(SUBDIRS)
+# The subdirectory targets should not run in parallel, due to issues with
+# running multiple concurrent krun processes.
+$(TOPTARGETS):
+	for subdir in $(SUBDIRS); do \
+		$(MAKE) -C "$$subdir" $(MAKECMDGOALS); \
+	done

--- a/src/main/k/working/tests/bitrange/Makefile
+++ b/src/main/k/working/tests/bitrange/Makefile
@@ -1,19 +1,15 @@
-TOP != git rev-parse --show-toplevel
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := bitrange-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): bitrange.k $(KOMPILE)
+$(DEFINITION): bitrange.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module bitrange
 
-%.bitrange.kore: %.eqtest $(DEFINITION) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.bitrange $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.bitrange $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.bitrange $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.bitrange $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.bitrange.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/Makefile
+++ b/src/main/k/working/tests/collections/Makefile
@@ -1,9 +1,14 @@
+include ../../include.mk
+
 TOPTARGETS := all clean test test-k golden
+
+.PHONY: $(TOPTARGETS)
 
 SUBDIRS := $(wildcard */.)
 
-$(TOPTARGETS): $(SUBDIRS)
-$(SUBDIRS):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-.PHONY: $(TOPTARGETS) $(SUBDIRS)
+# The subdirectory targets should not run in parallel, due to issues with
+# running multiple concurrent krun processes.
+$(TOPTARGETS):
+	for subdir in $(SUBDIRS); do \
+		$(MAKE) -C "$$subdir" $(MAKECMDGOALS); \
+	done

--- a/src/main/k/working/tests/collections/list-map-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/list-map-unify-concrete/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-map-unify-concrete-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-map-unify-concrete.k $(KOMPILE)
+$(DEFINITION): list-map-unify-concrete.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-map-unify-concrete
 
-%.list-map-unify-concrete.kore: %.list-map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-map-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-map-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-map-unify-concrete.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-requires/Makefile
+++ b/src/main/k/working/tests/collections/list-requires/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-requires-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-requires.k $(KOMPILE)
+$(DEFINITION): list-requires.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module LIST-REQUIRES
 
-%.list-requires.kore: %.list-requires $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-requires $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-requires $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-requires $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-requires $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test
 golden: tests/1.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-requires.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-concrete/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-unify-concrete-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-unify-concrete.k $(KOMPILE)
+$(DEFINITION): list-unify-concrete.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module list-unify-concrete
 
-%.list-unify-concrete.kore: %.list-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test tests/5.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden tests/5.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-unify-concrete.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-unify-first-elem/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-first-elem/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-unify-first-elem-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-unify-first-elem.k $(KOMPILE)
+$(DEFINITION): list-unify-first-elem.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module LIST-UNIFY-FIRST-ELEM
 
-%.list-unify-first-elem.kore: %.list-unify-first-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-unify-first-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-unify-first-elem $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-first-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-unify-first-elem $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-unify-first-elem.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-unify-framing-variable-left/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-framing-variable-left/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-unify-framing-variable-left-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-unify-framing-variable-left.k $(KOMPILE)
+$(DEFINITION): list-unify-framing-variable-left.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module LIST-UNIFY-FRAMING-VARIABLE-LEFT
 
-%.list-unify-framing-variable-left.kore: %.list-unify-framing-variable-left $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-unify-framing-variable-left $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-unify-framing-variable-left $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-framing-variable-left $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-unify-framing-variable-left $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-unify-framing-variable-left.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-unify-framing-variable-right/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-framing-variable-right/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-unify-framing-variable-right-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-unify-framing-variable-right.k $(KOMPILE)
+$(DEFINITION): list-unify-framing-variable-right.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module LIST-UNIFY-FRAMING-VARIABLE-RIGHT
 
-%.list-unify-framing-variable-right.kore: %.list-unify-framing-variable-right $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-unify-framing-variable-right $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-unify-framing-variable-right $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-framing-variable-right $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-unify-framing-variable-right $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-unify-framing-variable-right.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/list-unify-last-elem/Makefile
+++ b/src/main/k/working/tests/collections/list-unify-last-elem/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := list-unify-last-elem-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): list-unify-last-elem.k $(KOMPILE)
+$(DEFINITION): list-unify-last-elem.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module LIST-UNIFY-LAST-ELEM
 
-%.list-unify-last-elem.kore: %.list-unify-last-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.list-unify-last-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.list-unify-last-elem $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.list-unify-last-elem $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.list-unify-last-elem $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.list-unify-last-elem.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/map-lookup/Makefile
+++ b/src/main/k/working/tests/collections/map-lookup/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := map-lookup-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): map-lookup.k $(KOMPILE)
+$(DEFINITION): map-lookup.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module MAP-LOOKUP
 
-%.map-lookup.kore: %.map-lookup $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.map-lookup $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.map-lookup $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.map-lookup $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.map-lookup $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test
 golden: tests/1.output.golden tests/2.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.map-lookup.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/map-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/map-unify-concrete/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := map-unify-concrete-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): map-unify-concrete.k $(KOMPILE)
+$(DEFINITION): map-unify-concrete.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module map-unify-concrete
 
-%.map-unify-concrete.kore: %.map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.map-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.map-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.map-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test tests/5.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden tests/5.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.map-unify-concrete.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/map-unify-framing-variable/Makefile
+++ b/src/main/k/working/tests/collections/map-unify-framing-variable/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := map-unify-framing-variable-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): map-unify-framing-variable.k $(KOMPILE_TARGETS)
+$(DEFINITION): map-unify-framing-variable.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module MAP-UNIFY-FRAMING-VARIABLE
 
-%.map-unify-framing-variable.kore: %.map-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.map-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.map-unify-framing-variable $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.map-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.map-unify-framing-variable $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.map-unify-framing-variable.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/set-unify-concrete/Makefile
+++ b/src/main/k/working/tests/collections/set-unify-concrete/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := set-unify-concrete-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): set-unify-concrete.k $(KOMPILE)
+$(DEFINITION): set-unify-concrete.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module set-unify-concrete
 
-%.set-unify-concrete.kore: %.set-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.set-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.set-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.set-unify-concrete $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.set-unify-concrete $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test tests/5.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden tests/5.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.set-unify-concrete.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/collections/set-unify-framing-variable/Makefile
+++ b/src/main/k/working/tests/collections/set-unify-framing-variable/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../../include.mk
 
 KOMPILED := set-unify-framing-variable-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): set-unify-framing-variable.k $(KOMPILE)
+$(DEFINITION): set-unify-framing-variable.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module SET-UNIFY-FRAMING-VARIABLE
 
-%.set-unify-framing-variable.kore: %.set-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.set-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.set-unify-framing-variable $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.set-unify-framing-variable $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.set-unify-framing-variable $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.set-unify-framing-variable.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/eqtest/Makefile
+++ b/src/main/k/working/tests/eqtest/Makefile
@@ -1,19 +1,15 @@
-TOP != git rev-parse --show-toplevel
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := eqtest-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): eqtest.k $(KOMPILE)
+$(DEFINITION): eqtest.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module eqtest
 
-%.eqtest.kore: %.eqtest $(DEFINITION) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.eqtest $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.eqtest $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.eqtest $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.eqtest $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.eqtest.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/kprove/Makefile
+++ b/src/main/k/working/tests/kprove/Makefile
@@ -1,5 +1,4 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := imp-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
@@ -7,19 +6,16 @@ DEFINITION := $(KOMPILED)/definition.kore
 $(DEFINITION): imp.k $(KOMPILE)
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module IMP
 
-%.imp.kore: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.krun: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
-%.kprove: %.k $(DEFINITION) $(KPROVE) $(KORE_EXEC)
+%.kprove: %.k $(DEFINITION) $(KORE_EXEC)
 	$(KPROVE) $(KPROVE_OPTS) -d . -m VERIFICATION $<
 
-%.output: %.k $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.k $(DEFINITION) $(KORE_EXEC)
 	$(KPROVE) $(KPROVE_OPTS) -d . -m VERIFICATION $< --output-file $@
 
-%.search.final.output: %.imp $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.search.final.output: %.imp $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@ --search-final \
 		$(foreach pat, $(wildcard $*.search.pattern), --pattern "$$(cat $(pat))")
 
@@ -41,6 +37,6 @@ test-prove: $(foreach test, $(prove_tests), prove/$(test).kprove)
 golden: $(foreach test, $(prove_tests), prove/$(test).output.golden)
 
 clean:
-	rm -rf $(KOMPILED) prove/*.imp.kore prove/*.output
+	rm -rf $(KOMPILED) prove/*.output
 
 .PHONY: test-k test test-prove golden clean %.test %.krun

--- a/src/main/k/working/tests/ord/Makefile
+++ b/src/main/k/working/tests/ord/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := ord-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): ord.k $(K)
+$(DEFINITION): ord.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module ord
 
-%.ord.kore: %.ord $(DEFINITION) $(K) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.ord $(DEFINITION) $(K) $(KORE_EXEC)
+%.output: %.ord $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.ord $(DEFINITION) $(K) $(KORE_EXEC)
+%.krun: %.ord $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test
 golden: tests/1.output.golden tests/2.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.ord.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/owise-1/Makefile
+++ b/src/main/k/working/tests/owise-1/Makefile
@@ -1,19 +1,15 @@
-TOP != git rev-parse --show-toplevel
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := demo-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): demo.k $(KOMPILE)
+$(DEFINITION): demo.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module demo
 
-%.demo.kore: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.demo $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.demo $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.demo $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/2.test tests/3.test tests/4.test
 golden: tests/1.output.golden tests/2.output.golden tests/3.output.golden tests/4.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.demo.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun

--- a/src/main/k/working/tests/strict/Makefile
+++ b/src/main/k/working/tests/strict/Makefile
@@ -1,19 +1,15 @@
-TOP := $(shell git rev-parse --show-toplevel)
-include $(TOP)/include.mk
+include $(CURDIR)/../../include.mk
 
 KOMPILED := strict-kompiled
 DEFINITION := $(KOMPILED)/definition.kore
 
-$(DEFINITION): strict.k $(KOMPILE)
+$(DEFINITION): strict.k
 	$(KOMPILE) $(KOMPILE_OPTS) $< --syntax-module STRICT
 
-%.strict.kore: %.strict $(DEFINITION) $(KRUN) $(KORE_EXEC)
-	$(KRUN) $(KRUN_OPTS) $< --dry-run
-
-%.output: %.strict $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.output: %.strict $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $< --output-file $@
 
-%.krun: %.strict $(DEFINITION) $(KRUN) $(KORE_EXEC)
+%.krun: %.strict $(DEFINITION) $(KORE_EXEC)
 	$(KRUN) $(KRUN_OPTS) $<
 
 %.test: %.output
@@ -29,6 +25,6 @@ test-k: tests/1.test tests/10.test tests/g2.test tests/g21.test tests/g3.test te
 golden: tests/1.output.golden tests/10.output.golden tests/g2.output.golden tests/g21.output.golden tests/g3.output.golden tests/seq.output.golden tests/nd.output.golden
 
 clean:
-	rm -rf $(KOMPILED) tests/*.strict.kore tests/*.output
+	rm -rf $(KOMPILED) tests/*.output
 
 .PHONY: test-k test golden clean %.test %.krun


### PR DESCRIPTION
The Makefile is refactored to allow the integration tests and other targets to run in parallel. There is no more `make jenkins` target, rather there is `./scripts/ci.sh`, so the Jenkins job for this branch will fail until I change the configuration on the server.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

