### PR TITLE
Refactor the function evaluation code

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -104,8 +104,7 @@ import           Kore.Step.ExpandedPattern
 import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( top )
 import           Kore.Step.Function.Data
-                 ( ApplicationFunctionEvaluator (ApplicationFunctionEvaluator),
-                 AttemptedAxiom (..) )
+                 ( AttemptedAxiom (..), AxiomSimplifier (AxiomSimplifier) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
@@ -119,7 +118,7 @@ import           Kore.Unparser
 
 type Parser = Parsec Void Text
 
-type Function = ApplicationFunctionEvaluator Object
+type Function = AxiomSimplifier Object
 
 type HookedSortDescription = SortDescription Object Domain.Builtin
 
@@ -256,7 +255,7 @@ symbolVerifier Verifiers { symbolVerifiers } hook =
 
 notImplemented :: Function
 notImplemented =
-    ApplicationFunctionEvaluator notImplemented0
+    AxiomSimplifier notImplemented0
   where
     notImplemented0 _ _ _ _ = pure (NotApplicable, SimplificationProof)
 
@@ -623,7 +622,7 @@ functionEvaluator
     -- ^ Builtin function implementation
     -> Function
 functionEvaluator impl =
-    ApplicationFunctionEvaluator evaluator
+    AxiomSimplifier evaluator
   where
     evaluator
         :: (Ord (variable Object), Show (variable Object))

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -48,7 +48,7 @@ module Kore.Builtin.Builtin
     , lookupSymbol
     , isSymbol
     , expectNormalConcreteTerm
-    , getAttemptedFunction
+    , getAttemptedAxiom
       -- * Implementing builtin unification
     , unifyEqualsUnsolved
     ) where
@@ -105,7 +105,7 @@ import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( top )
 import           Kore.Step.Function.Data
                  ( ApplicationFunctionEvaluator (ApplicationFunctionEvaluator),
-                 AttemptedFunction (..) )
+                 AttemptedAxiom (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
@@ -450,7 +450,7 @@ parseString parser lit =
     castParseError =
         either (Kore.Error.koreFail . Parsec.errorBundlePretty) pure
 
-{- | Return the supplied pattern as an 'AttemptedFunction'.
+{- | Return the supplied pattern as an 'AttemptedAxiom'.
 
   No substitution or predicate is applied.
 
@@ -459,7 +459,7 @@ parseString parser lit =
 appliedFunction
     :: (Monad m, Ord (variable level), level ~ Object)
     => ExpandedPattern level variable
-    -> m (AttemptedFunction level variable)
+    -> m (AttemptedAxiom level variable)
 appliedFunction epat =
     (return . Applied . OrOfExpandedPattern.make) [epat]
 
@@ -502,7 +502,7 @@ unaryOperator
         -> StepPatternSimplifier level variable
         -> Sort level
         -> [StepPattern level variable]
-        -> Simplifier (AttemptedFunction level variable)
+        -> Simplifier (AttemptedAxiom level variable)
     unaryOperator0 _ _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
             [DomainValuePattern a] -> do
@@ -552,7 +552,7 @@ binaryOperator
         -> StepPatternSimplifier level variable
         -> Sort level
         -> [StepPattern level variable]
-        -> Simplifier (AttemptedFunction level variable)
+        -> Simplifier (AttemptedAxiom level variable)
     binaryOperator0 _ _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
             [DomainValuePattern a, DomainValuePattern b] -> do
@@ -601,7 +601,7 @@ ternaryOperator
         -> StepPatternSimplifier level variable
         -> Sort level
         -> [StepPattern level variable]
-        -> Simplifier (AttemptedFunction level variable)
+        -> Simplifier (AttemptedAxiom level variable)
     ternaryOperator0 _ _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
             [DomainValuePattern a, DomainValuePattern b, DomainValuePattern c] -> do
@@ -618,7 +618,7 @@ functionEvaluator
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
         )
     -- ^ Builtin function implementation
     -> Function
@@ -635,7 +635,7 @@ functionEvaluator impl =
             (Valid (variable Object) Object)
             (StepPattern Object variable)
         -> Simplifier
-            ( AttemptedFunction Object variable
+            ( AttemptedAxiom Object variable
             , SimplificationProof Object
             )
     evaluator tools _ simplifier (valid :< app) = do
@@ -707,11 +707,11 @@ expectNormalConcreteTerm tools purePattern =
 
 {- | Run a function evaluator that can terminate early.
  -}
-getAttemptedFunction
+getAttemptedAxiom
     :: Monad m
-    => MaybeT m (AttemptedFunction level variable)
-    -> m (AttemptedFunction level variable)
-getAttemptedFunction attempt =
+    => MaybeT m (AttemptedAxiom level variable)
+    -> m (AttemptedAxiom level variable)
+getAttemptedAxiom attempt =
     fromMaybe NotApplicable <$> runMaybeT attempt
 
 -- | Return an unsolved unification problem.

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -104,7 +104,8 @@ import           Kore.Step.ExpandedPattern
 import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( top )
 import           Kore.Step.Function.Data
-                 ( AttemptedAxiom (..), AxiomSimplifier (AxiomSimplifier),
+                 ( AttemptedAxiom (..),
+                 BuiltinAndAxiomSimplifier (BuiltinAndAxiomSimplifier),
                  applicationAxiomSimplifier )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
@@ -119,7 +120,7 @@ import           Kore.Unparser
 
 type Parser = Parsec Void Text
 
-type Function = AxiomSimplifier Object
+type Function = BuiltinAndAxiomSimplifier Object
 
 type HookedSortDescription = SortDescription Object Domain.Builtin
 
@@ -256,7 +257,7 @@ symbolVerifier Verifiers { symbolVerifiers } hook =
 
 notImplemented :: Function
 notImplemented =
-    AxiomSimplifier notImplemented0
+    BuiltinAndAxiomSimplifier notImplemented0
   where
     notImplemented0 _ _ _ _ = pure (NotApplicable, SimplificationProof)
 

--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -104,7 +104,8 @@ import           Kore.Step.ExpandedPattern
 import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( top )
 import           Kore.Step.Function.Data
-                 ( AttemptedAxiom (..), AxiomSimplifier (AxiomSimplifier) )
+                 ( AttemptedAxiom (..), AxiomSimplifier (AxiomSimplifier),
+                 applicationAxiomSimplifier )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
@@ -622,7 +623,7 @@ functionEvaluator
     -- ^ Builtin function implementation
     -> Function
 functionEvaluator impl =
-    AxiomSimplifier evaluator
+    applicationAxiomSimplifier evaluator
   where
     evaluator
         :: (Ord (variable Object), Show (variable Object))

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -44,7 +44,7 @@ import qualified Kore.Error
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( ApplicationFunctionEvaluator (..), AttemptedAxiom (..),
+                 ( AttemptedAxiom (..), AxiomSimplifier (..),
                  notApplicableFunctionEvaluator, purePatternFunctionEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
@@ -117,9 +117,9 @@ otherwise.
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
     Map.fromList
-    [ (eqKey, ApplicationFunctionEvaluator (evalKEq True))
-    , (neqKey, ApplicationFunctionEvaluator (evalKEq False))
-    , (iteKey, ApplicationFunctionEvaluator evalKIte)
+    [ (eqKey, AxiomSimplifier (evalKEq True))
+    , (neqKey, AxiomSimplifier (evalKEq False))
+    , (iteKey, AxiomSimplifier evalKIte)
     ]
 
 evalKEq

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -44,7 +44,7 @@ import qualified Kore.Error
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( ApplicationFunctionEvaluator (..), AttemptedFunction (..),
+                 ( ApplicationFunctionEvaluator (..), AttemptedAxiom (..),
                  notApplicableFunctionEvaluator, purePatternFunctionEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
@@ -138,7 +138,7 @@ evalKEq
         (Valid (variable Object) Object)
         (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
+        ( AttemptedAxiom Object variable
         , SimplificationProof Object
         )
 evalKEq true tools substitutionSimplifier _ (valid :< app) =
@@ -176,7 +176,7 @@ evalKIte
         (Valid (variable Object) Object)
         (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
+        ( AttemptedAxiom Object variable
         , SimplificationProof Object
         )
 evalKIte _ _ _ (_ :< app) =

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -44,7 +44,7 @@ import qualified Kore.Error
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( AttemptedAxiom (..), AxiomSimplifier (..),
+                 ( AttemptedAxiom (..), applicationAxiomSimplifier,
                  notApplicableFunctionEvaluator, purePatternFunctionEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
@@ -117,9 +117,9 @@ otherwise.
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
     Map.fromList
-    [ (eqKey, AxiomSimplifier (evalKEq True))
-    , (neqKey, AxiomSimplifier (evalKEq False))
-    , (iteKey, AxiomSimplifier evalKIte)
+    [ (eqKey, applicationAxiomSimplifier (evalKEq True))
+    , (neqKey, applicationAxiomSimplifier (evalKEq False))
+    , (iteKey, applicationAxiomSimplifier evalKIte)
     ]
 
 evalKEq

--- a/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/KEqual.hs
@@ -45,7 +45,7 @@ import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
                  ( AttemptedAxiom (..), applicationAxiomSimplifier,
-                 notApplicableFunctionEvaluator, purePatternFunctionEvaluator )
+                 notApplicableAxiomEvaluator, purePatternAxiomEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
@@ -153,10 +153,10 @@ evalKEq true tools substitutionSimplifier _ (valid :< app) =
         (result, _proof) <- makeEvaluate tools substitutionSimplifier ep1 ep2
         case () of
             _ | OrOfExpandedPattern.isTrue result ->
-                purePatternFunctionEvaluator (Bool.asPattern patternSort true)
+                purePatternAxiomEvaluator (Bool.asPattern patternSort true)
               | OrOfExpandedPattern.isFalse result ->
-                purePatternFunctionEvaluator (Bool.asPattern patternSort false)
-              | otherwise -> notApplicableFunctionEvaluator
+                purePatternAxiomEvaluator (Bool.asPattern patternSort false)
+              | otherwise -> notApplicableAxiomEvaluator
       where
         ep1 = ExpandedPattern.fromPurePattern t1
         ep2 = ExpandedPattern.fromPurePattern t2
@@ -201,9 +201,9 @@ evalKIte _ _ _ (_ :< app) =
     evalIte expr t1 t2 =
         case evaluate expr of
             Just result
-                | result    -> purePatternFunctionEvaluator t1
-                | otherwise -> purePatternFunctionEvaluator t2
-            Nothing    -> notApplicableFunctionEvaluator
+                | result    -> purePatternAxiomEvaluator t1
+                | otherwise -> purePatternAxiomEvaluator t2
+            Nothing    -> notApplicableAxiomEvaluator
 
 eqKey :: IsString s => s
 eqKey = "KEQUAL.eq"

--- a/src/main/haskell/kore/src/Kore/Builtin/Krypto.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Krypto.hs
@@ -42,7 +42,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Sort
                  ( Sort )
 import           Kore.Step.Function.Data
-                 ( AttemptedFunction )
+                 ( AttemptedAxiom )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
                  ( Simplifier, StepPatternSimplifier )
@@ -83,9 +83,9 @@ evalKeccak =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalKeccak0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let
                 arg =
                     case arguments of

--- a/src/main/haskell/kore/src/Kore/Builtin/List.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/List.hs
@@ -157,7 +157,7 @@ returnList
     :: (Monad m, Ord (variable Object))
     => Sort Object
     -> (Builtin variable)
-    -> m (AttemptedFunction Object variable)
+    -> m (AttemptedAxiom Object variable)
 returnList resultSort list =
     Builtin.appliedFunction
         $ ExpandedPattern.fromPurePattern
@@ -183,9 +183,9 @@ evalGet =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalGet0 _ _ _ = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_list, _ix) =
                     case arguments of
@@ -230,9 +230,9 @@ evalConcat =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalConcat0 _ _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_list1, _list2) =
                     case arguments of

--- a/src/main/haskell/kore/src/Kore/Builtin/Map.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Map.hs
@@ -81,7 +81,7 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( AttemptedFunction (..) )
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier, SimplificationProof (..),
@@ -181,7 +181,7 @@ returnMap
     :: (Monad m, Ord (variable Object))
     => Sort Object
     -> Builtin variable
-    -> m (AttemptedFunction Object variable)
+    -> m (AttemptedAxiom Object variable)
 returnMap resultSort map' =
     Builtin.appliedFunction
         $ ExpandedPattern.fromPurePattern
@@ -197,9 +197,9 @@ evalLookup =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalLookup0 tools _ _ arguments =
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_map, _key) =
                     case arguments of
@@ -224,7 +224,7 @@ evalElement =
     Builtin.functionEvaluator evalElement0
   where
     evalElement0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_key, _value) =
                     case arguments of
@@ -245,9 +245,9 @@ evalConcat =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalConcat0 _ _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_map1, _map2) =
                     case arguments of
@@ -302,7 +302,7 @@ evalUpdate =
     Builtin.functionEvaluator evalUpdate0
   where
     evalUpdate0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_map, _key, value) =
                     case arguments of
@@ -318,7 +318,7 @@ evalInKeys =
     Builtin.functionEvaluator evalInKeys0
   where
     evalInKeys0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_key, _map) =
                     case arguments of
@@ -341,9 +341,9 @@ evalKeys =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalKeys0 _ _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let _map =
                     case arguments of

--- a/src/main/haskell/kore/src/Kore/Builtin/Set.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Set.hs
@@ -85,7 +85,7 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( AttemptedFunction (..) )
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier (..),
@@ -188,7 +188,7 @@ returnSet
     :: (Monad m, Ord (variable Object))
     => Sort Object
     -> Builtin
-    -> m (AttemptedFunction Object variable)
+    -> m (AttemptedAxiom Object variable)
 returnSet resultSort set =
     Builtin.appliedFunction
     $ ExpandedPattern.fromPurePattern
@@ -199,7 +199,7 @@ evalElement =
     Builtin.functionEvaluator evalElement0
   where
     evalElement0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (case arguments of
             [_elem] -> do
                 _elem <- Builtin.expectNormalConcreteTerm tools _elem
@@ -217,9 +217,9 @@ evalIn =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalIn0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_elem, _set) =
                     case arguments of
@@ -253,9 +253,9 @@ evalConcat =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalConcat0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_set1, _set2) =
                     case arguments of
@@ -293,9 +293,9 @@ evalDifference =
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalDifference0 tools _ resultSort = \arguments ->
-        Builtin.getAttemptedFunction
+        Builtin.getAttemptedAxiom
         (do
             let (_set1, _set2) =
                     case arguments of
@@ -324,9 +324,9 @@ evalToList = Builtin.functionEvaluator evalToList0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalToList0 tools _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _set =
                         case arguments of
                             [_set] -> _set
@@ -347,9 +347,9 @@ evalSize = Builtin.functionEvaluator evalSize0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalSize0 tools _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _set =
                         case arguments of
                             [_set] -> _set

--- a/src/main/haskell/kore/src/Kore/Builtin/String.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/String.hs
@@ -78,7 +78,7 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Function.Data
-                 ( AttemptedFunction (..) )
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
                  ( Simplifier, StepPatternSimplifier )
@@ -282,9 +282,9 @@ evalSubstr = Builtin.functionEvaluator evalSubstr0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalSubstr0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let (_str, _start, _end) =
                     case arguments of
                         [_str, _start, _end] -> (_str, _start, _end)
@@ -305,9 +305,9 @@ evalLength = Builtin.functionEvaluator evalLength0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalLength0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _str =
                     case arguments of
                         [_str] -> _str
@@ -330,9 +330,9 @@ evalFind = Builtin.functionEvaluator evalFind0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalFind0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let (_str, _substr, _idx) =
                     case arguments of
                         [_str, _substr, _idx] -> (_str, _substr, _idx)
@@ -354,9 +354,9 @@ evalString2Base = Builtin.functionEvaluator evalString2Base0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalString2Base0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let (_str, _base) =
                     case arguments of
                         [_str, _base] -> (_str, _base)
@@ -390,9 +390,9 @@ evalString2Int = Builtin.functionEvaluator evalString2Int0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalString2Int0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _str =
                     case arguments of
                         [_str] -> _str
@@ -415,9 +415,9 @@ evalChr = Builtin.functionEvaluator evalChr0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalChr0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _n =
                     case arguments of
                         [_n] -> _n
@@ -436,9 +436,9 @@ evalOrd = Builtin.functionEvaluator evalOrd0
         -> StepPatternSimplifier Object variable
         -> Sort Object
         -> [StepPattern Object variable]
-        -> Simplifier (AttemptedFunction Object variable)
+        -> Simplifier (AttemptedAxiom Object variable)
     evalOrd0 _ _ resultSort arguments =
-        Builtin.getAttemptedFunction $ do
+        Builtin.getAttemptedAxiom $ do
             let _str =
                     case arguments of
                         [_str] -> _str

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -10,9 +10,9 @@ Portability : portable
 module Kore.Step.Function.Data
     ( ApplicationFunctionEvaluator (..)
     , BuiltinAndAxiomsFunctionEvaluatorMap
-    , AttemptedFunction (..)
+    , AttemptedAxiom (..)
     , BuiltinAndAxiomsFunctionEvaluator
-    , CommonAttemptedFunction
+    , CommonAttemptedAxiom
     , FunctionEvaluators (..)
     , notApplicableFunctionEvaluator
     , purePatternFunctionEvaluator
@@ -79,7 +79,7 @@ newtype ApplicationFunctionEvaluator level =
             (Valid (variable level) level)
             (StepPattern level variable)
         -> Simplifier
-            ( AttemptedFunction level variable
+            ( AttemptedAxiom level variable
             , SimplificationProof level
             )
         )
@@ -114,23 +114,23 @@ their corresponding evaluators.
 type BuiltinAndAxiomsFunctionEvaluatorMap level =
     Map.Map (Id level) (BuiltinAndAxiomsFunctionEvaluator level)
 
-{-| 'AttemptedFunction' is a generalized 'FunctionResult' that handles
-cases where the function can't be fully evaluated.
+{-| 'AttemptedAxiom' hods the result of axiom-based simplification, with
+a case for axioms that can't be applied.
 -}
-data AttemptedFunction level variable
+data AttemptedAxiom level variable
     = NotApplicable
     | Applied !(OrOfExpandedPattern level variable)
   deriving (Show, Eq)
 
-{-| 'CommonAttemptedFunction' particularizes 'AttemptedFunction' to 'Variable',
+{-| 'CommonAttemptedAxiom' particularizes 'AttemptedAxiom' to 'Variable',
 following the same pattern as the other `Common*` types.
 -}
-type CommonAttemptedFunction level = AttemptedFunction level Variable
+type CommonAttemptedAxiom level = AttemptedAxiom level Variable
 
 -- |Yields a pure 'Simplifier' which always returns 'NotApplicable'
 notApplicableFunctionEvaluator
     :: Simplifier
-        (AttemptedFunction level1 variable, SimplificationProof level2)
+        (AttemptedAxiom level1 variable, SimplificationProof level2)
 notApplicableFunctionEvaluator = pure (NotApplicable, SimplificationProof)
 
 -- |Yields a pure 'Simplifier' which produces a given 'StepPattern'
@@ -138,7 +138,7 @@ purePatternFunctionEvaluator
     :: (MetaOrObject level, Ord (variable level))
     => StepPattern level variable
     -> Simplifier
-        (AttemptedFunction level variable, SimplificationProof level)
+        (AttemptedAxiom level variable, SimplificationProof level)
 purePatternFunctionEvaluator p =
     pure
         ( Applied (makeFromSinglePurePattern p)

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -113,7 +113,7 @@ their corresponding evaluators.
 type BuiltinAndAxiomSimplifierMap level =
     Map.Map (Id level) (BuiltinAndAxiomsFunctionEvaluator level)
 
-{-| 'AttemptedAxiom' hods the result of axiom-based simplification, with
+{-| 'AttemptedAxiom' holds the result of axiom-based simplification, with
 a case for axioms that can't be applied.
 -}
 data AttemptedAxiom level variable

--- a/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Data.hs
@@ -8,7 +8,7 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Function.Data
-    ( ApplicationFunctionEvaluator (..)
+    ( AxiomSimplifier (..)
     , BuiltinAndAxiomsFunctionEvaluatorMap
     , AttemptedAxiom (..)
     , BuiltinAndAxiomsFunctionEvaluator
@@ -40,8 +40,8 @@ import Kore.Unparser
 import Kore.Variables.Fresh
        ( FreshVariable )
 
-{-| 'ApplicationFunctionEvaluator' evaluates functions on an 'Application'
-pattern. This can be either a built-in evaluator or a user-defined one.
+{-| 'AxiomSimplifier' simplifies 'Application' patterns using either an axiom
+or builtin code.
 
 Arguments:
 
@@ -58,8 +58,8 @@ Return value:
 It returns the result of appling the function, together with a proof certifying
 that the function was applied correctly (which is only a placeholder right now).
 -}
-newtype ApplicationFunctionEvaluator level =
-    ApplicationFunctionEvaluator
+newtype AxiomSimplifier level =
+    AxiomSimplifier
         (forall variable
         .   ( FreshVariable variable
             , MetaOrObject level
@@ -90,7 +90,7 @@ data FunctionEvaluators level
         { definitionRules :: [EqualityRule level]
         -- ^ Evaluators used when evaluating functions according to their
         -- definition.
-        , simplificationEvaluators :: [ApplicationFunctionEvaluator level]
+        , simplificationEvaluators :: [AxiomSimplifier level]
         -- ^ Evaluators used when simplifying functions.
         }
 
@@ -105,7 +105,7 @@ other succeeds, using both results would introduce a split in the search space.
 -}
 type BuiltinAndAxiomsFunctionEvaluator level =
     These
-        (ApplicationFunctionEvaluator level)
+        (AxiomSimplifier level)
         (FunctionEvaluators level)
 
 {-|A type to abstract away the mapping from symbol identifiers to

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -15,6 +15,7 @@ import           Control.Exception
                  ( assert )
 import           Control.Monad
                  ( when )
+import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map as Map
 import           Data.Maybe
                  ( isJust )
@@ -178,13 +179,13 @@ evaluateApplication
             , SimplificationProof level
             )
     applyEvaluator
-        app' (AxiomSimplifier evaluator)
+        (valid' :< app') (AxiomSimplifier evaluator)
       = do
         result <- evaluator
             tools
             substitutionSimplifier
             simplifier
-            app'
+            (Recursive.embed (valid' :< ApplicationPattern app'))
         mergeWithConditionAndSubstitution
             tools
             substitutionSimplifier

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -15,7 +15,6 @@ import           Control.Exception
                  ( assert )
 import           Control.Monad
                  ( when )
-import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map as Map
 import           Data.Maybe
                  ( isJust )
@@ -42,6 +41,8 @@ import qualified Kore.Step.BaseStep as OrStepResult
                  ( OrStepResult (..) )
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, PredicateSubstitution, Predicated (..) )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+                 ( fromPurePattern )
 import           Kore.Step.Function.Data
                  ( BuiltinAndAxiomSimplifier (..),
                  BuiltinAndAxiomSimplifierMap,
@@ -57,7 +58,7 @@ import qualified Kore.Step.Merging.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
-                 ( extractPatterns, make, traverseWithPairs )
+                 ( extractPatterns, flatten, make, traverseWithPairs )
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier, SimplificationProof (..),
@@ -104,7 +105,7 @@ evaluateApplication
     simplifier
     symbolIdToEvaluator
     childrenPredicateSubstitution
-    validApp@(valid :< app)
+    (valid :< app)
   =
     case Map.lookup symbolId symbolIdToEvaluator of
         Nothing
@@ -122,11 +123,31 @@ evaluateApplication
             traceNonErrorMonad
                 D_Function_evaluateApplication
                 [debugArg "symbolId" (getId symbolId)]
-            $ these
-                evaluateWithBuiltins
-                evaluateWithFunctionAxioms
-                evaluateBuiltinAndAxioms
-                builtinOrAxiomEvaluators
+            $ do
+                (result, proof) <- these
+                    evaluateWithBuiltins
+                    evaluateWithFunctionAxioms
+                    evaluateBuiltinAndAxioms
+                    builtinOrAxiomEvaluators
+                flattened <- case result of
+                    AttemptedAxiom.NotApplicable ->
+                        return AttemptedAxiom.NotApplicable
+                    AttemptedAxiom.Applied orResults -> do
+                        simplified <- mapM simplifyIfNeeded orResults
+                        return
+                            (AttemptedAxiom.Applied
+                                (OrOfExpandedPattern.flatten simplified)
+                            )
+                (merged, _proof) <- mergeWithConditionAndSubstitution
+                    tools
+                    substitutionSimplifier
+                    simplifier
+                    childrenPredicateSubstitution
+                    (flattened, proof)
+                case merged of
+                    AttemptedAxiom.NotApplicable -> return unchanged
+                    AttemptedAxiom.Applied orPatt ->
+                        return (orPatt, SimplificationProof)
   where
     Application { applicationSymbolOrAlias = appHead } = app
     SymbolOrAlias { symbolOrAliasConstructor = symbolId } = appHead
@@ -137,26 +158,19 @@ evaluateApplication
         :: BuiltinAndAxiomSimplifier level
         -> FunctionEvaluators level
         -> Simplifier
-            (OrOfExpandedPattern level variable, SimplificationProof level)
-    evaluateBuiltinAndAxioms builtinEvaluator axiomEvaluators = do
-        (result, _proof) <- applyEvaluator validApp builtinEvaluator
-        case result of
-            AttemptedAxiom.NotApplicable
-              | isAppConcrete
-              , Just hook <- getAppHookString ->
-                error
-                    (   "Expecting hook " ++ hook
-                    ++  " to reduce concrete pattern\n\t"
-                    ++ show app
-                    )
-              | otherwise ->
-                -- If the builtin axioms failed, in many cases we can't just
-                -- apply evaluation axioms, since may of them are recursive
-                -- and will be applied indefinitely.
-                -- TODO(virgil): We should refine this at some point.
-                evaluateWithFunctionAxioms
-                    axiomEvaluators { definitionRules = [] }
-            AttemptedAxiom.Applied pat -> return (pat, SimplificationProof)
+            (AttemptedAxiom level variable, SimplificationProof level)
+    evaluateBuiltinAndAxioms
+        builtinEvaluator
+        FunctionEvaluators { definitionRules, simplificationEvaluators }
+      =
+        evaluateBuiltinOrFirstWorkingSimplifierOrDefinitionRulesIfAny
+            builtinEvaluator
+            simplificationEvaluators
+            definitionRules
+            tools
+            substitutionSimplifier
+            simplifier
+            appPurePattern
 
     unchangedPatt =
         case childrenPredicateSubstitution of
@@ -169,178 +183,324 @@ evaluateApplication
     unchangedOr = OrOfExpandedPattern.make [unchangedPatt]
     unchanged = (unchangedOr, SimplificationProof)
 
-    applyEvaluator
-        :: CofreeF
-            (Application level)
-            (Valid (variable level) level)
-            (StepPattern level variable)
-        -> BuiltinAndAxiomSimplifier level
-        -> Simplifier
-            ( AttemptedAxiom level variable
-            , SimplificationProof level
-            )
-    applyEvaluator
-        (valid' :< app') (BuiltinAndAxiomSimplifier evaluator)
-      = do
-        result <- evaluator
-            tools
-            substitutionSimplifier
-            simplifier
-            (Recursive.embed (valid' :< ApplicationPattern app'))
-        mergeWithConditionAndSubstitution
-            tools
-            substitutionSimplifier
-            simplifier
-            childrenPredicateSubstitution
-            result
-
-    isAppConcrete = isJust (asConcretePurePattern appPurePattern)
     getAppHookString =
         Text.unpack <$> (getHook . hook . symAttributes tools) appHead
 
     evaluateWithFunctionAxioms
         :: FunctionEvaluators level
         -> Simplifier
-            (OrOfExpandedPattern level variable, SimplificationProof level)
+            (AttemptedAxiom level variable, SimplificationProof level)
     evaluateWithFunctionAxioms
         FunctionEvaluators { definitionRules, simplificationEvaluators }
-      = do
-        (simplifiedResult, proof) <-
-            evaluateWithSimplificationAxioms simplificationEvaluators
-        case simplifiedResult of
-            AttemptedAxiom.NotApplicable ->
-                if null definitionRules
-                    then
-                        -- We don't have a definition, so we shouldn't attempt
-                        -- to evaluate it, since it would currently evaluate
-                        -- to bottom.
-                        return (OrOfExpandedPattern.make [unchangedPatt], proof)
-                    else evaluateWithDefinitionAxioms definitionRules
-            AttemptedAxiom.Applied result -> return (result, proof)
+      =
+        evaluateFirstWorkingSimplifierOrDefinitionRulesIfAny
+            simplificationEvaluators
+            definitionRules
+            tools
+            substitutionSimplifier
+            simplifier
+            appPurePattern
 
-    evaluateWithSimplificationAxioms [] =
-        return
-            ( AttemptedAxiom.NotApplicable
-            , SimplificationProof
-            )
-    evaluateWithSimplificationAxioms (evaluator : evaluators) = do
-        (applicationResult, _proof) <- applyEvaluator validApp evaluator
-
-        let
-            simplify
-                :: ExpandedPattern level variable
-                -> Simplifier [ExpandedPattern level variable]
-            simplify result = do
-                orPatt <- reevaluateFunctions
-                    tools
-                    substitutionSimplifier
-                    simplifier
-                    result
-                return (OrOfExpandedPattern.extractPatterns orPatt)
-        case applicationResult of
-            AttemptedAxiom.Applied orResults -> do
-                when
-                    (length (OrOfExpandedPattern.extractPatterns orResults) > 1)
-                    -- We should only allow multiple simplification results
-                    -- when they are created by unification splitting the
-                    -- configuration.
-                    -- However, right now, we shouldn't be able to get more
-                    -- than one result, so we throw an error.
-                    (error
-                        (  "Unexpected simplification result with more "
-                        ++ "than one configuration: "
-                        ++ show orResults
-                        )
-                    )
-                patts <-
-                    mapM
-                        simplify
-                        (OrOfExpandedPattern.extractPatterns orResults)
-                return
-                    ( AttemptedAxiom.Applied
-                        (OrOfExpandedPattern.make (concat patts))
-                    , SimplificationProof
-                    )
-            AttemptedAxiom.NotApplicable ->
-                evaluateWithSimplificationAxioms evaluators
-
-    evaluateWithBuiltins evaluator = do
-        (result, _proof) <- applyEvaluator validApp evaluator
-        case result of
-            AttemptedAxiom.NotApplicable -> return
-                ( OrOfExpandedPattern.make [unchangedPatt]
-                , SimplificationProof
-                )
-            AttemptedAxiom.Applied orResult -> do
-                -- TODO(virgil): Find out if builtin results need to be
-                -- resimplified and, if they don't, skip resimplification.
-                simplifiedPatts <-
-                    mapM simplifyIfNeeded
-                        (OrOfExpandedPattern.extractPatterns orResult)
-                return
-                    ( OrOfExpandedPattern.make (concat simplifiedPatts)
-                    , SimplificationProof
-                    )
-
-    evaluateWithDefinitionAxioms
-        :: [EqualityRule level]
-        -> Simplifier
-            (OrOfExpandedPattern level variable, SimplificationProof level)
-    evaluateWithDefinitionAxioms definitionRules = do
-        (OrStepResult { rewrittenPattern, remainder }, _proof) <-
-            stepWithRemaindersForUnifier
-                tools
-                (UnificationProcedure unificationWithAppMatchOnTop)
-                substitutionSimplifier
-                (map (\ (EqualityRule rule) -> rule) definitionRules)
-                unchangedPatt
-        let
-            evaluationResults :: [ExpandedPattern level variable]
-            evaluationResults =
-                OrOfExpandedPattern.extractPatterns rewrittenPattern
-
-            remainderResults :: [ExpandedPattern level variable]
-            remainderResults =
-                    OrOfExpandedPattern.extractPatterns remainder
-
-            simplifyPredicate
-                :: ExpandedPattern level variable
-                -> Simplifier
-                    (ExpandedPattern level variable, SimplificationProof level)
-            simplifyPredicate =
-                ExpandedPattern.simplifyPredicate
-                    tools
-                    substitutionSimplifier
-                    simplifier
-        simplifiedEvaluationLists <- mapM simplifyIfNeeded evaluationResults
-        simplifiedRemainderList <-
-            mapM simplifyPredicate remainderResults
-        let
-            simplifiedEvaluationResults :: [ExpandedPattern level variable]
-            simplifiedEvaluationResults = concat simplifiedEvaluationLists
-
-            simplifiedRemainderResults :: [ExpandedPattern level variable]
-            (simplifiedRemainderResults, _proofs) =
-                unzip simplifiedRemainderList
-        return
-            ( OrOfExpandedPattern.make
-                (simplifiedEvaluationResults ++ simplifiedRemainderResults)
-            , SimplificationProof
-            )
+    evaluateWithBuiltins (BuiltinAndAxiomSimplifier evaluator) =
+        evaluator
+            tools
+            substitutionSimplifier
+            simplifier
+            appPurePattern
 
     simplifyIfNeeded
         :: ExpandedPattern level variable
-        -> Simplifier [ExpandedPattern level variable]
-    simplifyIfNeeded result =
-        if result == unchangedPatt
-            then return [unchangedPatt]
-            else do
-                orPatt <- reevaluateFunctions
+        -> Simplifier (OrOfExpandedPattern level variable)
+    simplifyIfNeeded patt =
+        if patt == unchangedPatt
+            then return (OrOfExpandedPattern.make [unchangedPatt])
+            else
+                reevaluateFunctions
                     tools
                     substitutionSimplifier
                     simplifier
-                    result
-                return (OrOfExpandedPattern.extractPatterns orPatt)
+                    patt
+
+
+evaluateBuiltinOrFirstWorkingSimplifierOrDefinitionRulesIfAny
+    :: forall variable level
+    .   ( FreshVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , SortedVariable variable
+        , Show (variable level)
+        , Show (variable Object)
+        , Unparse (variable level)
+        , ShowMetaOrObject variable
+        )
+    -- TODO(virgil): Merge the BuiltinAndAxiomSimplifier objects in
+    -- a single list.
+    => BuiltinAndAxiomSimplifier level
+    -> [BuiltinAndAxiomSimplifier level]
+    -> [EqualityRule level]
+    -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level Simplifier
+    -> StepPatternSimplifier level variable
+    -> StepPattern level variable
+    -> Simplifier
+        (AttemptedAxiom level variable, SimplificationProof level)
+evaluateBuiltinOrFirstWorkingSimplifierOrDefinitionRulesIfAny
+    builtinEvaluator
+    axiomEvaluators
+    definitionRules
+    tools
+    substitutionSimplifier
+    simplifier
+    patt
+  = do
+    (result, _proof) <-
+        evaluateBuiltin
+            builtinEvaluator
+            tools
+            substitutionSimplifier
+            simplifier
+            patt
+    case result of
+        AttemptedAxiom.NotApplicable ->
+            -- If the builtin axioms failed, in many cases we can't just
+            -- apply evaluation axioms, since may of them are recursive
+            -- and will be applied indefinitely.
+            -- TODO(virgil): We should refine this at some point.
+            evaluateFirstWorkingSimplifierOrDefinitionRulesIfAny
+                axiomEvaluators
+                definitionRules
+                tools
+                substitutionSimplifier
+                simplifier
+                patt
+        AttemptedAxiom.Applied _ -> return (result, SimplificationProof)
+
+evaluateBuiltin
+    :: forall variable level
+    .   ( FreshVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , SortedVariable variable
+        , Show (variable level)
+        , Show (variable Object)
+        , Unparse (variable level)
+        , ShowMetaOrObject variable
+        )
+    => BuiltinAndAxiomSimplifier level
+    -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level Simplifier
+    -> StepPatternSimplifier level variable
+    -> StepPattern level variable
+    -> Simplifier
+        (AttemptedAxiom level variable, SimplificationProof level)
+evaluateBuiltin
+    (BuiltinAndAxiomSimplifier builtinEvaluator)
+    tools
+    substitutionSimplifier
+    simplifier
+    patt
+  = do
+    (result, _proof) <-
+        builtinEvaluator
+            tools
+            substitutionSimplifier
+            simplifier
+            patt
+    case result of
+        AttemptedAxiom.NotApplicable
+          | isPattConcrete
+          , Just hook <- getAppHookString ->
+            error
+                (   "Expecting hook " ++ hook
+                ++  " to reduce concrete pattern\n\t"
+                ++ show patt
+                )
+          | otherwise ->
+            return (AttemptedAxiom.NotApplicable, SimplificationProof)
+        AttemptedAxiom.Applied _ -> return (result, SimplificationProof)
+  where
+    isPattConcrete = isJust (asConcretePurePattern patt)
+    appHead = case patt of
+        App_ head0 _children -> head0
+        _ -> error
+            ("Expected an application pattern, but got " ++ show patt ++ ".")
+    -- TODO(virgil): Send this from outside after replacing `These` as a
+    -- representation for application evaluators.
+    getAppHookString =
+        Text.unpack <$> (getHook . hook . symAttributes tools) appHead
+
+evaluateFirstWorkingSimplifierOrDefinitionRulesIfAny
+    :: forall variable level
+    .   ( FreshVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , SortedVariable variable
+        , Show (variable level)
+        , Show (variable Object)
+        , Unparse (variable level)
+        , ShowMetaOrObject variable
+        )
+    => [BuiltinAndAxiomSimplifier level]
+    -> [EqualityRule level]
+    -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level Simplifier
+    -> StepPatternSimplifier level variable
+    -> StepPattern level variable
+    -> Simplifier
+        (AttemptedAxiom level variable, SimplificationProof level)
+evaluateFirstWorkingSimplifierOrDefinitionRulesIfAny
+    simplificationEvaluators
+    definitionRules
+    tools
+    substitutionSimplifier
+    simplifier
+    patt
+  = do
+    (simplifiedResult, proof) <-
+        applyFirstSimplifierThatWorks
+            simplificationEvaluators
+            tools
+            substitutionSimplifier
+            simplifier
+            patt
+    case simplifiedResult of
+        AttemptedAxiom.NotApplicable ->
+            if null definitionRules
+                then
+                    -- We don't have a definition, so we shouldn't attempt
+                    -- to evaluate it, since it would currently evaluate
+                    -- to bottom.
+                    return (AttemptedAxiom.NotApplicable, proof)
+                else evaluateWithDefinitionAxioms
+                    definitionRules
+                    tools
+                    substitutionSimplifier
+                    simplifier
+                    patt
+        AttemptedAxiom.Applied _ -> return (simplifiedResult, proof)
+
+applyFirstSimplifierThatWorks
+    :: forall variable level
+    .   ( FreshVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , SortedVariable variable
+        , Show (variable level)
+        , Show (variable Object)
+        , Unparse (variable level)
+        , ShowMetaOrObject variable
+        )
+    => [BuiltinAndAxiomSimplifier level]
+    -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level Simplifier
+    -> StepPatternSimplifier level variable
+    -> StepPattern level variable
+    -> Simplifier
+        (AttemptedAxiom level variable, SimplificationProof level)
+applyFirstSimplifierThatWorks [] _ _ _ _ =
+    return
+        ( AttemptedAxiom.NotApplicable
+        , SimplificationProof
+        )
+applyFirstSimplifierThatWorks
+    (BuiltinAndAxiomSimplifier evaluator : evaluators)
+    tools
+    substitutionSimplifier
+    simplifier
+    patt
+  = do
+    (applicationResult, _proof) <-
+        evaluator tools substitutionSimplifier simplifier patt
+
+    case applicationResult of
+        AttemptedAxiom.Applied orResults -> do
+            when
+                (length (OrOfExpandedPattern.extractPatterns orResults) > 1)
+                -- We should only allow multiple simplification results
+                -- when they are created by unification splitting the
+                -- configuration.
+                -- However, right now, we shouldn't be able to get more
+                -- than one result, so we throw an error.
+                (error
+                    (  "Unexpected simplification result with more "
+                    ++ "than one configuration: "
+                    ++ show orResults
+                    )
+                )
+            return (applicationResult, SimplificationProof)
+        AttemptedAxiom.NotApplicable ->
+            applyFirstSimplifierThatWorks
+                evaluators tools substitutionSimplifier simplifier patt
+
+evaluateWithDefinitionAxioms
+    :: forall variable level
+    .   ( FreshVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , SortedVariable variable
+        , Show (variable level)
+        , Show (variable Object)
+        , Unparse (variable level)
+        , ShowMetaOrObject variable
+        )
+    => [EqualityRule level]
+    -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level Simplifier
+    -> StepPatternSimplifier level variable
+    -> StepPattern level variable
+    -> Simplifier
+        (AttemptedAxiom level variable, SimplificationProof level)
+evaluateWithDefinitionAxioms
+    definitionRules tools substitutionSimplifier simplifier patt
+  = do
+    let
+        expanded :: ExpandedPattern level variable
+        expanded = ExpandedPattern.fromPurePattern patt
+
+    (OrStepResult { rewrittenPattern, remainder }, _proof) <-
+        stepWithRemaindersForUnifier
+            tools
+            (UnificationProcedure unificationWithAppMatchOnTop)
+            substitutionSimplifier
+            (map (\ (EqualityRule rule) -> rule) definitionRules)
+            expanded
+    let
+        evaluationResults :: [ExpandedPattern level variable]
+        evaluationResults = OrOfExpandedPattern.extractPatterns rewrittenPattern
+
+        remainderResults :: [ExpandedPattern level variable]
+        remainderResults = OrOfExpandedPattern.extractPatterns remainder
+
+        simplifyPredicate
+            :: ExpandedPattern level variable
+            -> Simplifier
+                (ExpandedPattern level variable, SimplificationProof level)
+        simplifyPredicate =
+            ExpandedPattern.simplifyPredicate
+                tools
+                substitutionSimplifier
+                simplifier
+
+    simplifiedRemainderList <- mapM simplifyPredicate remainderResults
+    let
+        simplifiedEvaluationResults :: [ExpandedPattern level variable]
+        simplifiedEvaluationResults = evaluationResults
+
+        simplifiedRemainderResults :: [ExpandedPattern level variable]
+        (simplifiedRemainderResults, _proofs) =
+            unzip simplifiedRemainderList
+    return
+        ( AttemptedAxiom.Applied
+            (OrOfExpandedPattern.make
+                (simplifiedEvaluationResults ++ simplifiedRemainderResults)
+            )
+        , SimplificationProof
+        )
 
 {-| 'reevaluateFunctions' re-evaluates functions after a user-defined function
 was evaluated.

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -42,8 +42,7 @@ import qualified Kore.Step.BaseStep as OrStepResult
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, PredicateSubstitution, Predicated (..) )
 import           Kore.Step.Function.Data
-                 ( ApplicationFunctionEvaluator (..),
-                 BuiltinAndAxiomsFunctionEvaluatorMap,
+                 ( AxiomSimplifier (..), BuiltinAndAxiomsFunctionEvaluatorMap,
                  FunctionEvaluators (FunctionEvaluators) )
 import           Kore.Step.Function.Data as FunctionEvaluators
                  ( FunctionEvaluators (..) )
@@ -133,7 +132,7 @@ evaluateApplication
     appPurePattern = asPurePattern (valid :< ApplicationPattern app)
 
     evaluateBuiltinAndAxioms
-        :: ApplicationFunctionEvaluator level
+        :: AxiomSimplifier level
         -> FunctionEvaluators level
         -> Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
@@ -173,13 +172,13 @@ evaluateApplication
             (Application level)
             (Valid (variable level) level)
             (StepPattern level variable)
-        -> ApplicationFunctionEvaluator level
+        -> AxiomSimplifier level
         -> Simplifier
             ( AttemptedAxiom level variable
             , SimplificationProof level
             )
     applyEvaluator
-        app' (ApplicationFunctionEvaluator evaluator)
+        app' (AxiomSimplifier evaluator)
       = do
         result <- evaluator
             tools

--- a/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Evaluator.hs
@@ -43,7 +43,8 @@ import qualified Kore.Step.BaseStep as OrStepResult
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, PredicateSubstitution, Predicated (..) )
 import           Kore.Step.Function.Data
-                 ( AxiomSimplifier (..), BuiltinAndAxiomsFunctionEvaluatorMap,
+                 ( BuiltinAndAxiomSimplifier (..),
+                 BuiltinAndAxiomSimplifierMap,
                  FunctionEvaluators (FunctionEvaluators) )
 import           Kore.Step.Function.Data as FunctionEvaluators
                  ( FunctionEvaluators (..) )
@@ -86,7 +87,7 @@ evaluateApplication
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> PredicateSubstitution level variable
     -- ^ Aggregated children predicate and substitution.
@@ -133,7 +134,7 @@ evaluateApplication
     appPurePattern = asPurePattern (valid :< ApplicationPattern app)
 
     evaluateBuiltinAndAxioms
-        :: AxiomSimplifier level
+        :: BuiltinAndAxiomSimplifier level
         -> FunctionEvaluators level
         -> Simplifier
             (OrOfExpandedPattern level variable, SimplificationProof level)
@@ -173,13 +174,13 @@ evaluateApplication
             (Application level)
             (Valid (variable level) level)
             (StepPattern level variable)
-        -> AxiomSimplifier level
+        -> BuiltinAndAxiomSimplifier level
         -> Simplifier
             ( AttemptedAxiom level variable
             , SimplificationProof level
             )
     applyEvaluator
-        (valid' :< app') (AxiomSimplifier evaluator)
+        (valid' :< app') (BuiltinAndAxiomSimplifier evaluator)
       = do
         result <- evaluator
             tools

--- a/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
@@ -39,7 +39,8 @@ import qualified Kore.Step.AxiomPatterns as AxiomPatterns
                  Idem (..), RulePattern (..), Unit (..) )
 import           Kore.Step.Function.Data
                  ( AxiomSimplifier (..),
-                 FunctionEvaluators (FunctionEvaluators) )
+                 FunctionEvaluators (FunctionEvaluators),
+                 applicationAxiomSimplifier )
 import           Kore.Step.Function.Data as FunctionEvaluators
                  ( FunctionEvaluators (..) )
 import           Kore.Step.Function.UserDefined
@@ -177,7 +178,7 @@ axiomPatternEvaluator axiomPat@(EqualityRule RulePattern { attributes })
     | isUnit = Nothing
     | isIdem = Nothing
     | otherwise =
-        Just (AxiomSimplifier $ ruleFunctionEvaluator axiomPat)
+        Just (applicationAxiomSimplifier $ ruleFunctionEvaluator axiomPat)
   where
     Assoc { isAssoc } = AxiomPatterns.assoc attributes
     Comm { isComm } = AxiomPatterns.comm attributes

--- a/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
@@ -38,7 +38,7 @@ import qualified Kore.Step.AxiomPatterns as AxiomPatterns
                  ( Assoc (..), AxiomPatternAttributes (..), Comm (..),
                  Idem (..), RulePattern (..), Unit (..) )
 import           Kore.Step.Function.Data
-                 ( ApplicationFunctionEvaluator (..),
+                 ( AxiomSimplifier (..),
                  FunctionEvaluators (FunctionEvaluators) )
 import           Kore.Step.Function.Data as FunctionEvaluators
                  ( FunctionEvaluators (..) )
@@ -125,7 +125,7 @@ axiomToIdAxiomPatternPair level (asKoreAxiomSentence -> axiom) =
         Right (RewriteAxiomPattern _) -> Nothing
 
 -- |Converts a registry of 'RulePattern's to one of
--- 'ApplicationFunctionEvaluator's
+-- 'AxiomSimplifier's
 axiomPatternsToEvaluators
     :: forall level
     .  Map.Map (Id level) [EqualityRule level]
@@ -168,7 +168,7 @@ axiom; this is determined by checking the 'AxiomPatternAttributes'.
  -}
 axiomPatternEvaluator
     :: EqualityRule level
-    -> Maybe (ApplicationFunctionEvaluator level)
+    -> Maybe (AxiomSimplifier level)
 axiomPatternEvaluator axiomPat@(EqualityRule RulePattern { attributes })
     | isAssoc = Nothing
     | isComm = Nothing
@@ -177,7 +177,7 @@ axiomPatternEvaluator axiomPat@(EqualityRule RulePattern { attributes })
     | isUnit = Nothing
     | isIdem = Nothing
     | otherwise =
-        Just (ApplicationFunctionEvaluator $ ruleFunctionEvaluator axiomPat)
+        Just (AxiomSimplifier $ ruleFunctionEvaluator axiomPat)
   where
     Assoc { isAssoc } = AxiomPatterns.assoc attributes
     Comm { isComm } = AxiomPatterns.comm attributes

--- a/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
@@ -38,9 +38,8 @@ import qualified Kore.Step.AxiomPatterns as AxiomPatterns
                  ( Assoc (..), AxiomPatternAttributes (..), Comm (..),
                  Idem (..), RulePattern (..), Unit (..) )
 import           Kore.Step.Function.Data
-                 ( AxiomSimplifier (..),
-                 FunctionEvaluators (FunctionEvaluators),
-                 applicationAxiomSimplifier )
+                 ( BuiltinAndAxiomSimplifier (..),
+                 FunctionEvaluators (FunctionEvaluators) )
 import           Kore.Step.Function.Data as FunctionEvaluators
                  ( FunctionEvaluators (..) )
 import           Kore.Step.Function.UserDefined
@@ -126,7 +125,7 @@ axiomToIdAxiomPatternPair level (asKoreAxiomSentence -> axiom) =
         Right (RewriteAxiomPattern _) -> Nothing
 
 -- |Converts a registry of 'RulePattern's to one of
--- 'AxiomSimplifier's
+-- 'BuiltinAndAxiomSimplifier's
 axiomPatternsToEvaluators
     :: forall level
     .  Map.Map (Id level) [EqualityRule level]
@@ -169,7 +168,7 @@ axiom; this is determined by checking the 'AxiomPatternAttributes'.
  -}
 axiomPatternEvaluator
     :: EqualityRule level
-    -> Maybe (AxiomSimplifier level)
+    -> Maybe (BuiltinAndAxiomSimplifier level)
 axiomPatternEvaluator axiomPat@(EqualityRule RulePattern { attributes })
     | isAssoc = Nothing
     | isComm = Nothing
@@ -178,7 +177,7 @@ axiomPatternEvaluator axiomPat@(EqualityRule RulePattern { attributes })
     | isUnit = Nothing
     | isIdem = Nothing
     | otherwise =
-        Just (applicationAxiomSimplifier $ ruleFunctionEvaluator axiomPat)
+        Just (BuiltinAndAxiomSimplifier $ ruleFunctionEvaluator axiomPat)
   where
     Assoc { isAssoc } = AxiomPatterns.assoc attributes
     Comm { isComm } = AxiomPatterns.comm attributes

--- a/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/Registry.hs
@@ -149,15 +149,41 @@ axiomPatternsToEvaluators axiomPatterns =
             }
       where
         simplifications :: [EqualityRule level]
-        evaluations :: [EqualityRule level]
-        (simplifications, evaluations) =
+        nonSimplifications :: [EqualityRule level]
+        (simplifications, nonSimplifications) =
             partition isSimplificationRule equalities
+        evaluations :: [EqualityRule level]
+        evaluations =
+            filter
+                (\rule ->
+                    not (isCommRule rule)
+                    && not (isAssocRule rule)
+                    && not (isIdemRule rule)
+                    && not (isUnitRule rule)
+                )
+                nonSimplifications
         simplification = mapMaybe axiomPatternEvaluator simplifications
         isSimplificationRule (EqualityRule RulePattern { attributes }) =
             isSimplification
           where
             Simplification { isSimplification } =
                 AxiomPatterns.simplification attributes
+        isCommRule (EqualityRule RulePattern { attributes }) =
+            isComm
+          where
+            Comm { isComm } = AxiomPatterns.comm attributes
+        isAssocRule (EqualityRule RulePattern { attributes }) =
+            isAssoc
+          where
+            Assoc { isAssoc } = AxiomPatterns.assoc attributes
+        isIdemRule (EqualityRule RulePattern { attributes }) =
+            isIdem
+          where
+            Idem { isIdem } = AxiomPatterns.idem attributes
+        isUnitRule (EqualityRule RulePattern { attributes }) =
+            isUnit
+          where
+            Unit { isUnit } = AxiomPatterns.unit attributes
 
 {- | Return the function evaluator corresponding to the 'AxiomPattern'.
 

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -36,8 +36,8 @@ import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, Predicated (..) )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( bottom )
-import           Kore.Step.Function.Data as AttemptedFunction
-                 ( AttemptedFunction (..) )
+import           Kore.Step.Function.Data as AttemptedAxiom
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Function.Matcher
                  ( matchAsUnification )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -83,7 +83,7 @@ ruleFunctionEvaluator
         (StepPattern level variable)
     -- ^ The function on which to evaluate the current function.
     -> Simplifier
-        (AttemptedFunction level variable, SimplificationProof level)
+        (AttemptedAxiom level variable, SimplificationProof level)
 ruleFunctionEvaluator
     (EqualityRule rule)
     tools
@@ -101,13 +101,13 @@ ruleFunctionEvaluator
         Right results -> do
             processedResults <- mapM processResult results
             return
-                ( AttemptedFunction.Applied
+                ( AttemptedAxiom.Applied
                     (OrOfExpandedPattern.make (map dropProof processedResults))
                 , SimplificationProof
                 )
   where
     notApplicable =
-        return (AttemptedFunction.NotApplicable, SimplificationProof)
+        return (AttemptedAxiom.NotApplicable, SimplificationProof)
     dropProof :: (a, SimplificationProof level) -> a
     dropProof = fst
 

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Application.hs
@@ -24,7 +24,7 @@ import           Kore.Step.ExpandedPattern
 import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( Predicated (..) )
 import           Kore.Step.Function.Data
-                 ( BuiltinAndAxiomsFunctionEvaluatorMap )
+                 ( BuiltinAndAxiomSimplifierMap )
 import           Kore.Step.Function.Evaluator
                  ( evaluateApplication )
 import           Kore.Step.OrOfExpandedPattern
@@ -76,7 +76,7 @@ simplify
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> CofreeF
         (Application level)
@@ -133,7 +133,7 @@ makeAndEvaluateApplications
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> Valid (variable level) level
     -> SymbolOrAlias level
@@ -175,7 +175,7 @@ makeAndEvaluateSymbolApplications
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> Valid (variable level) level
     -> SymbolOrAlias level
@@ -221,7 +221,7 @@ evaluateApplicationFunction
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> ExpandedApplication level variable
     -- ^ The pattern to be evaluated

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -19,7 +19,7 @@ import           Kore.IndexedModule.MetadataTools
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern )
 import           Kore.Step.Function.Data
-                 ( BuiltinAndAxiomsFunctionEvaluatorMap )
+                 ( BuiltinAndAxiomSimplifierMap )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -91,7 +91,7 @@ simplify
         )
     => MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> StepPattern level variable
     -> Simplifier
@@ -120,7 +120,7 @@ simplifyToOr
         , FreshVariable variable
         )
     => MetadataTools level StepperAttributes
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPattern level variable
@@ -152,7 +152,7 @@ simplifyInternal
     => MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> Base (StepPattern level variable) (StepPattern level variable)
     -> Simplifier

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -180,7 +180,7 @@ testMetadataTools = extractMetadataTools (constructorFunctions verifiedModule)
 testSubstitutionSimplifier :: PredicateSubstitutionSimplifier Object Simplifier
 testSubstitutionSimplifier = Mock.substitutionSimplifier testMetadataTools
 
-evaluators :: BuiltinAndAxiomsFunctionEvaluatorMap Object
+evaluators :: BuiltinAndAxiomSimplifierMap Object
 evaluators = Map.map This $ Builtin.koreEvaluators verifiedModule
 
 evaluate

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -39,8 +39,8 @@ import           Kore.Step.BaseStep as OrStepResult
 import           Kore.Step.Error
 import           Kore.Step.ExpandedPattern
                  ( Predicated (..) )
-import           Kore.Step.Function.Data as AttemptedFunction
-                 ( AttemptedFunction (..) )
+import           Kore.Step.Function.Data as AttemptedAxiom
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.OrOfExpandedPattern
 import           Kore.Step.Pattern
 import qualified Kore.Step.PatternAttributesError as PatternAttributesError
@@ -1085,23 +1085,23 @@ instance
     , EqualWithExplanation (variable level)
     , EqualWithExplanation (StepPattern level variable)
     )
-    => SumEqualWithExplanation (AttemptedFunction level variable)
+    => SumEqualWithExplanation (AttemptedAxiom level variable)
   where
     sumConstructorPair
-        AttemptedFunction.NotApplicable
-        AttemptedFunction.NotApplicable
+        AttemptedAxiom.NotApplicable
+        AttemptedAxiom.NotApplicable
       =
         SumConstructorSameNoArguments
-    sumConstructorPair a1@AttemptedFunction.NotApplicable a2 =
+    sumConstructorPair a1@AttemptedAxiom.NotApplicable a2 =
         SumConstructorDifferent
             (printWithExplanation a1) (printWithExplanation a2)
 
     sumConstructorPair
-        (AttemptedFunction.Applied a1) (AttemptedFunction.Applied a2)
+        (AttemptedAxiom.Applied a1) (AttemptedAxiom.Applied a2)
       =
         SumConstructorSameWithArguments
             (EqWrap "Applied" a1 a2)
-    sumConstructorPair a1@(AttemptedFunction.Applied _) a2 =
+    sumConstructorPair a1@(AttemptedAxiom.Applied _) a2 =
         SumConstructorDifferent
             (printWithExplanation a1) (printWithExplanation a2)
 
@@ -1111,7 +1111,7 @@ instance
     , EqualWithExplanation (variable level)
     , EqualWithExplanation (StepPattern level variable)
     )
-    => EqualWithExplanation (AttemptedFunction level variable)
+    => EqualWithExplanation (AttemptedAxiom level variable)
   where
     compareWithExplanation = sumCompareWithExplanation
     printWithExplanation = show

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -29,8 +29,8 @@ import           Kore.Step.ExpandedPattern as ExpandedPattern
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( Predicated (..), mapVariables )
 import           Kore.Step.Function.Data
-import           Kore.Step.Function.Data as AttemptedFunction
-                 ( AttemptedFunction (..) )
+import           Kore.Step.Function.Data as AttemptedAxiom
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Function.UserDefined
                  ( ruleFunctionEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -583,7 +583,7 @@ appliedMockEvaluator
 appliedMockEvaluator result =
     ApplicationFunctionEvaluator
     $ mockEvaluator
-    $ AttemptedFunction.Applied
+    $ AttemptedAxiom.Applied
     $ OrOfExpandedPattern.make
         [Test.Kore.Step.Function.Integration.mapVariables result]
 
@@ -598,7 +598,7 @@ mapVariables =
     ExpandedPattern.mapVariables (\v -> freshVariableFromVariable v 1)
 
 mockEvaluator
-    :: AttemptedFunction level variable
+    :: AttemptedAxiom level variable
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
@@ -607,7 +607,7 @@ mockEvaluator
         (Valid (variable level) level)
         (StepPattern level variable)
     -> Simplifier
-        (AttemptedFunction level variable, SimplificationProof level)
+        (AttemptedAxiom level variable, SimplificationProof level)
 mockEvaluator evaluation _ _ _ _ =
     return (evaluation, SimplificationProof)
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -141,7 +141,7 @@ test_functionIntegration =
                 mockMetadataTools
                 (Map.singleton Mock.functionalConstr10Id
                     (theseSimplification
-                        (ApplicationFunctionEvaluator
+                        (AxiomSimplifier
                             (\_ _ _ _ -> notApplicableFunctionEvaluator)
                         )
                         [ axiomEvaluator
@@ -560,9 +560,9 @@ test_functionIntegration =
 axiomEvaluator
     :: CommonStepPattern Object
     -> CommonStepPattern Object
-    -> ApplicationFunctionEvaluator Object
+    -> AxiomSimplifier Object
 axiomEvaluator left right =
-    ApplicationFunctionEvaluator
+    AxiomSimplifier
         (ruleFunctionEvaluator (axiom left right makeTruePredicate))
 
 axiom
@@ -579,9 +579,9 @@ axiom left right predicate =
         }
 
 appliedMockEvaluator
-    :: CommonExpandedPattern level -> ApplicationFunctionEvaluator level
+    :: CommonExpandedPattern level -> AxiomSimplifier level
 appliedMockEvaluator result =
-    ApplicationFunctionEvaluator
+    AxiomSimplifier
     $ mockEvaluator
     $ AttemptedAxiom.Applied
     $ OrOfExpandedPattern.make
@@ -612,8 +612,8 @@ mockEvaluator evaluation _ _ _ _ =
     return (evaluation, SimplificationProof)
 
 thatSimplification
-    :: [ApplicationFunctionEvaluator Object]
-    -> These (ApplicationFunctionEvaluator Object) (FunctionEvaluators Object)
+    :: [AxiomSimplifier Object]
+    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
 thatSimplification evaluators =
     That FunctionEvaluators
         { definitionRules = []
@@ -621,9 +621,9 @@ thatSimplification evaluators =
         }
 
 theseSimplification
-    :: ApplicationFunctionEvaluator Object
-    -> [ApplicationFunctionEvaluator Object]
-    -> These (ApplicationFunctionEvaluator Object) (FunctionEvaluators Object)
+    :: AxiomSimplifier Object
+    -> [AxiomSimplifier Object]
+    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
 theseSimplification evaluator evaluators =
     These
         evaluator

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -141,8 +141,8 @@ test_functionIntegration =
                 mockMetadataTools
                 (Map.singleton Mock.functionalConstr10Id
                     (theseSimplification
-                        (AxiomSimplifier
-                            (\_ _ _ _ -> notApplicableFunctionEvaluator)
+                        (BuiltinAndAxiomSimplifier
+                            (\_ _ _ _ -> notApplicableAxiomEvaluator)
                         )
                         [ axiomEvaluator
                             (Mock.functionalConstr10 (mkVar Mock.x))
@@ -560,9 +560,9 @@ test_functionIntegration =
 axiomEvaluator
     :: CommonStepPattern Object
     -> CommonStepPattern Object
-    -> AxiomSimplifier Object
+    -> BuiltinAndAxiomSimplifier Object
 axiomEvaluator left right =
-    AxiomSimplifier
+    BuiltinAndAxiomSimplifier
         (ruleFunctionEvaluator (axiom left right makeTruePredicate))
 
 axiom
@@ -579,9 +579,9 @@ axiom left right predicate =
         }
 
 appliedMockEvaluator
-    :: CommonExpandedPattern level -> AxiomSimplifier level
+    :: CommonExpandedPattern level -> BuiltinAndAxiomSimplifier level
 appliedMockEvaluator result =
-    AxiomSimplifier
+    BuiltinAndAxiomSimplifier
     $ mockEvaluator
     $ AttemptedAxiom.Applied
     $ OrOfExpandedPattern.make
@@ -602,18 +602,15 @@ mockEvaluator
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable
-    -> CofreeF
-        (Application level)
-        (Valid (variable level) level)
-        (StepPattern level variable)
+    -> StepPattern level variable
     -> Simplifier
         (AttemptedAxiom level variable, SimplificationProof level)
 mockEvaluator evaluation _ _ _ _ =
     return (evaluation, SimplificationProof)
 
 thatSimplification
-    :: [AxiomSimplifier Object]
-    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
+    :: [BuiltinAndAxiomSimplifier Object]
+    -> These (BuiltinAndAxiomSimplifier Object) (FunctionEvaluators Object)
 thatSimplification evaluators =
     That FunctionEvaluators
         { definitionRules = []
@@ -621,9 +618,9 @@ thatSimplification evaluators =
         }
 
 theseSimplification
-    :: AxiomSimplifier Object
-    -> [AxiomSimplifier Object]
-    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
+    :: BuiltinAndAxiomSimplifier Object
+    -> [BuiltinAndAxiomSimplifier Object]
+    -> These (BuiltinAndAxiomSimplifier Object) (FunctionEvaluators Object)
 theseSimplification evaluator evaluators =
     These
         evaluator
@@ -635,7 +632,7 @@ theseSimplification evaluator evaluators =
 evaluate
     :: forall level . MetaOrObject level
     => MetadataTools level StepperAttributes
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -> CommonStepPattern level
     -> IO (CommonExpandedPattern level)
 evaluate metadataTools functionIdToEvaluator patt =

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Registry.hs
@@ -232,7 +232,7 @@ testId name =
         }
 
 testEvaluators
-    :: BuiltinAndAxiomsFunctionEvaluatorMap Object
+    :: BuiltinAndAxiomSimplifierMap Object
 testEvaluators =
     Map.map That
     $ axiomPatternsToEvaluators

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -30,10 +30,10 @@ import           Kore.Step.AxiomPatterns as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( Predicated (..), bottom )
-import           Kore.Step.Function.Data as AttemptedFunction
-                 ( AttemptedFunction (..) )
+import           Kore.Step.Function.Data as AttemptedAxiom
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.Function.Data
-                 ( CommonAttemptedFunction )
+                 ( CommonAttemptedAxiom )
 import           Kore.Step.Function.UserDefined
                  ( ruleFunctionEvaluator )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -57,7 +57,7 @@ test_userDefinedFunction :: [TestTree]
 test_userDefinedFunction =
     [ testCase "Applies one step" $ do
         let expect =
-                AttemptedFunction.Applied $ OrOfExpandedPattern.make
+                AttemptedAxiom.Applied $ OrOfExpandedPattern.make
                     [ Predicated
                         { term =
                             asApplicationPattern $ metaG (mkVar $ x patternMetaSort)
@@ -82,7 +82,7 @@ test_userDefinedFunction =
         assertEqualWithExplanation "f(x) => g(x)" expect actual
     , testCase "Cannot apply concrete rule to symbolic pattern" $ do
         let expect =
-                AttemptedFunction.NotApplicable
+                AttemptedAxiom.NotApplicable
         actual <-
             evaluateWithAxiom
                 mockMetadataTools
@@ -100,7 +100,7 @@ test_userDefinedFunction =
         assertEqualWithExplanation "f(x) => g(x)" expect actual
     , testCase "Can apply concrete rule to concrete pattern" $ do
         let expect =
-                AttemptedFunction.NotApplicable
+                AttemptedAxiom.NotApplicable
         actual <-
             evaluateWithAxiom
                 mockMetadataTools
@@ -118,7 +118,7 @@ test_userDefinedFunction =
         assertEqualWithExplanation "f(x) => g(x)" expect actual
     , testCase "Cannot apply step with unsat axiom pre-condition" $ do
         let expect =
-                AttemptedFunction.Applied (OrOfExpandedPattern.make [])
+                AttemptedAxiom.Applied (OrOfExpandedPattern.make [])
         actual <-
             evaluateWithAxiom
                 mockMetadataTools
@@ -137,7 +137,7 @@ test_userDefinedFunction =
 
     , testCase "Cannot apply step with unsat condition" $ do
         let expect =
-                AttemptedFunction.Applied
+                AttemptedAxiom.Applied
                 $ OrOfExpandedPattern.make [ ExpandedPattern.bottom ]
         actual <-
             evaluateWithAxiom
@@ -160,7 +160,7 @@ test_userDefinedFunction =
 
     , testCase "Preserves step substitution" $ do
         let expect =
-                AttemptedFunction.Applied $ OrOfExpandedPattern.make
+                AttemptedAxiom.Applied $ OrOfExpandedPattern.make
                     [ Predicated
                         { term =
                             asApplicationPattern $ metaG (mkVar $ b patternMetaSort)
@@ -298,7 +298,7 @@ evaluateWithAxiom
         (Application level)
         (Valid (Variable level) level)
         (CommonStepPattern level)
-    -> IO (CommonAttemptedFunction level)
+    -> IO (CommonAttemptedAxiom level)
 evaluateWithAxiom
     metadataTools
     axiom
@@ -309,11 +309,11 @@ evaluateWithAxiom
     return (normalizeResult results)
   where
     normalizeResult
-        :: CommonAttemptedFunction level -> CommonAttemptedFunction level
+        :: CommonAttemptedAxiom level -> CommonAttemptedAxiom level
     normalizeResult =
         \case
-            AttemptedFunction.Applied orPattern ->
-                AttemptedFunction.Applied (fmap sortSubstitution orPattern)
+            AttemptedAxiom.Applied orPattern ->
+                AttemptedAxiom.Applied (fmap sortSubstitution orPattern)
             result -> result
 
     sortSubstitution Predicated {term, predicate, substitution} =
@@ -322,7 +322,7 @@ evaluateWithAxiom
             , predicate = predicate
             , substitution = Substitution.modify sort substitution
             }
-    evaluated :: IO (CommonAttemptedFunction level)
+    evaluated :: IO (CommonAttemptedAxiom level)
     evaluated =
         (<$>) fst
         $ SMT.runSMT SMT.defaultConfig

--- a/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -126,6 +126,8 @@ functionalConstr10Id :: Id Object
 functionalConstr10Id = testId "functionalConstr10"
 functionalConstr11Id :: Id Object
 functionalConstr11Id = testId "functionalConstr11"
+functionalConstr12Id :: Id Object
+functionalConstr12Id = testId "functionalConstr12"
 functionalConstr20Id :: Id Object
 functionalConstr20Id = testId "functionalConstr20"
 functionalConstr30Id :: Id Object
@@ -358,6 +360,11 @@ functionalConstr10Symbol = SymbolOrAlias
 functionalConstr11Symbol :: SymbolOrAlias Object
 functionalConstr11Symbol = SymbolOrAlias
     { symbolOrAliasConstructor = functionalConstr11Id
+    , symbolOrAliasParams      = []
+    }
+functionalConstr12Symbol :: SymbolOrAlias Object
+functionalConstr12Symbol = SymbolOrAlias
+    { symbolOrAliasConstructor = functionalConstr12Id
     , symbolOrAliasParams      = []
     }
 functionalConstr20Symbol :: SymbolOrAlias Object
@@ -664,6 +671,12 @@ functionalConstr11
     -> StepPattern Object variable
 functionalConstr11 arg = mkApp testSort functionalConstr11Symbol [arg]
 
+functionalConstr12
+    :: Ord (variable Object)
+    => StepPattern Object variable
+    -> StepPattern Object variable
+functionalConstr12 arg = mkApp testSort functionalConstr12Symbol [arg]
+
 functionalConstr20
     :: Ord (variable Object)
     => StepPattern Object variable
@@ -918,6 +931,9 @@ attributesMapping =
     ,   ( functionalConstr11Symbol
         , Mock.constructorFunctionalAttributes
         )
+    ,   ( functionalConstr12Symbol
+        , Mock.constructorFunctionalAttributes
+        )
     ,   ( functionalConstr20Symbol
         , Mock.constructorFunctionalAttributes
         )
@@ -1118,6 +1134,9 @@ headTypeMapping =
         , HeadType.Symbol
         )
     ,   ( functionalConstr11Symbol
+        , HeadType.Symbol
+        )
+    ,   ( functionalConstr12Symbol
         , HeadType.Symbol
         )
     ,   ( functionalConstr20Symbol

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -121,7 +121,7 @@ test_applicationSimplification =
                 (Map.singleton
                     Mock.fId
                     (thatSimplification
-                        [ AxiomSimplifier
+                        [ BuiltinAndAxiomSimplifier
                             (const $ const $ const $ const $ return
                                 ( AttemptedAxiom.Applied
                                     (OrOfExpandedPattern.make [gOfAExpanded])
@@ -216,7 +216,7 @@ test_applicationSimplification =
                     (Map.singleton
                         Mock.sigmaId
                         (thatSimplification
-                            [ AxiomSimplifier
+                            [ BuiltinAndAxiomSimplifier
                                 (const $ const $ const $ const $ do
                                     let zvar =
                                             freshVariableFromVariable Mock.z 1
@@ -308,8 +308,8 @@ test_applicationSimplification =
             Mock.subsorts
 
 thatSimplification
-    :: [AxiomSimplifier Object]
-    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
+    :: [BuiltinAndAxiomSimplifier Object]
+    -> These (BuiltinAndAxiomSimplifier Object) (FunctionEvaluators Object)
 thatSimplification evaluators =
     That FunctionEvaluators
         { definitionRules = []
@@ -343,7 +343,7 @@ evaluate
     => MetadataTools level StepperAttributes
     -> CommonStepPatternSimplifier level
     -- ^ Evaluates functions.
-    -> BuiltinAndAxiomsFunctionEvaluatorMap level
+    -> BuiltinAndAxiomSimplifierMap level
     -- ^ Map from symbol IDs to defined functions
     -> CofreeF
         (Application level)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -22,8 +22,8 @@ import           Kore.Step.ExpandedPattern
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( bottom )
 import           Kore.Step.Function.Data
-import qualified Kore.Step.Function.Data as AttemptedFunction
-                 ( AttemptedFunction (..) )
+import qualified Kore.Step.Function.Data as AttemptedAxiom
+                 ( AttemptedAxiom (..) )
 import           Kore.Step.OrOfExpandedPattern
                  ( CommonOrOfExpandedPattern, OrOfExpandedPattern )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -123,7 +123,7 @@ test_applicationSimplification =
                     (thatSimplification
                         [ ApplicationFunctionEvaluator
                             (const $ const $ const $ const $ return
-                                ( AttemptedFunction.Applied
+                                ( AttemptedAxiom.Applied
                                     (OrOfExpandedPattern.make [gOfAExpanded])
                                 , SimplificationProof
                                 )
@@ -221,7 +221,7 @@ test_applicationSimplification =
                                     let zvar =
                                             freshVariableFromVariable Mock.z 1
                                     return
-                                        ( AttemptedFunction.Applied
+                                        ( AttemptedAxiom.Applied
                                             (OrOfExpandedPattern.make
                                                 [ Predicated
                                                     { term = fOfA

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -121,7 +121,7 @@ test_applicationSimplification =
                 (Map.singleton
                     Mock.fId
                     (thatSimplification
-                        [ ApplicationFunctionEvaluator
+                        [ AxiomSimplifier
                             (const $ const $ const $ const $ return
                                 ( AttemptedAxiom.Applied
                                     (OrOfExpandedPattern.make [gOfAExpanded])
@@ -216,7 +216,7 @@ test_applicationSimplification =
                     (Map.singleton
                         Mock.sigmaId
                         (thatSimplification
-                            [ ApplicationFunctionEvaluator
+                            [ AxiomSimplifier
                                 (const $ const $ const $ const $ do
                                     let zvar =
                                             freshVariableFromVariable Mock.z 1
@@ -308,8 +308,8 @@ test_applicationSimplification =
             Mock.subsorts
 
 thatSimplification
-    :: [ApplicationFunctionEvaluator Object]
-    -> These (ApplicationFunctionEvaluator Object) (FunctionEvaluators Object)
+    :: [AxiomSimplifier Object]
+    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
 thatSimplification evaluators =
     That FunctionEvaluators
         { definitionRules = []

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -440,7 +440,7 @@ evaluateWithAxioms tools axioms patt =
                 builtinAxioms
                 (Map.map That axioms)
             )
-    builtinAxioms :: BuiltinAndAxiomsFunctionEvaluatorMap Object
+    builtinAxioms :: BuiltinAndAxiomSimplifierMap Object
     builtinAxioms =
         Map.fromList
             [ (Mock.concatMapId, This Map.evalConcat)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
@@ -333,7 +333,7 @@ simpleEvaluator
         (Valid (variable Object) Object)
         (StepPattern Object variable)
     -> Simplifier
-        ( AttemptedFunction Object variable
+        ( AttemptedAxiom Object variable
         , SimplificationProof Object
         )
 simpleEvaluator [] _ = return (NotApplicable, SimplificationProof)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
@@ -299,8 +299,8 @@ runSimplifier patternSimplifierMap predicateSubstitution =
             (Simplifier.create mockMetadataTools patternSimplifierMap)
 
 thatSimplification
-    :: [ApplicationFunctionEvaluator Object]
-    -> These (ApplicationFunctionEvaluator Object) (FunctionEvaluators Object)
+    :: [AxiomSimplifier Object]
+    -> These (AxiomSimplifier Object) (FunctionEvaluators Object)
 thatSimplification evaluators =
     That FunctionEvaluators
         { definitionRules = []
@@ -316,9 +316,9 @@ makeEvaluator
             )
         => [(StepPattern Object variable, StepPattern Object variable)]
         )
-    -> ApplicationFunctionEvaluator Object
+    -> AxiomSimplifier Object
 makeEvaluator mapping =
-    ApplicationFunctionEvaluator
+    AxiomSimplifier
         $ const $ const $ const $ simpleEvaluator mapping
 
 simpleEvaluator


### PR DESCRIPTION
This makes the code uniform enough that next I'll be able to replace `These` as a representation for a symbol's simplification code with a single BuiltinAndAxiomSimplifier, then I'll be able to treat ceils and applications in a uniform way.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

