### PR TITLE
Kore.Step.Simplification.Or: tests and bugfix

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
@@ -80,9 +80,9 @@ simplifyEvaluated
         )
 simplifyEvaluated first second =
     case OrOfExpandedPattern.extractPatterns first of
-        [patt] -> halfSimplifyEvaluated patt second
+        [patt] | Just result <- mergePredicates patt second -> result
         _ -> case OrOfExpandedPattern.extractPatterns second of
-            [patt] -> halfSimplifyEvaluated patt first
+            [patt] | Just result <- mergePredicates patt first -> result
             _ -> defaultMerge
   where
     defaultMerge =
@@ -90,9 +90,16 @@ simplifyEvaluated first second =
         , SimplificationProof
         )
 
+{- | Merge the predicate of a @\\top@ term with the first disjunct.
+
+If the configuration's term is not @\\top@ or the substitutions of the
+configuration and the first disjunct are not the same, then the predicates
+cannot be merged.
+
+ -}
 -- TODO(virgil): This should do all possible mergings, not just the first
 -- term with the second.
-halfSimplifyEvaluated
+mergePredicates
     ::  ( MetaOrObject level
         , SortedVariable variable
         , Ord (variable level)
@@ -100,11 +107,11 @@ halfSimplifyEvaluated
         , Unparse (variable level)
         )
     => ExpandedPattern level variable
+    -- ^ Configuration
     -> OrOfExpandedPattern level variable
-    ->  ( OrOfExpandedPattern level variable
-        , SimplificationProof level
-        )
-halfSimplifyEvaluated
+    -- ^ Disjunction
+    -> Maybe (OrOfExpandedPattern level variable, SimplificationProof level)
+mergePredicates
     Predicated
         { term = term1
         , predicate = predicate1
@@ -117,19 +124,16 @@ halfSimplifyEvaluated
   , Predicated { substitution = substitution2 } <- pattern2
   , Substitution.unwrap substitution1 == Substitution.unwrap substitution2
   =
-    ( OrOfExpandedPattern.make
-        ( Predicated
-            { term = term1
-            , predicate = makeOrPredicate predicate1 predicate2
-            , substitution = substitution1
-            }
-        : patterns
+    Just
+        ( OrOfExpandedPattern.make
+            ( Predicated
+                { term = term1
+                , predicate = makeOrPredicate predicate1 predicate2
+                , substitution = substitution1
+                }
+            : patterns
+            )
+        , SimplificationProof
         )
-    , SimplificationProof
-    )
-halfSimplifyEvaluated
-    first second
-  =
-    ( OrOfExpandedPattern.merge (OrOfExpandedPattern.make [first]) second
-    , SimplificationProof
-    )
+  | otherwise =
+    Nothing

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Or.hs
@@ -105,37 +105,28 @@ halfSimplifyEvaluated
         , SimplificationProof level
         )
 halfSimplifyEvaluated
-    first@Predicated
+    Predicated
         { term = term1
-        , predicate = firstPredicate
-        , substitution = (Substitution.unwrap -> [])
+        , predicate = predicate1
+        , substitution = substitution1
         }
     second
-  | (Recursive.project -> _ :< TopPattern _) <- term1
+  | _ :< TopPattern _ <- Recursive.project term1
+  , pattern2 : patterns <- OrOfExpandedPattern.extractPatterns second
+  , Predicated { predicate = predicate2 } <- pattern2
+  , Predicated { substitution = substitution2 } <- pattern2
+  , Substitution.unwrap substitution1 == Substitution.unwrap substitution2
   =
-    case OrOfExpandedPattern.extractPatterns second of
-        [] ->
-            ( OrOfExpandedPattern.make [first]
-            , SimplificationProof
-            )
+    ( OrOfExpandedPattern.make
         ( Predicated
-            { term = term2, predicate, substitution}
-         : patts
-         ) ->
-            let
-                mergedPredicate =
-                    makeOrPredicate firstPredicate predicate
-            in
-                ( OrOfExpandedPattern.make
-                    ( Predicated
-                        { term = term2
-                        , predicate = mergedPredicate
-                        , substitution = substitution
-                        }
-                    : patts
-                    )
-                , SimplificationProof
-                )
+            { term = term1
+            , predicate = makeOrPredicate predicate1 predicate2
+            , substitution = substitution1
+            }
+        : patterns
+        )
+    , SimplificationProof
+    )
 halfSimplifyEvaluated
     first second
   =

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -45,6 +45,19 @@ test_highestTop =
   , ((tT, pT, sT), (tT, pT, sT)) `simplifiesTo_` (tT, pT, sT)
   ]
 
+test_mergePredicates :: TestTree
+test_mergePredicates =
+    testGroup "Merge predicates when first term is Top and substitutions are equal"
+    [ ((tT, pM, sT), (tm, pm, sT)) `simplifiesTo_` (tT, makeOrPredicate pM pm, sT)
+    -- This fails because the halfSimplifyEvaluated is not commutative:
+    -- , ((tm, pm, sT), (tT, pM, sT)) `simplifiesTo_` (tT, makeOrPredicate pm pM, sT)
+    , ((tT, pM, sm), (tm, pm, sm)) `simplifiesTo_` (tT, makeOrPredicate pM pm, sm)
+    , testGroup "Inequal substitutions prevent merging"
+        [ ((tT, pM, sT), (tm, pm, sm)) `becomes_` MultiOr [orChild (tT, pM, sT), orChild (tm, pm, sm)]
+        , ((tm, pm, sm), (tT, pM, sT)) `becomes_` MultiOr [orChild (tT, pM, sT), orChild (tm, pm, sm)]
+        ]
+    ]
+
 test_anyBottom :: TestTree
 test_anyBottom =
   testGroup "Any bottom is removed from the result"

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -110,7 +110,7 @@ type TestTerm =
   PurePattern Object Domain.Builtin Variable (Valid (Variable Object) Object)
 
 tT :: TestTerm
-tT = mkTop_
+tT = mkTop Mock.testSort
 
 tm :: TestTerm
 tm = mkVar Mock.x
@@ -119,8 +119,10 @@ tM :: TestTerm
 tM = mkVar Mock.y
 
 t_ :: TestTerm
-t_ = mkBottom_
+t_ = mkBottom Mock.testSort
 
+testVar :: Text -> Variable Object
+testVar ident = Variable (testId ident) Mock.testSort
 
 type TestPredicate = CommonPredicate Object
 
@@ -130,22 +132,14 @@ pT = makeTruePredicate
 pm :: TestPredicate
 pm =
   makeEqualsPredicate
-    (mkVar $ var "#left")
-    (mkVar $ var "#right")
-  where
-    var :: Text -> Variable Object
-    var ident =
-      Variable (testId ident) predicateSort
+    (mkVar $ testVar "left")
+    (mkVar $ testVar "right")
 
 pM :: TestPredicate
 pM =
   makeEqualsPredicate
-    (mkVar $ var "#LEFT")
-    (mkVar $ var "#RIGHT")
-  where
-    var :: Text -> Variable Object
-    var ident =
-      Variable (testId ident) predicateSort
+    (mkVar $ testVar "LEFT")
+    (mkVar $ testVar "RIGHT")
 
 p_ :: TestPredicate
 p_ = makeFalsePredicate

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -134,8 +134,8 @@ middleY = mkMiddle Mock.y
 test_testValuesAreAsExpected :: TestTree
 test_testValuesAreAsExpected =
   testGroup "check properties of test values"
-  [ topOr `has`    [ (isTop, True),  (isBottom, False) ]
-  , middleX `has`  [ (isTop, False), (isBottom, False) ]
-  , bottomOr `has` [ (isTop, False), (isBottom, True) ]
+  [ topOr `has_`    [ (isTop, True),  (isBottom, False) ]
+  , middleX `has_`  [ (isTop, False), (isBottom, False) ]
+  , bottomOr `has_` [ (isTop, False), (isBottom, True) ]
   ]
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -116,7 +116,7 @@ test_simplify =
   where
     orPattern1 :: OrOfExpandedPattern Object Variable
     orPattern1 = wrapInOrPattern (tM, pM, sM)
-    
+
     orPattern2 :: OrOfExpandedPattern Object Variable
     orPattern2 = wrapInOrPattern (tm, pm, sm)
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -77,6 +77,21 @@ test_anyBottom =
     ]
   ]
 
+test_distinctMiddle :: TestTree
+test_distinctMiddle =
+    testGroup "Distinct middle patterns are not simplified"
+    [ ((tM, pm, sm), (tm, pm, sm)) `becomes_` MultiOr [orChild (tM, pm, sm), orChild (tm, pm, sm)]
+    , ((tm, pM, sm), (tm, pm, sm)) `becomes_` MultiOr [orChild (tm, pM, sm), orChild (tm, pm, sm)]
+    , ((tm, pm, sM), (tm, pm, sm)) `becomes_` MultiOr [orChild (tm, pm, sM), orChild (tm, pm, sm)]
+    ]
+
+test_deduplicateMiddle :: TestTree
+test_deduplicateMiddle =
+    testGroup "Middle patterns are deduplicated"
+    [ ((tM, pM, sM), (tM, pM, sM)) `becomes_` MultiOr [orChild (tM, pM, sM)]
+    , ((tm, pm, sm), (tm, pm, sm)) `becomes_` MultiOr [orChild (tm, pm, sm)]
+    ]
+
 
         {- Part 2: `simplify` is just a trivial use of `simplifyEvaluated` -}
 

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -77,8 +77,8 @@ test_anyBottom =
   , ((t_, pm, sm), (tm, p_, sm)) `becomes_` (MultiOr [])
 
   , testGroup "check this test's expectations"
-    [ orChild (t_, pm, sm) `is_` isBottom
-    , orChild (tm, p_, sm) `is_` isBottom
+    [ orChild (t_, pm, sm) `satisfies_` isBottom
+    , orChild (tm, p_, sm) `satisfies_` isBottom
       -- Note that it's impossible for the substitution to be bottom.
     ]
   ]

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -1,0 +1,108 @@
+module Test.Kore.Step.Simplification.Or where
+
+import           Kore.Step.Simplification.Or
+                 ( simplify, simplifyEvaluated )
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.HUnit.Extensions
+import Test.Terse
+
+import           Kore.AST.Pure
+import           Kore.AST.Valid
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import qualified Data.Set as Set
+import           Kore.Predicate.Predicate
+                 ( makeAndPredicate, makeCeilPredicate, makeEqualsPredicate,
+                 makeFalsePredicate, makeTruePredicate )
+import           Kore.Step.ExpandedPattern
+                 ( CommonExpandedPattern, Predicated (..), isTop, isBottom)
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+                 ( bottom, top, allVariables )
+import           Kore.Step.OrOfExpandedPattern
+                 ( OrOfExpandedPattern , extractPatterns )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+                 ( make, merge )
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier, SimplificationProof )
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
+import qualified Kore.Unification.Substitution as Substitution
+import qualified SMT
+
+import           Test.Kore.Comparators ()
+import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
+                 ( makeMetadataTools )
+import qualified Test.Kore.Step.MockSimplifiers as Mock
+import           Test.Kore.Step.MockSymbols
+                 ( testSort )
+import qualified Test.Kore.Step.MockSymbols as Mock
+import           Kore.Step.Simplification.Data
+                 ( SimplificationProof (..) )
+
+{- Part 1: `SimplifyEvaluated` is the core function. It converts two
+   `OrOfExpandedPattern` values into a simplifier that is to
+   produce a single `OrOfExpandedPattern`. We run the simplifier to
+   check correctness.
+-}
+
+{- Part 1a: Handling of the easy cases: Top and Bottom values -}
+
+topOr :: OrOfExpandedPattern Object Variable
+topOr = OrOfExpandedPattern.make [ExpandedPattern.top]
+
+middle :: OrOfExpandedPattern Object Variable
+middle =
+  OrOfExpandedPattern.make [raw]
+  where
+    raw = Predicated
+            { term = mkVar Mock.y
+            , predicate = makeTruePredicate 
+            , substitution = mempty
+            }
+
+
+test_testValuesAreAsExpected :: TestTree
+test_testValuesAreAsExpected =
+  testGroup "check properties of test values"
+  [ topOr `has`  [ (isTop, True),  (isBottom, False) ]
+  , middle `has` [ (isTop, False), (isBottom, False) ]
+  ]
+
+
+test_topIsEliminated :: TestTree
+test_topIsEliminated =
+  testGroup "top values are eliminated"
+  [
+    -- omission next line produces (OrOfExpandedPattern.merge middle topOr, SimplificationProof)
+    simplifyEvaluated middle topOr  `equals_` (topOr, SimplificationProof)
+    -- bug: following produces `middle`. 
+  , simplifyEvaluated topOr  middle `equals_` (topOr, SimplificationProof)
+  , simplifyEvaluated topOr  topOr  `equals_` (topOr, SimplificationProof)
+  ]
+    
+
+
+
+
+
+
+
+-- equal :: HasCallStack => Eq a => Show a => a -> a -> TestTree
+-- equal actual expected =
+--   testCase "equality" $ do
+--     assertEqual "" expected actual
+
+-- test_simplify :: [TestTree]
+-- test_simplify =
+--     [
+--       equal proof SimplificationProof
+--     , equal (map ExpandedPattern.allVariables (extractPatterns simplified)) $ [Set.empty]
+--     ]
+--     where
+--       raw_variable :: Variable Object
+--       raw_variable = Mock.y
+
+-- --      (simplified, proof) :: ( OrOfExpandedPattern Object Variable , SimplificationProof Object)
+--       (simplified, proof) = simplify raw_variable

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
@@ -17,7 +17,6 @@ import Kore.AST.Pure hiding
 import Kore.Step.Pattern
        ( StepPattern )
 import Kore.Unification.Substitution
-import Kore.Unification.Substitution as Substitution
 import Kore.TopBottom
        ( isTop, isBottom )
 

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
@@ -6,6 +6,8 @@ import Test.Tasty
        ( TestTree, testGroup )
 import Test.Tasty.HUnit
        ( assertEqual, testCase )
+import Test.Terse
+       ( gives_ )
 
 import Prelude hiding
        ( null )
@@ -15,6 +17,9 @@ import Kore.AST.Pure hiding
 import Kore.Step.Pattern
        ( StepPattern )
 import Kore.Unification.Substitution
+import Kore.Unification.Substitution as Substitution
+import Kore.TopBottom
+       ( isTop, isBottom )
 
 import qualified Test.Kore.Step.MockSymbols as Mock
 
@@ -27,7 +32,22 @@ test_substitution =
     , isNormalizedTests
     , nullTests
     , variablesTests
+    , propertyTests
     ]
+
+propertyTests:: TestTree
+propertyTests =
+  testGroup "the three notable kinds of `Substitution` values"
+  [ isTop `gives_`        [(empty, True),  (normalized, False), (unnormalized, False) ]
+  , isBottom `gives_`     [(empty, False), (normalized, False), (unnormalized, False) ]
+  , isNormalized `gives_` [(empty, True),  (normalized, True),  (unnormalized, False) ]
+  , null `gives_`         [(empty, True),  (normalized, False), (unnormalized, False) ]
+  ]
+  where
+    empty = (mempty::Substitution level variable)
+    normalized = unsafeWrap [(Mock.x, Mock.a)]
+    unnormalized = wrap [(Mock.x, Mock.a)]
+
 
 monoidTests:: TestTree
 monoidTests =

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Substitution.hs
@@ -16,9 +16,9 @@ import Kore.AST.Pure hiding
        ( mapVariables )
 import Kore.Step.Pattern
        ( StepPattern )
-import Kore.Unification.Substitution
 import Kore.TopBottom
-       ( isTop, isBottom )
+       ( isBottom, isTop )
+import Kore.Unification.Substitution
 
 import qualified Test.Kore.Step.MockSymbols as Mock
 

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -1,0 +1,235 @@
+module Test.Terse where
+
+import Prelude
+import Test.Tasty
+       ( TestTree, testGroup )
+import Test.Tasty.HUnit
+import Test.Tasty.HUnit.Extensions
+import Data.Foldable
+       ( traverse_ )
+
+
+
+{-  Part 1: Predefined functions
+
+  By default, these assertions take a final comment argument. When
+  no comment is useful, use the variants with a trailing `_`.
+-}
+
+is :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
+is = actual_predicate_comment
+
+is_ :: HasCallStack => a -> (a -> Bool)-> TestTree
+is_ = actual_predicate
+
+isn't :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
+isn't actual pred = actual_predicate_comment actual (not . pred)
+
+isn't_ :: HasCallStack => a -> (a -> Bool) -> TestTree
+isn't_ actual pred = actual_predicate actual (not . pred)
+
+equals :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> String -> TestTree
+equals = actual_expected_comment
+
+equals_ :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
+equals_ = actual_expected
+
+
+
+has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> TestTree
+has value tuples =
+  testCase "Properties" (traverse_ checkOne tuples)
+  where
+    checkOne :: (a->Bool, Bool) -> Assertion
+    checkOne (predicate, expected) =
+      assertEqual "" expected (predicate value)
+
+
+gives :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
+gives predicate tuples =
+  testCase "Properties" (traverse_ checkOne tuples)
+  where
+    checkOne :: (a, Bool) -> Assertion
+    checkOne (value, expected) =
+      assertEqual "" expected (predicate value)
+
+
+{- Part 2: Raw builder functions
+
+A set of functions used to build tests. The emphasis is on building
+tests that look tabular, such as these for a "convert a string into an
+integer-representing-hours" function:
+
+
+    testGroup "hours conversion"
+      [ rejects "1a"           "the usual non-numeric values are rejected"
+      , rejects "1.0"          "rejects floats"
+
+      , when "24" (Just 24)    "upper boundary"
+      , rejects "25"           "too big"
+
+      , when "0" (Just 0)      "0 is allowed"
+      , rejects "-1"           "negative numbers are disallowed"
+
+      , when " 3 " (Just 3)  "spaces are allowed"
+      ]
+
+Notice that the comments come last. That makes them easily scannable
+(important!)  when you want to look at words, and ignorable when you
+want to look at code.
+
+Here's how those helper functions are created:
+
+   hours : Test
+   hours =
+     let
+       run = (Validated.hours >> .value)
+---    when = Build.f_1_expected_comment run
+---    rejects = Build.f_expected_1_comment run Nothing
+   in
+     describe "hours"
+
+
+The important lines are those marked. They show that the (many!)
+builder functions follow a consistent format. Consider this example:
+
+   when = f_1_expected_comment run
+
+* `f_1`: The constructed test will apply a function to an argument to
+  construct a value to check. In this particular case, the function
+  (`run`) is supplied, so the individual tests don't have to.
+
+* `_expected_`: The result of the function is to be compared to an
+  expected value (rather than to be passed to a checker predicate).
+  That is, we know the constructed test uses `Expect.equal`.
+
+* These tests will require a specific comment (like "negative values
+  are not allowed") as the last argument.
+
+  Often, comments are redundant. That is, they're equivalent to this
+  notorious code comment:
+
+       i = i + 1;    // increment i
+
+  However, elm-test requires them so that it can direct you to which
+  test failed. A variant of `f_1_expected_comment` lets you leave the
+  comment off. The variant is: `f_1_expected`. Since it's given no
+  comment argument, the comment is constructed by applying `toString`
+  to the single argument.
+
+Let's look at another builder function:
+
+   f_expected_1_comment f alwaysExpected arg1 comment =
+
+That takes the expected value *before* the function-under-test's
+argument. That allows partial application to supply the expected value
+to every test. Like this:
+
+    rejects = Build.f_expected_1_comment run Nothing
+
+In this case, `rejects` is for any test case where the expected value
+is `Nothing`.
+
+You may notice that we don't really need two builder functions. We
+could use only `f_1_expected_comment`. Tests that have specific (non
+"default", non `Nothing`) expected values could just partially apply
+the first argument, so would be written with the expected value first:
+
+      run (wrapped 59) "59"    "upper boundary"
+
+No. Elm encourages programmers to treat execution order
+left-to-right. That is, it follows the convention embedded in many
+(but not all) written natural languages that time flows left-to-right
+and top-to-bottom. Consider calendars. Consider how examples are
+written in programming texts: every one I've ever seen shows what you
+can type, then what you should expect to see as a result:
+
+  -- `rem` gives the remainder of an integer division
+  > rem 5 2
+  1 : Int
+
+As my final argument, consider how `Expect.equal` is typically used:
+
+    functionUnderTest 1 2 3 |> Expect.equal 83
+
+This module should adhere to the idiomatic Elm order:
+
+    test values .... how to check them ... commentary
+
+"Redundant" builder functions are a small price to pay for
+readability and consistency of presentation.
+
+------
+
+Now consider functions-under-test that take multiple arguments,
+described by builder functions like this:
+
+    when = Build.f_3_expected_comment run
+
+I thought it useful to group the arguments together in a tuple, like this:
+
+   when ("1.5", "0", "3") <| Just (1.5, 0, 3) "hours can be 0 if minutes are not"
+
+In testing, I like some mechanism to separate the expected result from
+the actual result. In my Clojure testing tool, I used arrows for that:
+
+   (+ 1 2) => 3
+
+Something similar can be done in Elm, but I eventually decided it's more
+trouble than it's worth. So I group arguments in a tuple.
+
+----
+
+All of the builders described above assume that you'll have multiple
+tests that share something in common, if only what function they're
+testing. However, there are other cases. Consider this builder
+function:
+
+    actual_expected_comment actual expected comment = ...
+
+Instead of asking for the function and its arguments separately, it
+requires that the specific test calculate the value to be
+checked. Tests of this sort aren't going to partially apply anything,
+but typing or reading `actual_expected_comment` is offensive, so I
+expect it'd always be renamed:
+
+  let
+    record = {i = 3}
+    lens = Lens.lens .i (\part whole -> { whole | i = part })
+    equal = Build.actual_expected_comment                          ------
+  in
+    [ equal (Lens.get    lens        record)        3     "get"    ------
+    , equal (Lens.set    lens 5      record) { i =  5 }   "set"    ------
+    , equal (Lens.update lens negate record) { i = -3 }   "update" ------
+    ]
+
+It would be dumb to make everyone define shorthand for
+`actual_expected_comment`, so `equal` is defined as a synonym in this
+module.
+
+-}
+
+
+actual_predicate_comment :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
+actual_predicate_comment actual pred comment =
+  testCase comment $
+    assertEqual "" True $ pred actual
+
+actual_predicate :: HasCallStack => a -> (a -> Bool) -> TestTree
+actual_predicate actual pred =
+  actual_predicate_comment actual pred "actual_predicate with no comment"
+
+actual_expected_comment :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> String -> TestTree
+actual_expected_comment actual expected comment =
+  testCase comment $
+    assertEqualWithExplanation "" expected actual
+
+actual_expected :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
+actual_expected actual expected =
+  actual_expected_comment actual expected "actual_expected with no comment"
+
+f_2_expected f (arg1, arg2) expected =
+  assertEqualWithExplanation "" expected =<< f arg1 arg2
+
+f_2_expected_comment f (arg1, arg2) expected comment =
+  assertEqualWithExplanation comment expected =<< f arg1 arg2

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -5,12 +5,14 @@ module Test.Terse
     is
   , isn't
   , equals
+  , unequals
   , has
   , gives
     -- * Variants
   , is_
   , isn't_
   , equals_
+  , unequals_
   , has_
   , gives_
 
@@ -71,6 +73,17 @@ equals = actual_expected_comment
 -- |      3 + 4 `equals_` 7
 equals_ :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
 equals_ = actual_expected
+
+-- |      3 + 4 `unequals` 8  "comment"
+unequals :: (HasCallStack, Eq a, Show a) => a -> a -> String -> TestTree
+unequals actual unexpected comment =
+  actual_predicate_comment actual (/= unexpected) comment
+
+-- |      3 + 4 `unequals` 8
+unequals_ :: (HasCallStack, Eq a, Show a) => a -> a -> TestTree
+unequals_ actual unexpected = 
+  unequals actual unexpected ""
+
 
 -- | 1 `has` [(isPositive, True), (isEven, False) ] "comment" 
 has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> String -> TestTree

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -2,15 +2,13 @@ module Test.Terse
   ( -- * Common Functions
     --
     -- $commonFunctions
-    is
-  , isn't
+    satisfies
   , equals
   , unequals
   , has
   , gives
     -- * Variants
-  , is_
-  , isn't_
+  , satisfies_
   , equals_
   , unequals_
   , has_
@@ -49,20 +47,12 @@ import Data.Foldable
 -}
 
 -- |      3 + 4 `is` isOdd "addition works"
-is :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
-is = actual_predicate_comment
+satisfies :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
+satisfies = actual_predicate_comment
 
--- |      3 + 4 `is_` isOdd
-is_ :: HasCallStack => a -> (a -> Bool)-> TestTree
-is_ = actual_predicate
-
--- |      3 + 4 `isn't` isEven "addition works"
-isn't :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
-isn't actual pred = actual_predicate_comment actual (not . pred)
-
--- |      3 + 4 `isn't_` isEven 
-isn't_ :: HasCallStack => a -> (a -> Bool) -> TestTree
-isn't_ actual pred = actual_predicate actual (not . pred)
+-- |      3 + 4 `satisfies_` isOdd
+satisfies_ :: HasCallStack => a -> (a -> Bool)-> TestTree
+satisfies_ = actual_predicate
 
 -- |      3 + 4 `equals` 7  "addition works"
 equals
@@ -74,18 +64,20 @@ equals = actual_expected_comment
 equals_ :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
 equals_ = actual_expected
 
--- |      3 + 4 `unequals` 8  "comment"
+-- |
+-- > 3 + 4 `'unequals'` 8  "comment"
 unequals :: (HasCallStack, Eq a, Show a) => a -> a -> String -> TestTree
 unequals actual unexpected comment =
   actual_predicate_comment actual (/= unexpected) comment
 
--- |      3 + 4 `unequals` 8
+-- |
+-- > 3 + 4 `'unequals'` 8
 unequals_ :: (HasCallStack, Eq a, Show a) => a -> a -> TestTree
-unequals_ actual unexpected = 
+unequals_ actual unexpected =
   unequals actual unexpected ""
 
 
--- | 1 `has` [(isPositive, True), (isEven, False) ] "comment" 
+-- | 1 `has` [(isPositive, True), (isEven, False) ] "comment"
 has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> String -> TestTree
 has value tuples comment=
   testCase comment (traverse_ checkOne tuples)
@@ -97,7 +89,7 @@ has value tuples comment=
 -- | 1 `has_` [(isPositive, True), (isEven, False) ]
 has_ :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> TestTree
 has_ value tuples = has value tuples "Has properties"
-      
+
 
 -- | isOdd `gives` [ (1, True), (2, False) ] "arity"
 gives :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> String -> TestTree

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -11,7 +11,7 @@ module Test.Terse
     -- > , t_ `has_` [ (isTop, False),  (isBottom, True) ]
     -- > , tm `unequals_` tM
     -- > ...
-    -- 
+    --
     --
     -- * Common Functions
     --
@@ -44,13 +44,13 @@ module Test.Terse
     -- $rationale
   ) where
 
+import Data.Foldable
+       ( traverse_ )
 import Prelude
 import Test.Tasty
        ( TestTree )
 import Test.Tasty.HUnit
 import Test.Tasty.HUnit.Extensions
-import Data.Foldable
-       ( traverse_ )
 
 
 
@@ -121,7 +121,7 @@ gives predicate tuples comment =
     checkOne (value, expected) =
       assertEqual "" expected (predicate value)
 
--- | 
+-- |
 -- > isOdd `gives_` [ (1, True), (2, False) ]
 gives_ :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
 gives_ predicate tuples =
@@ -137,20 +137,20 @@ gives_ predicate tuples =
 -- Note: if you use these functions, the domain-specific function has to
 -- be constrained by `HasCallStack`. See above.
 
--- | 
+-- |
 -- > actual_predicate_comment 3 isOdd "check odd numbers"
 actual_predicate_comment :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
 actual_predicate_comment actual predicate comment =
   testCase comment $
     assertEqual "" True $ predicate actual
 
--- | 
+-- |
 -- > actual_predicate 3 isOdd
 actual_predicate :: HasCallStack => a -> (a -> Bool) -> TestTree
 actual_predicate actual predicate =
   actual_predicate_comment actual predicate "actual_predicate with no comment"
 
--- | 
+-- |
 -- > actual_expected_comment (+ 1 1) 2 "addition"
 actual_expected_comment
   :: (HasCallStack, Eq a, Show a, EqualWithExplanation a)
@@ -159,7 +159,7 @@ actual_expected_comment actual expected comment =
   testCase comment $
     assertEqualWithExplanation "" expected actual
 
--- | 
+-- |
 -- > actual_expected (+ 1 1) 2
 actual_expected
   :: (HasCallStack, Eq a, Show a, EqualWithExplanation a)
@@ -168,16 +168,16 @@ actual_expected actual expected =
   actual_expected_comment actual expected "actual_expected with no comment"
 
 
--- | 
+-- |
 -- > f_2_expected_comment (+) (1, 2) 3 "addition"
 f_2_expected_comment
   :: (HasCallStack, Eq e, Show e, EqualWithExplanation e)
   => (a -> b -> e) -> (a, b) -> e -> String -> TestTree
 f_2_expected_comment f (arg1, arg2) expected comment =
-  testCase comment $ 
+  testCase comment $
     assertEqualWithExplanation "" expected (f arg1 arg2)
 
--- | 
+-- |
 -- > f_2_expected (+) (1, 2) 3
 f_2_expected
   :: (HasCallStack, Eq e, Show e, EqualWithExplanation e)

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -1,4 +1,34 @@
-module Test.Terse where
+module Test.Terse
+  ( -- * Common Functions
+    --
+    -- $commonFunctions
+    is
+  , isn't
+  , equals
+  , has
+  , gives
+    -- * Variants
+  , is_
+  , isn't_
+  , equals_
+  , has_
+  , gives_
+
+    -- * Builder Functions
+    --
+    -- $builderFunctions
+
+  , actual_predicate_comment
+  , actual_predicate
+  , actual_expected_comment
+  , actual_expected
+  , f_2_expected_comment
+  , f_2_expected
+
+    -- * Rationale
+    --
+    -- $rationale
+  ) where
 
 import Prelude
 import Test.Tasty
@@ -10,12 +40,13 @@ import Data.Foldable
 
 
 
-{-  Part 1: Predefined functions
+{- $commonFunctions
 
   By default, these assertions take a final comment argument. When
   no comment is useful, use the variants with a trailing `_`.
 -}
 
+-- |      3 + 4 `is` 5 "addition works"
 is :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
 is = actual_predicate_comment
 
@@ -33,7 +64,6 @@ equals = actual_expected_comment
 
 equals_ :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
 equals_ = actual_expected
-
 
 
 has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> String -> TestTree
@@ -61,161 +91,15 @@ gives_ :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
 gives_ predicate tuples =
   gives predicate tuples "Gives"
 
-{- Part 2: Raw builder functions
 
-A set of functions used to build tests. The emphasis is on building
-tests that look tabular, such as these for a "convert a string into an
-integer-representing-hours" function:
-
-
-    testGroup "hours conversion"
-      [ rejects "1a"           "the usual non-numeric values are rejected"
-      , rejects "1.0"          "rejects floats"
-
-      , when "24" (Just 24)    "upper boundary"
-      , rejects "25"           "too big"
-
-      , when "0" (Just 0)      "0 is allowed"
-      , rejects "-1"           "negative numbers are disallowed"
-
-      , when " 3 " (Just 3)  "spaces are allowed"
-      ]
-
-Notice that the comments come last. That makes them easily scannable
-(important!)  when you want to look at words, and ignorable when you
-want to look at code.
-
-Here's how those helper functions are created:
-
-   hours : Test
-   hours =
-     let
-       run = (Validated.hours >> .value)
----    when = Build.f_1_expected_comment run
----    rejects = Build.f_expected_1_comment run Nothing
-   in
-     describe "hours"
-
-
-The important lines are those marked. They show that the (many!)
-builder functions follow a consistent format. Consider this example:
-
-   when = f_1_expected_comment run
-
-* `f_1`: The constructed test will apply a function to an argument to
-  construct a value to check. In this particular case, the function
-  (`run`) is supplied, so the individual tests don't have to.
-
-* `_expected_`: The result of the function is to be compared to an
-  expected value (rather than to be passed to a checker predicate).
-  That is, we know the constructed test uses `Expect.equal`.
-
-* These tests will require a specific comment (like "negative values
-  are not allowed") as the last argument.
-
-  Often, comments are redundant. That is, they're equivalent to this
-  notorious code comment:
-
-       i = i + 1;    // increment i
-
-  However, elm-test requires them so that it can direct you to which
-  test failed. A variant of `f_1_expected_comment` lets you leave the
-  comment off. The variant is: `f_1_expected`. Since it's given no
-  comment argument, the comment is constructed by applying `toString`
-  to the single argument.
-
-Let's look at another builder function:
-
-   f_expected_1_comment f alwaysExpected arg1 comment =
-
-That takes the expected value *before* the function-under-test's
-argument. That allows partial application to supply the expected value
-to every test. Like this:
-
-    rejects = Build.f_expected_1_comment run Nothing
-
-In this case, `rejects` is for any test case where the expected value
-is `Nothing`.
-
-You may notice that we don't really need two builder functions. We
-could use only `f_1_expected_comment`. Tests that have specific (non
-"default", non `Nothing`) expected values could just partially apply
-the first argument, so would be written with the expected value first:
-
-      run (wrapped 59) "59"    "upper boundary"
-
-No. Elm encourages programmers to treat execution order
-left-to-right. That is, it follows the convention embedded in many
-(but not all) written natural languages that time flows left-to-right
-and top-to-bottom. Consider calendars. Consider how examples are
-written in programming texts: every one I've ever seen shows what you
-can type, then what you should expect to see as a result:
-
-  -- `rem` gives the remainder of an integer division
-  > rem 5 2
-  1 : Int
-
-As my final argument, consider how `Expect.equal` is typically used:
-
-    functionUnderTest 1 2 3 |> Expect.equal 83
-
-This module should adhere to the idiomatic Elm order:
-
-    test values .... how to check them ... commentary
-
-"Redundant" builder functions are a small price to pay for
-readability and consistency of presentation.
-
-------
-
-Now consider functions-under-test that take multiple arguments,
-described by builder functions like this:
-
-    when = Build.f_3_expected_comment run
-
-I thought it useful to group the arguments together in a tuple, like this:
-
-   when ("1.5", "0", "3") <| Just (1.5, 0, 3) "hours can be 0 if minutes are not"
-
-In testing, I like some mechanism to separate the expected result from
-the actual result. In my Clojure testing tool, I used arrows for that:
-
-   (+ 1 2) => 3
-
-Something similar can be done in Elm, but I eventually decided it's more
-trouble than it's worth. So I group arguments in a tuple.
-
-----
-
-All of the builders described above assume that you'll have multiple
-tests that share something in common, if only what function they're
-testing. However, there are other cases. Consider this builder
-function:
-
-    actual_expected_comment actual expected comment = ...
-
-Instead of asking for the function and its arguments separately, it
-requires that the specific test calculate the value to be
-checked. Tests of this sort aren't going to partially apply anything,
-but typing or reading `actual_expected_comment` is offensive, so I
-expect it'd always be renamed:
-
-  let
-    record = {i = 3}
-    lens = Lens.lens .i (\part whole -> { whole | i = part })
-    equal = Build.actual_expected_comment                          ------
-  in
-    [ equal (Lens.get    lens        record)        3     "get"    ------
-    , equal (Lens.set    lens 5      record) { i =  5 }   "set"    ------
-    , equal (Lens.update lens negate record) { i = -3 }   "update" ------
-    ]
-
-It would be dumb to make everyone define shorthand for
-`actual_expected_comment`, so `equal` is defined as a synonym in this
-module.
-
--}
-
+-- $builderFunctions
+--
+-- Functions used to build domain-specific functions. Their names follow the
+-- left-to-right order of their arguments. So, for example `_comment`, when
+-- present, is always on the far right.
+--
+-- Note: if you use these functions, the domain-specific function has to
+-- be constrained by `HasCallStack`
 
 actual_predicate_comment :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
 actual_predicate_comment actual pred comment =
@@ -235,8 +119,13 @@ actual_expected :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> 
 actual_expected actual expected =
   actual_expected_comment actual expected "actual_expected with no comment"
 
+f_2_expected_comment f (arg1, arg2) expected comment =
+  assertEqualWithExplanation comment expected =<< f arg1 arg2
+
 f_2_expected f (arg1, arg2) expected =
   assertEqualWithExplanation "" expected =<< f arg1 arg2
 
-f_2_expected_comment f (arg1, arg2) expected comment =
-  assertEqualWithExplanation comment expected =<< f arg1 arg2
+{- $rationale
+
+   To be copied and tweaked from Elm documentation.
+-}

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -46,26 +46,33 @@ import Data.Foldable
   no comment is useful, use the variants with a trailing `_`.
 -}
 
--- |      3 + 4 `is` 5 "addition works"
+-- |      3 + 4 `is` isOdd "addition works"
 is :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
 is = actual_predicate_comment
 
+-- |      3 + 4 `is_` isOdd
 is_ :: HasCallStack => a -> (a -> Bool)-> TestTree
 is_ = actual_predicate
 
+-- |      3 + 4 `isn't` isEven "addition works"
 isn't :: HasCallStack => a -> (a -> Bool) -> String -> TestTree
 isn't actual pred = actual_predicate_comment actual (not . pred)
 
+-- |      3 + 4 `isn't_` isEven 
 isn't_ :: HasCallStack => a -> (a -> Bool) -> TestTree
 isn't_ actual pred = actual_predicate actual (not . pred)
 
-equals :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> String -> TestTree
+-- |      3 + 4 `equals` 7  "addition works"
+equals
+  :: (HasCallStack, Eq a, Show a, EqualWithExplanation a)
+  => a -> a -> String -> TestTree
 equals = actual_expected_comment
 
+-- |      3 + 4 `equals_` 7
 equals_ :: (HasCallStack, Eq a, Show a, EqualWithExplanation a) => a -> a -> TestTree
 equals_ = actual_expected
 
-
+-- | 1 `has` [(isPositive, True), (isEven, False) ] "comment" 
 has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> String -> TestTree
 has value tuples comment=
   testCase comment (traverse_ checkOne tuples)
@@ -74,11 +81,12 @@ has value tuples comment=
     checkOne (predicate, expected) =
       assertEqual "" expected (predicate value)
 
+-- | 1 `has_` [(isPositive, True), (isEven, False) ]
 has_ :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> TestTree
 has_ value tuples = has value tuples "Has properties"
       
 
-
+-- | isOdd `gives` [ (1, True), (2, False) ] "arity"
 gives :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> String -> TestTree
 gives predicate tuples comment =
   testCase comment (traverse_ checkOne tuples)
@@ -87,6 +95,7 @@ gives predicate tuples comment =
     checkOne (value, expected) =
       assertEqual "" expected (predicate value)
 
+-- | isOdd `gives_` [ (1, True), (2, False) ]
 gives_ :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
 gives_ predicate tuples =
   gives predicate tuples "Gives"

--- a/src/main/haskell/kore/test/Test/Terse.hs
+++ b/src/main/haskell/kore/test/Test/Terse.hs
@@ -36,23 +36,30 @@ equals_ = actual_expected
 
 
 
-has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> TestTree
-has value tuples =
-  testCase "Properties" (traverse_ checkOne tuples)
+has :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> String -> TestTree
+has value tuples comment=
+  testCase comment (traverse_ checkOne tuples)
   where
     checkOne :: (a->Bool, Bool) -> Assertion
     checkOne (predicate, expected) =
       assertEqual "" expected (predicate value)
 
+has_ :: forall a . HasCallStack => a -> [(a -> Bool, Bool)] -> TestTree
+has_ value tuples = has value tuples "Has properties"
+      
 
-gives :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
-gives predicate tuples =
-  testCase "Properties" (traverse_ checkOne tuples)
+
+gives :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> String -> TestTree
+gives predicate tuples comment =
+  testCase comment (traverse_ checkOne tuples)
   where
     checkOne :: (a, Bool) -> Assertion
     checkOne (value, expected) =
       assertEqual "" expected (predicate value)
 
+gives_ :: forall a . HasCallStack => (a -> Bool) -> [(a, Bool)] -> TestTree
+gives_ predicate tuples =
+  gives predicate tuples "Gives"
 
 {- Part 2: Raw builder functions
 


### PR DESCRIPTION
The main contribution of this pull requests is a set of tests for `Or` simplification and a bug fix for a bug that they found.

The tests were written in "terse/tabular style". The `Test.Terse` module contains support functions for that style.

There's also an additional documentation test that explains the three kinds of `Kore.Unification.Substitution` values. 


###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

