### PR TITLE
Clean up StepperVariable remapper

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -235,6 +235,7 @@ newline: native
 # Please keep this up-to-date with default-extensions in package.yaml
 language_extensions:
   - BangPatterns
+  - BlockArguments
   - ConstraintKinds
   - DataKinds
   - DeriveDataTypeable

--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -63,6 +63,7 @@ build-tools:
 
 default-extensions:
   - BangPatterns
+  - BlockArguments
   - ConstraintKinds
   - DataKinds
   - DeriveDataTypeable

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -92,6 +92,8 @@ instance NFData (SymbolOrAlias level)
 @meta-variable@ syntactic categories from the Semantics of K,
 Section 9.1.4 (Patterns).
 
+Particularly, this is the type of variable in patterns returned by the parser.
+
 The 'level' type parameter is used to distiguish between the meta- and object-
 versions of symbol declarations. It should verify 'MetaOrObject level'.
 -}
@@ -120,13 +122,22 @@ instance Hashable (Concrete level)
 
 instance NFData (Concrete level)
 
-{-| 'SortedVariable' is a variable which has a sort.
--}
-class SortedVariable variable where
+{- | 'SortedVariable' is a Kore variable with a known sort.
+
+The instances of @SortedVariable@ must encompass the 'Variable' type by
+implementing 'fromVariable', i.e. we must be able to construct a
+@SortedVariable@ given a parsed 'Variable'.
+
+ -}
+class SortedVariable (variable :: * -> *) where
+    -- | The known 'Sort' of the given variable.
     sortedVariableSort :: variable level -> Sort level
+    -- | Convert a variable from the parsed syntax of Kore.
+    fromVariable :: Variable level -> variable level
 
 instance SortedVariable Variable where
     sortedVariableSort = variableSort
+    fromVariable = id
 
 {-|Enumeration of patterns starting with @\@
 -}

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -175,13 +175,11 @@ instance
     fromVariable = AxiomVariable
 
 instance
-    FreshVariable variable
-    => FreshVariable (StepperVariable variable)
+    (FreshVariable variable, SortedVariable variable) =>
+    FreshVariable (StepperVariable variable)
   where
-    freshVariableFromVariable var n =
-        ConfigurationVariable (freshVariableFromVariable var n)
     freshVariableWith (AxiomVariable a) n =
-        ConfigurationVariable $ freshVariableFromVariable a n
+        ConfigurationVariable $ freshVariableWith (fromVariable a) n
     freshVariableWith (ConfigurationVariable a) n =
         ConfigurationVariable $ freshVariableWith a n
 
@@ -833,6 +831,7 @@ stepWithRemainders tools substitutionSimplifier patt rules =
 stepperVariableToVariableForError
     :: forall a level variable
     .   ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -864,6 +863,7 @@ stepperVariableToVariableForError existingVars = mapExceptT mapper
 
 unificationProofStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -994,6 +994,7 @@ listStepVariablesToCommon elementMapper existingVars mapping (proof : proofs)
 
 functionalProofStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1024,6 +1025,7 @@ functionalProofStepVariablesToCommon _ mapping (FunctionalDomainValue dv) =
 
 variableStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1066,6 +1068,7 @@ variableStepVariablesToCommon existingVars mapping variable =
 
 predicateStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1095,6 +1098,7 @@ predicateStepVariablesToCommon existingVars mapped predicate' = do
 
 patternStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1139,6 +1143,7 @@ replacePatternVariables mapping =
 
 addAxiomVariablesAsConfig
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -167,10 +167,12 @@ instance
     SortedVariable variable
     => SortedVariable (StepperVariable variable)
   where
-    sortedVariableSort (ConfigurationVariable variable) =
-        sortedVariableSort variable
-    sortedVariableSort (AxiomVariable variable) =
-        sortedVariableSort variable
+    sortedVariableSort =
+        \case
+            AxiomVariable variable -> variableSort variable
+            ConfigurationVariable variable ->
+                sortedVariableSort variable
+    fromVariable = AxiomVariable
 
 instance
     FreshVariable variable

--- a/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
@@ -33,13 +33,9 @@ import Kore.AST.Common
 import Kore.AST.Identifier
 import Kore.AST.MetaOrObject
 
-{- | A 'FreshVariable' can be freshened in a 'MonadCounter'.
+{- | A 'FreshVariable' can be freshened, given a 'Natural' counter.
 -}
 class FreshVariable var where
-    {-|Given an existing Variable, generate a fresh one.
-    -}
-    freshVariableFromVariable
-        :: MetaOrObject level => Variable level -> Natural -> var level
     {-|Given an existing variable, generate a fresh one of
     the same kind.
     -}
@@ -71,7 +67,6 @@ variableSeparator :: Text
 variableSeparator = "_"
 
 instance FreshVariable Variable where
-    freshVariableFromVariable = freshVariableWith
     {-| See the comment at the top of the file for the variable name syntax. -}
     freshVariableWith var n
       | not (Text.null prefix) =

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -133,6 +133,7 @@ instance Unparse (W level) where
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVariable
+    fromVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (V level)
   where
@@ -147,6 +148,7 @@ instance EqualWithExplanation (V level)
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVariable
+    fromVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (W level)
   where

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -50,7 +50,6 @@ import           Kore.Step.StepperAttributes
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unparser
 import           Kore.Variables.Fresh
-                 ( FreshVariable, freshVariableFromVariable )
 import qualified SMT
 
 import           Test.Kore.Comparators ()
@@ -589,13 +588,14 @@ appliedMockEvaluator result =
 
 mapVariables
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         )
     => CommonExpandedPattern level
     -> ExpandedPattern level variable
 mapVariables =
-    ExpandedPattern.mapVariables (\v -> freshVariableFromVariable v 1)
+    ExpandedPattern.mapVariables (\v -> freshVariableWith (fromVariable v) 1)
 
 mockEvaluator
     :: AttemptedFunction level variable

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -38,7 +38,6 @@ import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Variables.Fresh
-                 ( freshVariableFromVariable )
 import qualified SMT
 
 import           Test.Kore.Comparators ()
@@ -203,7 +202,7 @@ test_applicationSimplification =
                                         (makeEqualsPredicate gOfA gOfB)
                                     )
                             , substitution = Substitution.unsafeWrap
-                                [ (freshVariableFromVariable Mock.z 1, gOfB)
+                                [ (freshVariableWith Mock.z 1, gOfB)
                                 , (Mock.x, fOfA)
                                 , (Mock.y, gOfA)
                                 ]
@@ -219,7 +218,9 @@ test_applicationSimplification =
                             [ ApplicationFunctionEvaluator
                                 (const $ const $ const $ const $ do
                                     let zvar =
-                                            freshVariableFromVariable Mock.z 1
+                                            freshVariableWith
+                                                (fromVariable Mock.z)
+                                                1
                                     return
                                         ( AttemptedFunction.Applied
                                             (OrOfExpandedPattern.make

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -613,9 +613,11 @@ newtype W level = W String
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVar
+    fromVariable = error "Not implemented"
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVar
+    fromVariable = error "Not implemented"
 
 instance EqualWithExplanation (V level)
   where


### PR DESCRIPTION
While working on [removing the global counter](https://trello.com/c/de83F6ea), I keep tripping on problems with `FreshVariable` and the `StepperVariable` remapper. This pull request covers two basic tasks:

1. The responsibilities of `SortedVariable` and `FreshVariable` are more evenly divided between the two.
1. The code in `Kore.Step.BaseStep` that is responsible for mapping `StepperVariable`s back into configuration variables is simplified.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

