### PR TITLE
include.mk: Allow overriding K_DIST from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ kore-exec: $(KORE_EXEC)
 
 k-frontend:
 	mkdir -p $(BUILD_DIR)
-	rm -rf $(K_DIST) $(K_NIGHTLY)
+	rm -rf $(K_DIST_DEFAULT) $(K_NIGHTLY)
 	curl --location --output $(K_NIGHTLY) \
 	    $$(curl 'https://api.github.com/repos/kframework/k/releases' | jq --raw-output '.[0].assets[].browser_download_url | match(".*nightly.tar.gz").string')
-	mkdir --parents $(K_DIST)
-	tar --extract --file $(K_NIGHTLY) --strip-components 1 --directory $(K_DIST)
+	mkdir --parents $(K_DIST_DEFAULT)
+	tar --extract --file $(K_NIGHTLY) --strip-components 1 --directory $(K_DIST_DEFAULT)
 	$(KRUN) --version
 
 docs: haddock

--- a/include.mk
+++ b/include.mk
@@ -5,7 +5,8 @@ UPSTREAM_BRANCH = origin/master
 
 BUILD_DIR = $(TOP)/.build
 K_NIGHTLY = $(BUILD_DIR)/nightly.tar.gz
-K_DIST = $(BUILD_DIR)/k
+K_DIST_DEFAULT = $(BUILD_DIR)/k
+K_DIST ?= $(K_DIST_DEFAULT)
 K_DIST_BIN = $(K_DIST)/bin
 K_DIST_LIB = $(K_DIST)/lib
 K_REPO = 'https://github.com/kframework/k'


### PR DESCRIPTION
Allowing the user's environment to override K_DIST makes it much simpler to test
different versions of K with the Makefile.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

