### PR TITLE
Fix functions defined on constants.

### DIFF
--- a/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/src/Kore/Builtin/Builtin.hs
@@ -105,8 +105,11 @@ import           Kore.Step.ExpandedPattern as ExpandedPattern
                  ( top )
 import           Kore.Step.Function.Data
                  ( AttemptedAxiom (..),
+                 AttemptedAxiomResults (AttemptedAxiomResults),
                  BuiltinAndAxiomSimplifier (BuiltinAndAxiomSimplifier),
                  applicationAxiomSimplifier )
+import qualified Kore.Step.Function.Data as AttemptedAxiomResults
+                 ( AttemptedAxiomResults (..) )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import           Kore.Step.Simplification.Data
@@ -462,7 +465,10 @@ appliedFunction
     => ExpandedPattern level variable
     -> m (AttemptedAxiom level variable)
 appliedFunction epat =
-    (return . Applied . OrOfExpandedPattern.make) [epat]
+    return $ Applied AttemptedAxiomResults
+        { results = OrOfExpandedPattern.make [epat]
+        , remainders = OrOfExpandedPattern.make []
+        }
 
 {- | Construct a builtin unary operator.
 

--- a/src/main/haskell/kore/test/Test/Kore/Comparators.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Comparators.hs
@@ -41,6 +41,8 @@ import           Kore.Step.ExpandedPattern
                  ( Predicated (..) )
 import           Kore.Step.Function.Data as AttemptedAxiom
                  ( AttemptedAxiom (..) )
+import           Kore.Step.Function.Data as AttemptedAxiomResults
+                 ( AttemptedAxiomResults (..) )
 import           Kore.Step.OrOfExpandedPattern
 import           Kore.Step.Pattern
 import qualified Kore.Step.PatternAttributesError as PatternAttributesError
@@ -1035,7 +1037,9 @@ instance
     )
     => StructEqualWithExplanation (Predicated level variable child)
   where
-    structFieldsWithNames expected actual =
+    structFieldsWithNames
+        expected@(Predicated _ _ _) actual@(Predicated _ _ _)
+      =
         [ EqWrap
             "term = "
             (term expected)
@@ -1078,6 +1082,37 @@ instance
             ++ ")"
     printWithExplanation = show
 
+instance
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => StructEqualWithExplanation (AttemptedAxiomResults level variable)
+  where
+    structFieldsWithNames
+        expected@(AttemptedAxiomResults _ _)
+        actual@(AttemptedAxiomResults _ _)
+      =
+        [ EqWrap
+            "results = "
+            (results expected)
+            (results actual)
+        , EqWrap
+            "remainders = "
+            (remainders expected)
+            (remainders actual)
+        ]
+    structConstructorName _ = "AttemptedAxiomResults"
+
+instance
+    ( Show level, Show (variable level)
+    , Eq level, Eq (variable level)
+    , EqualWithExplanation (variable level)
+    )
+    => EqualWithExplanation (AttemptedAxiomResults level variable)
+  where
+    compareWithExplanation = structCompareWithExplanation
+    printWithExplanation = show
 
 instance
     ( Show level, Show (variable level)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -574,22 +574,22 @@ test_functionIntegration =
                                 )
                             )
                         )
-                    (mkAnd
-                        (Mock.f (mkVar Mock.x))
                         (mkAnd
-                            (mkNot
-                                (mkEquals Mock.testSort
-                                    (mkVar Mock.x) Mock.a
+                            (Mock.f (mkVar Mock.x))
+                            (mkAnd
+                                (mkNot
+                                    (mkEquals Mock.testSort
+                                        (mkVar Mock.x) Mock.a
+                                    )
                                 )
-                            )
-                            (mkNot
-                                (mkEquals Mock.testSort
-                                    (mkVar Mock.x) Mock.b
+                                (mkNot
+                                    (mkEquals Mock.testSort
+                                        (mkVar Mock.x) Mock.b
+                                    )
                                 )
                             )
                         )
-                    )
-        , predicate = makeTruePredicate
+                    , predicate = makeTruePredicate
                     , substitution = mempty
                     }
         actual <-

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -555,6 +555,66 @@ test_functionIntegration =
                 )
                 (Mock.f (mkVar Mock.x))
         assertEqualWithExplanation "" expect actual
+
+    , testCase "Variable expansion." $ do
+        let expect =
+                Predicated
+                    { term = mkOr
+                        (mkOr
+                            (mkAnd
+                                Mock.a
+                                (mkEquals Mock.testSort
+                                    (mkVar Mock.x) Mock.a
+                                )
+                            )
+                            (mkAnd
+                                Mock.b
+                                (mkEquals Mock.testSort
+                                    (mkVar Mock.x) Mock.b
+                                )
+                            )
+                        )
+                    (mkAnd
+                        (Mock.f (mkVar Mock.x))
+                        (mkAnd
+                            (mkNot
+                                (mkEquals Mock.testSort
+                                    (mkVar Mock.x) Mock.a
+                                )
+                            )
+                            (mkNot
+                                (mkEquals Mock.testSort
+                                    (mkVar Mock.x) Mock.b
+                                )
+                            )
+                        )
+                    )
+        , predicate = makeTruePredicate
+                    , substitution = mempty
+                    }
+        actual <-
+            evaluate
+                mockMetadataTools
+                (Map.map That $ Map.fromList
+                    [   ( Mock.fId
+                        ,   FunctionEvaluators
+                            { definitionRules =
+                                [ axiom
+                                    (Mock.f Mock.a)
+                                    Mock.a
+                                    makeTruePredicate
+                                , axiom
+                                    (Mock.f Mock.b)
+                                    Mock.b
+                                    makeTruePredicate
+                                ]
+                            , simplificationEvaluators = []
+                            }
+                        )
+                    ]
+                )
+                (Mock.f (mkVar Mock.x))
+        assertEqualWithExplanation "" expect actual
     ]
 
 axiomEvaluator
@@ -583,9 +643,11 @@ appliedMockEvaluator
 appliedMockEvaluator result =
     BuiltinAndAxiomSimplifier
     $ mockEvaluator
-    $ AttemptedAxiom.Applied
-    $ OrOfExpandedPattern.make
-        [Test.Kore.Step.Function.Integration.mapVariables result]
+    $ AttemptedAxiom.Applied AttemptedAxiomResults
+        { results = OrOfExpandedPattern.make
+            [Test.Kore.Step.Function.Integration.mapVariables result]
+        , remainders = OrOfExpandedPattern.make []
+        }
 
 mapVariables
     ::  ( FreshVariable variable

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
@@ -335,10 +335,10 @@ simpleEvaluator [] _ = return (NotApplicable, SimplificationProof)
 simpleEvaluator ((from, to) : ps) patt
   | from == patt =
     return
-        ( Applied
-            (OrOfExpandedPattern.make
-                [Predicated.fromPurePattern to]
-            )
+        ( Applied AttemptedAxiomResults
+            { results = OrOfExpandedPattern.make [Predicated.fromPurePattern to]
+            , remainders = OrOfExpandedPattern.make []
+            }
         , SimplificationProof
         )
   | otherwise =


### PR DESCRIPTION
This fixes a bug where functions which were defined over a finite set, with an equation for each possible value, e.g.
```
f(a)=1
f(b)=2
```
were looping indefinitely. This is not the only possible case, but this was a very visible one.

What was happening:

Currently we don't have a way of specifying and using the fact that a function works on a limited set of values, unless the SMT already handles it (e.g. functions on booleans). Therefore, when evaluating such a function applied to a symbolic variable, e.g. `f(x)`, we would always get a remainder of the type `f(x) and (x!=a) and (x !=b) and ...`.

The function evaluator tried to resimplify all possible results, including the remainder, which meant that we would, again, try to re-evaluate `f(x)`.

There were three possible fixes:

1. Stop reevaluating remainders since we already know that we can't evaluate them (chosen solution).
2. Use existing predicates when reevaluating remainders, e.g. `(x!=a) and (x !=b) and ...`, which would have prevented using the various axioms, and we might have noticed that the remainder is the start pattern. This seemed too tricky and wasteful.
3. Having better definability conditions for functions - we will definitely need this in the future, but, right now, we are a bit too far from something that would actually solve this issue.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

