### PR TITLE
Disjoin predicates with inequal substitutions

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/ExpandedPattern.hs
@@ -345,7 +345,15 @@ bottomPredicate = bottom $> ()
 
 {- | Transform a predicate and substitution into a predicate only.
 
-    See also: 'substitutionToPredicate'.
+@toPredicate@ is intended for generalizing the 'Predicate' and 'Substitution' of
+a 'PredicateSubstition' into only a 'Predicate'; i.e. when @term ~ ()@,
+
+> Predicated level variable term ~ PredicateSubstitution level variable
+
+@toPredicate@ is also used to extract the 'Predicate' and 'Substitution' while
+discarding the 'term'.
+
+See also: 'substitutionToPredicate'.
 
 -}
 toPredicate
@@ -355,7 +363,7 @@ toPredicate
        , Show (variable level)
        , Unparse (variable level)
        )
-    => PredicateSubstitution level variable
+    => Predicated level variable term
     -> Predicate level variable
 toPredicate Predicated { predicate, substitution } =
     makeAndPredicate

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -23,6 +23,7 @@ module Kore.Step.OrOfExpandedPattern
     , isFalse
     , isTrue
     , make
+    , singleton
     , makeFromSinglePurePattern
     , merge
     , mergeAll
@@ -150,6 +151,14 @@ make
     => [term]
     -> MultiOr term
 make patts = filterOr (MultiOr patts)
+
+{- | Construct a normalized 'MultiOr' from a single pattern.
+ -}
+singleton
+    :: (Ord term, TopBottom term)
+    => term
+    -> MultiOr term
+singleton patt = make [patt]
 
 {-|'makeMultiOr' constructs a 'MultiOr'.
 -}

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -67,17 +67,24 @@ test_topTermAnnihilates =
 test_disjoinPredicates :: TestTree
 test_disjoinPredicates =
     testGroup "Disjoin predicates when other components are equal"
-        [ expectation ((t1, p1, s1), (t2, p2, s2)) (t1, p', s1)
+        [ expectation ((t1, p1, s1), (t2, p2, s2)) (t1, p', s')
         | t1 <- terms, t2 <- terms
         , p1 <- predicates, p2 <- predicates
         , s1 <- substitutions, s2 <- substitutions
         , let
-            -- If the terms and substitutions are equal, expect the given
-            -- simplification. Otherwise, the predicates should not be merged.
+            -- If the terms are equal, expect the given simplification.
+            -- Otherwise, the predicates should not be merged.
             expectation
-              | t1 == t2 && s1 == s2 = simplifiesTo
-              | otherwise            = \initial _ -> doesNotSimplify initial
-            p' = makeOrPredicate p1 p2
+              | t1 == t2  = simplifiesTo
+              | otherwise = \initial _ -> doesNotSimplify initial
+            (p', s')
+              | s1 == s2  = (makeOrPredicate p1 p2, s1)
+              | otherwise =
+                ( makeOrPredicate
+                    (makeAndPredicate p1 (substitutionToPredicate s1))
+                    (makeAndPredicate p2 (substitutionToPredicate s2))
+                , mempty
+                )
         ]
   where
     terms = [ tM, tm ]


### PR DESCRIPTION
`Kore.Step.Simplification.Equals.makeEvaluateFunctionalOr` requires that `Kore.Step.Simplification.Or.disjoinPredicates` disjoins predicates with inequal substitutions, so we do that by promoting the substitution to the predicate.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

