### PR TITLE
Cleanup Kore.Exec

### DIFF
--- a/src/main/haskell/kore/bench/exec/Main.hs
+++ b/src/main/haskell/kore/bench/exec/Main.hs
@@ -6,9 +6,12 @@ import qualified Control.Lens as Lens
 import           Data.Function
                  ( (&) )
 import           Data.Limit
-                 ( Limit (Unlimited) )
+                 ( Limit )
+import qualified Data.Limit as Limit
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import           Numeric.Natural
+                 ( Natural )
 
 import qualified Kore.AST.Kore as Kore
 import           Kore.AST.Pure
@@ -181,7 +184,11 @@ execBenchmark root kFile definitionFile mainModuleName test =
     execution (verifiedModule, purePattern) =
         SMT.runSMT SMT.defaultConfig
         $ evalSimplifier
-        $ exec verifiedModule purePattern Unlimited anyRewrite
+        $ exec verifiedModule strategy purePattern
+      where
+        unlimited :: Limit Natural
+        unlimited = Limit.Unlimited
+        strategy = Limit.replicate unlimited . anyRewrite
     kompile = myShell $ (kBin </> "kompile")
         ++ " --backend haskell -d " ++ root
         ++ " " ++ (root </> kFile)

--- a/src/main/haskell/kore/test/Test/Kore/Exec.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Exec.hs
@@ -12,6 +12,7 @@ import           Control.Applicative
                  ( liftA2 )
 import           Data.Limit
                  ( Limit (Unlimited) )
+import qualified Data.Limit as Limit
 import qualified Data.Map as Map
 import           Data.Set
                  ( Set )
@@ -55,11 +56,12 @@ import Test.Tasty.HUnit.Extensions
 test_exec :: TestTree
 test_exec = testCase "exec" $ actual >>= assertEqualWithExplanation "" expected
   where
+    unlimited :: Limit Integer
+    unlimited = Unlimited
     actual = SMT.runSMT SMT.defaultConfig $ evalSimplifier $ exec
         verifiedModule
+        (Limit.replicate unlimited . anyRewrite)
         inputPattern
-        Unlimited
-        anyRewrite
     verifiedModule = verifiedMyModule Module
         { moduleName = ModuleName "MY-MODULE"
         , moduleSentences =
@@ -87,6 +89,8 @@ test_search =
         "search"
         [ makeTestCase searchType | searchType <- [ ONE, STAR, PLUS, FINAL] ]
   where
+    unlimited :: Limit Integer
+    unlimited = Unlimited
     makeTestCase searchType =
         testCase (show searchType) (assertion searchType)
     assertion searchType = actual searchType
@@ -95,9 +99,8 @@ test_search =
         let
             simplifier = search
                 verifiedModule
+                (Limit.replicate unlimited . allRewrites)
                 inputPattern
-                Unlimited
-                allRewrites
                 searchPattern
                 Search.Config { bound = Unlimited, searchType }
         finalPattern <- SMT.runSMT SMT.defaultConfig $ evalSimplifier simplifier


### PR DESCRIPTION
While working on removing the global counter, I did some cleanup of `Kore.Exec`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

