### PR TITLE
Clean up SortedVariable

### DIFF
--- a/src/main/haskell/kore/app/exec/Main.hs
+++ b/src/main/haskell/kore/app/exec/Main.hs
@@ -53,7 +53,7 @@ import           Kore.Parser.Parser
 import           Kore.Predicate.Predicate
                  ( makePredicate )
 import           Kore.Step.AxiomPatterns
-                 ( AxiomPatternAttributes, RewriteRule )
+                 ( AxiomPatternAttributes )
 import           Kore.Step.ExpandedPattern
                  ( CommonExpandedPattern, Predicated (..) )
 import           Kore.Step.Pattern
@@ -199,8 +199,7 @@ data KoreExecOptions = KoreExecOptions
     , smtTimeOut          :: !SMT.TimeOut
     , smtPrelude          :: !(Maybe FilePath)
     , stepLimit           :: !(Limit Natural)
-    , strategy
-        :: !([RewriteRule Object] -> Strategy (Prim (RewriteRule Object)))
+    , strategy            :: !([Rewrite] -> Strategy (Prim Rewrite))
     , koreSearchOptions   :: !(Maybe KoreSearchOptions)
     , koreProveOptions    :: !(Maybe KoreProveOptions)
     }

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -128,16 +128,30 @@ The instances of @SortedVariable@ must encompass the 'Variable' type by
 implementing 'fromVariable', i.e. we must be able to construct a
 @SortedVariable@ given a parsed 'Variable'.
 
+'toVariable' may delete information so that
+
+> toVariable . fromVariable === id :: Variable level -> Variable level
+
+but the reverse is not required.
+
  -}
 class SortedVariable (variable :: * -> *) where
     -- | The known 'Sort' of the given variable.
     sortedVariableSort :: variable level -> Sort level
+    sortedVariableSort variable =
+        variableSort
+      where
+        Variable { variableSort } = toVariable variable
+
     -- | Convert a variable from the parsed syntax of Kore.
     fromVariable :: Variable level -> variable level
+    -- | Extract the parsed syntax of a Kore variable.
+    toVariable :: variable level -> Variable level
 
 instance SortedVariable Variable where
     sortedVariableSort = variableSort
     fromVariable = id
+    toVariable = id
 
 {-|Enumeration of patterns starting with @\@
 -}

--- a/src/main/haskell/kore/src/Kore/AST/Common.hs
+++ b/src/main/haskell/kore/src/Kore/AST/Common.hs
@@ -92,6 +92,8 @@ instance NFData (SymbolOrAlias level)
 @meta-variable@ syntactic categories from the Semantics of K,
 Section 9.1.4 (Patterns).
 
+Particularly, this is the type of variable in patterns returned by the parser.
+
 The 'level' type parameter is used to distiguish between the meta- and object-
 versions of symbol declarations. It should verify 'MetaOrObject level'.
 -}
@@ -120,13 +122,22 @@ instance Hashable (Concrete level)
 
 instance NFData (Concrete level)
 
-{-| 'SortedVariable' is a variable which has a sort.
--}
-class SortedVariable variable where
+{- | 'SortedVariable' is a Kore variable with a known sort.
+
+The instances of @SortedVariable@ must encompass the 'Variable' type by
+implementing 'fromVariable', i.e. we must be able to construct a
+@SortedVariable@ given a parsed 'Variable'.
+
+ -}
+class SortedVariable (variable :: * -> *) where
+    -- | The known 'Sort' of the given variable.
     sortedVariableSort :: variable level -> Sort level
+    -- | Convert a variable from the parsed syntax of Kore.
+    fromVariable :: Variable level -> variable level
 
 instance SortedVariable Variable where
     sortedVariableSort = variableSort
+    fromVariable = id
 
 {-|Enumeration of patterns starting with @\@
 -}

--- a/src/main/haskell/kore/src/Kore/OnePath/Step.hs
+++ b/src/main/haskell/kore/src/Kore/OnePath/Step.hs
@@ -183,7 +183,7 @@ transitionRule
     -> PredicateSubstitutionSimplifier level Simplifier
     -> CommonStepPatternSimplifier level
     -- ^ Evaluates functions in patterns
-    -> Prim (CommonExpandedPattern level) (RewriteRule level)
+    -> Prim (CommonExpandedPattern level) (RewriteRule level Variable)
     -> (StrategyPattern (CommonExpandedPattern level), StepProof level Variable)
     -- ^ Configuration being rewritten and its accompanying proof
     -> Simplifier
@@ -228,7 +228,7 @@ transitionRule
                 else return (prove <$> map wrapper (toList nonEmptyConfigs))
 
     transitionApplyWithRemainders
-        :: [RewriteRule level]
+        :: [RewriteRule level Variable]
         ->  ( StrategyPattern (CommonExpandedPattern level)
             , StepProof level Variable
             )
@@ -245,7 +245,7 @@ transitionRule
       = transitionMultiApplyWithRemainders rules (config, proof)
 
     transitionMultiApplyWithRemainders
-        :: [RewriteRule level]
+        :: [RewriteRule level Variable]
         ->  ( CommonExpandedPattern level
             , StepProof level Variable
             )

--- a/src/main/haskell/kore/src/Kore/OnePath/Verification.hs
+++ b/src/main/haskell/kore/src/Kore/OnePath/Verification.hs
@@ -59,14 +59,14 @@ import           Kore.Step.Strategy
 {- | Wrapper for a rewrite rule that should be used as a claim.
 -}
 data Claim level = Claim
-    { rule :: !(RewriteRule level)
+    { rule :: !(RewriteRule level Variable)
     , attributes :: !AxiomPatternAttributes
     }
 
 
 {- | Wrapper for a rewrite rule that should be used as an axiom.
 -}
-newtype Axiom level = Axiom (RewriteRule level)
+newtype Axiom level = Axiom (RewriteRule level Variable)
 
 {- | Verifies a set of claims. When it verifies a certain claim, after the
 first step, it also uses the claims as axioms (i.e. it does coinductive proofs).
@@ -85,11 +85,16 @@ verify
     -> PredicateSubstitutionSimplifier level Simplifier
     -- ^ Simplifies predicates
     ->  (  CommonStepPattern level
-        -> [Strategy (Prim (CommonExpandedPattern level) (RewriteRule level))]
+        -> [Strategy
+            (Prim
+                (CommonExpandedPattern level)
+                (RewriteRule level Variable)
+            )
+           ]
         )
     -- ^ Creates a one-step strategy from a target pattern. See
     -- 'defaultStrategy'.
-    -> [(RewriteRule level, Limit Natural)]
+    -> [(RewriteRule level Variable, Limit Natural)]
     -- ^ List of claims, together with a maximum number of verification steps
     -- for each.
     -> ExceptT
@@ -126,7 +131,12 @@ defaultStrategy
     -- The claims that we want to prove
     -> [Axiom level]
     -> CommonStepPattern level
-    -> [Strategy (Prim (CommonExpandedPattern level) (RewriteRule level))]
+    -> [Strategy
+        (Prim
+            (CommonExpandedPattern level)
+            (RewriteRule level Variable)
+        )
+       ]
 defaultStrategy
     claims
     axioms
@@ -140,11 +150,11 @@ defaultStrategy
             rewrites
         )
   where
-    rewrites :: [RewriteRule level]
+    rewrites :: [RewriteRule level Variable]
     rewrites = map unwrap axioms
       where
         unwrap (Axiom a) = a
-    coinductiveRewrites :: [RewriteRule level]
+    coinductiveRewrites :: [RewriteRule level Variable]
     coinductiveRewrites = map rule claims
     expandedTarget :: CommonExpandedPattern level
     expandedTarget = ExpandedPattern.fromPurePattern target
@@ -155,9 +165,14 @@ verifyClaim
     -> StepPatternSimplifier level Variable
     -> PredicateSubstitutionSimplifier level Simplifier
     ->  (  CommonStepPattern level
-        -> [Strategy (Prim (CommonExpandedPattern level) (RewriteRule level))]
+        -> [Strategy
+            (Prim
+                (CommonExpandedPattern level)
+                (RewriteRule level Variable)
+            )
+           ]
         )
-    -> (RewriteRule level, Limit Natural)
+    -> (RewriteRule level Variable, Limit Natural)
     -> ExceptT
         (CommonExpandedPattern level)
         Simplifier
@@ -193,4 +208,3 @@ verifyClaim
         StrategyPattern.RewritePattern p : _ -> throwE p
         StrategyPattern.Stuck p : _ -> throwE p
         StrategyPattern.Bottom : _ -> error "Unexpected bottom pattern."
-

--- a/src/main/haskell/kore/src/Kore/Proof/Functional.hs
+++ b/src/main/haskell/kore/src/Kore/Proof/Functional.hs
@@ -11,9 +11,11 @@ module Kore.Proof.Functional
     , FunctionProof (..)
     , FunctionalProof (..)
     , TotalProof (..)
+    , mapVariables
     ) where
 
 import           Kore.AST.Common
+                 ( CharLiteral, DomainValue, StringLiteral, SymbolOrAlias )
 import qualified Kore.Domain.Builtin as Domain
 
 -- |'FunctionalProof' is used for providing arguments that a pattern is
@@ -71,3 +73,15 @@ data TotalProof level variable
 data ConstructorLikeProof
     = ConstructorLikeProof
   deriving (Eq, Show)
+
+mapVariables
+    :: (variable1 level -> variable2 level)
+    -> FunctionalProof level variable1
+    -> FunctionalProof level variable2
+mapVariables mapping =
+    \case
+        FunctionalVariable variable -> FunctionalVariable (mapping variable)
+        FunctionalDomainValue value -> FunctionalDomainValue value
+        FunctionalHead symbol -> FunctionalHead symbol
+        FunctionalStringLiteral string -> FunctionalStringLiteral string
+        FunctionalCharLiteral char -> FunctionalCharLiteral char

--- a/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
@@ -385,16 +385,18 @@ refreshRulePattern avoiding rulePattern = do
     originalFreeVariables = freeVariables rulePattern
     refreshVariables =
         Monad.foldM refreshOneVariable (avoiding, Map.empty)
-    refreshOneVariable (avoiding', subst) var = do
-        var' <- freshVariableSuchThat var (\v -> Set.notMember v avoiding')
-        let avoiding'' =
+    refreshOneVariable (avoid, rename) var
+      | Set.notMember var avoid = return (avoid, rename)
+      | otherwise = do
+        var' <- freshVariableSuchThat var (\v -> Set.notMember v avoid)
+        let avoid' =
                 -- Avoid the freshly-generated variable in future renamings.
-                Set.insert var' avoiding'
-            subst' =
+                Set.insert var' avoid
+            rename' =
                 -- Record a mapping from the original variable to the
                 -- freshly-generated variable.
-                Map.insert var (mkVar var') subst
-        return (avoiding'', subst')
+                Map.insert var var' rename
+        return (avoid', rename')
 
 {- | Extract the free variables of a 'RulePattern'.
  -}

--- a/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/src/Kore/Step/AxiomPatterns.hs
@@ -31,6 +31,7 @@ module Kore.Step.AxiomPatterns
     , extractRewriteClaims
     , mkRewriteAxiom
     , mkFunctionAxiom
+    , refreshRulePattern
     ) where
 
 import           Control.DeepSeq
@@ -41,6 +42,8 @@ import           Control.Monad
 import           Data.Default
                  ( Default (..) )
 import           Data.Maybe
+import           Data.Set
+                 ( Set )
 import           GHC.Generics
                  ( Generic )
 
@@ -63,6 +66,7 @@ import           Kore.Error
 import           Kore.IndexedModule.IndexedModule
 import           Kore.Predicate.Predicate
 import           Kore.Step.Pattern
+import           Kore.Variables.Fresh
 
 {- | Attributes specific to interpreting axiom patterns.
  -}
@@ -338,3 +342,17 @@ mkFunctionAxiom lhs rhs requires =
         )
   where
     function = mkEquals_ lhs rhs
+
+{- | Refresh the variables of a 'RulePattern'.
+
+The free variables of a 'RulePattern' are implicitly quantified, so are renamed
+to avoid collision with any variables in the given set.
+
+ -}
+refreshRulePattern
+    :: MonadCounter m
+    => Set (Variable level)  -- ^ Variables to avoid
+    -> RulePattern level
+    -> m (RulePattern level)
+refreshRulePattern _avoiding rulePattern =
+    return rulePattern

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -279,7 +279,7 @@ stepWithRule
     -> PredicateSubstitutionSimplifier level Simplifier
     -> ExpandedPattern level variable
     -- ^ Configuration being rewritten.
-    -> RulePattern level
+    -> RulePattern level Variable
     -- ^ Rewriting axiom
     -> ExceptT
         (StepError level variable)
@@ -381,7 +381,7 @@ applyUnificationToRhs
         )
     => MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
-    -> RulePattern level
+    -> RulePattern level Variable
     -> Set.Set (StepperVariable variable level)
     -> ExpandedPattern level variable
     -> UnificationProof level (StepperVariable variable)
@@ -628,7 +628,7 @@ stepWithRewriteRule
     -> PredicateSubstitutionSimplifier level Simplifier
     -> ExpandedPattern level variable
     -- ^ Configuration being rewritten.
-    -> RewriteRule level
+    -> RewriteRule level Variable
     -- ^ Rewriting axiom
     -> ExceptT
         (StepError level variable)
@@ -687,7 +687,7 @@ stepWithRemaindersForUnifier
     => MetadataTools level StepperAttributes
     -> UnificationProcedure level
     -> PredicateSubstitutionSimplifier level Simplifier
-    -> [RulePattern level]
+    -> [RulePattern level Variable]
     -- ^ Rewriting axiom
     -> ExpandedPattern level variable
     -- ^ Configuration being rewritten.
@@ -816,7 +816,7 @@ stepWithRemainders
     -> PredicateSubstitutionSimplifier level Simplifier
     -> ExpandedPattern level variable
     -- ^ Configuration being rewritten.
-    -> [RewriteRule level]
+    -> [RewriteRule level Variable]
     -- ^ Rewriting axiom
     -> Simplifier
         ( OrStepResult level variable

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -175,13 +175,11 @@ instance
     fromVariable = AxiomVariable
 
 instance
-    FreshVariable variable
-    => FreshVariable (StepperVariable variable)
+    (FreshVariable variable, SortedVariable variable) =>
+    FreshVariable (StepperVariable variable)
   where
-    freshVariableFromVariable var n =
-        ConfigurationVariable (freshVariableFromVariable var n)
     freshVariableWith (AxiomVariable a) n =
-        ConfigurationVariable $ freshVariableFromVariable a n
+        ConfigurationVariable $ freshVariableWith (fromVariable a) n
     freshVariableWith (ConfigurationVariable a) n =
         ConfigurationVariable $ freshVariableWith a n
 
@@ -833,6 +831,7 @@ stepWithRemainders tools substitutionSimplifier patt rules =
 stepperVariableToVariableForError
     :: forall a level variable
     .   ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -864,6 +863,7 @@ stepperVariableToVariableForError existingVars = mapExceptT mapper
 
 unificationProofStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -994,6 +994,7 @@ listStepVariablesToCommon elementMapper existingVars mapping (proof : proofs)
 
 functionalProofStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1024,6 +1025,7 @@ functionalProofStepVariablesToCommon _ mapping (FunctionalDomainValue dv) =
 
 variableStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1066,6 +1068,7 @@ variableStepVariablesToCommon existingVars mapping variable =
 
 predicateStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1095,6 +1098,7 @@ predicateStepVariablesToCommon existingVars mapped predicate' = do
 
 patternStepVariablesToCommon
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)
@@ -1139,6 +1143,7 @@ replacePatternVariables mapping =
 
 addAxiomVariablesAsConfig
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         , Show (variable level)

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -167,10 +167,12 @@ instance
     SortedVariable variable
     => SortedVariable (StepperVariable variable)
   where
-    sortedVariableSort (ConfigurationVariable variable) =
-        sortedVariableSort variable
-    sortedVariableSort (AxiomVariable variable) =
-        sortedVariableSort variable
+    sortedVariableSort =
+        \case
+            AxiomVariable variable -> variableSort variable
+            ConfigurationVariable variable ->
+                sortedVariableSort variable
+    fromVariable = AxiomVariable
 
 instance
     FreshVariable variable

--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -173,6 +173,8 @@ instance
             ConfigurationVariable variable ->
                 sortedVariableSort variable
     fromVariable = AxiomVariable
+    toVariable (AxiomVariable var) = var
+    toVariable (ConfigurationVariable var) = toVariable var
 
 instance
     (FreshVariable variable, SortedVariable variable) =>
@@ -496,16 +498,18 @@ applyUnificationToRhs
                 (Predicate.allVariables normalizedCondition)
             <> extractAxiomVariables
                 (Predicate.allVariables normalizedRemainderPredicate)
-        toVariable :: StepperVariable variable level -> Maybe (Variable level)
-        toVariable (AxiomVariable v) = Just v
-        toVariable (ConfigurationVariable _) = Nothing
+        fromStepperVariable
+            :: StepperVariable variable level
+            -> Maybe (Variable level)
+        fromStepperVariable (AxiomVariable v) = Just v
+        fromStepperVariable (ConfigurationVariable _) = Nothing
         extractAxiomVariables
             :: Set.Set (StepperVariable variable level)
             -> Set.Set (Variable level)
         extractAxiomVariables =
-            Set.fromList . mapMaybe toVariable . Set.toList
+            Set.fromList . mapMaybe fromStepperVariable . Set.toList
         substitutions =
-            Set.fromList . mapMaybe toVariable . Map.keys
+            Set.fromList . mapMaybe fromStepperVariable . Map.keys
             $ substitution
 
     -- Unwrap internal 'StepperVariable's and collect the variable mappings

--- a/src/main/haskell/kore/src/Kore/Step/Function/EvaluationStrategy.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/EvaluationStrategy.hs
@@ -21,7 +21,7 @@ import           Data.Maybe
 import qualified Data.Text as Text
 
 import           Kore.AST.Common
-                 ( SortedVariable, Variable )
+                 ( SortedVariable (..), Variable )
 import           Kore.AST.MetaOrObject
                  ( MetaOrObject, Object, OrdMetaOrObject, ShowMetaOrObject )
 import           Kore.AST.Pure
@@ -32,6 +32,7 @@ import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (..) )
 import           Kore.Step.AxiomPatterns
                  ( EqualityRule (EqualityRule) )
+import qualified Kore.Step.AxiomPatterns as RulePattern
 import           Kore.Step.BaseStep
                  ( OrStepResult (OrStepResult),
                  UnificationProcedure (UnificationProcedure),
@@ -284,12 +285,15 @@ evaluateWithDefinitionAxioms
         expanded :: ExpandedPattern level variable
         expanded = ExpandedPattern.fromPurePattern patt
 
+    let unwrapEqualityRule =
+            \(EqualityRule rule) ->
+                RulePattern.mapVariables fromVariable rule
     (OrStepResult { rewrittenPattern, remainder }, _proof) <-
         stepWithRemaindersForUnifier
             tools
             (UnificationProcedure unificationWithAppMatchOnTop)
             substitutionSimplifier
-            (map (\ (EqualityRule rule) -> rule) definitionRules)
+            (map unwrapEqualityRule definitionRules)
             expanded
     let
         remainderResults :: [ExpandedPattern level variable]

--- a/src/main/haskell/kore/src/Kore/Step/Function/EvaluationStrategy.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/EvaluationStrategy.hs
@@ -21,7 +21,7 @@ import           Data.Maybe
 import qualified Data.Text as Text
 
 import           Kore.AST.Common
-                 ( SortedVariable )
+                 ( SortedVariable, Variable )
 import           Kore.AST.MetaOrObject
                  ( MetaOrObject, Object, OrdMetaOrObject, ShowMetaOrObject )
 import           Kore.AST.Pure
@@ -82,7 +82,7 @@ acceptsMultipleResults OnlyOneResult = False
 that define it.
 -}
 definitionEvaluation
-    :: [EqualityRule level]
+    :: [EqualityRule level Variable]
     -> BuiltinAndAxiomSimplifier level
 definitionEvaluation rules =
     BuiltinAndAxiomSimplifier
@@ -270,7 +270,7 @@ evaluateWithDefinitionAxioms
         , Unparse (variable level)
         , ShowMetaOrObject variable
         )
-    => [EqualityRule level]
+    => [EqualityRule level Variable]
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level Simplifier
     -> StepPatternSimplifier level variable

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -26,6 +26,7 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.AxiomPatterns
                  ( AxiomPatternAttributes (..), EqualityRule (EqualityRule),
                  RulePattern (..) )
+import qualified Kore.Step.AxiomPatterns as RulePattern
 import           Kore.Step.BaseStep
                  ( StepResult (StepResult), UnificationProcedure (..),
                  stepWithRule )
@@ -117,7 +118,7 @@ ruleFunctionEvaluator
             (UnificationProcedure matchAsUnification)
             substitutionSimplifier
             (ExpandedPattern.fromPurePattern patt)
-            rule
+            (RulePattern.mapVariables fromVariable rule)
 
     processResult
         :: (StepResult level variable, StepProof level variable)

--- a/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Function/UserDefined.hs
@@ -72,7 +72,7 @@ ruleFunctionEvaluator
         , OrdMetaOrObject variable
         , ShowMetaOrObject variable
         )
-    => EqualityRule level
+    => EqualityRule level Variable
     -- ^ Axiom defining the current function.
     -> MetadataTools level StepperAttributes
     -- ^ Tools for finding additional information about patterns

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -98,7 +98,7 @@ transitionRule
     -> PredicateSubstitutionSimplifier level Simplifier
     -> CommonStepPatternSimplifier level
     -- ^ Evaluates functions in patterns
-    -> Prim (RewriteRule level)
+    -> Prim (RewriteRule level Variable)
     -> (CommonExpandedPattern level, StepProof level Variable)
     -- ^ Configuration being rewritten and its accompanying proof
     -> Simplifier [(CommonExpandedPattern level, StepProof level Variable)]
@@ -176,8 +176,8 @@ anyRewrite rewrites =
 heatingCooling
     :: (forall rewrite. [rewrite] -> Strategy (Prim rewrite))
     -- ^ 'allRewrites' or 'anyRewrite'
-    -> [RewriteRule level]
-    -> Strategy (Prim (RewriteRule level))
+    -> [RewriteRule level Variable]
+    -> Strategy (Prim (RewriteRule level Variable))
 heatingCooling rewriteStrategy rewrites =
     Strategy.sequence [Strategy.many heat, normal, Strategy.try cool]
   where

--- a/src/main/haskell/kore/src/Kore/Unification/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/Unification/Substitution.hs
@@ -19,6 +19,7 @@ module Kore.Unification.Substitution
     , null
     , variables
     , unsafeWrap
+    , Kore.Unification.Substitution.filter
     ) where
 
 import           Control.DeepSeq
@@ -140,3 +141,11 @@ null _                           = False
 -- | Returns the list of variables in the 'Substitution'.
 variables :: Substitution level variable -> [(variable level)]
 variables = fmap fst . unwrap
+
+-- | Filter the variables of the 'Substitution'.
+filter
+    :: (variable level -> Bool)
+    -> Substitution level variable
+    -> Substitution level variable
+filter filtering =
+    modify (Prelude.filter (filtering . fst))

--- a/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
+++ b/src/main/haskell/kore/src/Kore/Variables/Fresh.hs
@@ -33,13 +33,9 @@ import Kore.AST.Common
 import Kore.AST.Identifier
 import Kore.AST.MetaOrObject
 
-{- | A 'FreshVariable' can be freshened in a 'MonadCounter'.
+{- | A 'FreshVariable' can be freshened, given a 'Natural' counter.
 -}
 class FreshVariable var where
-    {-|Given an existing Variable, generate a fresh one.
-    -}
-    freshVariableFromVariable
-        :: MetaOrObject level => Variable level -> Natural -> var level
     {-|Given an existing variable, generate a fresh one of
     the same kind.
     -}
@@ -71,7 +67,6 @@ variableSeparator :: Text
 variableSeparator = "_"
 
 instance FreshVariable Variable where
-    freshVariableFromVariable = freshVariableWith
     {-| See the comment at the top of the file for the variable name syntax. -}
     freshVariableWith var n
       | not (Text.null prefix) =

--- a/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -204,7 +204,7 @@ evaluateWith solver patt =
 runStep
     :: CommonExpandedPattern Object
     -- ^ configuration
-    -> RewriteRule Object
+    -> RewriteRule Object Variable
     -- ^ axiom
     -> IO
         (Either
@@ -221,7 +221,7 @@ runStep configuration axiom = do
 runStepResult
     :: CommonExpandedPattern Object
     -- ^ configuration
-    -> RewriteRule Object
+    -> RewriteRule Object Variable
     -- ^ axiom
     -> IO
         (Either
@@ -244,7 +244,7 @@ runStepWith
     :: MVar Solver
     -> CommonExpandedPattern Object
     -- ^ configuration
-    -> RewriteRule Object
+    -> RewriteRule Object Variable
     -- ^ axiom
     -> IO
         (Either
@@ -263,7 +263,7 @@ runStepResultWith
     :: MVar Solver
     -> CommonExpandedPattern Object
     -- ^ configuration
-    -> RewriteRule Object
+    -> RewriteRule Object Variable
     -- ^ axiom
     -> IO
         (Either

--- a/src/main/haskell/kore/test/Test/Kore/OnePath/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/OnePath/Step.hs
@@ -387,7 +387,7 @@ simpleRewrite
     :: MetaOrObject level
     => CommonStepPattern level
     -> CommonStepPattern level
-    -> RewriteRule level
+    -> RewriteRule level Variable
 simpleRewrite left right =
     RewriteRule RulePattern
         { left = left
@@ -401,7 +401,7 @@ rewriteWithPredicate
     => CommonStepPattern level
     -> CommonStepPattern level
     -> CommonPredicate level
-    -> RewriteRule level
+    -> RewriteRule level Variable
 rewriteWithPredicate left right predicate =
     RewriteRule RulePattern
         { left = left
@@ -423,7 +423,12 @@ runSteps
     -> (ExecutionGraph (b, StepProof level Variable) -> a)
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> [Strategy (Prim (CommonExpandedPattern level) (RewriteRule level))]
+    -> [Strategy
+        (Prim
+            (CommonExpandedPattern level)
+            (RewriteRule level Variable)
+        )
+       ]
     -> IO a
 runSteps metadataTools graphFilter picker configuration strategy =
     (<$>) picker
@@ -449,8 +454,8 @@ runOnePathSteps
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
     -> CommonStepPattern level
-    -> [RewriteRule level]
-    -> [RewriteRule level]
+    -> [RewriteRule level Variable]
+    -> [RewriteRule level Variable]
     -> IO [StrategyPattern (CommonExpandedPattern level)]
 runOnePathSteps
     metadataTools

--- a/src/main/haskell/kore/test/Test/Kore/OnePath/Verification.hs
+++ b/src/main/haskell/kore/test/Test/Kore/OnePath/Verification.hs
@@ -372,7 +372,7 @@ simpleRewrite
     :: MetaOrObject level
     => CommonStepPattern level
     -> CommonStepPattern level
-    -> RewriteRule level
+    -> RewriteRule level Variable
 simpleRewrite left right =
     RewriteRule RulePattern
         { left = left

--- a/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
@@ -8,6 +8,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import           Data.Default
+import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
 import           Data.Maybe
                  ( fromMaybe )
@@ -395,9 +396,17 @@ test_refreshRulePattern :: TestTree
 test_refreshRulePattern =
     testCase "Rename target variables" $ do
         let avoiding = AxiomPatterns.freeVariables testRulePattern
-            rulePattern' =
+            (renaming, rulePattern') =
                 evalCounter $ refreshRulePattern avoiding testRulePattern
+            renamed = Set.fromList (Foldable.toList renaming)
             free' = AxiomPatterns.freeVariables rulePattern'
+        assertEqual
+            "Expected to rename all free variables of original RulePattern"
+            avoiding
+            (Map.keysSet renaming)
+        assertBool
+            "Expected to renamed variables distinct from original variables"
+            (Set.null $ Set.intersection avoiding renamed)
         assertBool
             "Expected no free variables in common with original RulePattern"
             (Set.null $ Set.intersection avoiding free')

--- a/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/AxiomPatterns.hs
@@ -402,7 +402,7 @@ test_refreshRulePattern =
             "Expected no free variables in common with original RulePattern"
             (Set.null $ Set.intersection avoiding free')
 
-testRulePattern :: RulePattern Object
+testRulePattern :: RulePattern Object Variable
 testRulePattern =
     RulePattern
         { left =

--- a/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
@@ -1293,7 +1293,7 @@ runStep
     -- ^functions yielding metadata for pattern heads
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> RewriteRule level
+    -> RewriteRule level Variable
     -> IO
         (Either
             (StepError level Variable)
@@ -1315,7 +1315,7 @@ runStepWithRemainders
     -- ^functions yielding metadata for pattern heads
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> [RewriteRule level]
+    -> [RewriteRule level Variable]
     -> IO (OrStepResult level Variable)
 runStepWithRemainders metadataTools configuration axioms =
     fst
@@ -1334,7 +1334,7 @@ runSingleStepWithRemainder
     -- ^functions yielding metadata for pattern heads
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> RewriteRule level
+    -> RewriteRule level Variable
     -> IO
         (Either
             (StepError level Variable)

--- a/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/BaseStep.hs
@@ -289,11 +289,7 @@ test_baseStep =
                         }
                     , mconcat
                         (map stepProof
-                            [ StepProofVariableRenamings
-                                [ variableRenaming
-                                    (a1 patternMetaSort)
-                                    (var_a1_0 patternMetaSort)
-                                ]
+                            [ StepProofVariableRenamings []
                             , StepProofUnification EmptyUnificationProof
                             ]
                         )
@@ -783,15 +779,6 @@ test_baseStep =
     x1 = Variable (testId "#x1")
     y1 = Variable (testId "#y1")
     var_a1_0 = Variable (testId "#var_a1_0")
-    variableRenaming
-        :: Variable Meta
-        -> Variable Meta
-        -> VariableRenaming Meta Variable
-    variableRenaming from to =
-        VariableRenaming
-            { variableRenamingOriginal = AxiomVariable from
-            , variableRenamingRenamed = ConfigurationVariable to
-            }
 
     identicalVariablesAssertion var = do
         let expect = Right

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -133,6 +133,7 @@ instance Unparse (W level) where
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVariable
+    fromVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (V level)
   where
@@ -147,6 +148,7 @@ instance EqualWithExplanation (V level)
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVariable
+    fromVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (W level)
   where

--- a/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/ExpandedPattern.hs
@@ -134,6 +134,7 @@ instance Unparse (W level) where
 instance SortedVariable V where
     sortedVariableSort _ = sortVariable
     fromVariable = error "Not implemented"
+    toVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (V level)
   where
@@ -149,6 +150,7 @@ instance EqualWithExplanation (V level)
 instance SortedVariable W where
     sortedVariableSort _ = sortVariable
     fromVariable = error "Not implemented"
+    toVariable = error "Not implemented"
 
 instance SumEqualWithExplanation (W level)
   where

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/EvaluationStrategy.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/EvaluationStrategy.hs
@@ -535,7 +535,7 @@ axiom
     :: CommonStepPattern Object
     -> CommonStepPattern Object
     -> CommonPredicate Object
-    -> EqualityRule Object
+    -> EqualityRule Object Variable
 axiom left right predicate =
     EqualityRule RulePattern
         { left

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -608,7 +608,7 @@ axiom
     :: CommonStepPattern Object
     -> CommonStepPattern Object
     -> CommonPredicate Object
-    -> EqualityRule Object
+    -> EqualityRule Object Variable
 axiom left right predicate =
     EqualityRule RulePattern
         { left

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -51,7 +51,6 @@ import           Kore.Step.StepperAttributes
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unparser
 import           Kore.Variables.Fresh
-                 ( FreshVariable, freshVariableFromVariable )
 import qualified SMT
 
 import           Test.Kore.Comparators ()
@@ -631,13 +630,14 @@ appliedMockEvaluator result =
 
 mapVariables
     ::  ( FreshVariable variable
+        , SortedVariable variable
         , MetaOrObject level
         , Ord (variable level)
         )
     => CommonExpandedPattern level
     -> ExpandedPattern level variable
 mapVariables =
-    ExpandedPattern.mapVariables (\v -> freshVariableFromVariable v 1)
+    ExpandedPattern.mapVariables (\v -> freshVariableWith (fromVariable v) 1)
 
 mockEvaluator
     :: AttemptedAxiom level variable

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/UserDefined.hs
@@ -224,7 +224,7 @@ mockMetadataTools =
 evaluateWithAxiom
     :: forall level . MetaOrObject level
     => MetadataTools level StepperAttributes
-    -> EqualityRule level
+    -> EqualityRule level Variable
     -> CommonStepPatternSimplifier level
     -> CommonStepPattern level
     -> IO (CommonAttemptedAxiom level)

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -40,7 +40,6 @@ import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unparser
                  ( Unparse )
 import           Kore.Variables.Fresh
-                 ( FreshVariable, freshVariableFromVariable )
 import qualified SMT
 
 import           Test.Kore.Comparators ()
@@ -208,7 +207,7 @@ test_applicationSimplification =
                                         (makeEqualsPredicate gOfA gOfB)
                                     )
                             , substitution = Substitution.unsafeWrap
-                                [ (freshVariableFromVariable Mock.z 1, gOfB)
+                                [ (freshVariableWith Mock.z 1, gOfB)
                                 , (Mock.x, fOfA)
                                 , (Mock.y, gOfA)
                                 ]
@@ -223,7 +222,7 @@ test_applicationSimplification =
                             , SortedVariable variable
                             )
                         => variable Object
-                    zvar = freshVariableFromVariable Mock.z 1
+                    zvar = freshVariableWith (fromVariable Mock.z) 1
                     result
                         :: forall variable
                         .   ( FreshVariable variable

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -51,7 +51,7 @@ a1 = Variable (testId "#a1")
 b1 = Variable (testId "#b1")
 x1 = Variable (testId "#x1")
 
-rewriteIdentity :: RewriteRule Meta
+rewriteIdentity :: RewriteRule Meta Variable
 rewriteIdentity =
     RewriteRule RulePattern
         { left = mkVar (x1 patternMetaSort)
@@ -60,7 +60,7 @@ rewriteIdentity =
         , attributes = def
         }
 
-rewriteImplies :: RewriteRule Meta
+rewriteImplies :: RewriteRule Meta Variable
 rewriteImplies =
     RewriteRule $ RulePattern
         { left = mkVar (x1 patternMetaSort)
@@ -257,7 +257,7 @@ test_simpleStrategy =
             =<< actualZeroStepLimit)
     ]
 
-axiomsSimpleStrategy :: [RewriteRule Meta]
+axiomsSimpleStrategy :: [RewriteRule Meta Variable]
 axiomsSimpleStrategy =
     [ RewriteRule $ RulePattern
         { left = metaF (mkVar $ x1 patternMetaSort)
@@ -448,7 +448,7 @@ runStep
     -- ^functions yielding metadata for pattern heads
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> [RewriteRule level]
+    -> [RewriteRule level Variable]
     -> IO [(CommonExpandedPattern level, StepProof level Variable)]
 runStep metadataTools configuration axioms =
     (<$>) pickFinal
@@ -472,7 +472,7 @@ runSteps
     -> Limit Natural
     -> CommonExpandedPattern level
     -- ^left-hand-side of unification
-    -> [RewriteRule level]
+    -> [RewriteRule level Variable]
     -> IO (CommonExpandedPattern level, StepProof level Variable)
 runSteps metadataTools stepLimit configuration axioms =
     (<$>) pickLongest

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -613,9 +613,11 @@ newtype W level = W String
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVar
+    fromVariable = error "Not implemented"
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVar
+    fromVariable = error "Not implemented"
 
 instance EqualWithExplanation (V level)
   where

--- a/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Unification/Unifier.hs
@@ -614,10 +614,12 @@ newtype W level = W String
 instance SortedVariable V where
     sortedVariableSort _ = sortVar
     fromVariable = error "Not implemented"
+    toVariable = error "Not implemented"
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVar
     fromVariable = error "Not implemented"
+    toVariable = error "Not implemented"
 
 instance EqualWithExplanation (V level)
   where


### PR DESCRIPTION
The responsibilities of `SortedVariable` and `FreshVariable` are divided along clean lines in preparation to remove the global counter, which will involve rewriting the FreshVariable class.

`Kore.Step.BaseStep` is refactored so that variable renaming happens at the beginning of the step; this reduces the amount of state that must be threaded through the stepper. The only remaining complication is alpha-renaming, and that last complication will be removed also when I remove the global counter.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

