### PR TITLE
Refactoring - make ceil evaluation return MultiOr

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -575,7 +575,6 @@ applyUnificationToRhs
                         initialSubstitution
                 }
         }
-  where
 
 keepGoodResults
     :: ExceptT

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/And.hs
@@ -152,7 +152,8 @@ simplifyEvaluated tools substitutionSimplifier first second
         OrOfExpandedPattern.crossProductGenericF
             (makeEvaluate tools substitutionSimplifier) first second
     return
-        -- TODO: It's not obvious at all when filtering occurs and when it doesn't.
+        -- TODO: It's not obvious at all when filtering occurs and when it
+        -- doesn't.
         ( OrOfExpandedPattern.filterOr
             -- TODO: Remove fst.
             (fst <$> orWithProof)

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -1,0 +1,73 @@
+{-|
+Module      : Kore.Step.Simplification.And
+Description : Tools for And PredicateSubstitution simplification.
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+Stability   : experimental
+Portability : portable
+-}
+module Kore.Step.Simplification.AndPredicates
+    ( simplifyEvaluatedMultiPredicateSubstitution
+    ) where
+
+import           Kore.AST.Pure
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import           Kore.Step.ExpandedPattern
+                 ( PredicateSubstitution )
+import qualified Kore.Step.ExpandedPattern as ExpandedPattern
+                 ( Predicated (..) )
+import           Kore.Step.OrOfExpandedPattern
+                 ( MultiOr, OrOfPredicateSubstitution )
+import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
+                 ( fullCrossProduct )
+import           Kore.Step.Simplification.Data
+                 ( PredicateSubstitutionSimplifier, SimplificationProof (..) )
+import           Kore.Step.StepperAttributes
+                 ( StepperAttributes )
+import           Kore.Step.Substitution
+                 ( mergePredicatesAndSubstitutions )
+import           Kore.Unparser
+import           Kore.Variables.Fresh
+
+simplifyEvaluatedMultiPredicateSubstitution
+    :: forall level variable m .
+        ( MetaOrObject level
+        , Monad m
+        , SortedVariable variable
+        , Ord (variable level)
+        , Show (variable level)
+        , Unparse (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , FreshVariable variable
+        )
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> [OrOfPredicateSubstitution level variable]
+    -> m
+        (OrOfPredicateSubstitution level variable, SimplificationProof level)
+simplifyEvaluatedMultiPredicateSubstitution
+    tools substitutionSimplifier predicateSubstitutions
+  = do
+    let
+        crossProduct :: MultiOr [PredicateSubstitution level variable]
+        crossProduct =
+            OrOfExpandedPattern.fullCrossProduct predicateSubstitutions
+    result <- traverse andPredicateSubstitutions crossProduct
+    return
+        ( result
+        , SimplificationProof
+        )
+  where
+    andPredicateSubstitutions
+        :: [PredicateSubstitution level variable]
+        -> m (PredicateSubstitution level variable)
+    andPredicateSubstitutions predicateSubstitutions0 = do
+        (result, _proof) <- mergePredicatesAndSubstitutions
+            tools
+            substitutionSimplifier
+            (map ExpandedPattern.predicate predicateSubstitutions0)
+            (map ExpandedPattern.substitution predicateSubstitutions0)
+        return result

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -1,5 +1,5 @@
 {-|
-Module      : Kore.Step.Simplification.And
+Module      : Kore.Step.Simplification.AndPredicates
 Description : Tools for And PredicateSubstitution simplification.
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -49,11 +49,12 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.ExpandedPattern
                  ( ExpandedPattern, Predicated (..), erasePredicatedTerm )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
-                 ( Predicated (..), bottom, fromPurePattern, isBottom )
+                 ( Predicated (..), bottom, bottomPredicate, fromPurePattern,
+                 isBottom, toPredicate, top, topPredicate )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfPredicateSubstitution )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
-                 ( make )
+                 ( extractPatterns, make, toPredicate )
 import           Kore.Step.Pattern
 import           Kore.Step.PatternAttributes
                  ( isConstructorLikeTop )
@@ -70,7 +71,9 @@ import           Kore.Step.StepperAttributes
                  ( SortInjection (..), StepperAttributes (..) )
 import qualified Kore.Step.StepperAttributes as StepperAttributes
 import           Kore.Step.Substitution
-                 ( mergePredicatesAndSubstitutions )
+                 ( PredicateSubstitutionMerger (PredicateSubstitutionMerger),
+                 createLiftedPredicatesAndSubstitutionsMerger,
+                 createPredicatesAndSubstitutionsMergerExcept )
 import           Kore.Unification.Error
                  ( UnificationError (..), UnificationOrSubstitutionError (..) )
 import qualified Kore.Unification.Substitution as Substitution
@@ -141,6 +144,9 @@ termEqualsAnd tools substitutionSimplifier p1 p2 =
             maybeTermEquals
                 tools
                 substitutionSimplifier
+                (createPredicatesAndSubstitutionsMergerExcept
+                    tools substitutionSimplifier
+                )
                 termEqualsAndWorker
                 p1
                 p2
@@ -159,6 +165,9 @@ termEqualsAnd tools substitutionSimplifier p1 p2 =
             maybeTermEquals
                 tools
                 substitutionSimplifier
+                (createPredicatesAndSubstitutionsMergerExcept
+                    tools substitutionSimplifier
+                )
                 termEqualsAndWorker
                 first
                 second
@@ -192,6 +201,7 @@ maybeTermEquals
         )
     => MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> TermSimplifier level variable (err m)
     -- ^ Used to simplify subterm "and".
     -> StepPattern level variable
@@ -245,6 +255,9 @@ termUnification tools substitutionSimplifier =
                 maybeTermAnd
                     tools
                     substitutionSimplifier
+                    (createPredicatesAndSubstitutionsMergerExcept
+                        tools substitutionSimplifier
+                    )
                     termUnificationWorker
                     pat1
                     pat2
@@ -300,6 +313,9 @@ termAnd tools substitutionSimplifier p1 p2 = do
                 maybeTermAnd
                     tools
                     substitutionSimplifier
+                    (createLiftedPredicatesAndSubstitutionsMerger
+                        tools substitutionSimplifier
+                    )
                     termAndWorker
                     first
                     second
@@ -324,6 +340,7 @@ maybeTermAnd
         )
     => MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> TermSimplifier level variable (err m)
     -- ^ Used to simplify subterm "and".
     -> StepPattern level variable
@@ -401,17 +418,17 @@ andEqualsFunctions
 andEqualsFunctions =
     [ (AndT,    liftET boolAnd)
     , (BothT,   liftET equalAndEquals)
-    , (EqualsT, lift   bottomTermEquals)
-    , (EqualsT, lift   termBottomEquals)
-    , (BothT,   liftP  variableFunctionAndEquals)
-    , (BothT,   liftP  functionVariableAndEquals)
+    , (EqualsT, lift0  bottomTermEquals)
+    , (EqualsT, lift0  termBottomEquals)
+    , (BothT,   liftTS variableFunctionAndEquals)
+    , (BothT,   liftTS functionVariableAndEquals)
     , (BothT,   addT   equalInjectiveHeadsAndEquals)
     , (BothT,   addS   sortInjectionAndEqualsAssumesDifferentHeads)
     , (BothT,   liftE  constructorSortInjectionAndEquals)
     , (BothT,   liftE  constructorAndEqualsAssumesDifferentHeads)
-    , (BothT,          Builtin.Map.unifyEquals)
-    , (BothT,          Builtin.Set.unifyEquals)
-    , (BothT,          Builtin.List.unifyEquals)
+    , (BothT,   liftB  Builtin.Map.unifyEquals)
+    , (BothT,   liftB  Builtin.Set.unifyEquals)
+    , (BothT,   liftB  Builtin.List.unifyEquals)
     , (BothT,   liftE  domainValueAndConstructorErrors)
     , (BothT,   liftET domainValueAndEqualsAssumesDifferent)
     , (BothT,   liftET stringLiteralAndEqualsAssumesDifferent)
@@ -419,14 +436,22 @@ andEqualsFunctions =
     , (AndT,    lift   functionAnd)
     ]
   where
-    liftP = transformerLift
-    lift = addT . transformerLiftOld
+    liftB
+        f
+        simplificationType
+        tools
+        substitutionSimplifier
+        _substitutionMerger
+      = f simplificationType tools substitutionSimplifier
+
+    lift = pure . transformerLiftOld
     liftE = lift . toExpanded
     liftET = liftE . addToolsArg
-    addS f _simplificationType tools _substitutionSimplifier = f tools
+    addS f _simplificationType tools _substitutionSimplifier _substitutionMerger
+      = f tools
     addT
         ::  (  MetadataTools level StepperAttributes
-            -> PredicateSubstitutionSimplifier level m
+            -> PredicateSubstitutionMerger level variable (err m)
             -> TermSimplifier level variable (err m)
             -> StepPattern level variable
             -> StepPattern level variable
@@ -434,7 +459,29 @@ andEqualsFunctions =
                 (ExpandedPattern level variable , SimplificationProof level)
             )
         -> TermTransformation level variable m
-    addT = pure
+    addT f _simplificationType tools _substitutionSimplifier =
+        f tools
+    lift0
+        f
+        _simplificationType
+        tools
+        substitutionSimplifier
+        _substitutionMerger
+        _termSimplifier
+        p1
+        p2
+      = MaybeT $ Monad.Trans.lift $ runMaybeT $
+        f tools substitutionSimplifier p1 p2
+    liftTS
+        f
+        simplificationType
+        tools
+        substitutionSimplifier
+        substitutionMerger
+        _termSimplifier
+      =
+        f simplificationType tools substitutionSimplifier substitutionMerger
+
 
 {- | Construct the conjunction or unification of two terms.
 
@@ -453,6 +500,10 @@ type TermTransformation level variable m =
        SimplificationType
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger
+        level
+        variable
+        (ExceptT (UnificationOrSubstitutionError level variable) m)
     -> TermSimplifier
         level
         variable
@@ -465,6 +516,10 @@ type TermTransformation level variable m =
 type TermTransformationOld level variable m =
        MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger
+        level
+        variable
+        (ExceptT (UnificationOrSubstitutionError level variable) m)
     -> TermSimplifier
         level
         variable
@@ -489,6 +544,7 @@ maybeTransformTerm
     => [TermTransformationOld level variable m]
     -> MetadataTools level StepperAttributes
     -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> TermSimplifier level variable (err m)
     -- ^ Used to simplify subterm pairs.
     -> StepPattern level variable
@@ -497,12 +553,23 @@ maybeTransformTerm
         (err m)
         (ExpandedPattern level variable , SimplificationProof level)
 maybeTransformTerm
-    topTransformers tools substitutionSimplifier childTransformers first second
+    topTransformers
+    mergeException
+    tools
+    substitutionSimplifier
+    childTransformers
+    first
+    second
   =
     foldr (<|>) empty
         (map
             (\f -> f
-                tools substitutionSimplifier childTransformers first second
+                mergeException
+                tools
+                substitutionSimplifier
+                childTransformers
+                first
+                second
             )
             topTransformers
         )
@@ -550,25 +617,6 @@ toExpanded transformer tools first second =
         , SimplificationProof
         )
 
-transformerLift
-    :: Monad m
-    =>  (  SimplificationType
-        -> MetadataTools level StepperAttributes
-        -> StepPattern level variable
-        -> StepPattern level variable
-        -> Maybe (ExpandedPattern level variable, SimplificationProof level)
-        )
-    -> TermTransformation level variable m
-transformerLift
-    transformation
-    simplificationType
-    tools
-    _
-    _childSimplifier
-    first
-    second
-  = liftExpandedPattern (transformation simplificationType tools first second)
-
 transformerLiftOld
   :: Monad m
   =>  (  MetadataTools level StepperAttributes
@@ -580,7 +628,8 @@ transformerLiftOld
 transformerLiftOld
     transformation
     tools
-    _
+    _substitutionSimplifier
+    _substitutionMerger
     _childSimplifier
     first
     second
@@ -623,32 +672,48 @@ equalAndEquals _ _ = empty
 -- | Unify two patterns where the first is @\\bottom@.
 bottomTermEquals
     ::  ( MetaOrObject level
+        , FreshVariable variable
+        , Monad m
         , SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , Unparse (variable level)
         )
     => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
     -> StepPattern level variable
     -> StepPattern level variable
-    -> Maybe (ExpandedPattern level variable, SimplificationProof level)
+    -> MaybeT m (ExpandedPattern level variable, SimplificationProof level)
 bottomTermEquals
     tools
+    substitutionSimplifier
     (Bottom_ _)
     second
-  = case Ceil.makeEvaluateTerm tools second of
-    (PredicateTrue, _proof) ->
-        return (ExpandedPattern.bottom, SimplificationProof)
-    (predicate, _proof) ->
-        return
+  = Monad.Trans.lift $ do
+    (secondCeil, _proof) <-
+        Ceil.makeEvaluateTerm tools substitutionSimplifier second
+    case OrOfExpandedPattern.extractPatterns secondCeil of
+        [] -> return (ExpandedPattern.top, SimplificationProof)
+        [ Predicated
+            {term = (), predicate = PredicateTrue, substitution}
+          ]
+          | substitution == mempty ->
+            return (ExpandedPattern.bottom, SimplificationProof)
+        _ -> return
             ( Predicated
                 { term = mkTop_
-                , predicate = makeNotPredicate predicate
+                , predicate =
+                    makeNotPredicate
+                        (OrOfExpandedPattern.toPredicate
+                            (fmap ExpandedPattern.toPredicate secondCeil)
+                        )
                 , substitution = mempty
                 }
             , SimplificationProof
             )
-bottomTermEquals _ _ _ = empty
+bottomTermEquals _ _ _ _ = empty
 
 {- | Unify two patterns where the second is @\\bottom@.
 
@@ -657,16 +722,22 @@ See also: 'bottomTermEquals'
  -}
 termBottomEquals
     ::  ( MetaOrObject level
+        , FreshVariable variable
+        , Monad m
         , SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , Unparse (variable level)
         )
     => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
     -> StepPattern level variable
     -> StepPattern level variable
-    -> Maybe (ExpandedPattern level variable, SimplificationProof level)
-termBottomEquals tools first second = bottomTermEquals tools second first
+    -> MaybeT m (ExpandedPattern level variable, SimplificationProof level)
+termBottomEquals tools substitutionSimplifier first second =
+    bottomTermEquals tools substitutionSimplifier second first
 
 {- | Unify a variable with a function pattern.
 
@@ -675,19 +746,30 @@ See also: 'isFunctionPattern'
  -}
 variableFunctionAndEquals
     ::  ( MetaOrObject level
+        , FreshVariable variable
+        , Monad m
         , SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , Unparse (variable level)
+        , err ~ ExceptT (UnificationOrSubstitutionError level variable)
         )
     => SimplificationType
     -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> StepPattern level variable
     -> StepPattern level variable
-    -> Maybe (ExpandedPattern level variable, SimplificationProof level)
+    -> MaybeT
+        (err m)
+        (ExpandedPattern level variable, SimplificationProof level)
 variableFunctionAndEquals
     SimplificationType.And
-    _
+    _tools
+    _substitutionSimplifier
+    _substitutionMerger
     first@(Var_ v1)
     second@(Var_ v2)
   = return
@@ -705,27 +787,48 @@ variableFunctionAndEquals
 variableFunctionAndEquals
     simplificationType
     tools
+    substitutionSimplifier
+    (PredicateSubstitutionMerger substitutionMerger)
     (Var_ v)
     second
-  | isFunctionPattern tools second =
+  | isFunctionPattern tools second = Monad.Trans.lift $ do -- ExceptT Simplifier
+    Predicated {term = (), predicate, substitution} <- Monad.Trans.lift $
+        case simplificationType of -- Simplifier
+            SimplificationType.And ->
+                -- Ceil predicate not needed since 'second' being bottom
+                -- will make the entire term bottom. However, one must
+                -- be careful to not just drop the term.
+                return ExpandedPattern.topPredicate
+            SimplificationType.Equals -> do
+                (resultOr, _proof) <-
+                    Ceil.makeEvaluateTerm tools substitutionSimplifier second
+                case OrOfExpandedPattern.extractPatterns resultOr of
+                    [] -> return ExpandedPattern.bottomPredicate
+                    [resultPredicateSubstitution] ->
+                        return resultPredicateSubstitution
+                    _ -> error
+                        (  "Unimplemented, ceil of "
+                        ++ show second
+                        ++ " returned multiple results: "
+                        ++ show resultOr
+                        ++ "."
+                        )
+    Predicated
+        { term = ()
+        , predicate = resultPredicate
+        , substitution = resultSubstitution
+        } <- substitutionMerger
+            [predicate]
+            [substitution, Substitution.wrap [(v, second)]]
     return
         ( Predicated
             { term = second  -- different for Equals
-            , predicate =
-                case simplificationType of
-                    -- Ceil predicate not needed since 'second' being bottom
-                    -- will make the entire term bottom. However, one must
-                    -- be careful to not just drop the term.
-                    SimplificationType.And ->
-                        makeTruePredicate
-                    SimplificationType.Equals ->
-                        case Ceil.makeEvaluateTerm tools second of
-                            (pred', _proof) -> pred'
-            , substitution = Substitution.wrap [(v, second)]
+            , predicate = resultPredicate
+            , substitution = resultSubstitution
             }
         , SimplificationProof
         )
-variableFunctionAndEquals _ _ _ _ = empty
+variableFunctionAndEquals _ _ _ _ _ _ = empty
 
 {- | Unify a function pattern with a variable.
 
@@ -734,22 +837,40 @@ See also: 'variableFunctionAndEquals'
  -}
 functionVariableAndEquals
     ::  ( MetaOrObject level
+        , FreshVariable variable
+        , Monad m
         , SortedVariable variable
         , Ord (variable level)
         , Show (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
         , Unparse (variable level)
+        , err ~ ExceptT (UnificationOrSubstitutionError level variable)
         )
     => SimplificationType
     -> MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> StepPattern level variable
     -> StepPattern level variable
-    -> Maybe (ExpandedPattern level variable, SimplificationProof level)
+    -> MaybeT
+        (err m)
+        (ExpandedPattern level variable, SimplificationProof level)
 functionVariableAndEquals
     simplificationType
     tools
+    substitutionSimplifier
+    substitutionMerger
     first
     second
-  = variableFunctionAndEquals simplificationType tools second first
+  =
+    variableFunctionAndEquals
+        simplificationType
+        tools
+        substitutionSimplifier
+        substitutionMerger
+        second
+        first
 
 {- | Unify two application patterns with equal, injective heads.
 
@@ -772,7 +893,7 @@ equalInjectiveHeadsAndEquals
         , err ~ ExceptT (UnificationOrSubstitutionError level variable)
         )
     => MetadataTools level StepperAttributes
-    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
     -> TermSimplifier level variable (err m)
     -- ^ Used to simplify subterm "and".
     -> StepPattern level variable
@@ -782,7 +903,7 @@ equalInjectiveHeadsAndEquals
         (ExpandedPattern level variable, SimplificationProof level)
 equalInjectiveHeadsAndEquals
     tools
-    substitutionSimplifier
+    (PredicateSubstitutionMerger substitutionMerger)
     termMerger
     firstPattern@(App_ firstHead firstChildren)
     (App_ secondHead secondChildren)
@@ -791,18 +912,10 @@ equalInjectiveHeadsAndEquals
         children <- Monad.zipWithM termMerger firstChildren secondChildren
         let predicates = ExpandedPattern.predicate . fst <$> children
             substitutions = ExpandedPattern.substitution . fst <$> children
-        (merged, _proof) <- Monad.Trans.lift $
-            mergePredicatesAndSubstitutions
-                tools
-                substitutionSimplifier
-                predicates
-                substitutions
-        let Predicated
-                { predicate = mergedPredicate
-                , substitution = mergedSubstitution
-                }
-              =
-                merged
+        Predicated
+            { predicate = mergedPredicate
+            , substitution = mergedSubstitution
+            } <- substitutionMerger predicates substitutions
         return
             ( Predicated
                 { term =

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -811,7 +811,9 @@ variableFunctionAndEquals
                         ++ show second
                         ++ " returned multiple results: "
                         ++ show resultOr
-                        ++ "."
+                        ++ ". This could happen, as an example, when"
+                        ++ " defining ceil(f(x))=g(x), and the evaluation for"
+                        ++ " g(x) splits the configuration."
                         )
     Predicated
         { term = ()

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -180,7 +180,7 @@ simplifyInternal
                 axiomIdToEvaluator
                 (valid :< p)
         BottomPattern p -> return $ Bottom.simplify p
-        CeilPattern p -> return $ Ceil.simplify tools p
+        CeilPattern p -> Ceil.simplify tools substitutionSimplifier p
         DomainValuePattern p -> return $ DomainValue.simplify tools p
         EqualsPattern p -> Equals.simplify tools substitutionSimplifier p
         ExistsPattern p ->
@@ -189,7 +189,7 @@ simplifyInternal
         ForallPattern p -> return $ Forall.simplify p
         IffPattern p -> return $ Iff.simplify p
         ImpliesPattern p -> return $ Implies.simplify p
-        InPattern p -> return $ In.simplify tools p
+        InPattern p -> In.simplify tools substitutionSimplifier p
         -- TODO(virgil): Move next up through patterns.
         NextPattern p -> return $ Next.simplify p
         NotPattern p -> return $ Not.simplify p

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs
@@ -304,6 +304,9 @@ normalizePredicatedSubstitution
         Right (Predicated { predicate = p, substitution = s }, _) ->
             (Predicated term p s, EmptyUnificationProof)
 
+{-| Creates a 'PredicateSubstitutionMerger' that returns errors on unifications it
+can't handle.
+-}
 createPredicatesAndSubstitutionsMergerExcept
     :: forall level variable m err .
         ( Show (variable level)
@@ -332,6 +335,9 @@ createPredicatesAndSubstitutionsMergerExcept tools substitutionSimplifier =
             tools substitutionSimplifier predicates substitutions
         return merged
 
+{-| Creates a 'PredicateSubstitutionMerger' that creates predicates for
+unifications it can't handle.
+-}
 createPredicatesAndSubstitutionsMerger
     :: forall level variable m .
         ( Show (variable level)
@@ -359,6 +365,10 @@ createPredicatesAndSubstitutionsMerger tools substitutionSimplifier =
             tools substitutionSimplifier predicates substitutions
         return merged
 
+{-| Creates a 'PredicateSubstitutionMerger' that creates predicates for
+unifications it can't handle and whose result is in any monad transformer
+over the base monad.
+-}
 createLiftedPredicatesAndSubstitutionsMerger
     :: forall level variable m t .
         ( Show (variable level)

--- a/src/main/haskell/kore/src/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Substitution.hs
@@ -8,16 +8,23 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Substitution
-    ( mergePredicatesAndSubstitutions
+    ( PredicateSubstitutionMerger (..)
+    , createLiftedPredicatesAndSubstitutionsMerger
+    , createPredicatesAndSubstitutionsMerger
+    , createPredicatesAndSubstitutionsMergerExcept
+    , mergePredicatesAndSubstitutions
     , mergePredicatesAndSubstitutionsExcept
     , normalizePredicatedSubstitution
     , normalize
     ) where
 
-import Control.Monad.Except
-       ( ExceptT, lift, runExceptT, withExceptT )
-import Data.Foldable
-       ( fold )
+import           Control.Monad.Except
+                 ( ExceptT, lift, runExceptT, withExceptT )
+import           Control.Monad.Trans.Class
+                 ( MonadTrans )
+import qualified Control.Monad.Trans.Class as Monad.Trans
+import           Data.Foldable
+                 ( fold )
 
 import           Kore.AST.Common
                  ( SortedVariable )
@@ -49,6 +56,13 @@ import           Kore.Unification.UnifierImpl
                  ( normalizeSubstitutionDuplication )
 import           Kore.Unparser
 import           Kore.Variables.Fresh
+
+newtype PredicateSubstitutionMerger level variable m =
+    PredicateSubstitutionMerger
+    (  [Predicate level variable]
+    -> [Substitution level variable]
+    -> m (PredicateSubstitution level variable)
+    )
 
 -- | Normalize the substitution and predicate of 'expanded'.
 normalize
@@ -158,9 +172,6 @@ into a condition.
 
 If it does not know how to merge the substitutions, it will transform them into
 predicates and redo the merge.
-
-TODO(virgil): Reconsider: should this return an Either or is it safe to just
-make everything a Predicate?
 
 hs-boot: Please remember to update the hs-boot file when changing the signature.
 -}
@@ -292,3 +303,86 @@ normalizePredicatedSubstitution
             )
         Right (Predicated { predicate = p, substitution = s }, _) ->
             (Predicated term p s, EmptyUnificationProof)
+
+createPredicatesAndSubstitutionsMergerExcept
+    :: forall level variable m err .
+        ( Show (variable level)
+        , Unparse (variable level)
+        , SortedVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , FreshVariable variable
+        , Monad m
+        , err ~ ExceptT (UnificationOrSubstitutionError level variable)
+        )
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (err m)
+createPredicatesAndSubstitutionsMergerExcept tools substitutionSimplifier =
+    PredicateSubstitutionMerger worker
+  where
+    worker
+        :: [Predicate level variable]
+        -> [Substitution level variable]
+        -> (err m) (PredicateSubstitution level variable)
+    worker predicates substitutions = do
+        (merged, _proof) <- mergePredicatesAndSubstitutionsExcept
+            tools substitutionSimplifier predicates substitutions
+        return merged
+
+createPredicatesAndSubstitutionsMerger
+    :: forall level variable m .
+        ( Show (variable level)
+        , Unparse (variable level)
+        , SortedVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , FreshVariable variable
+        , Monad m
+        )
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable m
+createPredicatesAndSubstitutionsMerger tools substitutionSimplifier =
+    PredicateSubstitutionMerger worker
+  where
+    worker
+        :: [Predicate level variable]
+        -> [Substitution level variable]
+        -> m (PredicateSubstitution level variable)
+    worker predicates substitutions = do
+        (merged, _proof) <- mergePredicatesAndSubstitutions
+            tools substitutionSimplifier predicates substitutions
+        return merged
+
+createLiftedPredicatesAndSubstitutionsMerger
+    :: forall level variable m t .
+        ( Show (variable level)
+        , Unparse (variable level)
+        , SortedVariable variable
+        , MetaOrObject level
+        , Ord (variable level)
+        , OrdMetaOrObject variable
+        , ShowMetaOrObject variable
+        , FreshVariable variable
+        , Monad m
+        , MonadTrans t
+        )
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level m
+    -> PredicateSubstitutionMerger level variable (t m)
+createLiftedPredicatesAndSubstitutionsMerger tools substitutionSimplifier =
+    PredicateSubstitutionMerger worker
+  where
+    worker
+        :: [Predicate level variable]
+        -> [Substitution level variable]
+        -> (t m) (PredicateSubstitution level variable)
+    worker predicates substitutions = Monad.Trans.lift $ do
+        (merged, _proof) <- mergePredicatesAndSubstitutions
+            tools substitutionSimplifier predicates substitutions
+        return merged

--- a/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Function/Matcher.hs
@@ -388,7 +388,7 @@ test_matcherVariableFunction =
                 [ Predicated
                     { predicate = makeTruePredicate
                     , substitution =
-                        Substitution.wrap [(Mock.x, Mock.functional00)]
+                        Substitution.unsafeWrap [(Mock.x, Mock.functional00)]
                     , term = ()
                     }
                 ]
@@ -402,7 +402,7 @@ test_matcherVariableFunction =
         let expect = Just $ OrOfExpandedPattern.make
                 [ Predicated
                     { predicate = makeCeilPredicate Mock.cf
-                    , substitution = Substitution.wrap [(Mock.x, Mock.cf)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, Mock.cf)]
                     , term = ()
                     }
                 ]
@@ -534,7 +534,8 @@ test_matcherVariableFunction =
             let expect = Just $ OrOfExpandedPattern.make
                     [ Predicated
                         { predicate = makeCeilPredicate Mock.cf
-                        , substitution = Substitution.wrap [(Mock.x, Mock.cf)]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, Mock.cf)]
                         , term = ()
                         }
                     ]

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -103,7 +103,8 @@ test_andTermsSimplification =
                     Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap [(Mock.x, fOfA)]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, fOfA)]
                         }
             actual <-
                 simplifyUnify
@@ -116,7 +117,8 @@ test_andTermsSimplification =
                     Predicated
                         { term = fOfA
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap [(Mock.x, fOfA)]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, fOfA)]
                         }
             actual <-
                 simplifyUnify
@@ -550,7 +552,8 @@ test_andTermsSimplification =
                     Just Predicated
                         { term = Mock.builtinMap [(Mock.aConcrete, Mock.b)]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap [(Mock.x, Mock.b)]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, Mock.b)]
                         }
             actual <-
                 unify
@@ -714,12 +717,12 @@ test_andTermsSimplification =
             let term5 = Mock.concatList
                         (Mock.builtinList [Mock.a])
                         (mkVar Mock.x)
-                term6 = Mock.builtinList $ [Mock.a, Mock.b]
+                term6 = Mock.builtinList [Mock.a, Mock.b]
                 expect =
                     Just Predicated
-                        { term = Mock.builtinList $ [Mock.a, Mock.b]
+                        { term = Mock.builtinList [Mock.a, Mock.b]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [(Mock.x, Mock.builtinList [Mock.b])]
                         }
             actual <- unify mockMetadataTools term5 term6

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -12,6 +12,8 @@ import           Kore.AST.Valid
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
+import           Kore.Logger.Output as Logger
+                 ( emptyLogger )
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeCeilPredicate, makeEqualsPredicate,
                  makeTruePredicate )
@@ -26,13 +28,17 @@ import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
 import           Kore.Step.Pattern
 import qualified Kore.Step.Simplification.Ceil as Ceil
                  ( makeEvaluate, simplify )
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
 import           Kore.Step.StepperAttributes
                  ( StepperAttributes )
 import qualified Kore.Unification.Substitution as Substitution
+import qualified SMT
 
 import           Test.Kore.Comparators ()
 import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
                  ( makeMetadataTools )
+import qualified Test.Kore.Step.MockSimplifiers as Mock
 import           Test.Kore.Step.MockSymbols
                  ( testSort )
 import qualified Test.Kore.Step.MockSymbols as Mock
@@ -40,10 +46,10 @@ import           Test.Tasty.HUnit.Extensions
 
 test_ceilSimplification :: [TestTree]
 test_ceilSimplification =
-    [ testCase "Ceil - or distribution"
+    [ testCase "Ceil - or distribution" $ do
         -- ceil(a or b) = (top and ceil(a)) or (top and ceil(b))
-        (assertEqualWithExplanation ""
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate = makeCeilPredicate somethingOfA
@@ -55,89 +61,86 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
+        actual <- evaluate mockMetadataTools
+            (makeCeil
+                [somethingOfAExpanded, somethingOfBExpanded]
             )
-            (evaluate mockMetadataTools
-                (makeCeil
-                    [somethingOfAExpanded, somethingOfBExpanded]
-                )
-            )
-        )
+        assertEqualWithExplanation "" expected actual
     , testCase "Ceil - bool operations"
         (do
             -- ceil(top) = top
+            actual1 <- evaluate mockMetadataTools
+                (makeCeil
+                    [ExpandedPattern.top]
+                )
             assertEqualWithExplanation "ceil(top)"
                 (OrOfExpandedPattern.make
                     [ ExpandedPattern.top ]
                 )
-                (evaluate mockMetadataTools
-                    (makeCeil
-                        [ExpandedPattern.top]
-                    )
-                )
+                actual1
             -- ceil(bottom) = bottom
+            actual2 <- evaluate mockMetadataTools
+                (makeCeil
+                    []
+                )
             assertEqualWithExplanation "ceil(bottom)"
                 (OrOfExpandedPattern.make
                     []
                 )
-                (evaluate mockMetadataTools
-                    (makeCeil
-                        []
-                    )
-                )
+                actual2
         )
     , testCase "expanded Ceil - bool operations"
         (do
             -- ceil(top) = top
+            actual1 <- makeEvaluate mockMetadataTools
+                (ExpandedPattern.top :: CommonExpandedPattern Object)
             assertEqualWithExplanation "ceil(top)"
                 (OrOfExpandedPattern.make
                     [ ExpandedPattern.top ]
                 )
-                (makeEvaluate mockMetadataTools
-                    (ExpandedPattern.top :: CommonExpandedPattern Object)
-                )
+                actual1
             -- ceil(bottom) = bottom
+            actual2 <- makeEvaluate mockMetadataTools
+                (ExpandedPattern.bottom :: CommonExpandedPattern Object)
             assertEqualWithExplanation "ceil(bottom)"
                 (OrOfExpandedPattern.make
                     []
                 )
-                (makeEvaluate mockMetadataTools
-                    (ExpandedPattern.bottom :: CommonExpandedPattern Object)
-                )
+                actual2
         )
-    , testCase "ceil with predicates and substitutions"
+    , testCase "ceil with predicates and substitutions" $ do
         -- if term is not functional, then
         -- ceil(term and predicate and subst)
         --     = top and (ceil(term) and predicate) and subst
-        (assertEqualWithExplanation "ceil(something(a) and equals(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
                             (makeEqualsPredicate fOfA gOfA)
                             (makeCeilPredicate somethingOfA)
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = somethingOfA
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = somethingOfA
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation "ceil(something(a) and equals(f(a), g(a)))"
+            expected
+            actual
     , let
         constructorTerm = Mock.constr20 somethingOfA somethingOfB
       in
-        testCase "ceil with constructors"
+        testCase "ceil with constructors" $ do
             -- if term is a non-functional-constructor(params), then
             -- ceil(term and predicate and subst)
             --     = top and (ceil(term) and predicate) and subst
-            (assertEqualWithExplanation
-                "ceil(constr(something(a), something(b)) and eq(f(a), g(a)))"
-                (OrOfExpandedPattern.make
+            let
+                expected = OrOfExpandedPattern.make
                     [ Predicated
                         { term = mkTop_
                         , predicate =
@@ -147,36 +150,36 @@ test_ceilSimplification =
                                     (makeCeilPredicate somethingOfA)
                                     (makeCeilPredicate somethingOfB)
                                 )
-                        , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, fOfB)]
                         }
                     ]
-                )
-                (makeEvaluate mockMetadataTools
-                    Predicated
-                        { term = constructorTerm
-                        , predicate = makeEqualsPredicate fOfA gOfA
-                        , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                        }
-                )
-            )
-    , testCase "ceil of constructors is top"
-        (assertEqualWithExplanation ""
-            (OrOfExpandedPattern.make [ExpandedPattern.top])
-            (makeEvaluate mockMetadataTools
+            actual <- makeEvaluate mockMetadataTools
                 Predicated
-                    { term = Mock.constr10 Mock.a
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
+                    { term = constructorTerm
+                    , predicate = makeEqualsPredicate fOfA gOfA
+                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
                     }
-            )
-        )
-    , testCase "ceil with functional symbols"
+            assertEqualWithExplanation
+                "ceil(constr(something(a), something(b)) and eq(f(a), g(a)))"
+                expected
+                actual
+    , testCase "ceil of constructors is top" $ do
+        let
+            expected = OrOfExpandedPattern.make [ExpandedPattern.top]
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.constr10 Mock.a
+                , predicate = makeTruePredicate
+                , substitution = mempty
+                }
+        assertEqualWithExplanation "" expected actual
+    , testCase "ceil with functional symbols" $ do
         -- if term is a functional(params), then
         -- ceil(term and predicate and subst)
         --     = top and (ceil(params) and predicate) and subst
-        (assertEqualWithExplanation
-            "ceil(functional(something(a), something(b)) and eq(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
@@ -186,99 +189,99 @@ test_ceilSimplification =
                                 (makeCeilPredicate somethingOfA)
                                 (makeCeilPredicate somethingOfB)
                             )
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = Mock.functional20 somethingOfA somethingOfB
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
-    , testCase "ceil with function symbols"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.functional20 somethingOfA somethingOfB
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation
+            "ceil(functional(something(a), something(b)) and eq(f(a), g(a)))"
+            expected
+            actual
+    , testCase "ceil with function symbols" $ do
         -- if term is a function(params), then
         -- ceil(term and predicate and subst)
         --     = top and (ceil(term) and predicate) and subst
-        (assertEqualWithExplanation
-            "ceil(f(a)) and eq(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
                             (makeEqualsPredicate fOfA gOfA)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = fOfA
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
-    , testCase "ceil with function symbols"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = fOfA
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation
+            "ceil(f(a)) and eq(f(a), g(a)))"
+            expected
+            actual
+    , testCase "ceil with function symbols" $ do
         -- if term is a functional(params), then
         -- ceil(term and predicate and subst)
         --     = top and (ceil(params) and predicate) and subst
-        (assertEqualWithExplanation
-            "ceil(f(a)) and eq(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
                             (makeEqualsPredicate fOfA gOfA)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = fOfA
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
-    , testCase "ceil with functional terms"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = fOfA
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation
+            "ceil(f(a)) and eq(f(a), g(a)))"
+            expected
+            actual
+    , testCase "ceil with functional terms" $ do
         -- if term is functional, then
         -- ceil(term and predicate and subst)
         --     = top and predicate and subst
-        (assertEqualWithExplanation
-            "ceil(functional and eq(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = Mock.a
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
-    , testCase "ceil with functional composition"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.a
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation
+            "ceil(functional and eq(f(a), g(a)))"
+            expected
+            actual
+    , testCase "ceil with functional composition" $ do
         -- if term is functional(non-funct, non-funct), then
         -- ceil(term and predicate and subst)
         --     = top and
         --       ceil(non-funct) and ceil(non-funct) and predicate and
         --       subst
-        (assertEqualWithExplanation
-            "ceil(functional(non-funct, non-funct) and eq(f(a), g(a)))"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
@@ -288,50 +291,47 @@ test_ceilSimplification =
                                 (makeCeilPredicate fOfA)
                                 (makeCeilPredicate fOfB)
                             )
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = Mock.functional20 fOfA fOfB
-                    , predicate = makeEqualsPredicate fOfA gOfA
-                    , substitution = Substitution.wrap [(Mock.x, fOfB)]
-                    }
-            )
-        )
-    , testCase "ceil with normal domain value"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.functional20 fOfA fOfB
+                , predicate = makeEqualsPredicate fOfA gOfA
+                , substitution = Substitution.wrap [(Mock.x, fOfB)]
+                }
+        assertEqualWithExplanation
+            "ceil(functional(non-funct, non-funct) and eq(f(a), g(a)))"
+            expected
+            actual
+    , testCase "ceil with normal domain value" $ do
         -- ceil(1) = top
-        (assertEqualWithExplanation
-            "ceil(1)"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate = makeTruePredicate
                     , substitution = mempty
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term =
-                        mkDomainValue
-                            testSort
-                            (Domain.BuiltinPattern
-                                $ eraseAnnotations
-                                $ mkStringLiteral "a"
-                            )
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
-                    }
-            )
-        )
-    , testCase "ceil with map domain value"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term =
+                    mkDomainValue
+                        testSort
+                        (Domain.BuiltinPattern
+                            $ eraseAnnotations
+                            $ mkStringLiteral "a"
+                        )
+                , predicate = makeTruePredicate
+                , substitution = mempty
+                }
+        assertEqualWithExplanation "ceil(1)" expected actual
+    , testCase "ceil with map domain value" $ do
         -- maps assume that their keys are relatively functional, so
         -- ceil({a->b, c->d}) = ceil(b) and ceil(d)
-        (assertEqualWithExplanation
-            "ceil(map)"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
@@ -341,22 +341,19 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term =
-                        Mock.builtinMap
-                            [(asConcrete fOfA, fOfB), (asConcrete gOfA, gOfB)]
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
-                    }
-            )
-        )
-    , testCase "ceil with list domain value"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term =
+                    Mock.builtinMap
+                        [(asConcrete fOfA, fOfB), (asConcrete gOfA, gOfB)]
+                , predicate = makeTruePredicate
+                , substitution = mempty
+                }
+        assertEqualWithExplanation "ceil(map)" expected actual
+    , testCase "ceil with list domain value" $ do
         -- ceil([a, b]) = ceil(a) and ceil(b)
-        (assertEqualWithExplanation
-            "ceil(list)"
-            (OrOfExpandedPattern.make
+        let
+            expected = OrOfExpandedPattern.make
                 [ Predicated
                     { term = mkTop_
                     , predicate =
@@ -366,30 +363,25 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = Mock.builtinList [fOfA, fOfB]
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
-                    }
-            )
-        )
-    , testCase "ceil with set domain value"
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.builtinList [fOfA, fOfB]
+                , predicate = makeTruePredicate
+                , substitution = mempty
+                }
+        assertEqualWithExplanation "ceil(list)" expected actual
+    , testCase "ceil with set domain value" $ do
         -- sets assume that their elements are relatively functional,
         -- so ceil({a, b}) = top
-        (assertEqualWithExplanation
-            "ceil(set)"
-            (OrOfExpandedPattern.make [ ExpandedPattern.top ]
-            )
-            (makeEvaluate mockMetadataTools
-                Predicated
-                    { term = Mock.builtinSet [asConcrete fOfA, asConcrete fOfB]
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
-                    }
-            )
-        )
+        let
+            expected = OrOfExpandedPattern.make [ ExpandedPattern.top ]
+        actual <- makeEvaluate mockMetadataTools
+            Predicated
+                { term = Mock.builtinSet [asConcrete fOfA, asConcrete fOfB]
+                , predicate = makeTruePredicate
+                , substitution = mempty
+                }
+        assertEqualWithExplanation "ceil(set)" expected actual
     ]
   where
     fOfA :: StepPattern Object Variable
@@ -435,10 +427,12 @@ evaluate
         )
     => MetadataTools level StepperAttributes
     -> Ceil level (CommonOrOfExpandedPattern level)
-    -> CommonOrOfExpandedPattern level
+    -> IO (CommonOrOfExpandedPattern level)
 evaluate tools ceil =
-    case Ceil.simplify tools ceil of
-        (result, _proof) -> result
+    (<$>) fst
+    $ SMT.runSMT SMT.defaultConfig
+    $ evalSimplifier emptyLogger
+    $ Ceil.simplify tools (Mock.substitutionSimplifier tools) ceil
 
 
 makeEvaluate
@@ -446,7 +440,9 @@ makeEvaluate
         )
     => MetadataTools level StepperAttributes
     -> CommonExpandedPattern level
-    -> CommonOrOfExpandedPattern level
+    -> IO (CommonOrOfExpandedPattern level)
 makeEvaluate tools child =
-    case Ceil.makeEvaluate tools child of
-        (result, _proof) -> result
+    (<$>) fst
+    $ SMT.runSMT SMT.defaultConfig
+    $ evalSimplifier emptyLogger
+    $ Ceil.makeEvaluate tools (Mock.substitutionSimplifier tools) child

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -566,7 +566,8 @@ test_equalsSimplification_Patterns =
             Predicated
                 { term = ()
                 , predicate = makeTruePredicate
-                , substitution = Substitution.wrap [(Mock.x, functionalOfA)]
+                , substitution =
+                    Substitution.unsafeWrap [(Mock.x, functionalOfA)]
                 }
                 (mkVar Mock.x)
                 functionalOfA
@@ -577,7 +578,8 @@ test_equalsSimplification_Patterns =
             Predicated
                 { term = ()
                 , predicate = makeTruePredicate
-                , substitution = Substitution.wrap [(Mock.x, functionalOfA)]
+                , substitution =
+                    Substitution.unsafeWrap [(Mock.x, functionalOfA)]
                 }
                 functionalOfA
                 (mkVar Mock.x)
@@ -588,7 +590,7 @@ test_equalsSimplification_Patterns =
             Predicated
                 { term = ()
                 , predicate = makeCeilPredicate fOfA
-                , substitution = Substitution.wrap [(Mock.x, fOfA)]
+                , substitution = Substitution.unsafeWrap [(Mock.x, fOfA)]
                 }
             (mkVar Mock.x)
             fOfA
@@ -599,7 +601,7 @@ test_equalsSimplification_Patterns =
             Predicated
                 { term = ()
                 , predicate = makeCeilPredicate fOfA
-                , substitution = Substitution.wrap [(Mock.x, fOfA)]
+                , substitution = Substitution.unsafeWrap [(Mock.x, fOfA)]
                 }
             fOfA
             (mkVar Mock.x)
@@ -666,7 +668,7 @@ test_equalsSimplification_Patterns =
                 Predicated
                     { term = ()
                     , predicate = makeTruePredicate
-                    , substitution = Substitution.wrap [(Mock.x, Mock.b)]
+                    , substitution = Substitution.unsafeWrap [(Mock.x, Mock.b)]
                     }
                 (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
                 (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
@@ -819,7 +821,7 @@ test_equalsSimplification_Patterns =
                         Predicated
                             { term = ()
                             , predicate = makeTruePredicate
-                            , substitution = Substitution.wrap
+                            , substitution = Substitution.unsafeWrap
                                 [(Mock.x, Mock.builtinList [Mock.b])]
                             }
                         term5

--- a/src/main/haskell/kore/test/Test/Kore/Step/Substitution.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Substitution.hs
@@ -151,24 +151,13 @@ test_mergeAndNormalizeSubstitutions =
                     ]
             assertEqual "" expect actual
 
-    -- TODO(Vladimir): this should be fixed by making use of the predicate from
-    -- `solveGroupSubstitutions`.
     , testCase "Constructor and constructor of function with variables"
         -- [x=constructor(y)] + [x=constructor(f(y))]
         $ do
-            let expect =
-                    Right Predicated
-                        { term = ()
-                        , predicate =
-                            makeEqualsPredicate
-                                ( mkVar Mock.y )
-                                ( Mock.f (mkVar Mock.y) )
-                        , substitution = Substitution.unsafeWrap
-                            [   ( Mock.x
-                                , Mock.constr10 (Mock.f (mkVar Mock.y))
-                                )
-                            ]
-                        }
+            let
+                expect =
+                    Left $ SubstitutionError
+                        (NonCtorCircularVariableDependency [Mock.y])
             actual <-
                 normalize
                     [   ( Mock.x
@@ -184,20 +173,10 @@ test_mergeAndNormalizeSubstitutions =
     , testCase "Constructor and constructor of functional symbol"
         -- [x=constructor(y)] + [x=constructor(functional(y))]
         $ do
-            let expect =
-                    Right Predicated
-                        { term = ()
-                        , predicate =
-                            makeEqualsPredicate
-                                ( mkVar Mock.y )
-                                ( Mock.functional10 (mkVar Mock.y) )
-                        , substitution = Substitution.unsafeWrap
-                            [   ( Mock.x
-                                , Mock.constr10
-                                    (Mock.functional10 $ mkVar Mock.y)
-                                )
-                            ]
-                        }
+            let
+                expect =
+                    Left $ SubstitutionError
+                        (NonCtorCircularVariableDependency [Mock.y])
             actual <-
                 normalize
                     [   ( Mock.x


### PR DESCRIPTION
* Fix TODO - we now throw errors for x=f(x) substitutions.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

