### PR TITLE
Kore.Step.Step.transitionRule: Do not silence unification failures

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
+++ b/src/main/haskell/kore/src/Kore/Step/BaseStep.hs
@@ -29,8 +29,6 @@ module Kore.Step.BaseStep
 import           Control.Monad.Except
 import           Control.Monad.Trans.Except
                  ( throwE )
-import           Data.Either
-                 ( partitionEithers )
 import qualified Data.Hashable as Hashable
 import           Data.List
                  ( foldl' )
@@ -381,7 +379,7 @@ stepWithRule
         proof = renamingProof <> unificationProof'
         attachProof result = (result, proof)
     results <-
-        keepGoodResults $ return $ map
+        traverse
             (applyUnificationToRhs
                 tools
                 substitutionSimplifier
@@ -617,23 +615,6 @@ applyUnificationToRhs
                         initialSubstitution
                 }
         }
-
-keepGoodResults
-    :: ExceptT
-        a
-        Simplifier
-        [ ExceptT a Simplifier b ]
-    -> ExceptT a Simplifier [b]
-keepGoodResults mresultsm = do
-    resultsm <- mresultsm
-    resultsEither <- lift $ mapM runExceptT resultsm
-    let
-        (errors, goodResults) = partitionEithers resultsEither
-    if null goodResults
-        then case errors of
-            [] -> return []
-            (err : _) -> throwE err
-        else return goodResults
 
 stepWithRewriteRule
     ::  ( FreshVariable variable

--- a/src/main/haskell/kore/src/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Step.hs
@@ -139,7 +139,11 @@ transitionRule tools substitutionSimplifier simplifier axiomIdToSimplifier =
                 config
                 a
         case result of
-            Left _ -> pure []
+            Left _ -> error $
+                "Not implemented error \
+                \while applying a \\rewrite axiom to the pattern. \
+                \We decided to end the execution because we don't \
+                \understand this case well enough at the moment."
             Right results ->
                 Log.withLogScope "transitionRule" $
                     return $ mapMaybe (patternFromResult proof) results

--- a/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Step.hs
@@ -5,10 +5,9 @@ module Test.Kore.Step.Step
     ) where
 
 import Test.Tasty
-       ( TestTree )
 import Test.Tasty.HUnit
-       ( testCase )
 
+import qualified Control.Exception as Exception
 import           Data.Default
                  ( def )
 import qualified Data.List as List
@@ -395,9 +394,11 @@ actualStepLimit =
 
 test_unificationError :: TestTree
 test_unificationError =
-    testCase "Throws unification error"
-        (assertEqualWithExplanation "Expected unification error" []
-            =<< actualUnificationError)
+    testCase "Throws unification error" $ do
+        result <- Exception.try actualUnificationError
+        case result of
+            Left (Exception.ErrorCall _) -> return ()
+            Right _ -> assertFailure "Expected unification error"
 
 actualUnificationError
     :: IO [(CommonExpandedPattern Meta, StepProof Meta Variable)]


### PR DESCRIPTION
Unification failures should produce an error, not silently attempt to execute
down other paths.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

