### PR TITLE
Fix some leftover thing from the last ceil-as-or refactoring.

### DIFF
--- a/src/main/haskell/kore/src/Kore/Step/MultiAnd.hs
+++ b/src/main/haskell/kore/src/Kore/Step/MultiAnd.hs
@@ -51,7 +51,8 @@ instance TopBottom child => TopBottom (MultiAnd child)
 {-| 'AndBool' is an some sort of Bool data type used when evaluating things
 inside an 'MultiAnd'.
 -}
--- TODO(virgil): Refactor, this is the same as OrBool
+-- TODO(virgil): Refactor, this is the same as OrBool. Make it a
+-- Top | Bottom | Other or a Maybe Bool.
 data AndBool = AndTrue | AndFalse | AndUnknown
 
 {-|Does a very simple attempt to check whether a pattern
@@ -86,7 +87,7 @@ extractPatterns = getMultiAnd
 {- | Simplify the conjunction.
 
 The arguments are simplified by filtering on @\\top@ and @\\bottom@. The
-idempotency property of disjunction (@\\and(φ,φ)=φ@) is applied to remove
+idempotency property of conunction (@\\and(φ,φ)=φ@) is applied to remove
 duplicated items from the result.
 
 See also: 'filterUnique'
@@ -99,9 +100,9 @@ filterAnd =
     filterGeneric patternToAndBool . filterUnique
 
 
-{- | Simplify the disjunction by eliminating duplicate elements.
+{- | Simplify the conjunction by eliminating duplicate elements.
 
-The idempotency property of disjunction (@\\or(φ,φ)=φ@) is applied to remove
+The idempotency property of conjunction (@\\and(φ,φ)=φ@) is applied to remove
 duplicated items from the result.
 
 Note: Items are compared with their Ord instance. This does not attempt

--- a/src/main/haskell/kore/src/Kore/Step/MultiAnd.hs
+++ b/src/main/haskell/kore/src/Kore/Step/MultiAnd.hs
@@ -1,0 +1,136 @@
+{-|
+Module      : Kore.Step.MultiAnd
+Description : Data structures and functions for manipulating
+              And with any number of children.
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+Stability   : experimental
+Portability : portable
+-}
+module Kore.Step.MultiAnd
+    ( MultiAnd
+    , extractPatterns
+    , make
+    ) where
+
+import           Control.DeepSeq
+                 ( NFData )
+import qualified Data.Set as Set
+import           GHC.Generics
+                 ( Generic )
+
+import Kore.TopBottom
+       ( TopBottom (..) )
+
+{-| 'MultiAnd' is a Matching logic and of its children
+
+-}
+{- TODO (virgil): Make 'getMultiAnd' a non-empty list ("Data.NonEmpty").
+
+An empty 'MultiAnd' corresponding to 'Top' actually discards information
+about the sort of its child patterns! That is a problem for simplification,
+which should preserve pattern sorts.
+
+A non-empty 'MultiAnd' would also have a nice symmetry between 'Top' and
+'Bottom' patterns.
+-}
+newtype MultiAnd child = MultiAnd { getMultiAnd :: [child] }
+  deriving
+    (Applicative, Eq, Foldable, Functor, Generic, Monad, Ord, Show, Traversable)
+
+instance NFData child => NFData (MultiAnd child)
+
+instance TopBottom child => TopBottom (MultiAnd child)
+  where
+    isTop (MultiAnd []) = True
+    isTop _ = False
+    isBottom (MultiAnd [child]) = isBottom child
+    isBottom _ = False
+
+{-| 'AndBool' is an some sort of Bool data type used when evaluating things
+inside an 'MultiAnd'.
+-}
+-- TODO(virgil): Refactor, this is the same as OrBool
+data AndBool = AndTrue | AndFalse | AndUnknown
+
+{-|Does a very simple attempt to check whether a pattern
+is top or bottom.
+-}
+-- TODO(virgil): Refactor, this is the same as patternToOrBool
+patternToAndBool
+    :: TopBottom term
+    => term -> AndBool
+patternToAndBool patt
+  | isTop patt = AndTrue
+  | isBottom patt = AndFalse
+  | otherwise = AndUnknown
+
+{-| 'make' constructs a normalized 'MultiAnd'.
+-}
+make
+    :: (Ord term, TopBottom term)
+    => [term]
+    -> MultiAnd term
+make patts = filterAnd (MultiAnd patts)
+
+{-| Returns the patterns inside an @\and@.
+-}
+extractPatterns
+    :: TopBottom term
+    => MultiAnd term
+    -> [term]
+extractPatterns = getMultiAnd
+
+
+{- | Simplify the conjunction.
+
+The arguments are simplified by filtering on @\\top@ and @\\bottom@. The
+idempotency property of disjunction (@\\and(φ,φ)=φ@) is applied to remove
+duplicated items from the result.
+
+See also: 'filterUnique'
+-}
+filterAnd
+    :: (Ord term, TopBottom term)
+    => MultiAnd term
+    -> MultiAnd term
+filterAnd =
+    filterGeneric patternToAndBool . filterUnique
+
+
+{- | Simplify the disjunction by eliminating duplicate elements.
+
+The idempotency property of disjunction (@\\or(φ,φ)=φ@) is applied to remove
+duplicated items from the result.
+
+Note: Items are compared with their Ord instance. This does not attempt
+to account separately for things like α-equivalence, so, if that is not
+included in the Ord instance, items containing @\\forall@ and
+@\\exists@ may be considered inequal although they are equivalent in
+a logical sense.
+
+-}
+filterUnique :: Ord a => MultiAnd a -> MultiAnd a
+filterUnique = MultiAnd . Set.toList . Set.fromList . getMultiAnd
+
+{-| 'filterGeneric' simplifies a MultiAnd according to a function which
+evaluates its children to true/false/unknown.
+-}
+filterGeneric
+    :: (child -> AndBool)
+    -> MultiAnd child
+    -> MultiAnd child
+filterGeneric andFilter (MultiAnd patts) =
+    go andFilter [] patts
+  where
+    go  :: (child -> AndBool)
+        -> [child]
+        -> [child]
+        -> MultiAnd child
+    go _ filtered [] = MultiAnd (reverse filtered)
+    go filterAnd' filtered (element:unfiltered) =
+        case filterAnd' element of
+            AndFalse -> MultiAnd [element]
+            AndTrue -> go filterAnd' filtered unfiltered
+            AndUnknown -> go filterAnd' (element:filtered) unfiltered

--- a/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
+++ b/src/main/haskell/kore/src/Kore/Step/OrOfExpandedPattern.hs
@@ -73,7 +73,7 @@ patterns.
 -}
 newtype MultiOr child = MultiOr { getMultiOr :: [child] }
   deriving
-    (Applicative, Eq, Foldable, Functor, Generic, Monad, Show, Traversable)
+    (Applicative, Eq, Foldable, Functor, Generic, Monad, Ord, Show, Traversable)
 
 instance NFData child => NFData (MultiOr child)
 

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -20,6 +20,10 @@ import           Kore.Step.ExpandedPattern
                  ( PredicateSubstitution )
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
                  ( Predicated (..) )
+import           Kore.Step.MultiAnd
+                 ( MultiAnd )
+import qualified Kore.Step.MultiAnd as MultiAnd
+                 ( extractPatterns )
 import           Kore.Step.OrOfExpandedPattern
                  ( MultiOr, OrOfPredicateSubstitution )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -49,7 +53,7 @@ simplifyEvaluatedMultiPredicateSubstitution
     -> PredicateSubstitutionSimplifier level
     -> StepPatternSimplifier level
     -> BuiltinAndAxiomSimplifierMap level
-    -> [OrOfPredicateSubstitution level variable]
+    -> MultiAnd (OrOfPredicateSubstitution level variable)
     -> Simplifier
         (OrOfPredicateSubstitution level variable, SimplificationProof level)
 simplifyEvaluatedMultiPredicateSubstitution
@@ -62,7 +66,8 @@ simplifyEvaluatedMultiPredicateSubstitution
     let
         crossProduct :: MultiOr [PredicateSubstitution level variable]
         crossProduct =
-            OrOfExpandedPattern.fullCrossProduct predicateSubstitutions
+            OrOfExpandedPattern.fullCrossProduct
+                (MultiAnd.extractPatterns predicateSubstitutions)
     result <- traverse andPredicateSubstitutions crossProduct
     return
         ( result

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -36,6 +36,8 @@ import           Kore.Step.ExpandedPattern
 import qualified Kore.Step.ExpandedPattern as ExpandedPattern
 import qualified Kore.Step.Function.Evaluator as Axiom
                  ( evaluatePattern )
+import qualified Kore.Step.MultiAnd as MultiAnd
+                 ( make )
 import           Kore.Step.OrOfExpandedPattern
                  ( OrOfExpandedPattern, OrOfPredicateSubstitution )
 import qualified Kore.Step.OrOfExpandedPattern as OrOfExpandedPattern
@@ -231,9 +233,11 @@ makeEvaluateNonBoolCeil
         substitutionSimplifier
         simplifier
         axiomIdToEvaluator
-        [ OrOfExpandedPattern.make [erasePredicatedTerm patt]
-        , termCeil
-        ]
+        (MultiAnd.make
+            [ OrOfExpandedPattern.make [erasePredicatedTerm patt]
+            , termCeil
+            ]
+        )
     return (fmap predicateSubstitutionToExpandedPattern result, proof)
 
 -- TODO: Ceil(function) should be an and of all the function's conditions, both
@@ -292,7 +296,11 @@ makeEvaluateTerm
             let
                 (ceils, _proofs) = unzip simplifiedChildren
             And.simplifyEvaluatedMultiPredicateSubstitution
-                tools substitutionSimplifier simplifier axiomIdToEvaluator ceils
+                tools
+                substitutionSimplifier
+                simplifier
+                axiomIdToEvaluator
+                (MultiAnd.make ceils)
           where
             Application { applicationSymbolOrAlias = patternHead } = app
             Application { applicationChildren = children } = app
@@ -395,7 +403,11 @@ makeEvaluateBuiltin
         ceils :: [OrOfPredicateSubstitution level variable]
         (ceils, _proofs) = unzip children
     And.simplifyEvaluatedMultiPredicateSubstitution
-        tools substitutionSimplifier simplifier axiomIdToEvaluator ceils
+        tools
+        substitutionSimplifier
+        simplifier
+        axiomIdToEvaluator
+        (MultiAnd.make ceils)
   where
     values :: [StepPattern level variable]
     -- Maps assume that their keys are relatively functional.
@@ -416,7 +428,11 @@ makeEvaluateBuiltin
         ceils :: [OrOfPredicateSubstitution level variable]
         (ceils, _proofs) = unzip children
     And.simplifyEvaluatedMultiPredicateSubstitution
-        tools substitutionSimplifier simplifier axiomIdToEvaluator ceils
+        tools
+        substitutionSimplifier
+        simplifier
+        axiomIdToEvaluator
+        (MultiAnd.make ceils)
 makeEvaluateBuiltin
     _tools
     _substitutionSimplifier

--- a/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/src/Kore/Step/Simplification/Equals.hs
@@ -676,12 +676,24 @@ makeEvaluateTermsToPredicateSubstitution
                     axiomIdToSimplfier
                     second
             let
+                toPredicateSafe
+                    ps@Predicated {term = (), predicate, substitution}
+                  | Substitution.null substitution =
+                    predicate
+                  | otherwise =
+                    error
+                        (  "Unimplemented: we should split the configuration"
+                        ++ " for or with nonempty substitution."
+                        ++ " input=" ++ show ps
+                        ++ ", first=" ++ show first
+                        ++ ", second=" ++ show second
+                        )
                 firstCeil =
                     OrOfExpandedPattern.toPredicate
-                        (fmap ExpandedPattern.toPredicate firstCeilOr)
+                        (fmap toPredicateSafe firstCeilOr)
                 secondCeil =
                     OrOfExpandedPattern.toPredicate
-                        (fmap ExpandedPattern.toPredicate secondCeilOr)
+                        (fmap toPredicateSafe secondCeilOr)
                 firstCeilNegation = makeNotPredicate firstCeil
                 secondCeilNegation = makeNotPredicate secondCeil
                 ceilNegationAnd =

--- a/src/main/haskell/kore/test/Test/Kore/Step/MultiAnd.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/MultiAnd.hs
@@ -1,0 +1,78 @@
+module Test.Kore.Step.MultiAnd where
+
+import Test.Tasty
+       ( TestTree )
+import Test.Tasty.HUnit
+       ( assertEqual, testCase )
+
+import           Kore.Step.MultiAnd
+                 ( MultiAnd )
+import qualified Kore.Step.MultiAnd as MultiAnd
+import           Kore.TopBottom
+                 ( TopBottom (..) )
+
+
+import Test.Kore.Comparators ()
+--import Test.Tasty.HUnit.Extensions
+
+data TestTopBottom = TestTop | TestBottom | TestOther !Integer
+    deriving (Eq, Ord, Show)
+
+instance TopBottom TestTopBottom where
+    isTop TestTop = True
+    isTop _ = False
+    isBottom TestBottom = True
+    isBottom _ = False
+
+test_multiAndTopBottom :: [TestTree]
+test_multiAndTopBottom =
+    [ assertIsTop True  (MultiAnd.make [])
+    , assertIsTop True  (MultiAnd.make [TestTop])
+    , assertIsTop False (MultiAnd.make [TestTop, TestOther 1])
+    , assertIsTop False (MultiAnd.make [TestTop, TestBottom])
+    , assertIsTop False (MultiAnd.make [TestOther 1])
+    , assertIsTop False (MultiAnd.make [TestBottom])
+
+    , assertIsBottom False (MultiAnd.make [])
+    , assertIsBottom False (MultiAnd.make [TestTop])
+    , assertIsBottom False (MultiAnd.make [TestTop, TestOther 1])
+    , assertIsBottom True  (MultiAnd.make [TestTop, TestBottom])
+    , assertIsBottom False (MultiAnd.make [TestOther 1])
+    , assertIsBottom True  (MultiAnd.make [TestBottom])
+    ]
+
+test_multiAndMake :: [TestTree]
+test_multiAndMake =
+    [ MultiAnd.make []                         `hasPatterns` []
+    , MultiAnd.make [TestTop]                  `hasPatterns` []
+    , MultiAnd.make [TestTop, TestOther 1]     `hasPatterns` [TestOther 1]
+    , MultiAnd.make [TestTop, TestBottom]      `hasPatterns` [TestBottom]
+    , MultiAnd.make [TestOther 1, TestOther 1] `hasPatterns` [TestOther 1]
+    , MultiAnd.make [TestBottom]               `hasPatterns` [TestBottom]
+    , MultiAnd.make [TestOther 1, TestOther 2]
+        `hasPatterns` [TestOther 1, TestOther 2]
+    ]
+
+hasPatterns :: MultiAnd TestTopBottom -> [TestTopBottom] -> TestTree
+hasPatterns actual expected =
+    testCase "hasPattern"
+        (assertEqual ""
+            expected
+            (MultiAnd.extractPatterns actual)
+        )
+
+assertIsTop :: Bool -> MultiAnd TestTopBottom -> TestTree
+assertIsTop expected input =
+    testCase "isTop"
+        (assertEqual ""
+            expected
+            (isTop input)
+        )
+
+assertIsBottom :: Bool -> MultiAnd TestTopBottom -> TestTree
+assertIsBottom expected input =
+    testCase "isBottom"
+        (assertEqual ""
+            expected
+            (isBottom input)
+        )

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -140,8 +140,8 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
-                            (makeCeilPredicate somethingOfA)
+                        (makeCeilPredicate somethingOfA)
+                        (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
@@ -167,11 +167,11 @@ test_ceilSimplification =
                         { term = mkTop_
                         , predicate =
                             makeAndPredicate
-                                (makeEqualsPredicate fOfA gOfA)
                                 (makeAndPredicate
                                     (makeCeilPredicate somethingOfA)
                                     (makeCeilPredicate somethingOfB)
                                 )
+                                (makeEqualsPredicate fOfA gOfA)
                         , substitution =
                             Substitution.unsafeWrap [(Mock.x, fOfB)]
                         }
@@ -206,11 +206,11 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
                             (makeAndPredicate
                                 (makeCeilPredicate somethingOfA)
                                 (makeCeilPredicate somethingOfB)
                             )
+                            (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
@@ -234,8 +234,8 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
                             (makeCeilPredicate fOfA)
+                            (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
@@ -259,8 +259,8 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
                             (makeCeilPredicate fOfA)
+                            (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
@@ -308,11 +308,11 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
                             (makeAndPredicate
                                 (makeCeilPredicate fOfA)
                                 (makeCeilPredicate fOfB)
                             )
+                            (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
@@ -338,8 +338,8 @@ test_ceilSimplification =
                     { term = mkTop_
                     , predicate =
                         makeAndPredicate
-                            (makeEqualsPredicate fOfA gOfA)
                             (makeEqualsPredicate Mock.a Mock.cf)
+                            (makeEqualsPredicate fOfA gOfA)
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]

--- a/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/src/main/haskell/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -341,25 +341,25 @@ test_equalsSimplification_ExpandedPatterns =
                                         (makeAndPredicate
                                             (makeAndPredicate
                                                 (makeEqualsPredicate hOfA hOfB)
-                                                (makeEqualsPredicate fOfA fOfB)
+                                                (makeCeilPredicate hOfA)
                                             )
-                                            (makeCeilPredicate hOfA)
+                                            (makeEqualsPredicate fOfA fOfB)
                                         )
-                                        (makeEqualsPredicate gOfA gOfB)
+                                        (makeCeilPredicate hOfB)
                                     )
-                                    (makeCeilPredicate hOfB)
+                                    (makeEqualsPredicate gOfA gOfB)
                                 )
                                 (makeAndPredicate
                                     (makeNotPredicate
                                         (makeAndPredicate
-                                            (makeEqualsPredicate fOfA fOfB)
                                             (makeCeilPredicate hOfA)
+                                            (makeEqualsPredicate fOfA fOfB)
                                         )
                                     )
                                     (makeNotPredicate
                                         (makeAndPredicate
-                                            (makeEqualsPredicate gOfA gOfB)
                                             (makeCeilPredicate hOfB)
+                                            (makeEqualsPredicate gOfA gOfB)
                                         )
                                     )
                                 )


### PR DESCRIPTION
* Make And usage explicit when computing and-of-ceil
* Throw an error when or-of-ceil contains a substitution

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

