### PR TITLE
Hide successful tests by default

### DIFF
--- a/src/main/haskell/kore/package.yaml
+++ b/src/main/haskell/kore/package.yaml
@@ -140,7 +140,7 @@ executables:
 
 tests:
   kore-test:
-    main: Driver.hs
+    main: Test.hs
     source-dirs:
       - test
     ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"

--- a/src/main/haskell/kore/test/Driver.hs
+++ b/src/main/haskell/kore/test/Driver.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC
     -F -pgmF tasty-discover
     -optF --tree-display
+    -optF --hide-successes
     -optF --ingredient=Test.Tasty.Runners.consoleTestReporter
     -optF --ingredient=Test.Tasty.Runners.listingTests
     -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner

--- a/src/main/haskell/kore/test/Driver.hs
+++ b/src/main/haskell/kore/test/Driver.hs
@@ -5,6 +5,7 @@
     -optF --ingredient=Test.Tasty.Runners.consoleTestReporter
     -optF --ingredient=Test.Tasty.Runners.listingTests
     -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner
+    -optF --generated-module=Driver
 #-}
 
 {-

--- a/src/main/haskell/kore/test/Test.hs
+++ b/src/main/haskell/kore/test/Test.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import qualified System.Environment as Environment
+
+import qualified Driver
+
+main :: IO ()
+main = do
+    -- Set TERM=dumb so that the --hide-successes option works correctly.
+    Environment.setEnv "TERM" "dumb"
+    Driver.main


### PR DESCRIPTION
The test suite currently runs over 35,000 test cases; displaying all the
successful tests is never useful.

Due to a bug in tasty, the --hide-successes option only works if TERM=dumb is in
the environment. Therefore, we wrap the generated test driver to set that
variable.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

