### PR TITLE
k/working/*.golden: new syntax for `{_#Equals_}`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ k-frontend:
 	mkdir -p $(BUILD_DIR)
 	rm -rf $(K_DIST_DEFAULT) $(K_NIGHTLY)
 	curl --location --output $(K_NIGHTLY) \
-	    $$(curl 'https://api.github.com/repos/kframework/k/releases' | jq --raw-output '.[0].assets[].browser_download_url | match(".*nightly.tar.gz").string')
+	    $$(curl 'https://api.github.com/repos/kframework/k/releases' | jq --raw-output '.[${K_NIGHTLY_OFFSET}].assets[].browser_download_url | match(".*nightly.tar.gz").string')
 	mkdir -p $(K_DIST_DEFAULT)
 	tar --extract --file $(K_NIGHTLY) --strip-components 1 --directory $(K_DIST_DEFAULT)
 	$(KRUN) --version

--- a/include.mk
+++ b/include.mk
@@ -5,6 +5,7 @@ UPSTREAM_BRANCH = origin/master
 
 BUILD_DIR = $(TOP)/.build
 K_NIGHTLY = $(BUILD_DIR)/nightly.tar.gz
+K_NIGHTLY_OFFSET ?= 0
 K_DIST_DEFAULT = $(BUILD_DIR)/k
 K_DIST ?= $(K_DIST_DEFAULT)
 K_DIST_BIN = $(K_DIST)/bin

--- a/scripts/kevm-integration.sh
+++ b/scripts/kevm-integration.sh
@@ -31,7 +31,7 @@ make clean
 git submodule update --init --recursive
 ./.build/k/k-distribution/src/main/scripts/bin/k-configure-opam-dev
 
-make deps          -B
+make haskell-deps  -B
 make build-haskell -B
 (   cd .build/k/haskell-backend/src/main/native/haskell-backend
     git log --max-count 1

--- a/src/main/k/working/imp-concrete-heat-cool/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-concrete-heat-cool/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -8,15 +9,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I0 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -27,15 +34,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I1 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -46,15 +59,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -65,11 +84,16 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-concrete-state/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-concrete-state/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -8,15 +9,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I0 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -27,15 +34,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I1 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -46,15 +59,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -65,11 +84,16 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-map-strict/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-map-strict/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -11,15 +12,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -33,15 +40,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -55,15 +68,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -77,11 +96,16 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-map-unify-strict/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-map-unify-strict/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -11,15 +12,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -33,15 +40,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -55,15 +68,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -77,11 +96,16 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-map-unify/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-map-unify/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -11,15 +12,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -33,15 +40,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -55,15 +68,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -77,11 +96,16 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-map/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-map/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -11,15 +12,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -33,15 +40,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -55,15 +68,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -77,11 +96,16 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp-monosorted/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp-monosorted/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -8,15 +9,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I0 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -27,15 +34,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I1 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -46,15 +59,21 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -65,11 +84,16 @@
           x |-> varvarVar'Ques'I0 y |-> varvarVar'Ques'I1 z |-> varvarVar'Ques'I2 max |-> varvarVar'Ques'I2 .State
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/imp/tests/max-symbolic.search.final.output.golden
+++ b/src/main/k/working/imp/tests/max-symbolic.search.final.output.golden
@@ -1,3 +1,4 @@
+    {
       Result
     #Equals
       <T>
@@ -11,15 +12,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -33,15 +40,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -55,15 +68,21 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       false
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I2
+    }
 #Or
+    {
       Result
     #Equals
       <T>
@@ -77,11 +96,16 @@
           z |-> varvarVar'Ques'I2
         </state>
       </T>
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I0 <=Int varvarVar'Ques'I1
+    }
   #And
+    {
       true
     #Equals
       varvarVar'Ques'I1 <=Int varvarVar'Ques'I2
+    }

--- a/src/main/k/working/search/tests/initial.final.output.golden
+++ b/src/main/k/working/search/tests/initial.final.output.golden
@@ -1,11 +1,15 @@
+  {
     Result
   #Equals
     <k>
       final1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       final2
     </k>
+  }

--- a/src/main/k/working/search/tests/initial.one.output.golden
+++ b/src/main/k/working/search/tests/initial.one.output.golden
@@ -1,11 +1,15 @@
+  {
     Result
   #Equals
     <k>
       next1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       next2
     </k>
+  }

--- a/src/main/k/working/search/tests/initial.plus.output.golden
+++ b/src/main/k/working/search/tests/initial.plus.output.golden
@@ -1,23 +1,31 @@
+  {
     Result
   #Equals
     <k>
       final1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       final2
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       next1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       next2
     </k>
+  }

--- a/src/main/k/working/search/tests/initial.star.initial.output.golden
+++ b/src/main/k/working/search/tests/initial.star.initial.output.golden
@@ -1,5 +1,7 @@
+{
   DotVar0
 #Equals
   <generatedCounter>
     0
   </generatedCounter>
+}

--- a/src/main/k/working/search/tests/initial.star.output.golden
+++ b/src/main/k/working/search/tests/initial.star.output.golden
@@ -1,29 +1,39 @@
+  {
     Result
   #Equals
     <k>
       final1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       final2
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       initial
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       next1
     </k>
+  }
 #Or
+  {
     Result
   #Equals
     <k>
       next2
     </k>
+  }


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

This updates to the new syntax used by the frontend for `{_#Equals_}`.