### PR TITLE
Instances for ListT

### DIFF
--- a/kore/src/Kore/Step/Representation/MultiOr.hs
+++ b/kore/src/Kore/Step/Representation/MultiOr.hs
@@ -33,6 +33,8 @@ import           Control.DeepSeq
 import           Data.List
                  ( foldl' )
 import qualified Data.Set as Set
+import           GHC.Exts
+                 ( IsList )
 import           GHC.Generics
                  ( Generic )
 
@@ -53,8 +55,18 @@ patterns.
 
 -}
 newtype MultiOr child = MultiOr { getMultiOr :: [child] }
-  deriving
-    (Applicative, Eq, Foldable, Functor, Generic, Monad, Ord, Show, Traversable)
+    deriving
+        ( Applicative
+        , Eq
+        , Foldable
+        , Functor
+        , Generic
+        , IsList
+        , Monad
+        , Ord
+        , Show
+        , Traversable
+        )
 
 instance NFData child => NFData (MultiOr child)
 

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -12,7 +12,6 @@ module Kore.Step.Simplification.Data
     , runSimplifier
     , evalSimplifier
     , BranchT, runBranchT
-    , getBranches
     , liftPruned, returnPruned
     , evalSimplifierBranch
     , gather
@@ -27,6 +26,7 @@ module Kore.Step.Simplification.Data
 
 import           Colog
                  ( HasLog (..), LogAction (..) )
+import           Control.Applicative
 import           Control.Concurrent.MVar
                  ( MVar )
 import qualified Control.Monad as Monad
@@ -36,7 +36,6 @@ import           Control.Monad.State.Class
 import qualified Control.Monad.Trans as Monad.Trans
 import           Control.Monad.Trans.Except
                  ( ExceptT (..), runExceptT )
-import qualified Data.Foldable as Foldable
 import           Data.Typeable
 import           GHC.Stack
                  ( HasCallStack )
@@ -61,7 +60,7 @@ import           Kore.TopBottom
 import qualified Kore.TopBottom as TopBottom
 import           Kore.Unparser
 import           Kore.Variables.Fresh
-import           ListT
+import qualified ListT
 import           SimpleSMT
                  ( Solver )
 import           SMT
@@ -107,7 +106,7 @@ Use 'scatter' and 'gather' to translate between the two forms of branches.
 -}
 newtype BranchT m a =
     -- Pay no attention to the ListT behind the curtain!
-    BranchT { runBranchT :: ListT m a }
+    BranchT { runBranchT :: ListT.ListT m a }
     deriving
         ( Alternative
         , Applicative
@@ -126,11 +125,6 @@ deriving instance MonadState s m => MonadState s (BranchT m)
 instance MonadSMT m => MonadSMT (BranchT m) where
     liftSMT = lift . liftSMT
     {-# INLINE liftSMT #-}
-
-{- | Collect the values produced along the disjoint branches.
- -}
-getBranches :: Applicative m => BranchT m a -> m [a]
-getBranches (BranchT as) = toListM as
 
 {- | Lift a computation into 'BranchT' while pruning 'isBottom' results.
 
@@ -181,8 +175,8 @@ gather empty === pure ('OrOfExpandedPattern.make' [])
 See also: 'scatter'
 
  -}
-gather :: Applicative m => BranchT m a -> m (MultiOr a)
-gather simpl = OrOfExpandedPattern.MultiOr <$> getBranches simpl
+gather :: Monad m => BranchT m a -> m (MultiOr a)
+gather (BranchT simpl) = OrOfExpandedPattern.MultiOr <$> ListT.gather simpl
 
 {- | Collect results from many simplification branches into one result.
 
@@ -193,7 +187,7 @@ returns one result.
 See also: 'scatter', 'gather'
 
  -}
-gatherAll :: Applicative m => BranchT m (MultiOr a) -> m (MultiOr a)
+gatherAll :: Monad m => BranchT m (MultiOr a) -> m (MultiOr a)
 gatherAll simpl = Monad.join <$> gather simpl
 
 {- | Disperse results into many simplification branches.
@@ -211,10 +205,8 @@ scatter ('OrOfExpandedPattern.make' []) === empty
 See also: 'gather'
 
  -}
-scatter
-    :: MultiOr a
-    -> BranchT m a
-scatter ors = Foldable.asum (pure <$> ors)
+scatter :: MultiOr a -> BranchT m a
+scatter = BranchT . ListT.scatter
 
 -- * Simplifier
 
@@ -295,9 +287,9 @@ evalSimplifierBranch
     -- ^ initial counter for fresh variables
     -> BranchT Simplifier a
     -- ^ simplifier computation
-    -> SMT [a]
+    -> SMT (MultiOr a)
 evalSimplifierBranch logger =
-    evalSimplifier logger . getBranches
+    evalSimplifier logger . gather
 
 {- | Run a simplification, returning the result of only one branch.
 

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -30,6 +30,8 @@ import           Control.Applicative
 import           Control.Concurrent.MVar
                  ( MVar )
 import qualified Control.Monad as Monad
+import           Control.Monad.Morph
+                 ( MFunctor, MMonad )
 import           Control.Monad.Reader
 import           Control.Monad.State.Class
                  ( MonadState )
@@ -111,6 +113,8 @@ newtype BranchT m a =
         ( Alternative
         , Applicative
         , Functor
+        , MFunctor
+        , MMonad
         , Monad
         , MonadIO
         , MonadPlus

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -486,14 +486,14 @@ normalizeSubstitutionAfterMerge
     predicateSubstitution
   = do
     results <-
-        lift $ getBranches $ runExceptT
+        lift $ gather $ runExceptT
         $ normalizeWorker
             tools
             substitutionSimplifier
             simplifier
             axiomIdToSimplifier
             predicateSubstitution
-    case results of
+    case Foldable.toList results of
         [] -> return
             ( ExpandedPattern.bottomPredicate
             , EmptyUnificationProof

--- a/kore/src/ListT.hs
+++ b/kore/src/ListT.hs
@@ -28,6 +28,12 @@ import Data.Typeable
 
 {- | The list monad transformer written as a right-associative fold.
 
+This representation is similar to the
+<https://en.wikipedia.org/wiki/Church_encoding Church encoding> or the
+<https://en.wikipedia.org/wiki/Mogensen%E2%80%93Scott_encoding Scott encoding>.
+It inherits the performance benefits of the 'Control.Monad.Codensity.Codensity'
+of a free monad.
+
 Note that none of its basic instances—e.g. 'Functor', 'Applicative',
 'Alternative', 'Monad'—rely on the transformed type @m@ because @ListT@ takes
 those behaviors from the instances for lists.
@@ -61,8 +67,8 @@ newtype ListT m a =
         { foldListT
             :: forall n r
             .  (forall x y. m x -> (x -> n y) -> n y)
-            -- ^ analog of 'bind' to use an @m@-value within @n@; if @m ~ n@
-            -- this is literally 'bind'
+            -- ^ analog of 'bind' to use an @m@-value within @n@;
+            -- if @m ~ n@ this is literally 'bind'
             -> (a -> n r -> n r)
             -> n r
             -> n r

--- a/kore/src/ListT.hs
+++ b/kore/src/ListT.hs
@@ -33,6 +33,9 @@ This representation is similar to the
 <https://en.wikipedia.org/wiki/Mogensen%E2%80%93Scott_encoding Scott encoding>.
 It inherits the performance benefits of the 'Control.Monad.Codensity.Codensity'
 of a free monad.
+The first argument of 'foldListT' is a heterogenous analog of 'bind' that
+enables streaming instances of 'MFunctor' and 'MMorph'. When @n ~ m@, this
+argument is literally 'bind'.
 
 Note that none of its basic instances—e.g. 'Functor', 'Applicative',
 'Alternative', 'Monad'—rely on the transformed type @m@ because @ListT@ takes
@@ -67,8 +70,6 @@ newtype ListT m a =
         { foldListT
             :: forall n r
             .  (forall x y. m x -> (x -> n y) -> n y)
-            -- ^ analog of 'bind' to use an @m@-value within @n@;
-            -- if @m ~ n@ this is literally 'bind'
             -> (a -> n r -> n r)
             -> n r
             -> n r

--- a/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
+++ b/kore/test/Test/Kore/Step/Simplification/PredicateSubstitution.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Test.Kore.Step.Simplification.PredicateSubstitution
     ( test_predicateSubstitutionSimplification
     ) where
@@ -24,6 +26,8 @@ import           Kore.Step.Pattern
 import           Kore.Step.Representation.ExpandedPattern
                  ( CommonPredicateSubstitution, Predicated (..) )
 import qualified Kore.Step.Representation.ExpandedPattern as Predicated
+import           Kore.Step.Representation.MultiOr
+                 ( MultiOr )
 import qualified Kore.Step.Representation.MultiOr as MultiOr
                  ( make )
 import           Kore.Step.Simplification.Data hiding
@@ -285,11 +289,11 @@ mockMetadataTools =
 runSimplifier
     :: BuiltinAndAxiomSimplifierMap Object
     -> CommonPredicateSubstitution Object
-    -> IO [CommonPredicateSubstitution Object]
+    -> IO (MultiOr (CommonPredicateSubstitution Object))
 runSimplifier patternSimplifierMap predicateSubstitution =
     SMT.runSMT SMT.defaultConfig
     $ evalSimplifier emptyLogger
-    $ getBranches
+    $ gather
     $ simplifier predicateSubstitution
   where
     PredicateSubstitutionSimplifier simplifier =


### PR DESCRIPTION
Add instances of `MFunctor` and `MMonad` for `ListT`, requiring a small change to the internal representation (this part is pretty technical). The new instances are nicer `BranchT` in the simplifier: the exposed interface is cleaner, and we can sequence effects to, e.g., abort unification the first time any branch fails.

Depends: #504 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

