### PR TITLE
Add acronyms to glossary and fix typo in documentation.

### DIFF
--- a/docs/2018-11-08-Configuration-Splitting-Simplification.md
+++ b/docs/2018-11-08-Configuration-Splitting-Simplification.md
@@ -6,11 +6,9 @@ Background
 
 ### Functional and function-like patterns
 
-A functional pattern has exactly one element, i.e. `t` is functional iff
-`∃x . x=t`. A function-like pattern is similar, but it can also be `⊥`, i.e.
-`t` is function-like if `(∃x . x=t) ∨ ⌈¬t⌉`.
+See the `glossary.md` file for term definitions.
 
-Note that if `t` is functional (or function-like) and `φ` is a predicate,
+If `t` is functional (or function-like) and `φ` is a predicate,
 then `t ∧ φ` is function-like.
 
 In the sequel all of our pattern meta-variables will be assumes to denote

--- a/docs/2018-11-08-Configuration-Splitting-Simplification.md
+++ b/docs/2018-11-08-Configuration-Splitting-Simplification.md
@@ -6,7 +6,9 @@ Background
 
 ### Functional and function-like patterns
 
-See the `glossary.md` file for term definitions.
+See the `glossary.md` file for term definitions (e.g.
+[functional](glossary.md#functional) and
+[function-like](glossary.md#functionlike)).
 
 If `t` is functional (or function-like) and `φ` is a predicate,
 then `t ∧ φ` is function-like.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,7 +22,6 @@
 1. (adjective)
    A functional pattern has exactly one value, i.e. it satisfies `(∃x . x=φ)`.
 
-
 <a name="pattern"></a>*pattern*
 
 1. (noun)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,8 @@
+<a name="BMC"></a>*BMC*
+
+1. (noun, acronym)
+   Bounded model checking. Execute the program on all paths for a given number of steps (a.k.a. bound), attempting to identify given properties (bugs, unexpected behaviours, and so on) in the execution graph.
+
 <a name="function"></a>*function*
 
 1. (noun)
@@ -37,6 +42,13 @@
    identify, so some of the code that identifies predicates fails on these.
    Whenever a [substitution](#substitution) can be extracted efficiently,
    the "predicate" term may refer to the non-substitution part of the predicate.
+
+<a name="SBC"></a>*SBC*
+
+1. (noun, acronym)
+   Semantics-based compilation. Compilation that uses the semantics of the
+   language to analyze the behaviour of the program (e.g. through symbolic
+   execution), and uses what it learned to improve the compilation result.
 
 <a name="substitution"></a>*substitution*
 


### PR DESCRIPTION
###### Reviewer checklist

@yzhang90 Thanks for pointing out the ceil(not) typo.

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

