### PR TITLE
Extract original definition from IndexedModule

### DIFF
--- a/kore/src/Kore/AST/MetaOrObject.hs
+++ b/kore/src/Kore/AST/MetaOrObject.hs
@@ -16,6 +16,7 @@ module Kore.AST.MetaOrObject
     , MetaOrObject (..)
     , Unified (..)
     , asUnified
+    , fromUnified
     , applyUnified
     , transformUnified
     , mapUnified
@@ -144,3 +145,6 @@ into the corresponding 'Unified' @thing@.
 asUnified
     :: MetaOrObject level => thing level -> Unified thing
 asUnified x = UnifiedObject x
+
+fromUnified :: Unified thing -> thing Object
+fromUnified (UnifiedObject thing) = thing

--- a/kore/src/Kore/AST/MetaOrObject.hs
+++ b/kore/src/Kore/AST/MetaOrObject.hs
@@ -146,5 +146,8 @@ asUnified
     :: MetaOrObject level => thing level -> Unified thing
 asUnified x = UnifiedObject x
 
+{- | Remove a trivial 'Unified' wrapper.
+
+ -}
 fromUnified :: Unified thing -> thing Object
 fromUnified (UnifiedObject thing) = thing

--- a/kore/src/Kore/AST/Pure.hs
+++ b/kore/src/Kore/AST/Pure.hs
@@ -11,6 +11,7 @@ module Kore.AST.Pure
     , CommonPurePattern
     , ConcretePurePattern
     , ParsedPurePattern
+    , VerifiedPurePattern
     , asPurePattern
     , fromPurePattern
     , eraseAnnotations
@@ -333,6 +334,10 @@ type ConcretePurePattern level domain =
 -- | A pure pattern which has only been parsed and lacks 'Valid' annotations.
 type ParsedPurePattern level domain =
     PurePattern level domain Variable (Annotation.Null level)
+
+-- | A pure pattern which has been parsed and verified.
+type VerifiedPurePattern level domain =
+    PurePattern level domain Variable (Valid (Variable level) level)
 
 {- | Use the provided traversal to replace all variables in a 'PurePattern'.
 

--- a/kore/src/Kore/AST/PureToKore.hs
+++ b/kore/src/Kore/AST/PureToKore.hs
@@ -42,11 +42,29 @@ patternPureToKore =
     patternPureToKoreWorker (Recursive.project -> ann :< pat) =
         asUnified ann :< asUnifiedPattern pat
 
+{- | Unwrap a 'KorePattern'.
+
+For historical reasons, the parser produces a 'KorePattern' but most code
+operates on 'PurePattern'.
+
+ -}
+-- TODO (thomas.tuegel): Remove the distinction between KorePattern and
+-- PurePattern.
 patternKoreToPure
     :: Traversable domain
     => KorePattern domain Variable (Unified annotation)
     -> PurePattern Object domain Variable (annotation Object)
 patternKoreToPure = Recursive.fold extractPurePattern
+
+extractPurePattern
+    ::  ( MetaOrObject level
+        , Traversable domain
+        , result ~ PurePattern level domain variable (annotation level)
+        )
+    => Base (KorePattern domain variable (Unified annotation)) result
+    -> result
+extractPurePattern (UnifiedObject oann :< UnifiedObjectPattern opat) =
+    Recursive.embed (oann :< opat)
 
 annotationKoreToPure
     :: Functor f
@@ -54,6 +72,14 @@ annotationKoreToPure
     -> f (Valid (Variable Object) Object)
 annotationKoreToPure = fmap (Valid.mapVariables fromUnified)
 
+{- | Unwrap a 'UnifiedSentence'.
+
+For historical reasons, the parser produces a 'UnifiedSentence' but most code
+operates on 'Sentence'.
+
+ -}
+-- TODO (thomas.tuegel): Remove the distinction between UnifiedSentence and
+-- Sentence.
 sentenceKoreToPure
     :: UnifiedSentence UnifiedSortVariable VerifiedKorePattern
     -> Sentence Object (SortVariable Object) (VerifiedPurePattern Object Domain.Builtin)
@@ -88,16 +114,6 @@ sentenceKoreAxiomToPure sentenceAxiom =
 sortVariableKoreToPure
     :: UnifiedSortVariable -> SortVariable Object
 sortVariableKoreToPure (UnifiedObject var) = var
-
-extractPurePattern
-    ::  ( MetaOrObject level
-        , Traversable domain
-        , result ~ PurePattern level domain variable (annotation level)
-        )
-    => Base (KorePattern domain variable (Unified annotation)) result
-    -> result
-extractPurePattern (UnifiedObject oann :< UnifiedObjectPattern opat) =
-    Recursive.embed (oann :< opat)
 
 -- FIXME : all of this attribute record syntax stuff
 -- Should be temporary measure

--- a/kore/src/Kore/AST/Sentence.hs
+++ b/kore/src/Kore/AST/Sentence.hs
@@ -47,7 +47,15 @@ module Kore.AST.Sentence
     , PureModule
     , PureDefinition
     , castDefinitionDomainValues
+    , VerifiedPureSentenceSymbol
+    , VerifiedPureSentenceAlias
+    , VerifiedPureSentenceImport
+    , VerifiedPureSentenceAxiom
+    , VerifiedPureSentenceSort
+    , VerifiedPureSentenceHook
     , VerifiedPureSentence
+    , VerifiedPureModule
+    , VerifiedPureDefinition
     , UnifiedSentence (..)
     , constructUnifiedSentence
     , applyUnifiedSentence
@@ -819,6 +827,25 @@ type PureSentence level domain =
         (SortVariable level)
         (PurePattern level domain Variable (Annotation.Null level))
 
+
+type VerifiedPureSentenceSymbol level =
+    SentenceSymbol level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
+type VerifiedPureSentenceAlias level =
+    SentenceAlias level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
+type VerifiedPureSentenceImport level =
+    SentenceImport (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
+type VerifiedPureSentenceAxiom level =
+    SentenceAxiom (SortVariable level) (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
+type VerifiedPureSentenceSort level =
+    SentenceSort level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
+type VerifiedPureSentenceHook level =
+    SentenceHook (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+
 {- | A 'PureSentence' which has passed verification.
 
 The contained patterns are annotated by 'Valid'.
@@ -834,6 +861,10 @@ type VerifiedPureSentence level =
             Variable
             (Valid (Variable level) level)
         )
+
+type VerifiedPureModule level = Module (VerifiedPureSentence level)
+
+type VerifiedPureDefinition level = Definition (VerifiedPureSentence level)
 
 instance
     ( MetaOrObject level

--- a/kore/src/Kore/AST/Sentence.hs
+++ b/kore/src/Kore/AST/Sentence.hs
@@ -93,6 +93,8 @@ import           Data.Hashable
 import           Data.Maybe
                  ( catMaybes )
 import           Data.Proxy
+import           Data.String
+                 ( IsString )
 import           Data.Text
                  ( Text )
 import qualified Data.Text as Text
@@ -270,7 +272,7 @@ instance Unparse (SentenceSymbol level patternType) where
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 -}
 newtype ModuleName = ModuleName { getModuleName :: Text }
-    deriving (Eq, Generic, Ord, Show)
+    deriving (Eq, Generic, IsString, Ord, Show)
 
 instance Hashable ModuleName
 

--- a/kore/src/Kore/AST/Sentence.hs
+++ b/kore/src/Kore/AST/Sentence.hs
@@ -43,6 +43,7 @@ module Kore.AST.Sentence
     , PureSentenceAlias
     , PureSentenceImport
     , PureSentenceAxiom
+    , PureSentenceHook
     , PureSentence
     , PureModule
     , PureDefinition
@@ -807,46 +808,65 @@ instance
 
 -- |'PureSentenceAxiom' is the pure (fixed-@level@) version of 'SentenceAxiom'
 type PureSentenceAxiom level domain =
-    SentenceAxiom
-        (SortVariable level)
-        (PurePattern level domain Variable (Annotation.Null level))
+    SentenceAxiom (SortVariable level) (ParsedPurePattern level domain)
 
 -- |'PureSentenceAlias' is the pure (fixed-@level@) version of 'SentenceAlias'
 type PureSentenceAlias level domain =
-    SentenceAlias level (PurePattern level domain Variable (Annotation.Null level))
+    SentenceAlias level (ParsedPurePattern level domain)
 
 -- |'PureSentenceSymbol' is the pure (fixed-@level@) version of 'SentenceSymbol'
 type PureSentenceSymbol level domain =
-    SentenceSymbol level (PurePattern level domain Variable (Annotation.Null level))
+    SentenceSymbol level (ParsedPurePattern level domain)
 
 -- |'PureSentenceImport' is the pure (fixed-@level@) version of 'SentenceImport'
 type PureSentenceImport level domain =
-    SentenceImport (PurePattern level domain Variable (Annotation.Null level))
+    SentenceImport (ParsedPurePattern level domain)
+
+-- | 'PureSentenceHook' is the pure (fixed-@level@) version of 'SentenceHook'.
+type PureSentenceHook domain = SentenceHook (ParsedPurePattern Object domain)
 
 -- |'PureSentence' is the pure (fixed-@level@) version of 'Sentence'
 type PureSentence level domain =
-    Sentence level
-        (SortVariable level)
-        (PurePattern level domain Variable (Annotation.Null level))
+    Sentence level (SortVariable level) (ParsedPurePattern level domain)
 
-
+{- | A 'PureSentenceSymbol' which has passed verification.
+ -}
 type VerifiedPureSentenceSymbol level =
-    SentenceSymbol level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceSymbol level (VerifiedPurePattern level Domain.Builtin)
 
+{- | A 'PureSentenceAlias' which has passed verification.
+
+The patterns contained are annotated by 'Valid'.
+
+ -}
 type VerifiedPureSentenceAlias level =
-    SentenceAlias level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceAlias level (VerifiedPurePattern level Domain.Builtin)
 
+{- | A 'PureSentenceImport' which has passed verification.
+ -}
 type VerifiedPureSentenceImport level =
-    SentenceImport (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceImport (VerifiedPurePattern level Domain.Builtin)
 
+{- | A 'PureSentenceAxiom' which has passed verification.
+
+The patterns contained are annotated by 'Valid'.
+
+ -}
 type VerifiedPureSentenceAxiom level =
-    SentenceAxiom (SortVariable level) (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceAxiom
+        (SortVariable level)
+        (VerifiedPurePattern level Domain.Builtin)
 
 type VerifiedPureSentenceSort level =
-    SentenceSort level (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceSort level (VerifiedPurePattern level Domain.Builtin)
 
+{- | A 'PureSentenceHook' which has passed verification.
+
+The contained patterns are annotated by 'Valid'.
+
+ -}
 type VerifiedPureSentenceHook level =
-    SentenceHook (PurePattern level Domain.Builtin Variable (Valid (Variable level) level))
+    SentenceHook (VerifiedPurePattern level Domain.Builtin)
 
 {- | A 'PureSentence' which has passed verification.
 

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -32,6 +32,8 @@ module Kore.IndexedModule.IndexedModule
     , hookedObjectSymbolSentences
     , indexedModuleSubsorts
     , indexedModulesInScope
+    , toVerifiedPureModule
+    , toVerifiedPureDefinition
     ) where
 
 import           Control.DeepSeq
@@ -42,7 +44,7 @@ import           Control.Monad.State.Strict
                  ( execState )
 import qualified Control.Monad.State.Strict as Monad.State
 import           Data.Bifunctor
-import           Data.Default
+import           Data.Default as Default
 import qualified Data.Foldable as Foldable
 import           Data.Map.Strict
                  ( Map )
@@ -56,6 +58,7 @@ import           GHC.Generics
 import qualified Kore.Annotation.Null as Annotation
 import           Kore.AST.Error
 import           Kore.AST.Kore
+import           Kore.AST.PureToKore
 import           Kore.AST.Sentence
 import           Kore.Attribute.Hook
 import qualified Kore.Attribute.Null as Attribute
@@ -208,6 +211,28 @@ type KoreIndexedModule =
 
 type VerifiedModule =
     IndexedModule UnifiedSortVariable VerifiedKorePattern
+
+toVerifiedPureModule
+    :: VerifiedModule declAtts axiomAtts
+    -> VerifiedPureModule Object
+toVerifiedPureModule module' =
+    Module
+        { moduleName = indexedModuleName module'
+        , moduleSentences =
+            sentenceKoreToPure <$> indexedModuleRawSentences module'
+        , moduleAttributes = Default.def
+        }
+
+toVerifiedPureDefinition
+    :: Foldable t
+    => t (VerifiedModule declAtts axiomAtts)
+    -> VerifiedPureDefinition Object
+toVerifiedPureDefinition idx =
+    Definition
+        { definitionAttributes = Default.def
+        , definitionModules =
+            toVerifiedPureModule <$> Foldable.toList idx
+        }
 
 indexedModuleRawSentences
     :: IndexedModule param pat atts atts' -> [UnifiedSentence param pat]

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -212,6 +212,11 @@ type KoreIndexedModule =
 type VerifiedModule =
     IndexedModule UnifiedSortVariable VerifiedKorePattern
 
+{- | Convert a 'VerifiedModule' back into a 'Module'.
+
+The original module attributes /are/ preserved.
+
+ -}
 toVerifiedPureModule
     :: VerifiedModule declAtts axiomAtts
     -> VerifiedPureModule Object
@@ -220,7 +225,7 @@ toVerifiedPureModule module' =
         { moduleName = indexedModuleName module'
         , moduleSentences =
             sentenceKoreToPure <$> indexedModuleRawSentences module'
-        , moduleAttributes = Default.def
+        , moduleAttributes = snd (indexedModuleAttributes module')
         }
 
 toVerifiedPureDefinition

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -228,6 +228,17 @@ toVerifiedPureModule module' =
         , moduleAttributes = snd (indexedModuleAttributes module')
         }
 
+{- | Convert any collection of 'VerifiedModule's back into a 'Definition'.
+
+The definition attributes are lost in the process of indexing the original
+definition.
+
+Although all 'IndexedModule's refer to the implicit Kore module, it is not
+included in the output of this function because it is /implicit/.
+
+See also: 'toVerifiedPureModule'
+
+ -}
 toVerifiedPureDefinition
     :: Foldable t
     => t (VerifiedModule declAtts axiomAtts)
@@ -236,8 +247,12 @@ toVerifiedPureDefinition idx =
     Definition
         { definitionAttributes = Default.def
         , definitionModules =
-            toVerifiedPureModule <$> Foldable.toList idx
+            toVerifiedPureModule
+            <$> filter notImplicitKoreModule (Foldable.toList idx)
         }
+  where
+    notImplicitKoreModule verifiedModule =
+        indexedModuleName verifiedModule /= "kore"
 
 indexedModuleRawSentences
     :: IndexedModule param pat atts atts' -> [UnifiedSentence param pat]

--- a/kore/test/Test/Kore/AST/PureToKore.hs
+++ b/kore/test/Test/Kore/AST/PureToKore.hs
@@ -17,10 +17,9 @@ import           Kore.MetaML.AST
 import Test.Kore
 
 
-pureToKoreToPureProp
-    :: MonadTest m => CommonMetaPattern -> m ()
+pureToKoreToPureProp :: MonadTest m => CommonMetaPattern -> m ()
 pureToKoreToPureProp p =
-    Right p === patternKoreToPure Meta (patternPureToKore p)
+    p === patternKoreToPure (patternPureToKore p)
 
 test_pureToKore :: [TestTree]
 test_pureToKore =


### PR DESCRIPTION
Extracting a the original definition from the result of verification is very useful for @hreada's work on the new unparser.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

