### PR TITLE
Don't forget substitutions when simplifying \or

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -346,11 +346,11 @@ mainWithOptions
                 SMT.runSMT smtConfig
                 $ evalSimplifier logger
                 $ do
-                    give
-                        (extractMetadataTools indexedModule
-                            :: MetadataTools Object StepperAttributes
-                        )
-                        (declareSMTLemmas indexedModule)
+                    -- give
+                    --     (extractMetadataTools indexedModule
+                    --         :: MetadataTools Object StepperAttributes
+                    --     )
+                    --     (declareSMTLemmas indexedModule)
                     case proveParameters of
                         Nothing -> do
                             let

--- a/kore/src/Kore/OnePath/Step.hs
+++ b/kore/src/Kore/OnePath/Step.hs
@@ -302,11 +302,11 @@ transitionRule
                 config
                 rules
         case result of
-            Left _ ->
+            Left stepError ->
                 (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , "while applying a \\rewrite axiom to the pattern:"
+                [ "While applying a \\rewrite rule to the pattern:"
                 , Pretty.indent 4 (unparse config)
+                , Pretty.pretty stepError
                 ,   "We decided to end the execution because we don't \
                     \understand this case well enough at the moment."
                 ]

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -70,7 +70,7 @@ data RulePattern level variable = RulePattern
     , ensures :: !(Predicate level variable)
     , attributes :: !Attribute.Axiom
     }
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 instance Unparse (variable level) => Pretty (RulePattern level variable) where
     pretty rulePattern@(RulePattern _ _ _ _ _) =

--- a/kore/src/Kore/Step/Simplification/Or.lhs
+++ b/kore/src/Kore/Step/Simplification/Or.lhs
@@ -19,7 +19,6 @@ module Kore.Step.Simplification.Or
 
 import           Control.Applicative
                  ( Alternative (..) )
-import qualified Data.Function as Function
 import qualified Data.Functor.Foldable as Recursive
 
 import           Kore.AST.Pure
@@ -27,7 +26,6 @@ import           Kore.Predicate.Predicate
                  ( makeOrPredicate )
 import           Kore.Step.Representation.ExpandedPattern
                  ( ExpandedPattern, Predicated (..) )
-import qualified Kore.Step.Representation.Predicated as Predicated
 import           Kore.Step.Representation.OrOfExpandedPattern
                  ( OrOfExpandedPattern )
 import qualified Kore.Step.Representation.MultiOr as MultiOr
@@ -189,47 +187,18 @@ disjoinPredicates
         , predicate = predicate1
         , substitution = substitution1
         }
-    predicated2@Predicated
+    Predicated
         { term = term2
         , predicate = predicate2
         , substitution = substitution2
         }
 
-  | term1         == term2
-  =
-    let result
-          | substitution1 == substitution2 =
-            predicated1 { predicate = makeOrPredicate predicate1 predicate2 }
-\end{code}
-
-When the configurations have different substitutions, it is possible to disjoin
-them by promoting the substitutions into the predicate,
-```
-(t, p₁     , s₁) ∨ (t, p₂     , s₂)
-(t, p₁ ∧ s₁, ⊤ ) ∨ (t, p₂ ∧ s₂, ⊤ )
-```
-and following the algorithm described above for disjoining predicates when the
-substitutions are equal. This is not strictly a simplification: simplifying
-predicates extracts substitutions into the corresponding field of the
-configuration. Nevertheless, this simplification is required by
-`Kore.Step.Simplification.Equals.makeEvaluateFunctionalOr`.
-
-\begin{code}
-          | otherwise =
-            Predicated
-                { term = term1
-                , predicate =
-                    Function.on
-                        makeOrPredicate
-                        Predicated.toPredicate
-                        predicated1
-                        predicated2
-                , substitution = mempty
-                }
-    in Just (result, SimplificationProof)
-
+  | term1 == term2, substitution1 == substitution2 =
+    Just (result, SimplificationProof)
   | otherwise =
     Nothing
+  where
+    result = predicated1 { predicate = makeOrPredicate predicate1 predicate2 }
 \end{code}
 
 == `\top` annihilates `\or`

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -14,7 +14,6 @@ module Kore.Step.Substitution
     , createPredicatesAndSubstitutionsMergerExcept
     , mergePredicatesAndSubstitutions
     , mergePredicatesAndSubstitutionsExcept
-    , normalizePredicatedSubstitution
     , normalize
     , normalizeExcept
     ) where
@@ -294,54 +293,6 @@ mergePredicatesAndSubstitutionsExcept
             }
         , EmptyUnificationProof
         )
-
-normalizePredicatedSubstitution
-    ::  ( MetaOrObject level
-        , Ord (variable level)
-        , Show (variable level)
-        , Unparse (variable level)
-        , OrdMetaOrObject variable
-        , ShowMetaOrObject variable
-        , SortedVariable variable
-        , FreshVariable variable
-        )
-    => MetadataTools level StepperAttributes
-    -> PredicateSubstitutionSimplifier level
-    -> StepPatternSimplifier level
-    -> BuiltinAndAxiomSimplifierMap level
-    -> Predicated level variable a
-    -> Simplifier
-        ( Predicated level variable a
-        , UnificationProof level variable
-        )
-normalizePredicatedSubstitution
-    tools
-    substitutionSimplifier
-    simplifier
-    axiomIdToSimplifier
-    Predicated { term, predicate, substitution }
-  = do
-    x <- runExceptT $
-            normalizeSubstitutionAfterMerge
-                tools
-                substitutionSimplifier
-                simplifier
-                axiomIdToSimplifier
-                Predicated { term = (), predicate, substitution }
-    return $ case x of
-        Left _ ->
-            ( Predicated
-                { term
-                , predicate =
-                    makeAndPredicate
-                        predicate
-                        (substitutionToPredicate substitution)
-                , substitution = mempty
-                }
-            , EmptyUnificationProof
-            )
-        Right (Predicated { predicate = p, substitution = s }, _) ->
-            (Predicated term p s, EmptyUnificationProof)
 
 {-| Creates a 'PredicateSubstitutionMerger' that returns errors on unifications it
 can't handle.

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -224,9 +224,28 @@ test_equalsSimplification_OrOfExpandedPatterns =
                         , predicate =
                             makeMultipleAndPredicate
                                 [ definedF
-                                , makeOrPredicate definedG definedH
+                                , definedG
                                 , makeImpliesPredicate
-                                    definedG
+                                    (makeAndPredicate
+                                        definedG
+                                        (makeEqualsPredicate Mock.a Mock.a)
+                                    )
+                                    (makeEqualsPredicate Mock.cf Mock.cg)
+                                , makeImpliesPredicate
+                                    definedH
+                                    (makeEqualsPredicate Mock.cf Mock.ch)
+                                ]
+                        , substitution =
+                            Substitution.unsafeWrap [(Mock.x, Mock.a)]
+                        }
+                    , Predicated
+                        { term = mkTop_
+                        , predicate =
+                            makeMultipleAndPredicate
+                                [ definedF
+                                , definedH
+                                , makeImpliesPredicate
+                                    (makeAndPredicate definedG substG)
                                     (makeEqualsPredicate Mock.cf Mock.cg)
                                 , makeImpliesPredicate
                                     definedH
@@ -239,7 +258,8 @@ test_equalsSimplification_OrOfExpandedPatterns =
                         , predicate =
                             makeMultipleAndPredicate
                                 [ makeNotPredicate definedF
-                                , makeNotPredicate definedG
+                                , makeNotPredicate
+                                    (makeAndPredicate definedG substG)
                                 , makeNotPredicate definedH
                                 ]
                         , substitution = mempty
@@ -247,10 +267,8 @@ test_equalsSimplification_OrOfExpandedPatterns =
                     ]
               where
                 definedF = makeCeilPredicate Mock.cf
-                definedG =
-                    makeAndPredicate
-                        (makeCeilPredicate Mock.cg)
-                        (makeEqualsPredicate (mkVar Mock.x) Mock.a)
+                definedG = makeCeilPredicate Mock.cg
+                substG = makeEqualsPredicate (mkVar Mock.x) Mock.a
                 definedH = makeCeilPredicate Mock.ch
             first =
                 MultiOr.make

--- a/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -35,10 +35,10 @@ import qualified Test.Kore.Step.MockSymbols as Mock
 
 -- * Part 1: 'simplifyEvaluated'
 
-{-
+{- |
 
-`SimplifyEvaluated` is the core function. It converts two `OrOfExpandedPattern`
-values into a simplifier that is to produce a single `OrOfExpandedPattern`. We
+'simplifyEvaluated' is the core function. It converts two 'OrOfExpandedPattern'
+values into a simplifier that is to produce a single 'OrOfExpandedPattern'. We
 run the simplifier to check correctness.
 
 -}
@@ -73,19 +73,13 @@ test_disjoinPredicates =
         , p1 <- predicates, p2 <- predicates
         , s1 <- substitutions, s2 <- substitutions
         , let
-            -- If the terms are equal, expect the given simplification.
-            -- Otherwise, the predicates should not be merged.
+            -- If the terms and substitutions are equal, expect the given
+            -- simplification. Otherwise, the predicates should not be merged.
             expectation
-              | t1 == t2  = simplifiesTo
-              | otherwise = \initial _ -> doesNotSimplify initial
-            (p', s')
-              | s1 == s2  = (makeOrPredicate p1 p2, s1)
-              | otherwise =
-                ( makeOrPredicate
-                    (makeAndPredicate p1 (substitutionToPredicate s1))
-                    (makeAndPredicate p2 (substitutionToPredicate s2))
-                , mempty
-                )
+              | t1 == t2, s1 == s2 = simplifiesTo
+              | otherwise          = \initial _ -> doesNotSimplify initial
+            p' = makeOrPredicate p1 p2
+            s' = s1
         ]
   where
     terms = [ tM, tm ]
@@ -119,11 +113,11 @@ test_deduplicateMiddle =
         ]
 
 
--- * Part 2: `simplify` is just a trivial use of `simplifyEvaluated`
+-- * Part 2: 'simplify' is just a trivial use of 'simplifyEvaluated'
 
 test_simplify :: TestTree
 test_simplify =
-    testGroup "`simplify` just calls `simplifyEvaluated`"
+    testGroup "simplify just calls simplifyEvaluated"
         [ equals_
             (simplify $        binaryOr orPattern1 orPattern2 )
             (simplifyEvaluated          orPattern1 orPattern2 )
@@ -136,25 +130,25 @@ test_simplify =
     orPattern2 = wrapInOrPattern (tm, pm, sm)
 
     binaryOr
-      :: OrOfExpandedPattern Object Variable
-      -> OrOfExpandedPattern Object Variable
-      -> Or Object (OrOfExpandedPattern Object Variable)
+        :: OrOfExpandedPattern Object Variable
+        -> OrOfExpandedPattern Object Variable
+        -> Or Object (OrOfExpandedPattern Object Variable)
     binaryOr orFirst orSecond =
         Or { orSort = Mock.testSort, orFirst, orSecond }
 
 
 -- * Part 3: The values and functions relevant to this test
 
-{-
+{- |
 Key for variable names:
-1. `OrOfExpandedPattern` values are represented by a tuple containing
+1. 'OrOfExpandedPattern' values are represented by a tuple containing
    the term, predicate, and substitution, in that order. They're
-   also tagged with `t`, `p`, and `s`.
+   also tagged with 't', 'p', and 's'.
 2. The second character has this meaning:
    T : top
    _ : bottom
    m or M : a character neither top nor bottom. Two values
-            named `pm` and `pM` are expected to be unequal.
+            named 'pm' and 'pM' are expected to be unequal.
 -}
 
 {- | Short-hand for: @ExpandedPattern Object Variable@


### PR DESCRIPTION
1. In `disjoinPredicates`, don't attempt to combine predicates with different substitutions.
2. In `simplifyPartial`, remove an unforced error.
3. In `transitionRemoveDestination`, do not mix predicates with the term.
4. Remove some unused code.

Bonus: 35% speed-up on the slowest verification test!

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

