### PR TITLE
Allow branching in And.makeEvaluate

### DIFF
--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -13,6 +13,8 @@ module Kore.Step.Simplification.And
     , simplifyEvaluated
     ) where
 
+import           Control.Applicative
+                 ( Alternative (empty) )
 import qualified Control.Monad.Trans as Monad.Trans
 import           Data.List
                  ( foldl1', nub )
@@ -31,7 +33,7 @@ import           Kore.Step.Pattern
 import           Kore.Step.Representation.ExpandedPattern
                  ( ExpandedPattern )
 import qualified Kore.Step.Representation.ExpandedPattern as ExpandedPattern
-                 ( bottom, isBottom, isTop )
+                 ( isBottom, isTop )
 import qualified Kore.Step.Representation.MultiOr as MultiOr
                  ( make )
 import           Kore.Step.Representation.OrOfExpandedPattern
@@ -219,12 +221,9 @@ makeEvaluate
     -> BranchT Simplifier (ExpandedPattern level variable)
 makeEvaluate
     tools substitutionSimplifier simplifier axiomIdToSimplifier first second
-  | ExpandedPattern.isBottom first || ExpandedPattern.isBottom second =
-    return ExpandedPattern.bottom
-  | ExpandedPattern.isTop first =
-    return second
-  | ExpandedPattern.isTop second =
-    return first
+  | ExpandedPattern.isBottom first || ExpandedPattern.isBottom second = empty
+  | ExpandedPattern.isTop first = return second
+  | ExpandedPattern.isTop second = return first
   | otherwise =
     makeEvaluateNonBool
         tools

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -14,7 +14,6 @@ module Kore.Step.Substitution
     , createPredicatesAndSubstitutionsMergerExcept
     , mergePredicatesAndSubstitutions
     , mergePredicatesAndSubstitutionsExcept
-    , normalizePredicatedSubstitution
     , normalize
     , normalizeExcept
     ) where
@@ -294,54 +293,6 @@ mergePredicatesAndSubstitutionsExcept
             }
         , EmptyUnificationProof
         )
-
-normalizePredicatedSubstitution
-    ::  ( MetaOrObject level
-        , Ord (variable level)
-        , Show (variable level)
-        , Unparse (variable level)
-        , OrdMetaOrObject variable
-        , ShowMetaOrObject variable
-        , SortedVariable variable
-        , FreshVariable variable
-        )
-    => MetadataTools level StepperAttributes
-    -> PredicateSubstitutionSimplifier level
-    -> StepPatternSimplifier level
-    -> BuiltinAndAxiomSimplifierMap level
-    -> Predicated level variable a
-    -> Simplifier
-        ( Predicated level variable a
-        , UnificationProof level variable
-        )
-normalizePredicatedSubstitution
-    tools
-    substitutionSimplifier
-    simplifier
-    axiomIdToSimplifier
-    Predicated { term, predicate, substitution }
-  = do
-    x <- runExceptT $
-            normalizeSubstitutionAfterMerge
-                tools
-                substitutionSimplifier
-                simplifier
-                axiomIdToSimplifier
-                Predicated { term = (), predicate, substitution }
-    return $ case x of
-        Left _ ->
-            ( Predicated
-                { term
-                , predicate =
-                    makeAndPredicate
-                        predicate
-                        (substitutionToPredicate substitution)
-                , substitution = mempty
-                }
-            , EmptyUnificationProof
-            )
-        Right (Predicated { predicate = p, substitution = s }, _) ->
-            (Predicated term p s, EmptyUnificationProof)
 
 {-| Creates a 'PredicateSubstitutionMerger' that returns errors on unifications it
 can't handle.

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -319,7 +319,7 @@ test_andSimplification =
     -- (a or b) and (c or d) = (b and d) or (b and c) or (a and d) or (a and c)
     , testCase "And-Or distribution" $ do
         let expect =
-                MultiOr.make
+                MultiOr
                     [ Predicated
                         { term = fOfX
                         , predicate = makeEqualsPredicate fOfX gOfX

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -451,12 +451,12 @@ evaluatePatterns first second =
     $ evalSimplifier emptyLogger
     $ gather
     $ makeEvaluate
-            mockMetadataTools
-            (Mock.substitutionSimplifier mockMetadataTools)
-            (Simplifier.create mockMetadataTools Map.empty)
-            Map.empty
-            first
-            second
+        mockMetadataTools
+        (Mock.substitutionSimplifier mockMetadataTools)
+        (Simplifier.create mockMetadataTools Map.empty)
+        Map.empty
+        first
+        second
 
 mockMetadataTools :: MetadataTools Object StepperAttributes
 mockMetadataTools =

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -200,12 +200,6 @@ test_andSimplification =
             assertEqualWithExplanation "" (MultiOr [expect]) actual
 
         , testCase "And substitutions - failure" $ do
-            let expect =
-                    Predicated
-                        { term = mkTop_
-                        , predicate = makeFalsePredicate
-                        , substitution = mempty
-                        }
             actual <-
                 evaluatePatterns
                     Predicated
@@ -226,7 +220,7 @@ test_andSimplification =
                                 )
                             ]
                         }
-            assertEqualWithExplanation "" (MultiOr [expect]) actual
+            assertEqualWithExplanation "" (MultiOr []) actual
             {-
             TODO(virgil): Uncomment this after substitution merge can handle
             function equality.

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -19,7 +19,6 @@ import           Kore.Predicate.Predicate
 import           Kore.Step.Representation.ExpandedPattern
                  ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.Representation.ExpandedPattern as ExpandedPattern
-                 ( bottom, top )
 import           Kore.Step.Representation.MultiOr
                  ( MultiOr (MultiOr) )
 import qualified Kore.Step.Representation.MultiOr as MultiOr
@@ -302,7 +301,6 @@ test_andSimplification =
             assertEqualWithExplanation "" (MultiOr [expect]) actual
 
         , testCase "different constructors" $ do
-            let expect = ExpandedPattern.bottom
             actual <-
                 evaluatePatterns
                     Predicated
@@ -315,7 +313,7 @@ test_andSimplification =
                         , predicate = makeTruePredicate
                         , substitution = mempty
                         }
-            assertEqualWithExplanation "" (MultiOr [expect]) actual
+            assertEqualWithExplanation "" (MultiOr []) actual
         ]
 
     -- (a or b) and (c or d) = (b and d) or (b and c) or (a and d) or (a and c)


### PR DESCRIPTION
This is not critical, but it removes an unforced `error` call and some dead code.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

