### PR TITLE
No function remainders

### DIFF
--- a/kore/src/Kore/Step/Axiom/Data.hs
+++ b/kore/src/Kore/Step/Axiom/Data.hs
@@ -14,6 +14,7 @@ module Kore.Step.Axiom.Data
     , AttemptedAxiomResults (..)
     , CommonAttemptedAxiom
     , hasRemainders
+    , exceptNotApplicable
     , applicationAxiomSimplifier
     , notApplicableAxiomEvaluator
     , purePatternAxiomEvaluator
@@ -23,6 +24,8 @@ import           Control.Comonad.Trans.Cofree
                  ( CofreeF (..) )
 import           Control.DeepSeq
                  ( NFData )
+import           Control.Monad.Except
+                 ( ExceptT, runExceptT )
 import qualified Data.Map.Strict as Map
 import           GHC.Generics
                  ( Generic )
@@ -173,6 +176,17 @@ A 'NotApplicable' result is not considered to have remainders.
 hasRemainders :: AttemptedAxiom level variable -> Bool
 hasRemainders (Applied axiomResults) = (not . null) (remainders axiomResults)
 hasRemainders NotApplicable = False
+
+{- | Return a 'NotApplicable' result for a failing 'ExceptT' action.
+ -}
+exceptNotApplicable
+    :: Functor m
+    => ExceptT e m (AttemptedAxiom level variable, SimplificationProof level)
+    ->           m (AttemptedAxiom level variable, SimplificationProof level)
+exceptNotApplicable =
+    fmap (either (const notApplicable) id) . runExceptT
+  where
+    notApplicable = (NotApplicable, SimplificationProof)
 
 -- |Yields a pure 'Simplifier' which always returns 'NotApplicable'
 notApplicableAxiomEvaluator

--- a/kore/src/Kore/Step/Axiom/Data.hs
+++ b/kore/src/Kore/Step/Axiom/Data.hs
@@ -13,6 +13,7 @@ module Kore.Step.Axiom.Data
     , AttemptedAxiom (..)
     , AttemptedAxiomResults (..)
     , CommonAttemptedAxiom
+    , hasRemainders
     , applicationAxiomSimplifier
     , notApplicableAxiomEvaluator
     , purePatternAxiomEvaluator
@@ -163,6 +164,15 @@ instance (NFData (variable level))
 following the same pattern as the other `Common*` types.
 -}
 type CommonAttemptedAxiom level = AttemptedAxiom level Variable
+
+{- | Does the 'AttemptedAxiom' have remainders?
+
+A 'NotApplicable' result is not considered to have remainders.
+
+ -}
+hasRemainders :: AttemptedAxiom level variable -> Bool
+hasRemainders (Applied axiomResults) = (not . null) (remainders axiomResults)
+hasRemainders NotApplicable = False
 
 -- |Yields a pure 'Simplifier' which always returns 'NotApplicable'
 notApplicableAxiomEvaluator

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -359,6 +359,9 @@ evaluateWithDefinitionAxioms
     patt
   = do
     let
+        -- TODO (thomas.tuegel): Take an 'ExpandedPattern' as input so that its
+        -- conditions can be used to remove remainder branches and evaluate more
+        -- functions.
         expanded :: ExpandedPattern level variable
         expanded = ExpandedPattern.fromPurePattern patt
 

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -135,7 +135,7 @@ totalDefinitionEvaluation rules =
         axiomSimplifiers
         term
       = do
-        (result, proof) <- evaluate
+        (result, proof) <- evaluate term
         if AttemptedAxiom.hasRemainders result
             then return (AttemptedAxiom.NotApplicable, proof)
             else return (result, proof)
@@ -147,7 +147,6 @@ totalDefinitionEvaluation rules =
                 predicateSimplifier
                 termSimplifier
                 axiomSimplifiers
-                term
 
 {-| Creates an evaluator that choses the result of the first evaluator that
 returns Applicable.

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -359,9 +359,8 @@ evaluateWithDefinitionAxioms
   =
     AttemptedAxiom.exceptNotApplicable $ do
     let
-        -- TODO (thomas.tuegel): Take an 'ExpandedPattern' as input so that its
-        -- conditions can be used to remove remainder branches and evaluate more
-        -- functions.
+        -- TODO (thomas.tuegel): Figure out how to get the initial conditions
+        -- and apply them here, to remove remainder branches sooner.
         expanded :: ExpandedPattern level variable
         expanded = ExpandedPattern.fromPurePattern patt
 

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -91,7 +91,7 @@ definitionEvaluation rules =
     BuiltinAndAxiomSimplifier
         (evaluateWithDefinitionAxioms rules)
 
-{- | Creates an evaluator for a function all the rules that define it.
+{- | Creates an evaluator for a function from all the rules that define it.
 
 The function is not applied (@totalDefinitionEvaluation@ returns
 'AttemptedAxiom.NotApplicable') if the supplied rules do not match the entire

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -42,7 +42,7 @@ import           Kore.Step.Axiom.Data
 import qualified Kore.Step.Axiom.Data as AttemptedAxiomResults
                  ( AttemptedAxiomResults (..) )
 import qualified Kore.Step.Axiom.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..) )
+                 ( AttemptedAxiom (..), hasRemainders )
 import           Kore.Step.Axiom.Matcher
                  ( unificationWithAppMatchOnTop )
 import           Kore.Step.Pattern
@@ -138,11 +138,9 @@ totalDefinitionEvaluation rules =
         term
       = do
         (result, proof) <- evaluate
-        case result of
-            AttemptedAxiom.Applied axiomResults
-              | (not . null) (AttemptedAxiomResults.remainders axiomResults) ->
-                return (AttemptedAxiom.NotApplicable, proof)
-            _ -> return (result, proof)
+        if AttemptedAxiom.hasRemainders result
+            then return (AttemptedAxiom.NotApplicable, proof)
+            else return (result, proof)
       where
         evaluate =
             evaluateWithDefinitionAxioms

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -61,7 +61,6 @@ import qualified Kore.Step.Rule as RulePattern
 import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier, SimplificationProof (..),
                  Simplifier, StepPatternSimplifier (..) )
-import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Step
                  ( UnificationProcedure (UnificationProcedure) )
 import qualified Kore.Step.Step as Step
@@ -384,30 +383,10 @@ evaluateWithDefinitionAxioms
                     { Step.results = mempty
                     , Step.remainders = MultiOr.make [expanded]
                     }
-    let
-        remainderResults :: [ExpandedPattern level variable]
-        remainderResults = MultiOr.extractPatterns remainders
-
-        simplifyPredicate
-            :: ExpandedPattern level variable
-            -> Simplifier
-                (ExpandedPattern level variable, SimplificationProof level)
-        simplifyPredicate =
-            ExpandedPattern.simplifyPredicate
-                tools
-                substitutionSimplifier
-                simplifier
-                axiomIdToSimplifier
-
-    simplifiedRemainderList <- mapM simplifyPredicate remainderResults
-    let
-        simplifiedRemainderResults :: [ExpandedPattern level variable]
-        (simplifiedRemainderResults, _proofs) =
-            unzip simplifiedRemainderList
     return
         ( AttemptedAxiom.Applied AttemptedAxiomResults
             { results = Step.result <$> results
-            , remainders = MultiOr.make simplifiedRemainderResults
+            , remainders = remainders
             }
         , SimplificationProof
         )

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -34,8 +34,8 @@ import           Kore.IndexedModule.IndexedModule
 import           Kore.Step.Axiom.Data
                  ( BuiltinAndAxiomSimplifier (..) )
 import           Kore.Step.Axiom.EvaluationStrategy
-                 ( definitionEvaluation, firstFullEvaluation,
-                 simplifierWithFallback )
+                 ( firstFullEvaluation, simplifierWithFallback,
+                 totalDefinitionEvaluation )
 import           Kore.Step.Axiom.Identifier
                  ( AxiomIdentifier )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
@@ -158,7 +158,7 @@ axiomPatternsToEvaluators =
         definitionEvaluator =
             if null evaluations
                 then Nothing
-                else Just (definitionEvaluation evaluations)
+                else Just (totalDefinitionEvaluation evaluations)
 
 {- | Return the evaluator corresponding to the 'AxiomPattern'.
 


### PR DESCRIPTION
Return `NotApplicable` for a function evaluation if the definition does not cover the entire input, i.e. if there are any remainders. This is safe to do because the other backends do not allow functions to branch at all. (This still allows branching, but only if the branches can be proven to cover the entire input.) This is useful to do because it postpones evaluating functions until more information is available; concrete execution of KEVM is up to 40% faster! This also stops the problem where we would loop forever trying to evaluate stuck functions in a remainder: this allows one new KWASM proof to succeed, and all remaining failing proofs get stuck instead of looping!

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

