### PR TITLE
prototype of bmc for AG pattern

### DIFF
--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -44,7 +44,7 @@ import           Development.GitRev
 import           Options.Applicative
                  ( InfoMod, Parser, argument, disabled, execParser, flag,
                  flag', help, helper, hidden, info, internal, long, metavar,
-                 strOption, (<**>), (<|>) )
+                 strOption, switch, (<**>), (<|>) )
 import           System.Clock
                  ( Clock (Monotonic), diffTimeSpec, getTime )
 import           System.IO
@@ -76,6 +76,8 @@ data KoreProveOptions =
         -- ^ Name of file containing the spec to be proven
         , specMainModule :: !ModuleName
         -- ^ The main module of the spec to be proven
+        , bmc :: !Bool
+        -- ^ Whether to use bounded model checker
         }
 
 parseKoreProveOptions :: Parser KoreProveOptions
@@ -94,6 +96,9 @@ parseKoreProveOptions =
             <> help "The name of the main module in the spec to be proven."
             )
         )
+    <*> switch
+        ( long "bmc"
+        <> help "Whether to use the bounded model checker." )
 
 {- | Record Type containing common command-line arguments for each executable in
 the project -}

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -82,7 +82,8 @@ import qualified Kore.Step.Representation.PredicateSubstitution as PredicateSubs
 import           Kore.Step.Rule
                  ( EqualityRule (EqualityRule), OnePathRule (..),
                  RewriteRule (RewriteRule), RulePattern (RulePattern),
-                 extractOnePathClaims, extractImplicationClaims, extractRewriteAxioms, getRewriteRule )
+                 extractImplicationClaims, extractOnePathClaims,
+                 extractRewriteAxioms, getRewriteRule )
 import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Search

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -14,6 +14,7 @@ module Kore.Exec
     , search
     , prove
     , proveWithRepl
+    , boundedModelCheck
     , Rewrite
     , Equality
     ) where
@@ -50,6 +51,7 @@ import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
 import           Kore.IndexedModule.Resolvers
                  ( resolveSymbol )
 import qualified Kore.Logger as Log
+import qualified Kore.ModelChecker.Bounded as Bounded
 import           Kore.OnePath.Verification
                  ( Axiom (Axiom), Claim, defaultStrategy, verify )
 import qualified Kore.OnePath.Verification as Claim
@@ -80,7 +82,7 @@ import qualified Kore.Step.Representation.PredicateSubstitution as PredicateSubs
 import           Kore.Step.Rule
                  ( EqualityRule (EqualityRule), OnePathRule (..),
                  RewriteRule (RewriteRule), RulePattern (RulePattern),
-                 extractOnePathClaims, extractRewriteAxioms, getRewriteRule )
+                 extractOnePathClaims, extractImplicationClaims, extractRewriteAxioms, getRewriteRule )
 import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Search
@@ -279,6 +281,38 @@ proveWithRepl definitionModule specModule = do
         axiomIdToSimplifier
         axioms
         claims
+
+-- | Bounded model check a spec given as a module containing rules to be checked
+boundedModelCheck
+    :: Limit Natural
+    -> VerifiedModule StepperAttributes Attribute.Axiom
+    -- ^ The main module
+    -> VerifiedModule StepperAttributes Attribute.Axiom
+    -- ^ The spec module
+    -> Simplifier [Bounded.CheckResult]
+boundedModelCheck limit definitionModule specModule = do
+    let
+        tools = extractMetadataTools definitionModule
+    Initialized
+        { rewriteRules
+        , simplifier
+        , substitutionSimplifier
+        , axiomIdToSimplifier
+        } <-
+            initialize definitionModule tools
+    let
+        axioms = fmap Axiom rewriteRules
+        specAxioms = fmap snd $ (extractImplicationClaims specModule)
+
+    result <-
+        Bounded.check
+            tools
+            simplifier
+            substitutionSimplifier
+            axiomIdToSimplifier
+            (Bounded.bmcStrategy axioms)
+            (map (\x -> (x,limit)) specAxioms)
+    return result
 
 assertSomeClaims :: Monad m => [claim] -> m ()
 assertSomeClaims claims =

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -293,7 +293,7 @@ boundedModelCheck
     -> Simplifier [Bounded.CheckResult]
 boundedModelCheck limit definitionModule specModule = do
     let
-        tools = extractMetadataTools definitionModule
+        tools = MetadataTools.build definitionModule
     Initialized
         { rewriteRules
         , simplifier

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -25,7 +25,7 @@ import           Kore.AST.Valid
 import           Kore.Attribute.Symbol
                  ( StepperAttributes )
 import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools )
+                 ( SmtMetadataTools )
 import           Kore.ModelChecker.Step
                  ( CommonModalPattern, CommonProofState, ModalPattern (..),
                  Prim (..), defaultOneStepStrategy )
@@ -64,7 +64,7 @@ data CheckResult
 
 check
     :: MetaOrObject level
-    => MetadataTools level StepperAttributes
+    => SmtMetadataTools StepperAttributes
     -> StepPatternSimplifier level
     -- ^ Simplifies normal patterns through, e.g., function evaluation
     -> PredicateSubstitutionSimplifier level
@@ -123,7 +123,7 @@ bmcStrategy
 
 checkClaim
     :: forall level . (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    => SmtMetadataTools StepperAttributes
     -> StepPatternSimplifier level
     -> PredicateSubstitutionSimplifier level
     -> BuiltinAndAxiomSimplifierMap level

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -1,0 +1,189 @@
+{-|
+Module      : Kore.ModelChecker.Bounded
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+
+module Kore.ModelChecker.Bounded
+    ( CheckResult (..)
+    , bmcStrategy
+    , check
+    ) where
+
+import qualified Data.Foldable as Foldable
+import           Data.Limit
+                 ( Limit )
+import qualified Data.Limit as Limit
+import           Debug.Trace
+
+import           Kore.AST.Common
+                 ( SymbolOrAlias (..), Variable )
+import           Kore.AST.Identifier
+                 ( Id (..) )
+import           Kore.AST.MetaOrObject
+                 ( MetaOrObject )
+import           Kore.AST.Valid
+import           Kore.Attribute.Symbol
+                 ( StepperAttributes )
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import           Kore.ModelChecker.Step
+                 ( CommonModalPattern, ModalPattern (..), Prim (..), CommonProofState,
+                   defaultOneStepStrategy )
+import qualified Kore.ModelChecker.Step as ProofState
+                 ( ProofState (..) )
+import qualified Kore.ModelChecker.Step as ModelChecker
+                 ( transitionRule )
+import           Kore.OnePath.Verification
+                 ( Axiom (Axiom) )
+import qualified Kore.Predicate.Predicate as Predicate
+import           Kore.Step.Axiom.Data
+                 ( BuiltinAndAxiomSimplifierMap )
+import           Kore.Step.Representation.ExpandedPattern
+                 ( Predicated (Predicated) )
+import           Kore.Step.Representation.ExpandedPattern as Predicated
+                 ( Predicated (..) )
+import           Kore.Step.Rule
+                 ( RulePattern (..), RewriteRule, ImplicationRule (ImplicationRule) )
+import           Kore.Step.Simplification.Data
+                 ( PredicateSubstitutionSimplifier, Simplifier,
+                 StepPatternSimplifier )
+import           Kore.Step.Strategy
+                 ( Strategy, pickFinal, TransitionT, runStrategy )
+import           Numeric.Natural
+                 ( Natural )
+
+data CheckResult
+    = Proved
+    -- ^ Property is proved within the bound.
+    | Failed
+    -- ^ Counter example is found within the bound.
+    | Unknown
+    -- ^ Result is unknown within the bound.
+    deriving (Show)
+
+check
+    :: MetaOrObject level
+    => MetadataTools level StepperAttributes
+    -> StepPatternSimplifier level
+    -- ^ Simplifies normal patterns through, e.g., function evaluation
+    -> PredicateSubstitutionSimplifier level
+    -- ^ Simplifies predicates
+    -> BuiltinAndAxiomSimplifierMap level
+    -- ^ Map from symbol IDs to defined functions
+    ->  (  CommonModalPattern level
+        -> [Strategy
+            (Prim
+                (CommonModalPattern level)
+                (RewriteRule level Variable)
+            )
+           ]
+        )
+    -- ^ Creates a one-step strategy from a target pattern. See
+    -- 'defaultStrategy'.
+    -> [(ImplicationRule level Variable, Limit Natural)]
+    -- ^ List of claims, together with a maximum number of verification steps
+    -- for each.
+    -> Simplifier [CheckResult]
+check
+    metadataTools
+    simplifier
+    substitutionSimplifier
+    axiomIdToSimplifier
+    strategyBuilder
+  =
+    mapM
+        (checkClaim
+            metadataTools
+            simplifier
+            substitutionSimplifier
+            axiomIdToSimplifier
+            strategyBuilder
+        )
+
+bmcStrategy
+    :: forall level . (MetaOrObject level)
+    => [Axiom level]
+    -> CommonModalPattern level
+    -> [Strategy
+        (Prim
+            (CommonModalPattern level)
+            (RewriteRule level Variable)
+        )
+       ]
+bmcStrategy
+    axioms
+    goal
+  =  repeat (defaultOneStepStrategy goal rewrites)
+  where
+    rewrites :: [RewriteRule level Variable]
+    rewrites = map unwrap axioms
+      where
+        unwrap (Axiom a) = a
+
+checkClaim
+    :: forall level . (MetaOrObject level)
+    => MetadataTools level StepperAttributes
+    -> StepPatternSimplifier level
+    -> PredicateSubstitutionSimplifier level
+    -> BuiltinAndAxiomSimplifierMap level
+    -- ^ Map from symbol IDs to defined functions
+    ->  (  CommonModalPattern level
+        -> [Strategy
+            (Prim
+                (CommonModalPattern level)
+                (RewriteRule level Variable)
+            )
+           ]
+        )
+    -> (ImplicationRule level Variable, Limit Natural)
+    -> Simplifier CheckResult
+checkClaim
+    metadataTools
+    simplifier
+    substitutionSimplifier
+    axiomIdToSimplifier
+    strategyBuilder
+    (ImplicationRule RulePattern { left, right }, stepLimit)
+  = do
+        let
+            App_ SymbolOrAlias { symbolOrAliasConstructor = symbol } [prop] = right
+            goalPattern = ModalPattern { modalOp = getId symbol, term = prop }
+            strategy =
+                Limit.takeWithin
+                    stepLimit
+                    (strategyBuilder goalPattern)
+            startState :: CommonProofState level
+            startState =
+                ProofState.GoalLHS
+                    Predicated
+                        {term = left, predicate = Predicate.makeTruePredicate, substitution = mempty}
+        executionGraph <- runStrategy transitionRule' strategy startState
+        let
+            finalResult = (checkFinalNodes . pickFinal) executionGraph
+        trace (show finalResult) (return finalResult)
+  where
+    transitionRule'
+        :: Prim (CommonModalPattern level) (RewriteRule level Variable)
+        -> (CommonProofState level)
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level)
+    transitionRule' =
+        ModelChecker.transitionRule
+            metadataTools
+            substitutionSimplifier
+            simplifier
+            axiomIdToSimplifier
+
+    checkFinalNodes
+        :: [CommonProofState level]
+        -> CheckResult
+    checkFinalNodes nodes
+      = Foldable.foldl' checkFinalNodesHelper Proved nodes
+      where
+        checkFinalNodesHelper Proved  ProofState.Proven = Proved
+        checkFinalNodesHelper Proved  ProofState.Unprovable = Failed
+        checkFinalNodesHelper Proved  _ = Unknown
+        checkFinalNodesHelper Unknown ProofState.Unprovable = Failed
+        checkFinalNodesHelper Unknown _ = Unknown
+        checkFinalNodesHelper Failed  _ = Failed

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -1,6 +1,5 @@
 {-|
-Module      : Kore.ModelChecker.Bounded
-Copyright   : (c) Runtime Verification, 2018
+Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -28,8 +28,8 @@ import           Kore.Attribute.Symbol
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools )
 import           Kore.ModelChecker.Step
-                 ( CommonModalPattern, ModalPattern (..), Prim (..), CommonProofState,
-                   defaultOneStepStrategy )
+                 ( CommonModalPattern, CommonProofState, ModalPattern (..),
+                 Prim (..), defaultOneStepStrategy )
 import qualified Kore.ModelChecker.Step as ProofState
                  ( ProofState (..) )
 import qualified Kore.ModelChecker.Step as ModelChecker
@@ -44,12 +44,13 @@ import           Kore.Step.Representation.ExpandedPattern
 import           Kore.Step.Representation.ExpandedPattern as Predicated
                  ( Predicated (..) )
 import           Kore.Step.Rule
-                 ( RulePattern (..), RewriteRule, ImplicationRule (ImplicationRule) )
+                 ( ImplicationRule (ImplicationRule), RewriteRule,
+                 RulePattern (..) )
 import           Kore.Step.Simplification.Data
                  ( PredicateSubstitutionSimplifier, Simplifier,
                  StepPatternSimplifier )
 import           Kore.Step.Strategy
-                 ( Strategy, pickFinal, TransitionT, runStrategy )
+                 ( Strategy, TransitionT, pickFinal, runStrategy )
 import           Numeric.Natural
                  ( Natural )
 

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -29,7 +29,8 @@ import           Kore.Step.Representation.ExpandedPattern
                  ( CommonExpandedPattern, Predicated (..) )
 import qualified Kore.Step.Representation.ExpandedPattern as ExpandedPattern
 import           Kore.Step.Simplification.Data
-                 ( PredicateSubstitutionSimplifier, Simplifier, StepPatternSimplifier )
+                 ( PredicateSubstitutionSimplifier, Simplifier,
+                 StepPatternSimplifier )
 import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
                  ( simplify )
 import           Kore.TopBottom

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -1,0 +1,97 @@
+{-|
+Module      : Kore.ModelChecker.Simplification
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+
+module Kore.ModelChecker.Simplification
+    ( checkImplicationIsTop
+    ) where
+
+import qualified Data.Set as Set
+import qualified Data.Text.Prettyprint.Doc as Pretty
+
+import           Kore.AST.Common
+                 ( Variable )
+import           Kore.AST.MetaOrObject
+import           Kore.AST.Valid
+import           Kore.Attribute.Symbol
+                 ( StepperAttributes )
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import qualified Kore.Predicate.Predicate as Predicate
+import           Kore.Step.Axiom.Data
+                 ( BuiltinAndAxiomSimplifierMap )
+import           Kore.Step.Pattern
+                 ( CommonStepPattern )
+import qualified Kore.Step.Pattern as Pattern
+import           Kore.Step.Representation.ExpandedPattern
+                 ( CommonExpandedPattern, Predicated (..) )
+import qualified Kore.Step.Representation.ExpandedPattern as ExpandedPattern
+import           Kore.Step.Simplification.Data
+                 ( PredicateSubstitutionSimplifier, Simplifier, StepPatternSimplifier )
+import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
+                 ( simplify )
+import           Kore.TopBottom
+                 ( TopBottom (..) )
+import           Kore.Unparser
+import           Kore.Variables.Fresh
+
+checkImplicationIsTop
+    :: forall level . (MetaOrObject level)
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level
+    -> StepPatternSimplifier level
+    -- ^ Evaluates functions in patterns
+    -> BuiltinAndAxiomSimplifierMap level
+    -- ^ Map from symbol IDs to defined functions
+    -> CommonExpandedPattern level
+    -> CommonStepPattern level
+    -> Simplifier Bool
+checkImplicationIsTop
+    tools
+    predicateSimplifier
+    patternSimplifier
+    axiomSimplifers
+    lhs
+    rhs
+  = case (stripForallQuantifiers rhs) of
+        ( forallQuantifiers, Implies_ _ implicationLHS implicationRHS ) -> do
+            let rename = refreshVariables lhsFreeVariables forallQuantifiers
+                subst = mkVar <$> rename
+                implicationLHS' = Pattern.substitute subst implicationLHS
+                implicationRHS' = Pattern.substitute subst implicationRHS
+                resultTerm = mkCeil_
+                                (mkAnd
+                                    (mkAnd lhsMLPatt implicationLHS')
+                                    (mkNot implicationRHS')
+                                )
+                result = Predicated
+                            { term = resultTerm, predicate = Predicate.makeTruePredicate, substitution = mempty}
+            (orResult, _) <- ExpandedPattern.simplify
+                                tools
+                                predicateSimplifier
+                                patternSimplifier
+                                axiomSimplifers
+                                result
+            return (isBottom orResult)
+        _ -> (error . show . Pretty.vsep)
+             [ "Not implemented error:"
+             , "We don't know how to simplify the implication whose rhs is:"
+             , Pretty.indent 4 (unparse rhs)
+             ]
+      where
+        lhsFreeVariables = ExpandedPattern.freeVariables lhs
+        lhsMLPatt = ExpandedPattern.toMLPattern lhs
+
+stripForallQuantifiers
+    :: CommonStepPattern level
+    -> (Set.Set (Variable level), CommonStepPattern level)
+stripForallQuantifiers patt
+  = case patt of
+        Forall_ _ forallVar child ->
+            let
+                ( childVars, strippedChild ) = stripForallQuantifiers child
+            in
+                ( Set.insert forallVar childVars, strippedChild)
+        _ -> ( Set.empty , patt )

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -17,7 +17,7 @@ import           Kore.AST.Valid
 import           Kore.Attribute.Symbol
                  ( StepperAttributes )
 import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools )
+                 ( SmtMetadataTools )
 import qualified Kore.Predicate.Predicate as Predicate
 import           Kore.Step.Axiom.Data
                  ( BuiltinAndAxiomSimplifierMap )
@@ -39,7 +39,7 @@ import           Kore.Variables.Fresh
 
 checkImplicationIsTop
     :: forall level . (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    => SmtMetadataTools StepperAttributes
     -> PredicateSubstitutionSimplifier level
     -> StepPatternSimplifier level
     -- ^ Evaluates functions in patterns

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -1,6 +1,5 @@
 {-|
-Module      : Kore.ModelChecker.Simplification
-Copyright   : (c) Runtime Verification, 2018
+Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -1,6 +1,5 @@
 {-|
-Module      : Kore.ModelChecker.Step
-Copyright   : (c) Runtime Verification, 2018
+Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -31,7 +31,7 @@ import           Kore.AST.MetaOrObject
 import           Kore.Attribute.Symbol
                  ( StepperAttributes )
 import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools )
+                 ( SmtMetadataTools )
 import           Kore.ModelChecker.Simplification
                  ( checkImplicationIsTop )
 import           Kore.Step.Axiom.Data
@@ -107,7 +107,7 @@ type Transition = TransitionT (RewriteRule Object Variable) Simplifier
 
 transitionRule
     :: forall level . (MetaOrObject level)
-    => MetadataTools level StepperAttributes
+    => SmtMetadataTools StepperAttributes
     -> PredicateSubstitutionSimplifier level
     -> StepPatternSimplifier level
     -- ^ Evaluates functions in patterns

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -1,0 +1,287 @@
+{-|
+Module      : Kore.ModelChecker.Step
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+
+module Kore.ModelChecker.Step
+    ( -- * Primitive strategies
+      Prim (..)
+    , ModalPattern (..)
+    , CommonModalPattern
+    , ProofState (..)
+    , CommonProofState
+    , transitionRule
+    , defaultOneStepStrategy
+    ) where
+
+import           Control.Applicative
+                 ( Alternative (..) )
+import qualified Control.Monad.Trans as Monad.Trans
+import qualified Data.Foldable as Foldable
+import           Data.Hashable
+import           Data.Text
+                 ( Text )
+import qualified Data.Text.Prettyprint.Doc as Pretty
+import           Debug.Trace
+import           GHC.Generics
+
+import           Kore.AST.Common
+                 ( Variable )
+import           Kore.AST.MetaOrObject
+import           Kore.Attribute.Symbol
+                 ( StepperAttributes )
+import           Kore.IndexedModule.MetadataTools
+                 ( MetadataTools )
+import           Kore.ModelChecker.Simplification
+                 ( checkImplicationIsTop )
+import           Kore.Step.Axiom.Data
+                 ( BuiltinAndAxiomSimplifierMap )
+import           Kore.Step.Pattern
+                 ( StepPattern )
+import           Kore.Step.Representation.ExpandedPattern
+                 ( CommonExpandedPattern )
+import qualified Kore.Step.Representation.ExpandedPattern as ExpandedPattern
+import qualified Kore.Step.Representation.MultiOr as MultiOr
+import qualified Kore.Step.Representation.Predicated as Predicated
+import           Kore.Step.Rule
+                 ( RewriteRule (RewriteRule) )
+import           Kore.Step.Simplification.Data
+                 ( PredicateSubstitutionSimplifier, Simplifier,
+                 StepPatternSimplifier )
+import qualified Kore.Step.Simplification.ExpandedPattern as ExpandedPattern
+                 ( simplify )
+import qualified Kore.Step.Step as Step
+import           Kore.Step.Strategy
+                 ( Strategy, TransitionT )
+import qualified Kore.Step.Strategy as Strategy
+import qualified Kore.Step.Transition as Transition
+import qualified Kore.Unification.Procedure as Unification
+import qualified Kore.Unification.Unify as Monad.Unify
+import           Kore.Unparser
+
+data Prim patt rewrite =
+      CheckProofState
+    -- ^ Check the proof state and decide whether to terminate the computation
+    | Simplify
+    -- ^ Builtin and function symbol simplification step
+    | Unroll !patt
+    -- ^ Unroll the proof goal
+    | ComputeWeakNext ![rewrite]
+    -- ^ Compute next states
+    deriving (Show)
+
+data ModalPattern level variable = ModalPattern
+    { modalOp :: !Text
+    , term  :: !(StepPattern level variable)
+    } deriving (Eq, Show)
+
+type CommonModalPattern level = ModalPattern level Variable
+
+data ProofState patt
+    = Proven
+    | Unprovable
+    | GoalLHS !patt
+    -- ^ State on which a normal 'Rewrite' can be applied. Also used
+    -- for the start patterns.
+    | GoalRemLHS !patt
+    -- ^ State which can't be rewritten anymore.
+  deriving (Show, Eq, Ord, Generic)
+
+-- | A 'ProofState' instantiated to 'CommonExpandedPattern' for convenience.
+type CommonProofState level = ProofState (CommonExpandedPattern level)
+
+instance Hashable patt => Hashable (ProofState patt)
+
+checkProofState :: Prim patt rewriteResult
+checkProofState = CheckProofState
+
+simplify :: Prim patt rewrite
+simplify = Simplify
+
+unroll :: patt -> Prim patt rewrite
+unroll = Unroll
+
+computeWeakNext :: [rewrite] -> Prim patt rewrite
+computeWeakNext = ComputeWeakNext
+
+transitionRule
+    :: forall level . (MetaOrObject level)
+    => MetadataTools level StepperAttributes
+    -> PredicateSubstitutionSimplifier level
+    -> StepPatternSimplifier level
+    -- ^ Evaluates functions in patterns
+    -> BuiltinAndAxiomSimplifierMap level
+    -- ^ Map from symbol IDs to defined functions
+    -> Prim (CommonModalPattern level) (RewriteRule level Variable)
+    -> CommonProofState level
+    -> TransitionT (RewriteRule level Variable) Simplifier
+        (CommonProofState level)
+transitionRule
+    tools
+    predicateSimplifier
+    patternSimplifier
+    axiomSimplifiers
+    strategyPrim
+    proofState
+  =
+    case strategyPrim of
+        CheckProofState -> transitionCheckProofState proofState
+        Simplify -> transitionSimplify proofState
+        Unroll goalrhs -> transitionUnroll goalrhs proofState
+        ComputeWeakNext rewrites -> transitionComputeWeakNext rewrites proofState
+  where
+    transitionCheckProofState
+        :: CommonProofState level
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level )
+    transitionCheckProofState Proven = empty
+    transitionCheckProofState Unprovable = empty
+    transitionCheckProofState ps = return ps
+
+    transitionSimplify
+        :: CommonProofState level
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level )
+    transitionSimplify Proven = return Proven
+    transitionSimplify Unprovable = return Unprovable
+    transitionSimplify (GoalLHS config) =
+        applySimplify GoalLHS config
+    transitionSimplify (GoalRemLHS config) =
+        applySimplify GoalRemLHS config
+
+    applySimplify wrapper config =
+        do
+            (configs, _) <-
+                Monad.Trans.lift
+                $ ExpandedPattern.simplify
+                    tools
+                    predicateSimplifier
+                    patternSimplifier
+                    axiomSimplifiers
+                    config
+            let
+                -- Filter out ⊥ patterns
+                nonEmptyConfigs = MultiOr.filterOr configs
+            if null nonEmptyConfigs
+                then return Proven
+                else Foldable.asum (pure <$> map wrapper (Foldable.toList nonEmptyConfigs))
+
+    transitionUnroll
+        :: CommonModalPattern level
+        -> CommonProofState level
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level )
+    transitionUnroll _ Proven = empty
+    transitionUnroll _ Unprovable = empty
+    transitionUnroll goalrhs (GoalLHS config)
+        | ExpandedPattern.isBottom config = return Proven
+        | otherwise = applyUnroll goalrhs GoalLHS config
+    transitionUnroll goalrhs (GoalRemLHS config)
+        | ExpandedPattern.isBottom config = return Proven
+        | otherwise = applyUnroll goalrhs GoalRemLHS config
+
+    applyUnroll ModalPattern { modalOp, term } wrapper config
+      = case modalOp of
+            "ag" -> do
+                result <-
+                    Monad.Trans.lift
+                    $ checkImplicationIsTop
+                        tools
+                        predicateSimplifier
+                        patternSimplifier
+                        axiomSimplifiers
+                        config
+                        term
+                if result
+                    then return (wrapper config)
+                    else do
+                        trace
+                            (show . Pretty.vsep
+                                $ [ "config failed to prove the invariant:"
+                                  , Pretty.indent 4 (unparse config)
+                                  ]
+                            )
+                            return Unprovable
+            _ -> (error . show . Pretty.vsep)
+                 [ "Not implemented error:"
+                 , "We don't know how to unroll the modalOp:"
+                 , Pretty.pretty modalOp
+                 ]
+
+    transitionComputeWeakNext
+        :: [RewriteRule level Variable]
+        -> CommonProofState level
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level)
+    transitionComputeWeakNext _ Proven = return Proven
+    transitionComputeWeakNext _ Unprovable = return Unprovable
+    transitionComputeWeakNext rules (GoalLHS config)
+      = transitionComputeWeakNextHelper rules config
+    transitionComputeWeakNext _ (GoalRemLHS _)
+      = return (GoalLHS ExpandedPattern.bottom)
+
+    transitionComputeWeakNextHelper
+        :: [RewriteRule level Variable]
+        -> (CommonExpandedPattern level)
+        -> TransitionT (RewriteRule level Variable) Simplifier
+            (CommonProofState level)
+    transitionComputeWeakNextHelper _ config
+        | ExpandedPattern.isBottom config = return Proven
+    transitionComputeWeakNextHelper rules config = do
+        result <-
+            Monad.Trans.lift
+            $ Monad.Unify.runUnifier
+            $ Step.applyRewriteRules
+                tools
+                predicateSimplifier
+                patternSimplifier
+                axiomSimplifiers
+                (Step.UnificationProcedure Unification.unificationProcedure)
+                rules
+                config
+        case result of
+            Left _ ->
+                (error . show . Pretty.vsep)
+                [ "Not implemented error:"
+                , "while applying a \\rewrite axiom to the pattern:"
+                , Pretty.indent 4 (unparse config)
+                ,   "We decided to end the execution because we don't \
+                    \understand this case well enough at the moment."
+                ]
+            Right Step.Results { results, remainders } -> do
+                let
+                    rewriteResults, remainderResults
+                        ::  MultiOr.MultiOr
+                                (TransitionT
+                                    (RewriteRule level Variable)
+                                    Simplifier
+                                    ( CommonProofState level)
+                                )
+                    rewriteResults = transition <$> results
+                    transition result' = do
+                        let rule =
+                                Step.unwrapRule
+                                $ Predicated.term $ Step.unifiedRule result'
+                        Transition.addRule (RewriteRule rule)
+                        return (GoalLHS $ Step.result result')
+                    remainderResults =
+                        pure . GoalRemLHS <$> remainders
+
+                Foldable.asum
+                    (MultiOr.uncheckedMerge rewriteResults remainderResults)
+
+defaultOneStepStrategy
+    :: patt
+    -- ^ The modal pattern.
+    -> [rewrite]
+    -- ^ normal rewrites
+    -> Strategy (Prim patt rewrite)
+defaultOneStepStrategy goalrhs rewrites =
+    Strategy.sequence
+        [ Strategy.apply checkProofState
+        , Strategy.apply simplify
+        , Strategy.apply (unroll goalrhs)
+        , Strategy.apply (computeWeakNext rewrites)
+        , Strategy.apply simplify
+        ]

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -44,7 +44,7 @@ import           Kore.Step.Axiom.UserDefined
                  ( equalityRuleEvaluator )
 import           Kore.Step.Rule
                  ( EqualityRule (EqualityRule),
-                 QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, OnePathClaimPattern, RewriteAxiomPattern),
+                 QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, OnePathClaimPattern, ImplicationAxiomPattern, RewriteAxiomPattern),
                  RulePattern (RulePattern),
                  verifiedKoreSentenceToAxiomPattern )
 import qualified Kore.Step.Rule
@@ -113,6 +113,7 @@ axiomToIdAxiomPatternPair level (asKoreAxiomSentence -> axiom) =
         Right (RewriteAxiomPattern _) -> Nothing
         Right (OnePathClaimPattern _) -> Nothing
         Right (AllPathClaimPattern _) -> Nothing
+        Right (ImplicationAxiomPattern _) -> Nothing
 
 -- |Converts a registry of 'RulePattern's to one of
 -- 'BuiltinAndAxiomSimplifier's

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -44,7 +44,7 @@ import           Kore.Step.Axiom.UserDefined
                  ( equalityRuleEvaluator )
 import           Kore.Step.Rule
                  ( EqualityRule (EqualityRule),
-                 QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, OnePathClaimPattern, ImplicationAxiomPattern, RewriteAxiomPattern),
+                 QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, ImplicationAxiomPattern, OnePathClaimPattern, RewriteAxiomPattern),
                  RulePattern (RulePattern),
                  verifiedKoreSentenceToAxiomPattern )
 import qualified Kore.Step.Rule

--- a/src/main/k/in-progress/bmc/example1/bmc.k
+++ b/src/main/k/in-progress/bmc/example1/bmc.k
@@ -1,0 +1,47 @@
+module BMC-SYNTAX
+  imports DOMAINS-SYNTAX
+
+  syntax KItem ::= "#execute"
+                 | "#branchNoChange" | "#branchIncrease"
+                 | "#minusOne" | "#addOne"
+
+endmodule
+
+module BMC
+  imports BMC-SYNTAX
+  imports DOMAINS
+
+  configuration <T>
+                  <k> #execute </k>
+                  <state> "x" |-> 0 </state>
+                </T>
+
+  rule <k> #execute => #branchIncrease ~> #execute ... </k>
+       <state> "x" |-> X </state>
+    requires X <Int 0
+
+  rule <k> #execute => #branchNoChange ~> #execute ... </k>
+       <state> "x" |-> X </state>
+    requires 0 <Int X andBool X <=Int 5
+
+  rule <k> #execute => #branchNoChange ~> #execute ... </k>
+       <state> "x" |-> X </state>
+    requires X >Int 5
+
+  rule <k> #execute => #branchIncrease ~> #execute ... </k>
+       <state> "x" |-> X </state>
+    requires X >Int 5
+
+  rule <k> #branchNoChange => #minusOne ~> #addOne ...</k>
+
+  rule <k> #branchIncrease => #addOne ...</k>
+
+  rule <k> #minusOne => . ... </k>
+       <state> "x" |-> (X => X -Int 1) </state>
+
+  rule <k> #addOne => . ... </k>
+       <state> "x" |-> (X => X +Int 1) </state>
+
+endmodule
+
+

--- a/src/main/k/in-progress/bmc/example1/check/fail/test1.kore
+++ b/src/main/k/in-progress/bmc/example1/check/fail/test1.kore
@@ -1,0 +1,40 @@
+[]
+module TEST1-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> 6 </state>) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X <Int 10))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("10")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/fail/test2.kore
+++ b/src/main/k/in-progress/bmc/example1/check/fail/test2.kore
@@ -1,0 +1,40 @@
+[]
+module TEST2-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state>) -> AG (forall Y.((<k> #execute </k> <state> "x" |-> Y </state>) -> X ==Int Y))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{}, VarY:SortInt{}),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/fail/test3.kore
+++ b/src/main/k/in-progress/bmc/example1/check/fail/test3.kore
@@ -1,0 +1,43 @@
+[]
+module TEST3-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state> /\ 0 <Int X) -> AG (forall Y.((<k> _ </k> <state> "x" |-> Y </state>) -> 0 <Int Y))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+          \dv{SortInt{}}("0"),
+          VarX:SortInt{}),
+        \dv{SortBool{}}("true")),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(Var'Unds'19:SortK{}),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("0"), VarY:SortInt{}),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test1.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test1.kore
@@ -1,0 +1,40 @@
+[]
+module TEST1-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> -3 </state>) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X <=Int 0))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("-3"))))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("0")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test2.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test2.kore
@@ -1,0 +1,40 @@
+[]
+module TEST2-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> 0 </state>) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X ==Int 0))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("0")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test3.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test3.kore
@@ -1,0 +1,40 @@
+[]
+module TEST3-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> 2 </state>) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X ==Int 2))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("2"))))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("2")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test4.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test4.kore
@@ -1,0 +1,40 @@
+[]
+module TEST4-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> 6 </state>) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X >=Int 6))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6"))))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("6")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test5.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test5.kore
@@ -1,0 +1,48 @@
+[]
+module TEST5-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state> /\ 0 <Int X /\ X <Int 4) -> AG (forall X.((<k> #execute </k> <state> "x" |-> X </state>) -> X <Int 4))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(
+          Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+            \dv{SortInt{}}("0"),
+            VarX:SortInt{}),
+          Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+            VarX:SortInt{},
+            \dv{SortInt{}}("4"))),
+        \dv{SortBool{}}("true")),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarX:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("4")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test6.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test6.kore
@@ -1,0 +1,44 @@
+[]
+module TEST6-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state> /\ X <Int -2) -> AG (forall Y.((<k> #execute </k> <state> "x" |-> Y </state>) -> Y <=Int 0))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+          VarX:SortInt{},
+          \dv{SortInt{}}("-2")),
+        \dv{SortBool{}}("true")),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarY:SortInt{},\dv{SortInt{}}("0")),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test7.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test7.kore
@@ -1,0 +1,48 @@
+[]
+module TEST7-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state> /\ 0 <Int X /\ X <Int 4) -> AG (forall Y.((<k> #execute </k> <state> "x" |-> Y </state>) -> X ==Int Y))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(
+          Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+            \dv{SortInt{}}("0"),
+            VarX:SortInt{}),
+          Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+            VarX:SortInt{},
+            \dv{SortInt{}}("4"))),
+        \dv{SortBool{}}("true")),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{}, VarY:SortInt{}),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test8.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test8.kore
@@ -1,0 +1,40 @@
+[]
+module TEST8-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state>) -> AG (forall Y.((<k> #execute </k> <state> "x" |-> Y </state>) -> X <=Int Y))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(
+                kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{}, VarY:SortInt{}),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/check/success/test9.kore
+++ b/src/main/k/in-progress/bmc/example1/check/success/test9.kore
@@ -1,0 +1,43 @@
+[]
+module TEST9-SPEC
+
+// imports
+import VERIFICATION []
+
+
+// claims
+// (<k> #execute </k> <state> "x" |-> X </state> /\ 2 <Int X) -> AG (forall Y.((<k> _ </k> <state> "x" |-> Y </state>) -> 0 <Int Y))
+  claim{} \implies{SortGeneratedTopCell{}} (
+    \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(
+          \dv{SortInt{}}("2"),
+          VarX:SortInt{}),
+        \dv{SortBool{}}("true")),
+      Lbl'-LT-'generatedTop'-GT-'{}(
+        Lbl'-LT-'T'-GT-'{}(
+          Lbl'-LT-'k'-GT-'{}(
+            kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}())),
+          Lbl'-LT-'state'-GT-'{}(
+            Lbl'UndsPipe'-'-GT-Unds'{}(
+              inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+              inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),
+        VarDotVar0:SortGeneratedCounterCell{})),
+    ag{SortGeneratedTopCell{}}(
+      \forall{SortGeneratedTopCell{}}(
+        VarY:SortInt{},
+        \implies{SortGeneratedTopCell{}}(
+          Lbl'-LT-'generatedTop'-GT-'{}(
+            Lbl'-LT-'T'-GT-'{}(
+              Lbl'-LT-'k'-GT-'{}(Var'Unds'19:SortK{}),
+              Lbl'-LT-'state'-GT-'{}(
+                Lbl'UndsPipe'-'-GT-Unds'{}(
+                  inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),
+                  inj{SortInt{}, SortKItem{}}(VarY:SortInt{})))),
+            VarDotVar0:SortGeneratedCounterCell{}),
+          \equals{SortBool{},SortGeneratedTopCell{}}(
+            Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("0"), VarY:SortInt{}),
+            \dv{SortBool{}}("true"))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}(), contentStartLine{}(), contentStartColumn{}(), org'Stop'kframework'Stop'definition'Stop'Production{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}()]

--- a/src/main/k/in-progress/bmc/example1/vdefinition.kore
+++ b/src/main/k/in-progress/bmc/example1/vdefinition.kore
@@ -1,0 +1,5010 @@
+[topCellInitializer{}(LblinitGeneratedTopCell{}())]
+
+module BASIC-K
+  sort SortK{} []
+  sort SortKItem{} []
+endmodule []
+
+module KSEQ
+  import BASIC-K []
+
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+  symbol dotk{}() : SortK{} []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(dotk{}(),K2:SortK{}),
+      K2:SortK{})
+  []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
+      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
+  []
+
+endmodule []
+
+module INJ
+  symbol inj{From,To}(From) : To [sortInjection{}()]
+ 
+  axiom{S1,S2,S3,R} 
+    \equals{S3,R}(
+      inj{S2,S3}(inj{S1,S2}(T:S1)),
+      inj{S1,S3}(T:S1))
+  []
+
+endmodule []
+
+module K
+  import KSEQ []
+  import INJ []
+
+  alias ag{S}(S) : S
+  where ag{S}(X:S) := X:S []
+
+endmodule []
+
+module VERIFICATION
+
+// imports
+  import K []
+
+// sorts
+  sort SortTCellFragment{} []
+  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(363,3,363,28)"), hook{}("INT.Int")]
+  sort SortTCell{} []
+  sort SortKCellOpt{} []
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(188,3,188,28)"), hook{}("SET.Set")]
+  sort SortStateCell{} []
+  sort SortGeneratedCounterCellOpt{} []
+  hooked-sort SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,3,306,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), hook{}("BOOL.Bool")]
+  sort Sort'Hash'KVariable{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(69,3,69,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/kast.k)")]
+  sort SortCell{} []
+  hooked-sort SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(543,3,543,37)")]
+  sort SortGeneratedCounterCell{} []
+  sort SortGeneratedTopCell{} []
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,3,232,31)"), hook{}("LIST.List")]
+  sort SortKCell{} []
+  sort SortIOError{} []
+  sort SortTCellOpt{} []
+  sort SortStateCellOpt{} []
+  hooked-sort SortFloat{} [hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(462,3,462,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)")]
+  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)"), token{}()]
+  sort SortIOInt{} []
+  sort SortIOString{} []
+  sort SortId{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(779,3,779,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), token{}()]
+  sort SortStream{} []
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(96,3,96,28)"), hook{}("MAP.Map")]
+  sort SortGeneratedTopCellFragment{} []
+
+// symbols
+  hooked-symbol Lbl'Hash'isConcrete'LParUndsRParUnds'K-REFLECTION-SYMBOLIC'UndsUnds'K{}(SortK{}) : SortBool{} [productionID{}("397071633"), klabel{}("#isConcrete"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(859,19,859,73)"), function{}(), hook{}("KREFLECTION.isConcrete")]
+  hooked-symbol Lbl'Hash'stat'LParUndsRParUnds'K-IO'UndsUnds'String{}(SortString{}) : SortKItem{} [productionID{}("1763260873"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(954,20,954,75)"), function{}(), hook{}("IO.stat")]
+  hooked-symbol Lbl'Hash'sort'LParUndsRParUnds'K-REFLECTION'UndsUnds'K{}(SortK{}) : SortString{} [productionID{}("1104422581"), klabel{}("#sort"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(839,21,839,63)"), function{}(), hook{}("KREFLECTION.sort")]
+  hooked-symbol Lbl'Hash'opendir'LParUndsRParUnds'K-IO'UndsUnds'String{}(SortString{}) : SortKItem{} [productionID{}("236567414"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(956,20,956,81)"), function{}(), hook{}("IO.opendir")]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("or"), productionID{}("693267461"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(318,19,318,158)"), function{}(), boolOperation{}(), hook{}("BOOL.or")]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [productionID{}("369671357"), klabel{}("absInt"), functional{}(), originalPrd{}(), smtlib{}("int_abs"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(403,18,403,102)"), function{}(), hook{}("INT.abs")]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [productionID{}("1874028013"), klabel{}("#EPROTONOSUPPORT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(913,22,913,74)"), constructor{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortTCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [productionID{}("1850042097"), klabel{}("values"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,19,146,76)"), function{}(), hook{}("MAP.values")]
+  symbol Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}() : SortKItem{} [productionID{}("1711185459"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,20,4,29)"), constructor{}()]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [productionID{}("883455411"), klabel{}("#ECONNRESET"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(924,22,924,64)"), constructor{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [productionID{}("2131960182"), klabel{}("List:get"), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,20,275,98)"), function{}(), hook{}("LIST.get")]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("1997702454"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(587,19,587,82)"), function{}(), hook{}("STRING.gt")]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [productionID{}("1659840424"), klabel{}("#EEXIST"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(876,22,876,56)"), constructor{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortKItem{} [productionID{}("461129530"), klabel{}("Map:choice"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(155,20,155,100)"), function{}(), hook{}("MAP.choice")]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}("distinct"), productionID{}("1804126860"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(414,19,414,162)"), function{}(), hook{}("INT.ne")]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}()]
+  symbol LblisTCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCellOpt"), originalPrd{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [productionID{}("1668837760"), klabel{}("Map:lookup"), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(117,20,117,112)"), function{}(), hook{}("MAP.lookup")]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortTCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [functional{}(), cell{}(), originalPrd{}(), cellName{}("generatedTop"), format{}("%2"), topcell{}(), constructor{}()]
+  symbol LblinitKCell{}() : SortKCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [function{}(), predicate{}("Stream"), originalPrd{}()]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [productionID{}("1077873186"), klabel{}("#EPERM"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(898,22,898,54)"), constructor{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCellFragment"), originalPrd{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [productionID{}("187457031"), klabel{}("signExtendBitRangeInt"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(407,18,407,118)"), function{}(), hook{}("INT.signExtendBitRange")]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCell"), originalPrd{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCell"), originalPrd{}()]
+  symbol LblisTCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCellFragment"), originalPrd{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [productionID{}("1812831622"), klabel{}("SetItem"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(201,18,201,112)"), function{}(), hook{}("SET.element")]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [productionID{}("176683244"), klabel{}(".Map"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("\\dotCt{Map}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(106,18,106,128)"), function{}(), hook{}("MAP.unit")]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(".Set"), productionID{}("1398241764"), klabel{}("_Set_"), functional{}(), originalPrd{}(), element{}("SetItem"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), format{}("%1%n%2"), left{}(), assoc{}(), idem{}(), comm{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(194,18,194,176)"), function{}(), hook{}("SET.concat")]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [productionID{}("116289363"), klabel{}("#EHOSTUNREACH"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(933,22,933,68)"), constructor{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), cell{}(), originalPrd{}(), cellName{}("k"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), format{}("%1%i%n%2%d%n%3"), contentStartLine{}("14"), contentStartColumn{}("17"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,17,17,21)"), maincell{}(), constructor{}()]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [productionID{}("1280429864"), klabel{}("#ERANGE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(900,22,900,56)"), constructor{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("1424482154"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(585,19,585,82)"), function{}(), hook{}("STRING.lt")]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [productionID{}("790487766"), klabel{}("#ENOLCK"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(890,22,890,56)"), constructor{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [productionID{}("473153915"), klabel{}("Base2String"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(572,21,572,92)"), function{}(), hook{}("STRING.base2string")]
+  symbol Lbl'Hash'projectInt'LParUndsRParUnds'K-IO'UndsUnds'IOInt{}(SortIOInt{}) : SortInt{} [productionID{}("1573751930"), klabel{}("#projectInt"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(986,18,986,46)"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("1072506992"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(586,19,586,82)"), function{}(), hook{}("STRING.le")]
+  hooked-symbol Lbl'Hash'getKLabelString'LParUndsRParUnds'K-REFLECTION-SYMBOLIC'UndsUnds'K{}(SortK{}) : SortString{} [productionID{}("1963075870"), klabel{}("#getKLabelString"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(856,21,856,85)"), function{}(), hook{}("KREFLECTION.getKLabelString")]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCellOpt"), originalPrd{}()]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [productionID{}("1195942137"), klabel{}("#ENOBUFS"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(925,22,925,58)"), constructor{}()]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [productionID{}("1034094674"), klabel{}("#ENXIO"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(897,22,897,54)"), constructor{}()]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [productionID{}("1528741718"), klabel{}("#EALREADY"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(907,22,907,60)"), constructor{}()]
+  hooked-symbol Lbl'Hash'parseInModule'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortKItem{} [productionID{}("1901238627"), klabel{}("#parseInModule"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(959,20,962,76)"), function{}(), hook{}("IO.parseInModule")]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [productionID{}("692743054"), klabel{}("#ENOTSOCK"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(908,22,908,60)"), constructor{}()]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [productionID{}("1908571880"), klabel{}("#EWOULDBLOCK"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(905,22,905,66)"), constructor{}()]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [productionID{}("1792227359"), klabel{}("#ENETUNREACH"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(921,22,921,66)"), constructor{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [productionID{}("1690101810"), klabel{}("directionalityChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(591,21,591,86)"), function{}(), hook{}("STRING.directionality")]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("87674905"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,18,392,131)"), function{}(), hook{}("INT.shr")]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [productionID{}("2031588185"), klabel{}("#ENFILE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(886,22,886,56)"), constructor{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [productionID{}("330128595"), klabel{}("Int2String"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(571,21,571,103)"), function{}(), hook{}("STRING.int2string")]
+  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("147022238"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(397,18,397,146)"), function{}(), hook{}("INT.xor")]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'UndsUnds'String{}(SortString{}) : SortIOInt{} [productionID{}("1262408432"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(940,20,940,52)"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'UndsUnds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [productionID{}("1808432653"), klabel{}("List:set"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,93)"), function{}(), hook{}("LIST.update")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("and"), productionID{}("1380924218"), klabel{}("_andBool_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,19,315,189)"), function{}(), boolOperation{}(), hook{}("BOOL.and")]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [productionID{}("1633013890"), klabel{}("#EOF"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(867,22,867,50)"), constructor{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [smt-hook{}("="), productionID{}("851912430"), klabel{}("_==K_"), equalEqualK{}(), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{=_K}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(805,19,805,156)"), function{}(), hook{}("KEQUAL.eq")]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [productionID{}("768415370"), klabel{}("#EAGAIN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(870,22,870,56)"), constructor{}()]
+  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("div"), productionID{}("1811922029"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(386,18,386,95)"), function{}(), hook{}("INT.ediv")]
+  hooked-symbol Lbl'Hash'isVariable'LParUndsRParUnds'K-REFLECTION-SYMBOLIC'UndsUnds'K{}(SortK{}) : SortBool{} [productionID{}("1216198248"), klabel{}("#isVariable"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(860,19,860,73)"), function{}(), hook{}("KREFLECTION.isVariable")]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [productionID{}("1119622337"), klabel{}("#EDEADLK"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(874,22,874,58)"), constructor{}()]
+  hooked-symbol Lbl'Hash'argv'LParRParUnds'K-REFLECTION'Unds'{}() : SortList{} [productionID{}("170052458"), klabel{}("#argv"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(847,19,847,60)"), function{}(), hook{}("KREFLECTION.argv")]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [productionID{}("2035381640"), klabel{}("#ENOSPC"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(892,22,892,56)"), constructor{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("+"), productionID{}("2001321875"), klabel{}("_+Int_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(389,18,389,178)"), function{}(), hook{}("INT.add")]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortK{} [productionID{}("1688470144"), klabel{}("srandInt"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(458,16,458,56)"), function{}(), hook{}("INT.srand")]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [productionID{}("393996856"), klabel{}("ListItem"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), smtlib{}("smt_seq_elem"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(270,19,270,136)"), function{}(), hook{}("LIST.element")]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [productionID{}("605101809"), klabel{}("Set:difference"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("{#1}-_{\\it Set}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(207,18,207,146)"), function{}(), hook{}("SET.difference")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [productionID{}("701119748"), klabel{}("bitRangeInt"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(406,18,406,108)"), function{}(), hook{}("INT.bitRange")]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [productionID{}("820537534"), klabel{}("rfindChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(565,18,565,90)"), function{}(), hook{}("STRING.rfindChar")]
+  symbol LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [productionID{}("242282810"), klabel{}("freshInt"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), freshGenerator{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(454,18,454,72)"), function{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [productionID{}("1859383896"), klabel{}("updateList"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,19,281,78)"), function{}(), hook{}("LIST.updateAll")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(SortId{}) : SortString{} [productionID{}("661047965"), klabel{}("Id2String"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(781,21,781,89)"), function{}(), hook{}("STRING.token2string")]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [productionID{}("1731977615"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(577,21,577,107)"), function{}(), hook{}("STRING.replace")]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [productionID{}("1561502550"), klabel{}("#EOVERFLOW"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(935,22,935,62)"), constructor{}()]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [productionID{}("1260634890"), klabel{}("rfindString"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(563,18,563,86)"), function{}(), hook{}("STRING.rfind")]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [productionID{}("1855261647"), klabel{}("#ESOCKTNOSUPPORT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(914,22,914,74)"), constructor{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [smt-hook{}("not"), productionID{}("1990385139"), klabel{}("notBool_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(314,19,314,176)"), function{}(), boolOperation{}(), hook{}("BOOL.not")]
+  symbol Lbl'-LT-'T'-GT-'{}(SortKCell{}, SortStateCell{}) : SortTCell{} [functional{}(), cell{}(), originalPrd{}(), cellName{}("T"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), format{}("%1%i%n%2%n%3%d%n%4"), contentStartLine{}("14"), contentStartColumn{}("17"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,17,17,21)"), topcell{}(), constructor{}()]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [productionID{}("461591680"), klabel{}("#EMSGSIZE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(910,22,910,60)"), constructor{}()]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("xor"), productionID{}("1241480588"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(317,19,317,116)"), function{}(), boolOperation{}(), hook{}("BOOL.xor")]
+  symbol Lbl'UndsColnEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [productionID{}("885002305"), klabel{}("_:=K_"), equalEqualK{}(), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(818,19,818,96)"), function{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("or"), productionID{}("49222910"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(319,19,319,118)"), function{}(), boolOperation{}(), hook{}("BOOL.orElse")]
+  symbol Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [productionID{}("1916904573"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(980,20,980,110)"), constructor{}()]
+  symbol Lbl'-LT-'T'-GT-'-fragment{}(SortKCellOpt{}, SortStateCellOpt{}) : SortTCellFragment{} [cellFragment{}("TCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [productionID{}("858232531"), klabel{}("FloatFormat"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(568,21,568,113)"), function{}(), hook{}("STRING.floatFormat")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [productionID{}("1223240796"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(122,18,122,104)"), function{}(), prefer{}(), hook{}("MAP.update")]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [productionID{}("948250363"), klabel{}("#EBADF"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(871,22,871,54)"), constructor{}()]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [productionID{}("872306601"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(951,16,951,76)"), function{}(), hook{}("IO.lock")]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("89448984"), functional{}(), originalPrd{}(), smtlib{}("int_max"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,18,402,102)"), function{}(), hook{}("INT.max")]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [productionID{}("413218476"), klabel{}("#ETOOMANYREFS"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,22,929,68)"), constructor{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(".List"), productionID{}("421637524"), klabel{}("_List_"), functional{}(), originalPrd{}(), element{}("ListItem"), symbol'Kywd'{}(), smtlib{}("smt_seq_concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), format{}("%1%n%2"), left{}(), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(265,19,265,192)"), function{}(), hook{}("LIST.concat")]
+  symbol LblisStateCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCellOpt"), originalPrd{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [productionID{}("1844334363"), klabel{}("#ECONNREFUSED"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(931,22,931,68)"), constructor{}()]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [productionID{}("680988889"), klabel{}("#ENOTEMPTY"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(895,22,895,62)"), constructor{}()]
+  symbol LblinitStateCell{}() : SortStateCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [productionID{}("1783966110"), klabel{}("#ENOEXEC"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(889,22,889,58)"), constructor{}()]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [productionID{}("385739920"), klabel{}("#EISDIR"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(882,22,882,56)"), constructor{}()]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'UndsUnds'Int{}(SortInt{}) : SortIOInt{} [productionID{}("126234454"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(943,18,943,82)"), function{}(), hook{}("IO.getc")]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [productionID{}("1175371136"), klabel{}("#EFBIG"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(878,22,878,54)"), constructor{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [productionID{}("1560702077"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(553,21,553,139)"), function{}(), hook{}("STRING.concat")]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [productionID{}("1394557075"), klabel{}("#EDOM"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(875,22,875,52)"), constructor{}()]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [productionID{}("816798571"), klabel{}("List:range"), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,19,286,98)"), function{}(), hook{}("LIST.range")]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("(mod (^ #1 #2) #3)"), productionID{}("795011696"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(378,18,378,112)"), function{}(), hook{}("INT.powmod")]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortFloat{} [productionID{}("1325465767"), klabel{}("String2Float"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(569,21,569,93)"), function{}(), hook{}("STRING.string2float")]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [productionID{}("2005028997"), klabel{}("#ESRCH"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(903,22,903,54)"), constructor{}()]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("and"), productionID{}("1105628551"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(316,19,316,120)"), function{}(), boolOperation{}(), hook{}("BOOL.andThen")]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [productionID{}("524223214"), klabel{}("Set:in"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(210,19,210,106)"), function{}(), hook{}("SET.in")]
+  hooked-symbol LblnewUUID'Unds'STRING'Unds'{}() : SortString{} [productionID{}("124058278"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(593,21,593,67)"), function{}(), hook{}("STRING.uuid")]
+  symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}()]
+  symbol Lbl'UndsColnSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [productionID{}("124734309"), klabel{}("_:/=K_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), notEqualEqualK{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(819,19,819,100)"), function{}()]
+  symbol LblnoTCell{}() : SortTCellOpt{} [cellOptAbsent{}("TCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Hash'getenv'LParUndsRParUnds'K-REFLECTION'UndsUnds'String{}(SortString{}) : SortString{} [productionID{}("1789110533"), klabel{}("#getenv"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(843,21,843,80)"), function{}(), hook{}("KREFLECTION.getenv")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [productionID{}("877612522"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(152,19,152,91)"), function{}(), hook{}("MAP.inclusion")]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [productionID{}("573926093"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("{#1}-_{\\it Map}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,18,129,120)"), function{}(), hook{}("MAP.difference")]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [productionID{}("1452442375"), klabel{}("chrChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(558,21,558,69)"), function{}(), hook{}("STRING.chr")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [productionID{}("962944318"), klabel{}("removeAll"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,18,137,91)"), function{}(), hook{}("MAP.removeAll")]
+  symbol Lblis'Hash'KVariable{}(SortK{}) : SortBool{} [function{}(), predicate{}("#KVariable"), originalPrd{}()]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [productionID{}("1233308726"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(952,16,952,80)"), function{}(), hook{}("IO.unlock")]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [productionID{}("1958402562"), klabel{}("#EPFNOSUPPORT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(916,22,916,68)"), constructor{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("1827171553"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(581,19,581,94)"), function{}(), hook{}("STRING.ne")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("distinct"), productionID{}("2142852357"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(323,19,323,105)"), function{}(), hook{}("BOOL.ne")]
+  symbol Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}() : SortKItem{} [productionID{}("1123559518"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,40,5,56)"), constructor{}()]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(SortK{}) : SortStream{} [productionID{}("1059524106"), klabel{}("#buffer"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(974,21,974,30)"), constructor{}()]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [productionID{}("1076071888"), klabel{}("#EMLINK"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(884,22,884,56)"), constructor{}()]
+  symbol Lbl'Hash'projectString'LParUndsRParUnds'K-IO'UndsUnds'IOString{}(SortIOString{}) : SortString{} [productionID{}("1998949977"), klabel{}("#projectString"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(984,21,984,55)"), function{}()]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [productionID{}("373378624"), klabel{}("#EOPNOTSUPP"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(915,22,915,64)"), constructor{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [smt-hook{}("distinct"), productionID{}("586358252"), klabel{}("_=/=K_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), notEqualEqualK{}(), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(806,19,806,170)"), function{}(), hook{}("KEQUAL.ne")]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [productionID{}("940087898"), klabel{}("findChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(564,18,564,89)"), function{}(), hook{}("STRING.findChar")]
+  symbol LblisId{}(SortK{}) : SortBool{} [function{}(), predicate{}("Id"), originalPrd{}()]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [productionID{}("1260217713"), klabel{}("#EDESTADDRREQ"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(909,22,909,68)"), constructor{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}(">"), productionID{}("1430861186"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(412,19,412,147)"), function{}(), hook{}("INT.gt")]
+  symbol LblnoStateCell{}() : SortStateCellOpt{} [cellOptAbsent{}("StateCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [productionID{}("970865974"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(579,18,579,132)"), function{}(), hook{}("STRING.countAllOccurrences")]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}("="), productionID{}("438314766"), klabel{}("_==Int_"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(413,19,413,169)"), function{}(), hook{}("INT.eq")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("966966167"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,18,393,131)"), function{}(), hook{}("INT.shl")]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [productionID{}("145581669"), klabel{}("fillList"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,19,283,77)"), function{}(), hook{}("LIST.fill")]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [productionID{}("1021258849"), klabel{}("String2Int"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(570,21,570,91)"), function{}(), hook{}("STRING.string2int")]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [productionID{}("1866229258"), klabel{}("#EINTR"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(879,22,879,54)"), constructor{}()]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [productionID{}("2059461664"), klabel{}("#ENOTDIR"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(894,22,894,58)"), constructor{}()]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [productionID{}("1771421544"), klabel{}("#EROFS"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(901,22,901,54)"), constructor{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}("<="), productionID{}("1477637771"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(409,19,409,151)"), function{}(), hook{}("INT.le")]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [productionID{}("739333799"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(950,16,950,81)"), function{}(), hook{}("IO.write")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [productionID{}("48361312"), klabel{}("_[_<-undef]"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,121)"), function{}(), hook{}("MAP.remove")]
+  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("^"), productionID{}("2048013503"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(377,18,377,153)"), function{}(), hook{}("INT.pow")]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [productionID{}("1517328406"), klabel{}("#EADDRNOTAVAIL"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(919,22,919,70)"), constructor{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), predicate{}("String"), originalPrd{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}()]
+  symbol LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(SortInt{}) : SortId{} [productionID{}("1705072168"), klabel{}("freshId"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), freshGenerator{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(783,17,783,70)"), function{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'{}() : SortInt{} [productionID{}("1638435724"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(966,18,966,50)"), function{}()]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [productionID{}("974308356"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(944,23,944,86)"), function{}(), hook{}("IO.read")]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [productionID{}("125844477"), klabel{}("#ECHILD"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(873,22,873,56)"), constructor{}()]
+  symbol LblisTCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCell"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [productionID{}("428039780"), klabel{}("_inList_"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(289,19,289,101)"), function{}(), hook{}("LIST.in")]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [productionID{}("851765426"), klabel{}("categoryChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(590,21,590,80)"), function{}(), hook{}("STRING.category")]
+  symbol Lbl'-LT-'state'-GT-'{}(SortMap{}) : SortStateCell{} [functional{}(), cell{}(), originalPrd{}(), cellName{}("state"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), format{}("%1%i%n%2%d%n%3"), contentStartLine{}("14"), contentStartColumn{}("17"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,17,17,21)"), constructor{}()]
+  hooked-symbol Lbl'Hash'lstat'LParUndsRParUnds'K-IO'UndsUnds'String{}(SortString{}) : SortKItem{} [productionID{}("1327234595"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(955,20,955,77)"), function{}(), hook{}("IO.lstat")]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'{}() : SortInt{} [productionID{}("1524305331"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(968,19,968,50)"), function{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [productionID{}("1543043602"), klabel{}("log2Int"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(404,18,404,74)"), function{}(), hook{}("INT.log2")]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [productionID{}("2010545395"), klabel{}("#ETIMEDOUT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(930,22,930,62)"), constructor{}()]
+  symbol Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}() : SortKItem{} [productionID{}("25936709"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,20,5,36)"), constructor{}()]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [productionID{}("1327871893"), klabel{}("#ENOPROTOOPT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(912,22,912,66)"), constructor{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [productionID{}("1027495011"), klabel{}("randInt"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(457,18,457,56)"), function{}(), hook{}("INT.rand")]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [productionID{}("369347944"), klabel{}("substrString"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(561,21,561,99)"), function{}(), hook{}("STRING.substr")]
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [productionID{}("782689036"), klabel{}("#E2BIG"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(868,22,868,54)"), constructor{}()]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [productionID{}("948115224"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(949,16,949,81)"), function{}(), hook{}("IO.putc")]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("IOInt"), originalPrd{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [productionID{}("250112971"), klabel{}(".List"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), smtlib{}("smt_seq_nil"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("\\dotCt{List}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(267,19,267,146)"), function{}(), hook{}("LIST.unit")]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [productionID{}("973843173"), klabel{}("#ENOSYS"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(893,22,893,56)"), constructor{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'UndsUnds'String{}(SortString{}) : SortKItem{} [productionID{}("443942537"), klabel{}("#system"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(979,20,979,73)"), function{}(), hook{}("IO.system")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [productionID{}("946802083"), klabel{}("updateMap"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,18,134,91)"), function{}(), hook{}("MAP.updateAll")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortKItem{} [productionID{}("1904288897"), klabel{}("Set:choice"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(219,20,219,94)"), function{}(), hook{}("SET.choice")]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'UndsUnds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [productionID{}("640808588"), klabel{}("makeList"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,66)"), function{}(), hook{}("LIST.make")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [productionID{}("1756573246"), klabel{}("sizeList"), functional{}(), originalPrd{}(), smtlib{}("smt_seq_len"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,18,292,121)"), function{}(), hook{}("LIST.size")]
+  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}("<"), productionID{}("1143390193"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(410,19,410,147)"), function{}(), hook{}("INT.lt")]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("1479696465"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(588,19,588,82)"), function{}(), hook{}("STRING.ge")]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [productionID{}("584561912"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(947,16,947,76)"), function{}(), hook{}("IO.seek")]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(SortBool{}, SortS0, SortS0) : SortS0 [smt-hook{}("ite"), productionID{}("211090736"), functional{}(), originalPrd{}(), poly{}("0, 2, 3"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(826,16,826,124)"), function{}(), hook{}("KEQUAL.ite")]
+  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("mod"), productionID{}("461698165"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(387,18,387,95)"), function{}(), hook{}("INT.emod")]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'UndsUnds'Int{}(SortInt{}) : SortK{} [productionID{}("423733503"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(946,16,946,70)"), function{}(), hook{}("IO.close")]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("1868805237"), functional{}(), originalPrd{}(), smtlib{}("int_min"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(401,18,401,102)"), function{}(), hook{}("INT.min")]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(".Map"), productionID{}("1335503880"), klabel{}("_Map_"), originalPrd{}(), element{}("_|->_"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), format{}("%1%n%2"), left{}(), index{}("0"), assoc{}(), comm{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(104,18,104,172)"), function{}(), hook{}("MAP.concat")]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [productionID{}("2111457497"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,93)"), function{}(), hook{}("MAP.in_keys")]
+  hooked-symbol Lbl'Hash'fresh'LParUndsRParUnds'K-REFLECTION'UndsUnds'String{}(SortString{}) : SortKItem{} [productionID{}("148635643"), klabel{}("#fresh"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(840,20,840,79)"), function{}(), hook{}("KREFLECTION.fresh")]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [productionID{}("1444440224"), klabel{}("#unknownIOError"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(867,94,867,122)"), constructor{}()]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [productionID{}("1962266146"), klabel{}("#EINVAL"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(880,22,880,56)"), constructor{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [productionID{}("1413730361"), klabel{}("_|->_"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("{#1}\\mapsto{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(111,18,111,144)"), function{}(), hook{}("MAP.element")]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [productionID{}("1703009290"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(578,21,578,124)"), function{}(), hook{}("STRING.replaceFirst")]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [productionID{}("896072146"), klabel{}("#EXDEV"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(904,22,904,54)"), constructor{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [productionID{}("1537772520"), klabel{}("lengthString"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(557,18,557,84)"), function{}(), hook{}("STRING.length")]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [productionID{}("894024873"), klabel{}("#EPROTOTYPE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(911,22,911,64)"), constructor{}()]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [productionID{}("1189084611"), klabel{}("#EADDRINUSE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(918,22,918,64)"), constructor{}()]
+  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("-"), productionID{}("322112198"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(390,18,390,154)"), function{}(), hook{}("INT.sub")]
+  hooked-symbol Lbl'Hash'logToFile'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortK{} [returnsUnit{}(), productionID{}("1895143699"), klabel{}("#logToFile"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(982,16,982,99)"), function{}(), hook{}("IO.log")]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [productionID{}("443290224"), klabel{}("#ESHUTDOWN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(928,22,928,62)"), constructor{}()]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [productionID{}("1363396194"), klabel{}("#ESPIPE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(902,22,902,56)"), constructor{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [productionID{}("507911745"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(555,19,555,88)"), function{}(), hook{}("STRING.eq")]
+  symbol LblisStateCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCell"), originalPrd{}()]
+  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("mod"), productionID{}("1408695561"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(384,18,384,146)"), function{}(), hook{}("INT.tmod")]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [productionID{}("166454155"), klabel{}("findString"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(562,18,562,85)"), function{}(), hook{}("STRING.find")]
+  symbol LblinitTCell{}() : SortTCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [function{}(), predicate{}("IOString"), originalPrd{}()]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(SortString{}) : SortId{} [productionID{}("1415630650"), klabel{}("String2Id"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(782,17,782,84)"), function{}(), hook{}("STRING.string2token")]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [productionID{}("7829163"), klabel{}("#ENAMETOOLONG"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(885,22,885,68)"), constructor{}()]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [productionID{}("1336777650"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(941,18,941,84)"), function{}(), hook{}("IO.open")]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [productionID{}("1346292516"), klabel{}("#EPIPE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(899,22,899,54)"), constructor{}()]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [productionID{}("1109113497"), klabel{}("#ELOOP"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(934,22,934,54)"), constructor{}()]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [productionID{}("2016949136"), klabel{}("#ENETDOWN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(920,22,920,60)"), constructor{}()]
+  hooked-symbol Lbl'Hash'configuration'Unds'K-REFLECTION'Unds'{}() : SortK{} [productionID{}("857394605"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(838,16,838,83)"), function{}(), hook{}("KREFLECTION.configuration")]
+  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("1127338375"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(399,18,399,140)"), function{}(), hook{}("INT.or")]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [productionID{}("1406919011"), klabel{}("#ENETRESET"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(922,22,922,62)"), constructor{}()]
+  symbol Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}() : SortKItem{} [productionID{}("649769713"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,20,6,30)"), constructor{}()]
+  symbol Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}() : SortKItem{} [productionID{}("925150995"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,34,6,42)"), constructor{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [productionID{}("1542520418"), klabel{}("String2Base"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(573,21,573,92)"), function{}(), hook{}("STRING.string2base")]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCellOpt"), originalPrd{}()]
+  hooked-symbol LblgetKLabel'LParUndsRParUnds'K-REFLECTION'UndsUnds'K{}(SortK{}) : SortKItem{} [productionID{}("254896875"), klabel{}("getKLabel"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(841,20,841,72)"), function{}(), hook{}("KREFLECTION.getKLabel")]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [productionID{}("2099051403"), klabel{}("Map:lookupOrDefault"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(119,20,119,138)"), function{}(), hook{}("MAP.lookupOrDefault")]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), cell{}(), originalPrd{}(), cellName{}("generatedCounter"), format{}("%1%i%n%2%d%n%3"), constructor{}()]
+  hooked-symbol Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [productionID{}("729218894"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(375,18,375,133)"), function{}(), hook{}("INT.not")]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [productionID{}("229995302"), klabel{}("#ECONNABORTED"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(923,22,923,68)"), constructor{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("div"), productionID{}("950698351"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,18,383,148)"), function{}(), hook{}("INT.tdiv")]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [productionID{}("632071960"), klabel{}("#EIO"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(881,22,881,50)"), constructor{}()]
+  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [smt-hook{}("*"), productionID{}("616207929"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(380,18,380,157)"), function{}(), hook{}("INT.mul")]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("="), productionID{}("1160850402"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(322,19,322,98)"), function{}(), hook{}("BOOL.eq")]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [productionID{}("1025001676"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(141,19,141,79)"), function{}(), hook{}("MAP.keys_list")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [productionID{}("534666530"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(213,19,213,85)"), function{}(), hook{}("SET.inclusion")]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [productionID{}("503938393"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(576,21,576,122)"), function{}(), hook{}("STRING.replaceAll")]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [productionID{}("1320388319"), klabel{}("#ENOMEM"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(891,22,891,56)"), constructor{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [productionID{}("888287133"), klabel{}("keys"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,86)"), function{}(), hook{}("MAP.keys")]
+  symbol Lbl'Hash'noparse{}() : SortIOError{} [productionID{}("979291363"), klabel{}("#noparse"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(867,54,867,90)"), constructor{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [productionID{}("1289869008"), klabel{}("intersectSet"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,18,204,88)"), function{}(), hook{}("SET.intersection")]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [productionID{}("1048434276"), klabel{}("#EINPROGRESS"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(906,22,906,66)"), constructor{}()]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'UndsUnds'Int{}(SortInt{}) : SortIOInt{} [productionID{}("1367165453"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(942,18,942,70)"), function{}(), hook{}("IO.tell")]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [productionID{}("1631119258"), klabel{}("#EACCES"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(869,22,869,56)"), constructor{}()]
+  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [productionID{}("61681175"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,18,395,142)"), function{}(), hook{}("INT.and")]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [productionID{}("1511574902"), klabel{}("#ENOTTY"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(896,22,896,56)"), constructor{}()]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [productionID{}("564272228"), klabel{}("#EBUSY"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(872,22,872,54)"), constructor{}()]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [productionID{}("452842611"), klabel{}("#EMFILE"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(883,22,883,56)"), constructor{}()]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [productionID{}("1259639178"), klabel{}("#EISCONN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(926,22,926,58)"), constructor{}()]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [productionID{}("230526532"), klabel{}("#ENODEV"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(887,22,887,56)"), constructor{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [productionID{}("1265508963"), klabel{}("sizeMap"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(149,18,149,103)"), function{}(), hook{}("MAP.size")]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [productionID{}("1370283822"), klabel{}("#ENOENT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(888,22,888,56)"), constructor{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [productionID{}("862916729"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(415,19,415,52)"), function{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'{}() : SortInt{} [productionID{}("573136580"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(967,19,967,50)"), function{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(SortFloat{}) : SortString{} [productionID{}("1724457619"), klabel{}("Float2String"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(567,21,567,105)"), function{}(), hook{}("STRING.float2string")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [productionID{}("1573605215"), klabel{}("size"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(216,18,216,80)"), function{}(), hook{}("SET.size")]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [productionID{}("345887595"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(948,16,948,82)"), function{}(), hook{}("IO.seekEnd")]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [function{}(), predicate{}("IOError"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [smt-hook{}(">="), productionID{}("1014794348"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(411,19,411,151)"), function{}(), hook{}("INT.ge")]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}()]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [productionID{}("1681303515"), klabel{}("#EFAULT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(877,22,877,56)"), constructor{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), predicate{}("Float"), originalPrd{}()]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [productionID{}("392904516"), klabel{}("#EHOSTDOWN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(932,22,932,62)"), constructor{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [productionID{}("1409092880"), klabel{}(".Set"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), latex{}("\\dotCt{Set}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(196,18,196,122)"), function{}(), hook{}("SET.unit")]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [smt-hook{}("=>"), productionID{}("1997548433"), functional{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), left{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,19,320,119)"), function{}(), boolOperation{}(), hook{}("BOOL.implies")]
+  hooked-symbol Lbl'Hash'parse'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortKItem{} [productionID{}("1361393151"), klabel{}("#parse"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(958,20,958,80)"), function{}(), hook{}("IO.parse")]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [productionID{}("1830745997"), klabel{}("#ENOTCONN"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(927,22,927,60)"), constructor{}()]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [productionID{}("5395829"), klabel{}("#EAFNOSUPPORT"), functional{}(), originalPrd{}(), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(917,22,917,68)"), constructor{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [productionID{}("949581868"), klabel{}("ordChar"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,18,559,69)"), function{}(), hook{}("STRING.ord")]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortStateCell{}, SortCell{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTONOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ECONNRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortTCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortTCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortTCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortTCellOpt{}} (X0:SortTCellOpt{}, Y0:SortTCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortTCell{}, SortCell{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EEXIST{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EEXIST{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPERM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EEXIST{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortTCell{}, SortKItem{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortTCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortTCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortTCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortTCell{}} (X0:SortTCell{}, Y0:SortTCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPERM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EHOSTUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPERM{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ERANGE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ERANGE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOLCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ERANGE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOLCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOBUFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOLCK{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOBUFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENXIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENXIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EALREADY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENXIO{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EALREADY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTSOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EALREADY{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortInt{}, SortIOInt{}} (From:SortInt{}))) [subsort{SortInt{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTSOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EWOULDBLOCK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EWOULDBLOCK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENETUNREACH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETUNREACH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENFILE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCell{}, SortKItem{}} (From:SortCell{}))) [subsort{SortCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EAGAIN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOF{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAGAIN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDEADLK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EAGAIN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortKCell{}, SortCell{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDEADLK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSPC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDEADLK{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOError{}, SortKItem{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSPC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOVERFLOW{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSPC{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCellOpt{}, \equals{SortTCellOpt{}, R} (Val:SortTCellOpt{}, inj{SortTCell{}, SortTCellOpt{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortTCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOVERFLOW{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESOCKTNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESOCKTNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EMSGSIZE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortTCellFragment{}, SortKItem{}} (From:SortTCellFragment{}))) [subsort{SortTCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCell{}, \equals{SortTCell{}, R} (Val:SortTCell{}, Lbl'-LT-'T'-GT-'{}(K0:SortKCell{}, K1:SortStateCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCell{}} (\and{SortTCell{}} (Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortStateCell{}), Lbl'-LT-'T'-GT-'{}(Y0:SortKCell{}, Y1:SortStateCell{})), Lbl'-LT-'T'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortStateCell{}} (X1:SortStateCell{}, Y1:SortStateCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMSGSIZE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EBADF{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(K0:SortInt{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:SortInt{}, Y1:SortString{}, Y2:SortString{})), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortString{}} (X1:SortString{}, Y1:SortString{}), \and{SortString{}} (X2:SortString{}, Y2:SortString{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{}), Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortTCellFragment{}, \equals{SortTCellFragment{}, R} (Val:SortTCellFragment{}, Lbl'-LT-'T'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortStateCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCellFragment{}} (\and{SortTCellFragment{}} (Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}), Lbl'-LT-'T'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortStateCellOpt{})), Lbl'-LT-'T'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortStateCellOpt{}} (X1:SortStateCellOpt{}, Y1:SortStateCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBADF{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETOOMANYREFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBADF{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETOOMANYREFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ECONNREFUSED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNREFUSED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTEMPTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTEMPTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOEXEC{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOEXEC{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EISDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EFBIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISDIR{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFBIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EDOM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFBIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDOM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ESRCH{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDOM{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESRCH{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EPFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESRCH{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCellOpt{}, \equals{SortTCellOpt{}, R} (Val:SortTCellOpt{}, LblnoTCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, inj{SortKItem{}, SortK{}} (From:SortKItem{}))) [subsort{SortKItem{}, SortK{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EMLINK{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStream{}, \equals{SortStream{}, R} (Val:SortStream{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortStream{}} (\and{SortStream{}} (Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(X0:SortK{}), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(Y0:SortK{})), Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMLINK{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EOPNOTSUPP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMLINK{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EOPNOTSUPP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EDESTADDRREQ{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EDESTADDRREQ{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINTR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, LblnoStateCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINTR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTDIR{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINTR{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTDIR{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EROFS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EROFS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EADDRNOTAVAIL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EROFS{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStateCell{}, SortKItem{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRNOTAVAIL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECHILD{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdin'Unds'K-IO'Unds'{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECHILD{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ETIMEDOUT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECHILD{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOInt{}, \equals{SortIOInt{}, R} (Val:SortIOInt{}, inj{SortIOError{}, SortIOInt{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOInt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCell{}, \equals{SortStateCell{}, R} (Val:SortStateCell{}, Lbl'-LT-'state'-GT-'{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{}\implies{SortStateCell{}} (\and{SortStateCell{}} (Lbl'-LT-'state'-GT-'{}(X0:SortMap{}), Lbl'-LT-'state'-GT-'{}(Y0:SortMap{})), Lbl'-LT-'state'-GT-'{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stderr'Unds'K-IO'Unds'{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ETIMEDOUT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOPROTOOPT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOPROTOOPT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'E2BIG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, inj{SortStateCell{}, SortStateCellOpt{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortStateCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'E2BIG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOSYS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'E2BIG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOSYS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'unknownIOError{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOSYS{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R, SortS0} \exists{R} (Val:SortS0, \equals{SortS0, R} (Val:SortS0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(K0:SortBool{}, K1:SortS0, K2:SortS0))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'unknownIOError{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'unknownIOError{}(Y0:SortInt{})), Lbl'Hash'unknownIOError{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EINVAL{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'unknownIOError{}(X0:SortInt{}), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINVAL{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EXDEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINVAL{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EXDEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EPROTOTYPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EXDEV{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPROTOTYPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EADDRINUSE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EADDRINUSE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESHUTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'Hash'logToFile'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESHUTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ESPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ESPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENAMETOOLONG{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ESPIPE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENAMETOOLONG{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EPIPE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStateCellOpt{}, SortKItem{}} (From:SortStateCellOpt{}))) [subsort{SortStateCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EPIPE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ELOOP{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EPIPE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ELOOP{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ELOOP{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENETRESET{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENETRESET{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ECONNABORTED{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENETRESET{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}(), Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ECONNABORTED{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EIO{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EIO{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOMEM{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EIO{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOMEM{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'noparse{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOMEM{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'noparse{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EINPROGRESS{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'noparse{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EINPROGRESS{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EACCES{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EACCES{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTTY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EACCES{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTTY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EBUSY{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTTY{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EBUSY{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EMFILE{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EBUSY{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EMFILE{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EISCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EMFILE{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EISCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENODEV{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EISCONN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENODEV{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOENT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENODEV{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOENT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EFAULT{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOENT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortIOError{}, SortIOString{}} (From:SortIOError{}))) [subsort{SortIOError{}, SortIOString{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Hash'stdout'Unds'K-IO'Unds'{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EFAULT{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EHOSTDOWN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EFAULT{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EHOSTDOWN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'ENOTCONN{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'ENOTCONN{}())) [functional{}()] // functional
+  axiom{}\not{SortIOError{}} (\and{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), Lbl'Hash'EAFNOSUPPORT{}())) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortIOError{}, \equals{SortIOError{}, R} (Val:SortIOError{}, Lbl'Hash'EAFNOSUPPORT{}())) [functional{}()] // functional
+  axiom{} \or{SortTCellFragment{}} (\exists{SortTCellFragment{}} (X0:SortKCellOpt{}, \exists{SortTCellFragment{}} (X1:SortStateCellOpt{}, Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}))), \bottom{SortTCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortTCell{}} (\exists{SortTCell{}} (X0:SortKCell{}, \exists{SortTCell{}} (X1:SortStateCell{}, Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortStateCell{}))), \bottom{SortTCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortStateCell{}} (\exists{SortStateCell{}} (X0:SortMap{}, Lbl'-LT-'state'-GT-'{}(X0:SortMap{})), \bottom{SortStateCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
+  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortTCell{}, inj{SortTCell{}, SortCell{}} (Val:SortTCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortCell{}} (Val:SortStateCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortTCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortTCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIOError{}} (Lbl'Hash'ENOSPC{}(), \or{SortIOError{}} (Lbl'Hash'ESHUTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'EPROTONOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'ESPIPE{}(), \or{SortIOError{}} (Lbl'Hash'EINTR{}(), \or{SortIOError{}} (Lbl'Hash'ENOTDIR{}(), \or{SortIOError{}} (Lbl'Hash'EROFS{}(), \or{SortIOError{}} (Lbl'Hash'EOVERFLOW{}(), \or{SortIOError{}} (Lbl'Hash'ECONNRESET{}(), \or{SortIOError{}} (Lbl'Hash'ESOCKTNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'ENAMETOOLONG{}(), \or{SortIOError{}} (Lbl'Hash'EEXIST{}(), \or{SortIOError{}} (Lbl'Hash'EPIPE{}(), \or{SortIOError{}} (Lbl'Hash'ELOOP{}(), \or{SortIOError{}} (Lbl'Hash'EMSGSIZE{}(), \or{SortIOError{}} (Lbl'Hash'ENETDOWN{}(), \or{SortIOError{}} (Lbl'Hash'EADDRNOTAVAIL{}(), \or{SortIOError{}} (Lbl'Hash'ENETRESET{}(), \or{SortIOError{}} (Lbl'Hash'EBADF{}(), \or{SortIOError{}} (Lbl'Hash'EPERM{}(), \or{SortIOError{}} (Lbl'Hash'ECHILD{}(), \or{SortIOError{}} (Lbl'Hash'ETOOMANYREFS{}(), \or{SortIOError{}} (Lbl'Hash'ECONNABORTED{}(), \or{SortIOError{}} (Lbl'Hash'ECONNREFUSED{}(), \or{SortIOError{}} (Lbl'Hash'ENOTEMPTY{}(), \or{SortIOError{}} (Lbl'Hash'EIO{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'ERANGE{}(), \or{SortIOError{}} (Lbl'Hash'ENOEXEC{}(), \or{SortIOError{}} (Lbl'Hash'ENOLCK{}(), \or{SortIOError{}} (Lbl'Hash'EISDIR{}(), \or{SortIOError{}} (Lbl'Hash'EFBIG{}(), \or{SortIOError{}} (Lbl'Hash'ETIMEDOUT{}(), \or{SortIOError{}} (Lbl'Hash'ENOMEM{}(), \or{SortIOError{}} (Lbl'Hash'noparse{}(), \or{SortIOError{}} (Lbl'Hash'EINPROGRESS{}(), \or{SortIOError{}} (Lbl'Hash'EDOM{}(), \or{SortIOError{}} (Lbl'Hash'ENOBUFS{}(), \or{SortIOError{}} (Lbl'Hash'ENOPROTOOPT{}(), \or{SortIOError{}} (Lbl'Hash'ESRCH{}(), \or{SortIOError{}} (Lbl'Hash'ENXIO{}(), \or{SortIOError{}} (Lbl'Hash'EALREADY{}(), \or{SortIOError{}} (Lbl'Hash'EACCES{}(), \or{SortIOError{}} (Lbl'Hash'E2BIG{}(), \or{SortIOError{}} (Lbl'Hash'ENOTSOCK{}(), \or{SortIOError{}} (Lbl'Hash'ENOTTY{}(), \or{SortIOError{}} (Lbl'Hash'EBUSY{}(), \or{SortIOError{}} (Lbl'Hash'EMFILE{}(), \or{SortIOError{}} (Lbl'Hash'ENOSYS{}(), \or{SortIOError{}} (Lbl'Hash'EWOULDBLOCK{}(), \or{SortIOError{}} (Lbl'Hash'EISCONN{}(), \or{SortIOError{}} (Lbl'Hash'ENODEV{}(), \or{SortIOError{}} (Lbl'Hash'ENETUNREACH{}(), \or{SortIOError{}} (Lbl'Hash'ENOENT{}(), \or{SortIOError{}} (Lbl'Hash'ENFILE{}(), \or{SortIOError{}} (Lbl'Hash'EPFNOSUPPORT{}(), \or{SortIOError{}} (Lbl'Hash'EOF{}(), \or{SortIOError{}} (\exists{SortIOError{}} (X0:SortInt{}, Lbl'Hash'unknownIOError{}(X0:SortInt{})), \or{SortIOError{}} (Lbl'Hash'EINVAL{}(), \or{SortIOError{}} (Lbl'Hash'EMLINK{}(), \or{SortIOError{}} (Lbl'Hash'EFAULT{}(), \or{SortIOError{}} (Lbl'Hash'EOPNOTSUPP{}(), \or{SortIOError{}} (Lbl'Hash'EAGAIN{}(), \or{SortIOError{}} (Lbl'Hash'EHOSTDOWN{}(), \or{SortIOError{}} (Lbl'Hash'EXDEV{}(), \or{SortIOError{}} (Lbl'Hash'EDEADLK{}(), \or{SortIOError{}} (Lbl'Hash'EPROTOTYPE{}(), \or{SortIOError{}} (Lbl'Hash'EADDRINUSE{}(), \or{SortIOError{}} (Lbl'Hash'ENOTCONN{}(), \or{SortIOError{}} (Lbl'Hash'EDESTADDRREQ{}(), \or{SortIOError{}} (Lbl'Hash'EAFNOSUPPORT{}(), \bottom{SortIOError{}}()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortK{}} (Val:SortTCellFragment{})), \or{SortK{}} (\exists{SortK{}} (Val:SortInt{}, inj{SortInt{}, SortK{}} (Val:SortInt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortTCell{}, inj{SortTCell{}, SortK{}} (Val:SortTCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortK{}} (Val:SortKCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSet{}, inj{SortSet{}, SortK{}} (Val:SortSet{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortK{}} (Val:SortStateCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortBool{}, inj{SortBool{}, SortK{}} (Val:SortBool{})), \or{SortK{}} (\exists{SortK{}} (Val:SortCell{}, inj{SortCell{}, SortK{}} (Val:SortCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortString{}, inj{SortString{}, SortK{}} (Val:SortString{})), \or{SortK{}} (\exists{SortK{}} (Val:SortList{}, inj{SortList{}, SortK{}} (Val:SortList{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCell{}, inj{SortKCell{}, SortK{}} (Val:SortKCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortIOError{}, inj{SortIOError{}, SortK{}} (Val:SortIOError{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortK{}} (Val:SortStateCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortFloat{}, inj{SortFloat{}, SortK{}} (Val:SortFloat{})), \or{SortK{}} (\exists{SortK{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortK{}} (Val:SortIOInt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortIOString{}, inj{SortIOString{}, SortK{}} (Val:SortIOString{})), \or{SortK{}} (\exists{SortK{}} (Val:SortId{}, inj{SortId{}, SortK{}} (Val:SortId{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStream{}, inj{SortStream{}, SortK{}} (Val:SortStream{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMap{}, inj{SortMap{}, SortK{}} (Val:SortMap{})), \bottom{SortK{}}())))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortTCellOpt{}} (LblnoTCell{}(), \or{SortTCellOpt{}} (\exists{SortTCellOpt{}} (Val:SortTCell{}, inj{SortTCell{}, SortTCellOpt{}} (Val:SortTCell{})), \bottom{SortTCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(), \or{SortKItem{}} (Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \or{SortKItem{}} (Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}(), \or{SortKItem{}} (Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}(), \or{SortKItem{}} (Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortKItem{}} (Val:SortTCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCell{}, inj{SortTCell{}, SortKItem{}} (Val:SortTCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortKItem{}} (Val:SortStateCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortKItem{}} (Val:SortStateCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \bottom{SortKItem{}}()))))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortStateCellOpt{}} (LblnoStateCell{}(), \or{SortStateCellOpt{}} (\exists{SortStateCellOpt{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortStateCellOpt{}} (Val:SortStateCell{})), \bottom{SortStateCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortInt{}, inj{SortInt{}, SortIOInt{}} (Val:SortInt{})), \or{SortIOInt{}} (\exists{SortIOInt{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOInt{}} (Val:SortIOError{})), \bottom{SortIOInt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortString{}, inj{SortString{}, SortIOString{}} (Val:SortString{})), \or{SortIOString{}} (\exists{SortIOString{}} (Val:SortIOError{}, inj{SortIOError{}, SortIOString{}} (Val:SortIOError{})), \bottom{SortIOString{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'UndsUnds'K{}(X0:SortK{})), \bottom{SortStream{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortTCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortTCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+
+// rules
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orBool__BOOL__Bool_Bool`(_7,#token("true","Bool") #as _48)=>_48 requires _48 ensures _48 [contentStartColumn(8) contentStartLine(344) org.kframework.attributes.Location(Location(344,8,344,34)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'48:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'7:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'48:SortBool{})),
+        Var'Unds'48:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'48:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("344"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(344,8,344,34)")]
+
+// rule `#projectInt(_)_K-IO__IOInt`(inj{Int,IOInt}(I))=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(987) org.kframework.attributes.Location(Location(987,8,987,31)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Hash'projectInt'LParUndsRParUnds'K-IO'UndsUnds'IOInt{}(inj{SortInt{}, SortIOInt{}}(VarI:SortInt{})),
+        VarI:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("987"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(987,8,987,31)")]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initTCell(.KList),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCell{},R} (
+        LblinitGeneratedTopCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'generatedTop'-GT-'{}(LblinitTCell{}(),LblinitGeneratedCounterCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool") #as _3)=>K requires _3 ensures _3 [contentStartColumn(8) contentStartLine(334) org.kframework.attributes.Location(Location(334,8,334,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'3:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'3:SortBool{})),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'3:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("334"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,8,334,37)")]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisId{}(kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING__String_String_String_Int`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source)),ToReplace,Replacement,`_-Int__INT-COMMON__Int_Int`(Count,#token("1","Int")))) requires `_>Int__INT-COMMON__Int_Int`(Count,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(616) org.kframework.attributes.Location(Location(616,8,619,30)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},VarCount:SortInt{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("616"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(616,8,619,30)")]
+
+// rule `_andBool_`(#token("false","Bool") #as _13,_0)=>_13 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(330) org.kframework.attributes.Location(Location(330,8,330,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'13:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'13:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("330"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(330,8,330,37)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool") #as _5,_8)=>_5 requires _5 ensures _5 [contentStartColumn(8) contentStartLine(343) org.kframework.attributes.Location(Location(343,8,343,34)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'5:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'5:SortBool{}),Var'Unds'8:SortBool{}),
+        Var'Unds'5:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'5:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("343"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(343,8,343,34)")]
+
+// rule `is#KVariable`(inj{#KVariable,KItem}(#KVariable))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Hash'KVariable:Sort'Hash'KVariable{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `#stderr_K-IO_`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(972) org.kframework.attributes.Location(Location(972,8,972,20)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Hash'stderr'Unds'K-IO'Unds'{}(),
+        \dv{SortInt{}}("2")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("972"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(972,8,972,20)")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'1:SortGeneratedCounterCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `#open(_)_K-IO__String`(S)=>`#open(_,_)_K-IO__String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(964) org.kframework.attributes.Location(Location(964,8,964,48)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortIOInt{},R} (
+        Lbl'Hash'open'LParUndsRParUnds'K-IO'UndsUnds'String{}(VarS:SortString{}),
+        Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+"))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("964"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(964,8,964,48)")]
+
+// rule `_==Int__INT-COMMON__Int_Int`(I1,I2)=>`_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(450) org.kframework.attributes.Location(Location(450,8,450,40)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI1:SortInt{}),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(VarI2:SortInt{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("450"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(450,8,450,40)")]
+
+// rule `_andBool_`(_2,#token("false","Bool") #as _36)=>_36 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(331) org.kframework.attributes.Location(Location(331,8,331,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'2:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'36:SortBool{})),
+        Var'Unds'36:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("331"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(331,8,331,37)")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'1:SortKCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(340) org.kframework.attributes.Location(Location(340,8,340,38)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("340"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(340,8,340,38)")]
+
+// rule #Ceil(`_/Int__INT-COMMON__Int_Int`(I1,I2))=>#Equals(`_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")),#token("true","Bool")) requires #token("true","Bool") ensures #token("true","Bool") [anywhere() contentStartColumn(8) contentStartLine(426) org.kframework.attributes.Location(Location(426,8,426,65)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]) sortParams([Q0])]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{Q0,R} (
+        \ceil{SortInt{}, Q0}(Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true"))),
+      \top{R}()))
+  [simplification{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), sortParams{}("[Q0]"), contentStartLine{}("426"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(426,8,426,65)"), anywhere{}()]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisK{}(VarK:SortK{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'0:SortInt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCellFragment(inj{TCellFragment,KItem}(TCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(kseq{}(inj{SortTCellFragment{}, SortKItem{}}(VarTCellFragment:SortTCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(824) org.kframework.attributes.Location(Location(824,8,824,43)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:SortBool{},VarK2:SortBool{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK1:SortBool{}),dotk{}()),kseq{}(inj{SortBool{}, SortKItem{}}(VarK2:SortBool{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("824"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(824,8,824,43)")]
+
+// rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOInt{}(kseq{}(inj{SortIOInt{}, SortKItem{}}(VarIOInt:SortIOInt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_<=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(595) org.kframework.attributes.Location(Location(595,8,595,63)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("595"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(595,8,595,63)")]
+
+// rule isTCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortTCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCellFragment{}, SortKItem{}}(Var'Unds'0:SortTCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(604) org.kframework.attributes.Location(Location(604,8,605,59)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        \dv{SortInt{}}("0")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("604"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(604,8,605,59)")]
+
+// rule `_==String__STRING__String_String`(S1,S2)=>`_==K_`(inj{String,KItem}(S1),inj{String,KItem}(S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(583) org.kframework.attributes.Location(Location(583,8,583,49)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortString{}, SortKItem{}}(VarS1:SortString{}),dotk{}()),kseq{}(inj{SortString{}, SortKItem{}}(VarS2:SortString{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("583"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(583,8,583,49)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool") #as _9,B)=>B requires _9 ensures _9 [contentStartColumn(8) contentStartLine(353) org.kframework.attributes.Location(Location(353,8,353,36)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'9:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'9:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'9:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("353"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(353,8,353,36)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(341) org.kframework.attributes.Location(Location(341,8,341,57)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("341"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,8,341,57)")]
+
+// rule isStateCell(inj{StateCell,KItem}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(kseq{}(inj{SortStateCell{}, SortKItem{}}(VarStateCell:SortStateCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_10,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(829) org.kframework.attributes.Location(Location(829,8,829,67)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},Var'Unds'10:SortK{},VarB2:SortK{}),
+        VarB2:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("829"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(829,8,829,67)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool") #as _26,_9)=>_26 requires _26 ensures _26 [contentStartColumn(8) contentStartLine(348) org.kframework.attributes.Location(Location(348,8,348,33)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'26:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'26:SortBool{}),Var'Unds'9:SortBool{}),
+        Var'Unds'26:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'26:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("348"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,8,348,33)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(338) org.kframework.attributes.Location(Location(338,8,338,38)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("338"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(338,8,338,38)")]
+
+// rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOError{}(kseq{}(inj{SortIOError{}, SortKItem{}}(VarIOError:SortIOError{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_modInt__INT-COMMON__Int_Int`(I1,I2)=>`_%Int__INT-COMMON__Int_Int`(`_+Int_`(`_%Int__INT-COMMON__Int_Int`(I1,`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(442) org.kframework.attributes.Location(Location(442,5,445,23)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{}))),
+      \top{R}()))
+  [concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("442"), contentStartColumn{}("5"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(442,5,445,23)")]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,_16)=>Source requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(612) org.kframework.attributes.Location(Location(612,8,613,57)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},Var'Unds'16:SortString{}),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("612"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(612,8,613,57)")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'1:SortBool{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortTCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCell{}, SortKItem{}}(Var'Unds'1:SortTCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(351) org.kframework.attributes.Location(Location(351,8,351,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("351"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(351,8,351,37)")]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(448) org.kframework.attributes.Location(Location(448,8,448,57)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI2:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("448"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(448,8,448,57)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(```` `#execute_BMC-SYNTAX_`(.KList) #as _104``=>`#branchIncrease_BMC-SYNTAX_`(.KList)~>_104``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X)))),DotVar0) requires `_>Int__INT-COMMON__Int_Int`(X,#token("5","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(31) org.kframework.attributes.Location(Location(31,8,33,22)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("5")),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),Var'Unds'104:SortKItem{}),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(),kseq{}(Var'Unds'104:SortKItem{},VarDotVar2:SortK{}))),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("31"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,8,33,22)")]
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(447) org.kframework.attributes.Location(Location(447,8,447,57)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI1:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("447"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(447,8,447,57)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON__Int_Int`(`rfindString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(601) org.kframework.attributes.Location(Location(601,8,601,182)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("601"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(601,8,601,182)")]
+
+// rule `_=/=String__STRING__String_String`(S1,S2)=>`notBool_`(`_==String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(582) org.kframework.attributes.Location(Location(582,8,582,65)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("582"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(582,8,582,65)")]
+
+// rule `_>=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(597) org.kframework.attributes.Location(Location(597,8,597,63)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("597"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(597,8,597,63)")]
+
+// rule `_>String__STRING__String_String`(S1,S2)=>`_<String__STRING__String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(596) org.kframework.attributes.Location(Location(596,8,596,52)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("596"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(596,8,596,52)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_3,#token("false","Bool") #as _1)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(336) org.kframework.attributes.Location(Location(336,8,336,36)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'3:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'1:SortBool{})),
+        Var'Unds'1:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("336"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,8,336,36)")]
+
+// rule `_=/=Int__INT-COMMON__Int_Int`(I1,I2)=>`notBool_`(`_==Int__INT-COMMON__Int_Int`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(451) org.kframework.attributes.Location(Location(451,8,451,53)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("451"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(451,8,451,53)")]
+
+// rule isTCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortTCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCellOpt{}, SortKItem{}}(Var'Unds'0:SortTCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule initKCell(.KList)=>`<k>`(`#execute_BMC-SYNTAX_`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(),
+        Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),dotk{}()))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool") #as _50,K)=>K requires _50 ensures _50 [contentStartColumn(8) contentStartLine(333) org.kframework.attributes.Location(Location(333,8,333,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'50:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'50:SortBool{}),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'50:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("333"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,8,333,37)")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_-Int__INT-COMMON__Int_Int`(`_modInt__INT-COMMON__Int_Int`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(437) org.kframework.attributes.Location(Location(437,8,437,164)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("437"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(437,8,437,164)")]
+
+// rule `freshInt(_)_INT__Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(455) org.kframework.attributes.Location(Location(455,8,455,28)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI:SortInt{}),
+        VarI:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("455"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(455,8,455,28)")]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(346) org.kframework.attributes.Location(Location(346,8,346,32)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("346"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(346,8,346,32)")]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_divInt__INT-COMMON__Int_Int`(I1,I2)=>`_/Int__INT-COMMON__Int_Int`(`_-Int__INT-COMMON__Int_Int`(I1,`_modInt__INT-COMMON__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(439) org.kframework.attributes.Location(Location(439,8,440,23)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("439"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(439,8,440,23)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(`` `#branchNoChange_BMC-SYNTAX_`(.KList)=>`#minusOne_BMC-SYNTAX_`(.KList)~>`#addOne_BMC-SYNTAX_`(.KList)``~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(35) org.kframework.attributes.Location(Location(35,8,35,59)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}(),kseq{}(Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("35"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,8,35,59)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(_14,#token("\"\"","String"),_15)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(602) org.kframework.attributes.Location(Location(602,8,602,33)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'14:SortString{},\dv{SortString{}}(""),Var'Unds'15:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("602"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(602,8,602,33)")]
+
+// rule `_dividesInt__INT-COMMON__Int_Int`(I1,I2)=>`_==Int__INT-COMMON__Int_Int`(`_%Int__INT-COMMON__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(452) org.kframework.attributes.Location(Location(452,8,452,58)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("452"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(452,8,452,58)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(```` `#execute_BMC-SYNTAX_`(.KList) #as _113``=>`#branchNoChange_BMC-SYNTAX_`(.KList)~>_113``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X)))),DotVar0) requires `_andBool_`(`_<Int__INT-COMMON__Int_Int`(#token("0","Int"),X),`_<=Int__INT-COMMON__Int_Int`(X,#token("5","Int"))) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(23) org.kframework.attributes.Location(Location(23,8,25,40)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("0"),VarX:SortInt{}),Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("5"))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),Var'Unds'113:SortKItem{}),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(),kseq{}(Var'Unds'113:SortKItem{},VarDotVar2:SortK{}))),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("23"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(23,8,25,40)")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'0:SortMap{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_andBool_`(B,#token("true","Bool") #as _32)=>B requires _32 ensures _32 [contentStartColumn(8) contentStartLine(329) org.kframework.attributes.Location(Location(329,8,329,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'32:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'32:SortBool{})),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'32:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("329"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(329,8,329,37)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(`` `#branchIncrease_BMC-SYNTAX_`(.KList)=>`#addOne_BMC-SYNTAX_`(.KList)``~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(37) org.kframework.attributes.Location(Location(37,8,37,46)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("37"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(37,8,37,46)")]
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(_17,#token("\"\"","String"),_18)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(600) org.kframework.attributes.Location(Location(600,8,600,32)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'17:SortString{},\dv{SortString{}}(""),Var'Unds'18:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("600"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(600,8,600,32)")]
+
+// rule isTCellOpt(inj{TCellOpt,KItem}(TCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellOpt{}(kseq{}(inj{SortTCellOpt{}, SortKItem{}}(VarTCellOpt:SortTCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_11)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(828) org.kframework.attributes.Location(Location(828,8,828,59)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},VarB1:SortK{},Var'Unds'11:SortK{}),
+        VarB1:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("828"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(828,8,828,59)")]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(kseq{}(VarKItem:SortKItem{},dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'0:SortList{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(```` `#execute_BMC-SYNTAX_`(.KList) #as _101``=>`#branchIncrease_BMC-SYNTAX_`(.KList)~>_101``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X)))),DotVar0) requires `_<Int__INT-COMMON__Int_Int`(X,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(19) org.kframework.attributes.Location(Location(19,8,21,22)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),Var'Unds'101:SortKItem{}),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchIncrease'Unds'BMC-SYNTAX'Unds'{}(),kseq{}(Var'Unds'101:SortKItem{},VarDotVar2:SortK{}))),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("19"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(19,8,21,22)")]
+
+// rule isStateCellOpt(inj{StateCellOpt,KItem}(StateCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(kseq{}(inj{SortStateCellOpt{}, SortKItem{}}(VarStateCellOpt:SortStateCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'1:SortGeneratedCounterCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(`` `#minusOne_BMC-SYNTAX_`(.KList)=>.K``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X=>`_-Int__INT-COMMON__Int_Int`(X,#token("1","Int")))))),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(39) org.kframework.attributes.Location(Location(39,8,40,48)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'minusOne'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar2:SortK{}),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("1")))))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("39"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(39,8,40,48)")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'1:SortKConfigVar{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCell(inj{TCell,KItem}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCell{}(kseq{}(inj{SortTCell{}, SortKItem{}}(VarTCell:SortTCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(358) org.kframework.attributes.Location(Location(358,8,358,57)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("358"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,8,358,57)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool") #as _44,_1)=>_44 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(335) org.kframework.attributes.Location(Location(335,8,335,36)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'44:SortBool{}),Var'Unds'1:SortBool{}),
+        Var'Unds'44:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("335"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(335,8,335,36)")]
+
+// rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortIOString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortIOString{}, SortKItem{}}(Var'Unds'0:SortIOString{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOString{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `#stdin_K-IO_`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(970) org.kframework.attributes.Location(Location(970,8,970,19)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Hash'stdin'Unds'K-IO'Unds'{}(),
+        \dv{SortInt{}}("0")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("970"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(970,8,970,19)")]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortIOInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'0:SortIOInt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(#token("true","Bool") #as _30,B)=>B requires _30 ensures _30 [contentStartColumn(8) contentStartLine(328) org.kframework.attributes.Location(Location(328,8,328,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'30:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'30:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'30:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("328"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(328,8,328,37)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_6,#token("true","Bool") #as _38)=>_38 requires _38 ensures _38 [contentStartColumn(8) contentStartLine(355) org.kframework.attributes.Location(Location(355,8,355,39)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'38:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'6:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'38:SortBool{})),
+        Var'Unds'38:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'38:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("355"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(355,8,355,39)")]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(Var'Unds'0:SortKItem{},dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOString{}(kseq{}(inj{SortIOString{}, SortKItem{}}(VarIOString:SortIOString{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source))) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(609) org.kframework.attributes.Location(Location(609,8,611,66)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("609"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(609,8,611,66)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_5,#token("true","Bool") #as _19)=>_19 requires _19 ensures _19 [contentStartColumn(8) contentStartLine(349) org.kframework.attributes.Location(Location(349,8,349,33)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'19:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'5:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'19:SortBool{})),
+        Var'Unds'19:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'19:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("349"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,8,349,33)")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'1:SortSet{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(```` `#execute_BMC-SYNTAX_`(.KList) #as _106``=>`#branchNoChange_BMC-SYNTAX_`(.KList)~>_106``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X)))),DotVar0) requires `_>Int__INT-COMMON__Int_Int`(X,#token("5","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(27) org.kframework.attributes.Location(Location(27,8,29,22)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarX:SortInt{},\dv{SortInt{}}("5")),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(Lbl'Hash'execute'Unds'BMC-SYNTAX'Unds'{}(),Var'Unds'106:SortKItem{}),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'branchNoChange'Unds'BMC-SYNTAX'Unds'{}(),kseq{}(Var'Unds'106:SortKItem{},VarDotVar2:SortK{}))),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("27"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(27,8,29,22)")]
+
+// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortStream{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'0:SortStream{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStream{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `notBool_`(#token("true","Bool") #as _46)=>#token("false","Bool") requires _46 ensures _46 [contentStartColumn(8) contentStartLine(325) org.kframework.attributes.Location(Location(325,8,325,29)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'46:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'46:SortBool{})),
+        \dv{SortBool{}}("false")),
+      \equals{SortBool{},R}(
+        Var'Unds'46:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("325"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(325,8,325,29)")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'0:SortGeneratedTopCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(339) org.kframework.attributes.Location(Location(339,8,339,38)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("339"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,8,339,38)")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'1:SortGeneratedTopCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,_12,_13,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(620) org.kframework.attributes.Location(Location(620,8,620,49)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},Var'Unds'12:SortString{},Var'Unds'13:SortString{},\dv{SortInt{}}("0")),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("620"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(620,8,620,49)")]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isCell(inj{Cell,KItem}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblinitGeneratedCounterCell{}(),
+        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule isStateCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortStateCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStateCell{}, SortKItem{}}(Var'Unds'0:SortStateCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `is#KVariable`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:Sort'Hash'KVariable{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Unds'0:Sort'Hash'KVariable{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'1:SortString{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(326) org.kframework.attributes.Location(Location(326,8,326,29)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("326"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(326,8,326,29)")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_modInt__INT-COMMON__Int_Int`(`_>>Int__INT-COMMON__Int_Int`(I,IDX),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(435) org.kframework.attributes.Location(Location(435,8,435,85)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("435"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(435,8,435,85)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING__String`(ToCount)),`lengthString(_)_STRING__String`(Source)),ToCount)) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(606) org.kframework.attributes.Location(Location(606,8,607,60)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToCount:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("606"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(606,8,607,60)")]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `replaceAll(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING__String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(621) org.kframework.attributes.Location(Location(621,8,621,154)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("621"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(621,8,621,154)")]
+
+// rule #Ceil(`_%Int__INT-COMMON__Int_Int`(I1,I2))=>#Equals(`_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")),#token("true","Bool")) requires #token("true","Bool") ensures #token("true","Bool") [anywhere() contentStartColumn(8) contentStartLine(427) org.kframework.attributes.Location(Location(427,8,427,65)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]) sortParams([Q0])]
+  axiom{R,Q0} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{Q0,R} (
+        \ceil{SortInt{}, Q0}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \equals{SortBool{}, Q0}(Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),\dv{SortBool{}}("true"))),
+      \top{R}()))
+  [simplification{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), sortParams{}("[Q0]"), contentStartLine{}("427"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(427,8,427,65)"), anywhere{}()]
+
+// rule initStateCell(.KList)=>`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(#token("0","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortStateCell{},R} (
+        LblinitStateCell{}(),
+        Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0"))))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(822) org.kframework.attributes.Location(Location(822,8,822,45)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("822"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,8,822,45)")]
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)))) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(599) org.kframework.attributes.Location(Location(599,8,599,431)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("599"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(599,8,599,431)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(350) org.kframework.attributes.Location(Location(350,8,350,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("350"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(350,8,350,37)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(356) org.kframework.attributes.Location(Location(356,8,356,45)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("356"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(356,8,356,45)")]
+
+// rule isStateCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortStateCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStateCellOpt{}, SortKItem{}}(Var'Unds'1:SortStateCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule initTCell(.KList)=>`<T>`(initKCell(.KList),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortTCell{},R} (
+        LblinitTCell{}(),
+        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(),LblinitStateCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(`` `#addOne_BMC-SYNTAX_`(.KList)=>.K``~>DotVar2),`<state>`(`_|->_`(inj{String,KItem}(#token("\"x\"","String")),inj{Int,KItem}(X=>`_+Int_`(X,#token("1","Int")))))),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(42) org.kframework.attributes.Location(Location(42,8,43,48)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(Lbl'Hash'addOne'Unds'BMC-SYNTAX'Unds'{}(),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(VarX:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar2:SortK{}),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortString{}, SortKItem{}}(\dv{SortString{}}("x")),inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarX:SortInt{},\dv{SortInt{}}("1")))))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/./bmc.k)"), contentStartLine{}("42"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,8,43,48)")]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortCell{}, SortKItem{}}(Var'Unds'1:SortCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `freshId(_)_ID-SYNTAX__Int`(I)=>`String2Id(_)_ID-SYNTAX__String`(`_+String__STRING__String_String`(#token("\"_\"","String"),`Int2String(_)_STRING__Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(791) org.kframework.attributes.Location(Location(791,8,791,62)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortId{},R} (
+        LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(VarI:SortInt{}),
+        LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{})))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("791"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(791,8,791,62)")]
+
+// rule `#stdout_K-IO_`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(971) org.kframework.attributes.Location(Location(971,8,971,20)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Hash'stdout'Unds'K-IO'Unds'{}(),
+        \dv{SortInt{}}("1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("971"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(971,8,971,20)")]
+
+// rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStream{}(kseq{}(inj{SortStream{}, SortKItem{}}(VarStream:SortStream{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'1:SortId{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisId{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'1:SortFloat{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `#projectString(_)_K-IO__IOString`(inj{String,IOString}(S))=>S requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(985) org.kframework.attributes.Location(Location(985,8,985,37)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lbl'Hash'projectString'LParUndsRParUnds'K-IO'UndsUnds'IOString{}(inj{SortString{}, SortIOString{}}(VarS:SortString{})),
+        VarS:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("985"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(985,8,985,37)")]
+
+// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortIOError{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortIOError{}, SortKItem{}}(Var'Unds'0:SortIOError{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisIOError{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(345) org.kframework.attributes.Location(Location(345,8,345,32)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("345"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,8,345,32)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_4)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(354) org.kframework.attributes.Location(Location(354,8,354,40)) org.kframework.attributes.Source(Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'4:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/.build/k/include/builtin/domains.k)"), contentStartLine{}("354"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,8,354,40)")]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCellOpt{}(kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'1:SortKCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(4,1,6,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/zy/workspace/kore/src/main/k/in-progress/bmc/example2/test-spec.k)")]


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---
1. added '--bmc' flag to the command line which invokes the bounded model checker.
2. Introduced `ImplicationRule` to capture bmc specification (which is different from rewrite rules)
3. Bounded model checker is implemented in a separate module.
