### PR TITLE
Sort module sentences before indexing

### DIFF
--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -55,6 +55,7 @@ import qualified Control.Monad.State.Strict as Monad.State
 import           Data.Bifunctor
 import           Data.Default as Default
 import qualified Data.Foldable as Foldable
+import qualified Data.List as List
 import           Data.Map.Strict
                  ( Map )
 import qualified Data.Map.Strict as Map
@@ -404,6 +405,7 @@ the module is already in the 'IndexedModule' map.
 indexModuleIfNeeded
     ::  ( ParseAttributes declAttrs
         , ParseAttributes axiomAttrs
+        , Ord sentence
         , sentence ~ Sentence Object sortParam patternType
         , indexed ~ IndexedModule sortParam patternType declAttrs axiomAttrs
         )
@@ -415,16 +417,12 @@ indexModuleIfNeeded
     -- ^ Map containing all modules that were already indexed.
     -> Module sentence
     -- ^ Module to be indexed
-    -> Either
-        (Error IndexModuleError)
-        (Map.Map ModuleName indexed)
+    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed)
     -- ^ If the module was indexed succesfully, the map returned on 'Right'
     -- contains everything that the provided 'IndexedModule' map contained,
     -- plus the current module, plus all the modules that were indexed when
     -- resolving imports.
-indexModuleIfNeeded
-    implicitModule nameToModule indexedModules koreModule
-  =
+indexModuleIfNeeded implicitModule nameToModule indexedModules koreModule =
     fst <$>
         internalIndexModuleIfNeeded
             implicitModule Set.empty nameToModule indexedModules koreModule
@@ -432,6 +430,7 @@ indexModuleIfNeeded
 internalIndexModuleIfNeeded
     ::  ( ParseAttributes declAttrs
         , ParseAttributes axiomAttrs
+        , Ord sentence
         , sentence ~ Sentence Object sortParam patternType
         , indexed ~ IndexedModule sortParam patternType declAttrs axiomAttrs
         )
@@ -463,13 +462,15 @@ internalIndexModuleIfNeeded
                                     (parsedModuleAtts, moduleAtts)
                                 }
                             )
-                    (newIndex, newModule) <- foldM
-                        (indexModuleKoreSentence
-                            implicitModule
-                            importingModulesWithCurrentOne
-                            nameToModule)
-                        indexedModulesAndStartingIndexedModule
-                        (moduleSentences koreModule)
+                    (newIndex, newModule) <-
+                        foldM
+                            (indexModuleSentence
+                                implicitModule
+                                importingModulesWithCurrentOne
+                                nameToModule
+                            )
+                            indexedModulesAndStartingIndexedModule
+                            (List.sort $ moduleSentences koreModule)
                     -- Parse subsorts to fail now if subsort attributes are
                     -- malformed, so indexedModuleSubsorts can appear total
                     -- TODO: consider making subsorts an IndexedModule field
@@ -484,23 +485,10 @@ internalIndexModuleIfNeeded
     koreModuleName = moduleName koreModule
     importingModulesWithCurrentOne = Set.insert koreModuleName importingModules
 
-indexModuleKoreSentence
-    ::  ( ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , sentence ~ Sentence Object sortParam patternType
-        , indexed ~ IndexedModule sortParam patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule sortParam patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> (Map.Map ModuleName indexed, indexed)
-    -> sentence
-    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
-indexModuleKoreSentence = indexModuleSentence
-
 indexModuleSentence
     ::  ( ParseAttributes declAttrs
         , ParseAttributes axiomAttrs
+        , Ord sentence
         , sentence ~ Sentence Object sortParam patternType
         , indexed ~ IndexedModule sortParam patternType declAttrs axiomAttrs
         )
@@ -693,6 +681,7 @@ indexModuleSentence
 indexImportedModule
     ::  ( ParseAttributes declAttrs
         , ParseAttributes axiomAttrs
+        , Ord sentence
         , sentence ~ Sentence Object sortParam patternType
         , indexed ~ IndexedModule sortParam patternType declAttrs axiomAttrs
         )

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -222,7 +222,7 @@ extractRewriteAxioms
     :: VerifiedModule declAtts axiomAtts
     -> [RewriteRule Object Variable]
 extractRewriteAxioms idxMod =
-    mapMaybe (extractRewriteAxiomFrom. getIndexedSentence)
+    mapMaybe (extractRewriteAxiomFrom . getIndexedSentence)
         (indexedModuleAxioms idxMod)
 
 extractRewriteAxiomFrom

--- a/kore/test/Test/Kore/IndexedModule/Resolvers.hs
+++ b/kore/test/Test/Kore/IndexedModule/Resolvers.hs
@@ -1,14 +1,13 @@
-module Test.Kore.IndexedModule.Resolvers
-where
+module Test.Kore.IndexedModule.Resolvers where
 
 import Test.Tasty
 import Test.Tasty.HUnit
--- import Test.Terse
 
 import           Data.Default
+import qualified Data.List as List
+import           Data.Map
+                 ( Map )
 import qualified Data.Map as Map
-import           Data.Maybe
-                 ( fromMaybe )
 import qualified Data.Set as Set
 
 import           Kore.Annotation.Valid
@@ -37,6 +36,18 @@ objectS1 = simpleSort (SortName "s1")
 objectA :: SentenceSymbol Object (TermLike Variable)
 objectA = mkSymbol_ (testId "a") [] objectS1
 
+-- Two variations on a constructor axiom for 'objectA'.
+axiomA, axiomA' :: SentenceAxiom SortVariable (TermLike Variable)
+axiomA = mkAxiom_ $ applySymbol_ objectA []
+axiomA' =
+    mkAxiom [sortVariableR]
+    $ mkForall x
+    $ mkEquals sortR (mkVar x) (applySymbol_ objectA [])
+  where
+    x = varS "x" objectS1
+    sortVariableR = SortVariable (testId "R")
+    sortR = SortVariableSort sortVariableR
+
 objectB :: SentenceAlias Object (TermLike Variable)
 objectB = mkAlias_ (testId "b") objectS1 [] $ mkTop objectS1
 
@@ -62,8 +73,7 @@ strictAttribute :: ParsedPattern
 strictAttribute =
     (asParsedPattern . ApplicationPattern)
         Application
-            { applicationSymbolOrAlias =
-                groundHead "strict" AstLocationTest :: SymbolOrAlias
+            { applicationSymbolOrAlias = groundHead "strict" AstLocationTest
             , applicationChildren = []
             }
 
@@ -80,6 +90,8 @@ testObjectModule =
                     }
             , asSentence objectA
             , asSentence objectB
+            , asSentence axiomA
+            , asSentence axiomA'
             ]
         , moduleAttributes = Attributes [strictAttribute]
         }
@@ -130,19 +142,17 @@ testDefinition =
             ]
         }
 
-testIndexedModule :: VerifiedModule Attribute.Null Attribute.Null
-testIndexedModule =
-    case
-        verifyAndIndexDefinition
-            DoNotVerifyAttributes
-            Builtin.koreVerifiers
-            (eraseSentenceAnnotations <$> testDefinition)
-      of
-        Right modulesMap ->
-            fromMaybe
-                (error "This should not have happened")
-                (Map.lookup testMainModuleName modulesMap)
-        Left err -> error (printError err)
+indexedModules :: Map ModuleName (VerifiedModule Attribute.Null Attribute.Null)
+Right indexedModules =
+    verifyAndIndexDefinition
+        DoNotVerifyAttributes
+        Builtin.koreVerifiers
+        (eraseSentenceAnnotations <$> testDefinition)
+
+testIndexedModule, testIndexedObjectModule
+    :: VerifiedModule Attribute.Null Attribute.Null
+Just testIndexedModule = Map.lookup testMainModuleName indexedModules
+Just testIndexedObjectModule = Map.lookup testObjectModuleName indexedModules
 
 test_resolvers :: [TestTree]
 test_resolvers =
@@ -284,6 +294,11 @@ test_resolvers =
                 testIndexedModule
                 (getSentenceSymbolOrAliasHead objectB [])
             )
+        )
+    , testCase "sort indexed axioms"
+        (assertEqual ""
+            (reverse $ List.sort [axiomA, axiomA'])
+            (getIndexedSentence <$> indexedModuleAxioms testIndexedObjectModule)
         )
     ]
   where


### PR DESCRIPTION
Sort module sentences before indexing.

The order of sentences in a module is not formally significant, so the order produced by the frontend varies depending on the build, the operating system, the phases of the moon, non-local quantum variables, ...

Although the order of sentences is not formally significant, it affects debugging: if either of two axioms would produce an error, applying them in one order or the other changes which error is actually produced. Therefore, we sort all the sentences before beginning so that errors are more readily-reproducible.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

