### PR TITLE
Generic unparsing

### DIFF
--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -39,6 +39,7 @@ dependencies:
   - extra
   - fgl
   - free
+  - generics-sop
   - gitrev
   - graphviz
   - groom

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -54,8 +54,8 @@ import           Data.Sequence
 import           Data.Set
                  ( Set )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           GHC.Generics
-                 ( Generic )
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 
 import Control.Lens.TH.Rules
        ( makeLenses )
@@ -98,7 +98,7 @@ data InternalMap child =
         , builtinMapConcat :: !SymbolOrAlias
         , builtinMapChild :: !(Map Key child)
         }
-    deriving (Foldable, Functor, Generic, Traversable)
+    deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 instance Eq child => Eq (InternalMap child) where
     (==) = eq1
@@ -158,7 +158,7 @@ data InternalList child =
         , builtinListConcat :: !SymbolOrAlias
         , builtinListChild :: !(Seq child)
         }
-    deriving (Foldable, Functor, Generic, Traversable)
+    deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 instance Eq child => Eq (InternalList child) where
     (==) = eq1
@@ -214,7 +214,7 @@ data InternalSet =
         , builtinSetConcat :: !SymbolOrAlias
         , builtinSetChild :: !(Set Key)
         }
-    deriving Generic
+    deriving GHC.Generic
 
 instance Hashable InternalSet where
     hashWithSalt salt builtin =
@@ -258,7 +258,7 @@ data InternalInt =
         { builtinIntSort :: !Sort
         , builtinIntValue :: !Integer
         }
-    deriving (Eq, Generic, Ord, Show)
+    deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable InternalInt
 
@@ -284,7 +284,7 @@ data InternalBool =
         { builtinBoolSort :: !Sort
         , builtinBoolValue :: !Bool
         }
-    deriving (Eq, Generic, Ord, Show)
+    deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable InternalBool
 
@@ -318,7 +318,7 @@ data Builtin child
     | BuiltinSet !InternalSet
     | BuiltinInt !InternalInt
     | BuiltinBool !InternalBool
-    deriving (Foldable, Functor, Generic, Traversable)
+    deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 deriving instance Eq child => Eq (Builtin child)
 
@@ -326,28 +326,15 @@ deriving instance Ord child => Ord (Builtin child)
 
 deriving instance Show child => Show (Builtin child)
 
-instance Hashable child => Hashable (Builtin child) where
+instance SOP.Generic (Builtin child)
+
+instance Hashable child => Hashable (Builtin child)
 
 instance NFData child => NFData (Builtin child)
 
 instance Unparse child => Unparse (Builtin child) where
-    unparse =
-        \case
-            BuiltinExternal external -> unparse external
-            BuiltinInt builtinInt -> unparse builtinInt
-            BuiltinBool builtinBool -> unparse builtinBool
-            BuiltinMap builtinMap -> unparse builtinMap
-            BuiltinList builtinList -> unparse builtinList
-            BuiltinSet builtinSet -> unparse builtinSet
-
-    unparse2 =
-        \case
-            BuiltinExternal external -> unparse2 external
-            BuiltinInt builtinInt -> unparse2 builtinInt
-            BuiltinBool builtinBool -> unparse2 builtinBool
-            BuiltinMap builtinMap -> unparse2 builtinMap
-            BuiltinList builtinList -> unparse2 builtinList
-            BuiltinSet builtinSet -> unparse2 builtinSet
+    unparse = unparseGeneric
+    unparse2 = unparse2Generic
 
 makeLenses ''InternalMap
 makeLenses ''InternalList

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -158,9 +158,7 @@ Otherwise, the argument is returned.
 
  -}
 withoutFreeVariable
-    ::  ( Ord variable
-        , Unparse variable
-        )
+    :: (Ord variable, SortedVariable variable, Unparse variable)
     => variable  -- ^ variable
     -> TermLike variable
     -> a  -- ^ result, if the variable does not occur free in the pattern
@@ -399,7 +397,7 @@ termLikeSort = Attribute.patternSort . extract
 
 -- | Attempts to modify p to have sort s.
 forceSort
-    :: (Unparse variable, HasCallStack)
+    :: (SortedVariable variable, Unparse variable, HasCallStack)
     => Sort
     -> TermLike variable
     -> TermLike variable
@@ -487,9 +485,7 @@ same sort.
 
  -}
 makeSortsAgree
-    ::  ( Unparse variable
-        , HasCallStack
-        )
+    :: (SortedVariable variable, Unparse variable, HasCallStack)
     => (TermLike variable -> TermLike variable -> Sort -> a)
     -> TermLike variable
     -> TermLike variable
@@ -516,6 +512,7 @@ getRigidSort pattern' =
  -}
 mkAnd
     ::  ( Ord variable
+        , SortedVariable variable
         , Unparse variable
         , HasCallStack
         )
@@ -596,7 +593,7 @@ See also: 'mkApp', 'applyAlias_', 'applySymbol', 'mkAlias'
 
  -}
 applyAlias
-    :: (Ord variable, Unparse variable, HasCallStack)
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => SentenceAlias (TermLike variable)
     -- ^ 'Alias' declaration
     -> [Sort]
@@ -651,7 +648,9 @@ See also: 'mkApp', 'applyAlias'
  -}
 applyAlias_
     ::  ( Ord variable
+        , SortedVariable variable
         , Unparse variable
+        , HasCallStack
         )
     => SentenceAlias (TermLike variable)
     -> [TermLike variable]
@@ -666,9 +665,7 @@ See also: 'mkApp', 'applySymbol_', 'mkSymbol'
 
  -}
 applySymbol
-    ::  ( Ord variable
-        , Unparse variable
-        )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => SentenceSymbol pattern''
     -- ^ 'Symbol' declaration
     -> [Sort]
@@ -719,7 +716,7 @@ See also: 'mkApp', 'applySymbol'
 
  -}
 applySymbol_
-    :: (Ord variable, Unparse variable)
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => SentenceSymbol pattern''
     -> [TermLike variable]
     -> TermLike variable
@@ -803,7 +800,7 @@ See also: 'mkEquals_'
 
  -}
 mkEquals
-    :: ( Ord variable , Unparse variable, HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => Sort
     -> TermLike variable
     -> TermLike variable
@@ -839,6 +836,7 @@ See also: 'mkEquals'
  -}
 mkEquals_
     ::  ( Ord variable
+        , SortedVariable variable
         , Unparse variable
         , HasCallStack
         )
@@ -920,7 +918,7 @@ mkForall forallVariable forallChild =
 {- | Construct an 'Iff' pattern.
  -}
 mkIff
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => TermLike variable
     -> TermLike variable
     -> TermLike variable
@@ -941,7 +939,7 @@ mkIff = makeSortsAgree mkIffWorker
 {- | Construct an 'Implies' pattern.
  -}
 mkImplies
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => TermLike variable
     -> TermLike variable
     -> TermLike variable
@@ -965,7 +963,7 @@ See also: 'mkIn_'
 
  -}
 mkIn
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => Sort
     -> TermLike variable
     -> TermLike variable
@@ -999,7 +997,7 @@ See also: 'mkIn'
 
  -}
 mkIn_
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => TermLike variable
     -> TermLike variable
     -> TermLike variable
@@ -1036,7 +1034,7 @@ mkNot notChild =
 {- | Construct an 'Or' pattern.
  -}
 mkOr
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => TermLike variable
     -> TermLike variable
     -> TermLike variable
@@ -1057,7 +1055,7 @@ mkOr = makeSortsAgree mkOrWorker
 {- | Construct a 'Rewrites' pattern.
  -}
 mkRewrites
-    :: ( Ord variable , Unparse variable , HasCallStack )
+    :: (Ord variable, SortedVariable variable, Unparse variable, HasCallStack)
     => TermLike variable
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Predicate/Predicate.hs
+++ b/kore/src/Kore/Predicate/Predicate.hs
@@ -139,9 +139,7 @@ the resulting pattern into a particular sort.
 
  -}
 fromPredicate
-    :: ( Unparse variable
-       , HasCallStack
-       )
+    :: (SortedVariable variable, Unparse variable, HasCallStack)
     => Sort  -- ^ Sort of resulting pattern
     -> Predicate variable
     -> TermLike variable
@@ -155,10 +153,8 @@ pattern PredicateFalse :: Predicate variable
 -}
 pattern PredicateTrue :: Predicate variable
 
-pattern PredicateFalse
-    <- GenericPredicate (Recursive.project -> _ :< BottomF _)
-pattern PredicateTrue
-    <- GenericPredicate (Recursive.project -> _ :< TopF _)
+pattern PredicateFalse <- GenericPredicate (Recursive.project -> _ :< BottomF _)
+pattern PredicateTrue  <- GenericPredicate (Recursive.project -> _ :< TopF _)
 
 {-|'isFalse' checks whether a predicate is obviously bottom.
 -}

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -76,7 +76,10 @@ deriving instance Eq variable => Eq (RulePattern variable)
 deriving instance Ord variable => Ord (RulePattern variable)
 deriving instance Show variable => Show (RulePattern variable)
 
-instance Unparse variable => Pretty (RulePattern variable) where
+instance
+    (SortedVariable variable, Unparse variable) =>
+    Pretty (RulePattern variable)
+  where
     pretty rulePattern'@(RulePattern _ _ _ _ _) =
         Pretty.vsep
             [ "left:"
@@ -122,7 +125,10 @@ deriving instance Eq variable => Eq (RewriteRule variable)
 deriving instance Ord variable => Ord (RewriteRule variable)
 deriving instance Show variable => Show (RewriteRule variable)
 
-instance (Unparse variable, Ord variable) => Unparse (RewriteRule variable) where
+instance
+    (Ord variable, SortedVariable variable, Unparse variable) =>
+    Unparse (RewriteRule variable)
+  where
     unparse (RewriteRule RulePattern { left, right, requires } ) =
         unparse $ mkImplies
             (mkAnd left (Predicate.unwrapPredicate requires))

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -1025,6 +1025,7 @@ when @src1@ is a subsort of @src2@.
 sortInjectionAndEqualsAssumesDifferentHeads
     ::  forall variable unifier unifierM .
         ( Ord variable
+        , SortedVariable variable
         , Unparse variable
         , MonadUnify unifierM
         , unifier ~ unifierM variable
@@ -1214,6 +1215,7 @@ returns @\\bottom@.
 -- injection should always clash with constructors. We should clarify this.
 constructorSortInjectionAndEquals
     ::  ( Eq variable
+        , SortedVariable variable
         , Unparse variable
         , MonadUnify unifierM
         , unifier ~ unifierM variable
@@ -1251,6 +1253,7 @@ to be different; therefore their conjunction is @\\bottom@.
  -}
 constructorAndEqualsAssumesDifferentHeads
     ::  ( Eq variable
+        , SortedVariable variable
         , Unparse variable
         , MonadUnify unifierM
         , unifier ~ unifierM variable
@@ -1317,6 +1320,7 @@ See also: 'equalAndEquals'
 -- but it is not.
 domainValueAndEqualsAssumesDifferent
     :: Eq variable
+    => SortedVariable variable
     => Unparse variable
     => MonadUnify unifierM
     => unifier ~ unifierM variable
@@ -1339,6 +1343,7 @@ domainValueAndEqualsAssumesDifferent _ _ = empty
 
 cannotUnifyDomainValues
     :: Eq variable
+    => SortedVariable variable
     => Unparse variable
     => MonadUnify unifierM
     => unifier ~ unifierM variable
@@ -1363,6 +1368,7 @@ See also: 'equalAndEquals'
  -}
 stringLiteralAndEqualsAssumesDifferent
     :: Eq variable
+    => SortedVariable variable
     => Unparse variable
     => MonadUnify unifierM
     => unifier ~ unifierM variable
@@ -1385,6 +1391,7 @@ See also: 'equalAndEquals'
  -}
 charLiteralAndEqualsAssumesDifferent
     :: Eq variable
+    => SortedVariable variable
     => Unparse variable
     => MonadUnify unifierM
     => unifier ~ unifierM variable

--- a/kore/src/Kore/Syntax/Exists.hs
+++ b/kore/src/Kore/Syntax/Exists.hs
@@ -19,6 +19,7 @@ import           GHC.Generics
                  ( Generic )
 
 import Kore.Sort
+import Kore.Syntax.Variable
 import Kore.Unparser
 
 {-|'Exists' corresponds to the @\exists@ branches of the @object-pattern@ and
@@ -48,9 +49,7 @@ instance
     NFData (Exists sort variable child)
 
 instance
-    ( Unparse child
-    , Unparse variable
-    ) =>
+    (SortedVariable variable, Unparse variable, Unparse child) =>
     Unparse (Exists Sort variable child)
   where
     unparse Exists { existsSort, existsVariable, existsChild } =
@@ -61,6 +60,6 @@ instance
     unparse2 Exists { existsVariable, existsChild } =
         Pretty.parens (Pretty.fillSep
             [ "\\exists"
-            , unparse2BindingVariables existsVariable
+            , unparse2SortedVariable existsVariable
             , unparse2 existsChild
             ])

--- a/kore/src/Kore/Syntax/Forall.hs
+++ b/kore/src/Kore/Syntax/Forall.hs
@@ -19,6 +19,7 @@ import           GHC.Generics
                  ( Generic )
 
 import Kore.Sort
+import Kore.Syntax.Variable
 import Kore.Unparser
 
 {-|'Forall' corresponds to the @\forall@ branches of the @object-pattern@ and
@@ -48,7 +49,7 @@ instance
     NFData (Forall sort variable child)
 
 instance
-    (Unparse child, Unparse variable) =>
+    (SortedVariable variable, Unparse variable, Unparse child) =>
     Unparse (Forall Sort variable child)
   where
     unparse Forall { forallSort, forallVariable, forallChild } =
@@ -59,6 +60,6 @@ instance
     unparse2 Forall { forallVariable, forallChild } =
         Pretty.parens (Pretty.fillSep
             [ "\\forall"
-            , unparse2BindingVariables forallVariable
+            , unparse2SortedVariable forallVariable
             , unparse2 forallChild
             ])

--- a/kore/src/Kore/Syntax/Pattern.hs
+++ b/kore/src/Kore/Syntax/Pattern.hs
@@ -140,7 +140,7 @@ instance
 
 instance
     ( Functor domain
-    , Unparse variable
+    , SortedVariable variable, Unparse variable
     , Unparse (domain self)
     , self ~ Pattern domain variable annotation
     ) =>

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -53,6 +53,7 @@ import Kore.Syntax.Rewrites
 import Kore.Syntax.SetVariable
 import Kore.Syntax.StringLiteral
 import Kore.Syntax.Top
+import Kore.Syntax.Variable
 import Kore.Unparser
 
 {- | 'PatternF' is the 'Base' functor of Kore patterns
@@ -119,7 +120,9 @@ instance
     NFData (PatternF domain variable child)
 
 instance
-    (Unparse child, Unparse (domain child), Unparse variable) =>
+    ( SortedVariable variable, Unparse variable
+    , Unparse child, Unparse (domain child)
+    ) =>
     Unparse (PatternF domain variable child)
   where
     unparse = unparseGeneric

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -30,8 +30,8 @@ import           Data.Text
                  ( Text )
 import           Data.Void
                  ( Void )
-import           GHC.Generics
-                 ( Generic )
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 
 import Kore.Sort
 import Kore.Syntax.And
@@ -81,7 +81,7 @@ data PatternF domain variable child
     | VariableF      !variable
     | InhabitantF    !Sort
     | SetVariableF   !(SetVariable variable)
-    deriving (Foldable, Functor, Generic, Traversable)
+    deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 Deriving.deriveEq1 ''PatternF
 Deriving.deriveOrd1 ''PatternF
@@ -108,76 +108,22 @@ instance
     showsPrec = showsPrec1
     {-# INLINE showsPrec #-}
 
+instance SOP.Generic (PatternF domain variable child)
+
 instance
-    ( Hashable child
-    , Hashable variable
-    , Hashable (domain child)
-    ) =>
+    (Hashable child, Hashable variable, Hashable (domain child)) =>
     Hashable (PatternF domain variable child)
 
 instance
-    ( NFData child
-    , NFData variable
-    , NFData (domain child)
-    ) =>
+    (NFData child, NFData variable, NFData (domain child)) =>
     NFData (PatternF domain variable child)
 
 instance
-    ( Unparse child
-    , Unparse (domain child)
-    , Unparse variable
-    ) =>
+    (Unparse child, Unparse (domain child), Unparse variable) =>
     Unparse (PatternF domain variable child)
   where
-    unparse =
-        \case
-            AndF p           -> unparse p
-            ApplicationF p   -> unparse p
-            BottomF p        -> unparse p
-            CeilF p          -> unparse p
-            DomainValueF p   -> unparse p
-            EqualsF p        -> unparse p
-            ExistsF p        -> unparse p
-            FloorF p         -> unparse p
-            ForallF p        -> unparse p
-            IffF p           -> unparse p
-            ImpliesF p       -> unparse p
-            InF p            -> unparse p
-            NextF p          -> unparse p
-            NotF p           -> unparse p
-            OrF p            -> unparse p
-            RewritesF p      -> unparse p
-            StringLiteralF p -> unparse p
-            CharLiteralF p   -> unparse p
-            TopF p           -> unparse p
-            VariableF p      -> unparse p
-            InhabitantF s          -> unparse s
-            SetVariableF p   -> unparse p
-
-    unparse2 =
-        \case
-            AndF p           -> unparse2 p
-            ApplicationF p   -> unparse2 p
-            BottomF p        -> unparse2 p
-            CeilF p          -> unparse2 p
-            DomainValueF p   -> unparse2 p
-            EqualsF p        -> unparse2 p
-            ExistsF p        -> unparse2 p
-            FloorF p         -> unparse2 p
-            ForallF p        -> unparse2 p
-            IffF p           -> unparse2 p
-            ImpliesF p       -> unparse2 p
-            InF p            -> unparse2 p
-            NextF p          -> unparse2 p
-            NotF p           -> unparse2 p
-            OrF p            -> unparse2 p
-            RewritesF p      -> unparse2 p
-            StringLiteralF p -> unparse2 p
-            CharLiteralF p   -> unparse2 p
-            TopF p           -> unparse2 p
-            VariableF p      -> unparse2 p
-            InhabitantF s          -> unparse s
-            SetVariableF p   -> unparse p
+    unparse = unparseGeneric
+    unparse2 = unparse2Generic
 
 {- | Use the provided mapping to replace all variables in a 'PatternF' head.
 

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -156,9 +156,8 @@ traverseVariables traversing =
         ExistsF any0 -> ExistsF <$> traverseVariablesExists any0
         ForallF all0 -> ForallF <$> traverseVariablesForall all0
         VariableF variable -> VariableF <$> traversing variable
-        InhabitantF s -> pure (InhabitantF s)
-        SetVariableF (SetVariable variable)
-            -> SetVariableF . SetVariable <$> traversing variable
+        SetVariableF (SetVariable variable) ->
+            SetVariableF . SetVariable <$> traversing variable
         -- Trivial cases
         AndF andP -> pure (AndF andP)
         ApplicationF appP -> pure (ApplicationF appP)
@@ -177,6 +176,7 @@ traverseVariables traversing =
         StringLiteralF strP -> pure (StringLiteralF strP)
         CharLiteralF charP -> pure (CharLiteralF charP)
         TopF topP -> pure (TopF topP)
+        InhabitantF s -> pure (InhabitantF s)
   where
     traverseVariablesExists Exists { existsSort, existsVariable, existsChild } =
         Exists existsSort <$> traversing existsVariable <*> pure existsChild
@@ -192,7 +192,6 @@ mapDomainValues mapping =
     \case
         -- Non-trivial case
         DomainValueF domainP -> DomainValueF (mapping domainP)
-        InhabitantF s -> InhabitantF s
         -- Trivial cases
         AndF andP -> AndF andP
         ApplicationF appP -> ApplicationF appP
@@ -214,6 +213,7 @@ mapDomainValues mapping =
         TopF topP -> TopF topP
         VariableF varP -> VariableF varP
         SetVariableF varP -> SetVariableF varP
+        InhabitantF s -> InhabitantF s
 
 {- | Cast a 'PatternF' head with @'Const' 'Void'@ domain values into any domain.
 

--- a/kore/src/Kore/Syntax/Variable.hs
+++ b/kore/src/Kore/Syntax/Variable.hs
@@ -52,11 +52,11 @@ data Variable = Variable
     }
     deriving (Show, Eq, Ord, Generic)
 
-instance Hashable (Variable)
+instance Hashable Variable
 
-instance NFData (Variable)
+instance NFData Variable
 
-instance Unparse (Variable) where
+instance Unparse Variable where
     unparse Variable { variableName, variableCounter, variableSort } =
         unparse variableName
         <> Pretty.pretty variableCounter

--- a/kore/src/Kore/Syntax/Variable.hs
+++ b/kore/src/Kore/Syntax/Variable.hs
@@ -14,6 +14,7 @@ module Kore.Syntax.Variable
     , illegalVariableCounter
     , externalizeFreshVariable
     , SortedVariable (..)
+    , unparse2SortedVariable
     , Concrete
     ) where
 
@@ -62,14 +63,10 @@ instance Unparse Variable where
         <> Pretty.pretty variableCounter
         <> Pretty.colon
         <> unparse variableSort
+
     unparse2 Variable { variableName, variableCounter } =
         unparse2 variableName
         <> Pretty.pretty variableCounter
-    unparse2BindingVariables Variable { variableName, variableCounter, variableSort } =
-        unparse2 variableName
-        <> Pretty.pretty variableCounter
-        <> Pretty.colon
-        <> unparse2 variableSort
 
 {- | Is the variable original (as opposed to generated)?
  -}
@@ -136,6 +133,21 @@ instance SortedVariable Variable where
     fromVariable = id
     toVariable = id
 
+{- | Unparse any 'SortedVariable' in an Applicative Kore binder.
+
+Variables occur without their sorts as subterms in Applicative Kore patterns,
+but with their sorts in binders like @\\exists@ and
+@\\forall@. @unparse2SortedVariable@ adds the sort ascription to the unparsed
+variable for the latter case.
+
+ -}
+unparse2SortedVariable
+    :: (SortedVariable variable, Unparse variable)
+    => variable
+    -> Pretty.Doc ann
+unparse2SortedVariable variable =
+    unparse2 variable <> Pretty.colon <> unparse (sortedVariableSort variable)
+
 {- | @Concrete@ is a variable occuring in a concrete pattern.
 
 Concrete patterns do not contain variables, so this is an uninhabited type
@@ -154,3 +166,8 @@ instance NFData Concrete
 instance Unparse Concrete where
     unparse = \case {}
     unparse2 = \case {}
+
+instance SortedVariable Concrete where
+    sortedVariableSort = \case {}
+    toVariable = \case {}
+    fromVariable = error "Cannot construct a variable in a concrete term!"

--- a/kore/src/Kore/Unification/Unify.hs
+++ b/kore/src/Kore/Unification/Unify.hs
@@ -14,7 +14,7 @@ import           Data.Text.Prettyprint.Doc
                  ( Doc )
 
 import           Kore.Internal.TermLike
-                 ( TermLike )
+                 ( SortedVariable, TermLike )
 import qualified Kore.Logger as Log
 import           Kore.Step.Simplification.Data
                  ( Environment (..), Simplifier )
@@ -50,7 +50,7 @@ class (forall variable. Monad (unifier variable)) => MonadUnify unifier where
         -> unifier variable' a
 
     explainBottom
-        :: Unparse variable
+        :: (SortedVariable variable, Unparse variable)
         => Doc ()
         -> TermLike variable
         -> TermLike variable

--- a/kore/src/Kore/Unparser.hs
+++ b/kore/src/Kore/Unparser.hs
@@ -69,11 +69,6 @@ class Unparse p where
     -- | Render a type from abstract to concrete Applicative Kore syntax.
     unparse2 :: p -> Doc ann
 
-    -- special unparser only for binding variables
-    unparse2BindingVariables :: p -> Doc ann
-    -- default implementation of unparse2BindingVariables
-    unparse2BindingVariables = unparse2
-
 instance Unparse a => Unparse (Const a child) where
     unparse (Const a) = unparse a
     unparse2 (Const a) = unparse2 a


### PR DESCRIPTION
This pull request introduces a generic unparsing function to eliminate boilerplate associated with unparsing large sum types where the type is unparsed by delegating to each case in the sum. This is also a kind of warm-up exercise for more boilerplate reduction, such as in `Kore.ASTPrettyPrint` and `Test.Kore.Comparators`.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

