### PR TITLE
Fail early during one-path reachability proofs

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -136,7 +136,7 @@ exec indexedModule strategy purePattern = do
     let
         Execution { executionGraph } = execution
         finalConfig = pickLongest executionGraph
-    return (forceSort patternSort $ Pattern.toMLPattern finalConfig)
+    return (forceSort patternSort $ Pattern.toTermLike finalConfig)
   where
     patternSort = Attribute.patternSort $ extract purePattern
 

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -49,7 +49,6 @@ import           Kore.IndexedModule.Resolvers
 import qualified Kore.Internal.MultiOr as MultiOr
 import           Kore.Internal.OrPattern
                  ( OrPattern )
-import qualified Kore.Internal.OrPattern as OrPattern
 import           Kore.Internal.Pattern
                  ( Conditional (..), Pattern )
 import qualified Kore.Internal.Pattern as Pattern
@@ -238,7 +237,7 @@ prove limit definitionModule specModule = do
             axiomIdToSimplifier
             (defaultStrategy claims axioms)
             (map (\x -> (x,limit)) (extractUntrustedClaims claims))
-    return $ Bifunctor.first OrPattern.toTermLike result
+    return $ Bifunctor.first Pattern.toTermLike result
 
 -- | Initialize and run the repl with the main and spec modules. This will loop
 -- the repl until the user exits.

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -109,7 +109,7 @@ toPattern multiOr =
         [patt] -> patt
         patts ->
             Conditional.Conditional
-                { term = Foldable.foldr1 mkOr (Pattern.toMLPattern <$> patts)
+                { term = Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts)
                 , predicate = Syntax.Predicate.makeTruePredicate
                 , substitution = mempty
                 }
@@ -126,5 +126,5 @@ toTermLike
 toTermLike multiOr =
     case MultiOr.extractPatterns multiOr of
         [] -> mkBottom_
-        [patt] -> Pattern.toMLPattern patt
-        patts -> Foldable.foldr1 mkOr (Pattern.toMLPattern <$> patts)
+        [patt] -> Pattern.toTermLike patt
+        patts -> Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts)

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -12,7 +12,7 @@ module Kore.Internal.OrPattern
     , isFalse
     , top
     , isTrue
-    , toExpandedPattern
+    , toPattern
     , toTermLike
     , MultiOr.flatten
     ) where
@@ -93,18 +93,17 @@ top = fromPattern Pattern.top
 isTrue :: Ord variable => OrPattern variable -> Bool
 isTrue = isTop
 
-{-| 'toExpandedPattern' transforms an 'Pattern' into
+{-| 'toPattern' transforms an 'Pattern' into
 an 'Pattern.Pattern'.
 -}
-toExpandedPattern
+toPattern
     ::  ( SortedVariable variable
         , Ord variable
         , Show variable
         , Unparse variable
         )
     => OrPattern variable -> Pattern variable
-toExpandedPattern multiOr
-  =
+toPattern multiOr =
     case MultiOr.extractPatterns multiOr of
         [] -> Pattern.bottom
         [patt] -> patt

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -14,8 +14,7 @@ module Kore.Internal.Pattern
     , isBottom
     , isTop
     , Kore.Internal.Pattern.mapVariables
-    , toMLPattern
-    , toStepPattern
+    , toTermLike
     , top
     , topOf
     , fromTermLike
@@ -116,7 +115,7 @@ substitutions; this function should be used with care where that distinction is
 important.
 
  -}
-toStepPattern
+toTermLike
     ::  forall variable.
         ( SortedVariable variable
         , Ord variable
@@ -125,9 +124,7 @@ toStepPattern
         , HasCallStack
         )
     => Pattern variable -> TermLike variable
-toStepPattern
-    Conditional { term, predicate, substitution }
-  =
+toTermLike Conditional { term, predicate, substitution } =
     simpleAnd
         (simpleAnd term predicate)
         (Syntax.Predicate.fromSubstitution substitution)
@@ -146,17 +143,6 @@ toStepPattern
       where
         predicateTermLike = Syntax.Predicate.fromPredicate sort predicate'
         sort = termLikeSort pattern'
-
-toMLPattern
-    ::  forall variable.
-        ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , HasCallStack
-        )
-    => Pattern variable -> TermLike variable
-toMLPattern = toStepPattern
 
 {-|'bottom' is an expanded pattern that has a bottom condition and that
 should become Bottom when transformed to a ML pattern.

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -79,7 +79,7 @@ checkImplicationIsTop
              ]
       where
         lhsFreeVariables = Pattern.freeVariables lhs
-        lhsMLPatt = Pattern.toMLPattern lhs
+        lhsMLPatt = Pattern.toTermLike lhs
 
 stripForallQuantifiers
     :: TermLike Variable

--- a/kore/src/Kore/OnePath/Step.hs
+++ b/kore/src/Kore/OnePath/Step.hs
@@ -367,8 +367,8 @@ removalPredicate destination config =
         $ quantifyPredicate
         $ Predicate.makeCeilPredicate
         $ mkAnd
-            (Pattern.toStepPattern destination)
-            (Pattern.toStepPattern config)
+            (Pattern.toTermLike destination)
+            (Pattern.toTermLike config)
 
 
 {-| A strategy for doing the first step of a one-path verification.

--- a/kore/src/Kore/OnePath/StrategyPattern.hs
+++ b/kore/src/Kore/OnePath/StrategyPattern.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+
+ -}
 module Kore.OnePath.StrategyPattern
     ( StrategyPattern (..)
     , strategyPattern

--- a/kore/src/Kore/OnePath/StrategyPattern.hs
+++ b/kore/src/Kore/OnePath/StrategyPattern.hs
@@ -1,0 +1,96 @@
+module Kore.OnePath.StrategyPattern
+    ( StrategyPattern (..)
+    , strategyPattern
+    , StrategyPatternTransformer (..)
+    , CommonStrategyPattern
+    , extractUnproven
+    , extractStuck
+    ) where
+
+import Data.Hashable
+import GHC.Generics
+
+import Kore.Internal.Pattern
+       ( Pattern )
+import Kore.Internal.TermLike
+
+{- | A pattern on which a rule can be applied or on which a rule was applied.
+
+As an example, when rewriting
+
+@
+if x then phi else psi
+@
+
+with these rules
+
+@
+if true  then u else v => u
+if false then u else v => v
+@
+
+there would be two 'RewritePattern's, @phi and x=true@ and @psi and x=false@.
+If only the first rule was present, the results would be a 'RewritePattern' with
+@phi and x=true@ and a 'Remainder' with @psi and not x=true@.
+
+When rewriting the same pattern with an rule that does not match, e.g.
+
+@
+x + y => x +Int y
+@
+
+then rewriting produces no children.
+
+-}
+data StrategyPattern patt
+    = RewritePattern !patt
+    -- ^ Pattern on which a normal 'Rewrite' can be applied. Also used
+    -- for the start patterns.
+    | Stuck !patt
+    -- ^ Pattern which can't be rewritten anymore.
+    | Bottom
+    -- ^ special representation for a bottom rewriting/simplification result.
+    -- This is needed when bottom results are expected and we want to
+    -- differentiate between them and stuck results.
+  deriving (Show, Eq, Ord, Generic)
+
+{- | Extract the unproven part of a 'StrategyPattern'.
+
+Returns 'Nothing' if there is no remaining unproven part.
+
+ -}
+extractUnproven :: StrategyPattern patt -> Maybe patt
+extractUnproven (RewritePattern p) = Just p
+extractUnproven (Stuck          p) = Just p
+extractUnproven Bottom             = Nothing
+
+-- | Extract the 'Stuck' part of a 'StrategyPattern'.
+extractStuck :: StrategyPattern patt -> Maybe patt
+extractStuck (Stuck p) = Just p
+extractStuck _         = Nothing
+
+data StrategyPatternTransformer patt a =
+    StrategyPatternTransformer
+        { rewriteTransformer :: patt -> a
+        , stuckTransformer :: patt -> a
+        , bottomValue :: a
+        }
+
+-- | Catamorphism for 'StrategyPattern'
+strategyPattern
+    :: StrategyPatternTransformer patt a
+    -> StrategyPattern patt
+    -> a
+strategyPattern
+    StrategyPatternTransformer
+        {rewriteTransformer, stuckTransformer, bottomValue}
+  =
+    \case
+        RewritePattern patt -> rewriteTransformer patt
+        Stuck patt -> stuckTransformer patt
+        Bottom -> bottomValue
+
+-- | A 'StrategyPattern' instantiated to 'Pattern Variable' for convenience.
+type CommonStrategyPattern = StrategyPattern (Pattern Variable)
+
+instance Hashable patt => Hashable (StrategyPattern patt)

--- a/kore/src/Kore/OnePath/Verification.hs
+++ b/kore/src/Kore/OnePath/Verification.hs
@@ -44,12 +44,12 @@ import           Kore.Internal.Pattern as Pattern
 import           Kore.Internal.Pattern as Conditional
                  ( Conditional (..) )
 import           Kore.OnePath.Step
-                 ( CommonStrategyPattern, Prim, onePathFirstStep,
-                 onePathFollowupStep )
-import qualified Kore.OnePath.Step as StrategyPattern
-                 ( StrategyPattern (..), extractStuck, extractUnproven )
+                 ( Prim, onePathFirstStep, onePathFollowupStep )
 import qualified Kore.OnePath.Step as OnePath
                  ( transitionRule )
+import           Kore.OnePath.StrategyPattern
+                 ( CommonStrategyPattern )
+import qualified Kore.OnePath.StrategyPattern as StrategyPattern
 import           Kore.Step.Axiom.Data
                  ( BuiltinAndAxiomSimplifierMap )
 import           Kore.Step.Rule

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -18,6 +18,8 @@ import           Control.Monad
                  ( when )
 import           Control.Monad.Catch
                  ( MonadCatch, catch )
+import           Control.Monad.Except
+                 ( ExceptT, runExceptT )
 import           Control.Monad.Extra
                  ( whileM )
 import           Control.Monad.IO.Class
@@ -175,6 +177,7 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
         if Graph.outdeg (Strategy.graph graph) node == 0
             then
                 catchInterruptWithDefault graph
+                $ catchUnprovableWithDefault graph
                 $ verifyClaimStep
                     tools
                     simplifier
@@ -205,6 +208,11 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
         catch sa $ \UserInterrupt -> do
             liftIO $ putStrLn "Step evaluation interrupted."
             pure def
+
+    catchUnprovableWithDefault :: Monad m => a -> ExceptT e m a -> m a
+    catchUnprovableWithDefault def action = do
+        result <- runExceptT action
+        return $ either (const def) id result
 
     replGreeting :: MonadIO m => m ()
     replGreeting =

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -18,8 +18,6 @@ import           Control.Monad
                  ( when )
 import           Control.Monad.Catch
                  ( MonadCatch, catch )
-import           Control.Monad.Except
-                 ( ExceptT, runExceptT )
 import           Control.Monad.Extra
                  ( whileM )
 import           Control.Monad.IO.Class
@@ -177,7 +175,6 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
         if Graph.outdeg (Strategy.graph graph) node == 0
             then
                 catchInterruptWithDefault graph
-                $ catchUnprovableWithDefault graph
                 $ verifyClaimStep
                     tools
                     simplifier
@@ -208,11 +205,6 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
         catch sa $ \UserInterrupt -> do
             liftIO $ putStrLn "Step evaluation interrupted."
             pure def
-
-    catchUnprovableWithDefault :: Monad m => a -> ExceptT e m a -> m a
-    catchUnprovableWithDefault def action = do
-        result <- runExceptT action
-        return $ either (const def) id result
 
     replGreeting :: MonadIO m => m ()
     replGreeting =

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -72,9 +72,7 @@ import           Kore.Internal.Pattern
                  ( Conditional (..) )
 import           Kore.Internal.TermLike
                  ( TermLike )
-import           Kore.OnePath.Step
-                 ( CommonStrategyPattern, StrategyPattern (..),
-                 StrategyPatternTransformer (..), strategyPattern )
+import           Kore.OnePath.StrategyPattern
 import           Kore.OnePath.Verification
                  ( Axiom (..) )
 import           Kore.OnePath.Verification

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -68,11 +68,11 @@ import           Kore.Internal.Pattern
                  ( Conditional (..) )
 import           Kore.Internal.TermLike
                  ( TermLike )
-import           Kore.OnePath.Step
+import           Kore.OnePath.StrategyPattern
                  ( CommonStrategyPattern, StrategyPattern (..),
                  StrategyPatternTransformer (StrategyPatternTransformer),
                  strategyPattern )
-import qualified Kore.OnePath.Step as StrategyPatternTransformer
+import qualified Kore.OnePath.StrategyPattern as StrategyPatternTransformer
                  ( StrategyPatternTransformer (..) )
 import           Kore.OnePath.Verification
                  ( Axiom (..) )
@@ -804,4 +804,3 @@ showAxiomOrClaim _   (RuleIndex Nothing) = Nothing
 showAxiomOrClaim len (RuleIndex (Just rid))
   | rid < len = Just $ "Axiom " <> show rid
   | otherwise = Just $ "Claim " <> show (rid - len)
-

--- a/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -67,7 +67,7 @@ evaluate
             case refute of
                 Just False -> Pattern.bottom
                 Just True -> Pattern.top
-                _ -> OrPattern.toExpandedPattern simplified
+                _ -> OrPattern.toPattern simplified
     return $ asPredicate simplified'
   where
     simplifyTerm' = simplifyTerm termSimplifier substitutionSimplifier

--- a/kore/src/Kore/Step/Result.hs
+++ b/kore/src/Kore/Step/Result.hs
@@ -14,6 +14,7 @@ module Kore.Step.Result
     , transitionResults
     , mapRules
     , mapConfigs
+    , traverseConfigs
     ) where
 
 import           Control.Applicative
@@ -130,3 +131,17 @@ mapConfigs mapResults mapRemainders Results { results, remainders } =
         { results = fmap mapResults <$> results
         , remainders = mapRemainders <$> remainders
         }
+
+{- | Apply 'Applicative' transformations to the configurations of the 'results'
+and 'remainders'.
+ -}
+traverseConfigs
+   :: Applicative f
+   => (config1 -> f config2)  -- ^ traverse 'results'
+   -> (config1 -> f config2)  -- ^ traverse 'remainders'
+   -> Results rule config1
+   -> f (Results rule config2)
+traverseConfigs traverseResults traverseRemainders rs =
+    Results
+        <$> (traverse . traverse) traverseResults (results rs)
+        <*> traverse traverseRemainders (remainders rs)

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -246,8 +246,8 @@ simplifyEvaluated
                 substitutionSimplifier
                 simplifier
                 axiomIdToSimplfier
-                (OrPattern.toExpandedPattern first)
-                (OrPattern.toExpandedPattern second)
+                (OrPattern.toPattern first)
+                (OrPattern.toPattern second)
   where
     firstPatterns = MultiOr.extractPatterns first
     secondPatterns = MultiOr.extractPatterns second

--- a/kore/src/Kore/Step/Simplification/Floor.hs
+++ b/kore/src/Kore/Step/Simplification/Floor.hs
@@ -72,7 +72,7 @@ simplifyEvaluatedFloor child =
         [childP] -> makeEvaluateFloor childP
         _ ->
             makeEvaluateFloor
-                (OrPattern.toExpandedPattern child)
+                (OrPattern.toPattern child)
 
 {-| 'makeEvaluateFloor' simplifies a 'Floor' of 'Pattern'.
 

--- a/kore/src/Kore/Step/Simplification/Forall.hs
+++ b/kore/src/Kore/Step/Simplification/Forall.hs
@@ -94,4 +94,4 @@ makeEvaluate variable patt
   | Pattern.isTop patt    = Pattern.top
   | Pattern.isBottom patt = Pattern.bottom
   | otherwise =
-    Pattern.fromTermLike $ mkForall variable $ Pattern.toMLPattern patt
+    Pattern.fromTermLike $ mkForall variable $ Pattern.toTermLike patt

--- a/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/kore/src/Kore/Step/Simplification/Iff.hs
@@ -127,8 +127,8 @@ simplifyEvaluated
         ([firstP], [secondP]) -> makeEvaluate firstP secondP
         _ ->
             makeEvaluate
-                (OrPattern.toExpandedPattern first)
-                (OrPattern.toExpandedPattern second)
+                (OrPattern.toPattern first)
+                (OrPattern.toPattern second)
   where
     firstPatterns = MultiOr.extractPatterns first
     secondPatterns = MultiOr.extractPatterns second

--- a/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/kore/src/Kore/Step/Simplification/Iff.hs
@@ -193,5 +193,5 @@ makeEvaluateNonBoolIff
         ]
   | otherwise =
     OrPattern.fromTermLike $ mkIff
-        (Pattern.toMLPattern patt1)
-        (Pattern.toMLPattern patt2)
+        (Pattern.toTermLike patt1)
+        (Pattern.toTermLike patt2)

--- a/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/kore/src/Kore/Step/Simplification/Implies.hs
@@ -172,7 +172,7 @@ simplifyEvaluateHalfImplies
     -- TODO: Also merge predicate-only patterns for 'Or'
     return $ case MultiOr.extractPatterns first of
         [firstP] -> makeEvaluateImplies firstP second
-        _ -> makeEvaluateImplies (OrPattern.toExpandedPattern first) second
+        _ -> makeEvaluateImplies (OrPattern.toPattern first) second
 
 makeEvaluateImplies
     ::  ( SortedVariable variable

--- a/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/kore/src/Kore/Step/Simplification/Implies.hs
@@ -238,8 +238,8 @@ makeEvaluateImpliesNonBool
         [ Conditional
             { term =
                 mkImplies
-                    (Pattern.toMLPattern pattern1)
-                    (Pattern.toMLPattern pattern2)
+                    (Pattern.toTermLike pattern1)
+                    (Pattern.toTermLike pattern2)
             , predicate = Syntax.Predicate.makeTruePredicate
             , substitution = mempty
             }

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -170,7 +170,7 @@ makeEvaluateNonBoolIn patt1 patt2 =
         , predicate =
             makeInPredicate
                 -- TODO: Wrap in 'contained' and 'container'.
-                (Pattern.toMLPattern patt1)
-                (Pattern.toMLPattern patt2)
+                (Pattern.toTermLike patt1)
+                (Pattern.toTermLike patt2)
         , substitution = mempty
         }

--- a/kore/src/Kore/Step/Simplification/Next.hs
+++ b/kore/src/Kore/Step/Simplification/Next.hs
@@ -48,5 +48,5 @@ simplifyEvaluated
 simplifyEvaluated simplified =
     OrPattern.fromTermLike
     $ mkNext
-    $ Pattern.toMLPattern
+    $ Pattern.toTermLike
     $ OrPattern.toPattern simplified

--- a/kore/src/Kore/Step/Simplification/Next.hs
+++ b/kore/src/Kore/Step/Simplification/Next.hs
@@ -49,4 +49,4 @@ simplifyEvaluated simplified =
     OrPattern.fromTermLike
     $ mkNext
     $ Pattern.toMLPattern
-    $ OrPattern.toExpandedPattern simplified
+    $ OrPattern.toPattern simplified

--- a/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -65,8 +65,8 @@ simplifyEvaluatedRewrites
     -> OrPattern variable
 simplifyEvaluatedRewrites first second =
     makeEvaluateRewrites
-        (OrPattern.toExpandedPattern first)
-        (OrPattern.toExpandedPattern second)
+        (OrPattern.toPattern first)
+        (OrPattern.toPattern second)
 
 makeEvaluateRewrites
     ::  ( SortedVariable variable

--- a/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -80,5 +80,5 @@ makeEvaluateRewrites
 makeEvaluateRewrites first second =
     OrPattern.fromTermLike
     $ mkRewrites
-        (Pattern.toMLPattern first)
-        (Pattern.toMLPattern second)
+        (Pattern.toTermLike first)
+        (Pattern.toTermLike second)

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -93,7 +93,7 @@ simplify
     -> Simplifier (Pattern variable)
 simplify tools substitutionSimplifier axiomIdToEvaluator patt = do
     orPatt <- simplifyToOr tools axiomIdToEvaluator substitutionSimplifier patt
-    return (OrPattern.toExpandedPattern orPatt)
+    return (OrPattern.toPattern orPatt)
 
 {-|'simplifyToOr' simplifies a TermLike variable, returning an
 'OrPattern'.

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -34,10 +34,9 @@ import           Kore.Internal.MultiOr
 import           Kore.Internal.Pattern
                  ( Conditional (..) )
 import           Kore.Internal.TermLike
-import           Kore.OnePath.Step
+import           Kore.OnePath.StrategyPattern
                  ( StrategyPattern )
-import           Kore.OnePath.Step as StrategyPattern
-                 ( StrategyPattern (..) )
+import qualified Kore.OnePath.StrategyPattern as StrategyPattern
 import           Kore.Predicate.Predicate
 import           Kore.Proof.Functional
 import           Kore.Step.Axiom.Data as AttemptedAxiom

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -12,7 +12,7 @@ import           Data.Text.Prettyprint.Doc
                  ( Pretty (..) )
 
 import           Kore.Internal.Pattern as Pattern
-                 ( Conditional (..), allVariables, mapVariables, toMLPattern )
+                 ( Conditional (..), allVariables, mapVariables, toTermLike )
 import           Kore.Internal.TermLike hiding
                  ( V )
 import           Kore.Predicate.Predicate
@@ -63,7 +63,7 @@ test_expandedPattern =
                 )
                 (makeEq (var 4) (var 5))
             )
-            (Pattern.toMLPattern
+            (Pattern.toTermLike
                 Conditional
                     { term = var 1
                     , predicate = makeEquals (var 2) (var 3)
@@ -77,7 +77,7 @@ test_expandedPattern =
                 (makeEq (var 2) (var 3))
                 (makeEq (var 4) (var 5))
             )
-            (Pattern.toMLPattern
+            (Pattern.toTermLike
                 Conditional
                     { term = mkTop sortVariable
                     , predicate = makeEquals (var 2) (var 3)
@@ -88,7 +88,7 @@ test_expandedPattern =
     , testCase "Converting to a ML pattern - top predicate"
         (assertEqualWithExplanation ""
             (var 1)
-            (Pattern.toMLPattern
+            (Pattern.toTermLike
                 Conditional
                     { term = var 1
                     , predicate = makeTruePredicate
@@ -99,7 +99,7 @@ test_expandedPattern =
     , testCase "Converting to a ML pattern - bottom pattern"
         (assertEqualWithExplanation ""
             (mkBottom sortVariable)
-            (Pattern.toMLPattern
+            (Pattern.toTermLike
                 Conditional
                     { term = mkBottom sortVariable
                     , predicate = makeEquals (var 2) (var 3)
@@ -110,7 +110,7 @@ test_expandedPattern =
     , testCase "Converting to a ML pattern - bottom predicate"
         (assertEqualWithExplanation ""
             (mkBottom sortVariable)
-            (Pattern.toMLPattern
+            (Pattern.toTermLike
                 Conditional
                     { term = var 1
                     , predicate = makeFalsePredicate

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -28,6 +28,7 @@ import           Kore.Internal.TermLike
 import           Kore.Internal.TermLike
                  ( TermLike )
 import           Kore.OnePath.Step
+import           Kore.OnePath.StrategyPattern
 import           Kore.Predicate.Predicate
                  ( makeAndPredicate, makeEqualsPredicate, makeNotPredicate,
                  makeTruePredicate )

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -7,6 +7,9 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
+import           Control.Monad.Except
+                 ( runExceptT )
+import qualified Data.Bifunctor as Bifunctor
 import           Data.Default
                  ( def )
 import           Data.List
@@ -55,10 +58,7 @@ import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
-type ExecutionGraph a =
-    Strategy.ExecutionGraph
-        (a)
-        (RewriteRule Variable)
+type ExecutionGraph a = Strategy.ExecutionGraph a (RewriteRule Variable)
 
 test_onePathStrategy :: [TestTree]
 test_onePathStrategy =
@@ -68,7 +68,7 @@ test_onePathStrategy =
         -- Normal axiom: a => c
         -- Start pattern: a
         -- Expected: a
-        [ actual ] <- runOnePathSteps
+        Right [ actual ] <- runOnePathSteps
             metadataTools
             (Limit 0)
             (Pattern.fromTermLike Mock.a)
@@ -84,7 +84,7 @@ test_onePathStrategy =
         -- Normal axiom: a => c
         -- Start pattern: a
         -- Expected: bottom, since a->bottom
-        [ _actual ] <- runOnePathSteps
+        Right [ _actual ] <- runOnePathSteps
             metadataTools
             (Limit 1)
             (Pattern.fromTermLike Mock.a)
@@ -99,7 +99,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: c, since coinductive axioms are applied only at the second
         -- step
-        [ _actual ] <- runOnePathSteps
+        Right [ _actual ] <- runOnePathSteps
             metadataTools
             (Limit 1)
             (Pattern.fromTermLike Mock.a)
@@ -116,7 +116,7 @@ test_onePathStrategy =
         -- Normal axiom: a => b
         -- Start pattern: a
         -- Expected: bottom, since a->b = target
-        [ _actual ] <- runOnePathSteps
+        Right [ _actual ] <- runOnePathSteps
             metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
@@ -135,7 +135,7 @@ test_onePathStrategy =
         -- Normal axiom: a => b
         -- Start pattern: a
         -- Expected: c, since a->b->c and b->d is ignored
-        [ _actual1 ] <- runOnePathSteps
+        Right [ _actual1 ] <- runOnePathSteps
             metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
@@ -160,7 +160,7 @@ test_onePathStrategy =
         -- Normal axiom: a => b
         -- Start pattern: a
         -- Expected: d, since a->b->d
-        [ _actual ] <- runOnePathSteps
+        Right [ _actual ] <- runOnePathSteps
             metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
@@ -193,7 +193,7 @@ test_onePathStrategy =
         --   or (f(b) and x=b)
         --   or (f(c) and x=c)
         --   or (h(x) and x!=a and x!=b and x!=c )
-        [ _actual1, _actual2, _actual3, _actual4 ] <-
+        Right [ _actual1, _actual2, _actual3, _actual4 ] <-
             runOnePathSteps
                 metadataTools
                 (Limit 2)
@@ -264,7 +264,7 @@ test_onePathStrategy =
         --   or (f(b) and x=b)
         --   or (f(c) and x=c)
         --   Stuck (functionalConstr11(x) and x!=a and x!=b and x!=c )
-        [ _actual1, _actual2, _actual3 ] <-
+        Right [ _actual1, _actual2, _actual3 ] <-
             runOnePathSteps
                 metadataTools
                 (Limit 2)
@@ -322,12 +322,10 @@ test_onePathStrategy =
         -- Normal axiom: constr10(b) => a | f(b) == c
         -- Start pattern: constr10(b)
         -- Expected: a | f(b) == c
-        [ _actual1, _actual2 ] <- runOnePathSteps
+        Left actual <- runOnePathSteps
             metadataTools
             (Limit 2)
-            (Pattern.fromTermLike
-                (Mock.functionalConstr10 Mock.b)
-            )
+            (Pattern.fromTermLike (Mock.functionalConstr10 Mock.b))
             Mock.a
             []
             [ rewriteWithPredicate
@@ -337,27 +335,21 @@ test_onePathStrategy =
                     Mock.c
                     $ Mock.f Mock.b
             ]
-        assertEqualWithExplanation ""
-            [ Stuck Conditional
-                { term = Mock.functionalConstr10 Mock.b
-                , predicate =
-                    makeNotPredicate
-                        $ makeEqualsPredicate
-                            Mock.c
-                            $ Mock.f Mock.b
-                , substitution = mempty
-                }
-            , Bottom
-            ]
-            [ _actual1
-            , _actual2
-            ]
+        let stuck =
+                Conditional
+                    { term = Mock.functionalConstr10 Mock.b
+                    , predicate =
+                        makeNotPredicate
+                            $ makeEqualsPredicate Mock.c (Mock.f Mock.b)
+                    , substitution = mempty
+                    }
+        assertEqualWithExplanation "" stuck actual
     , testCase "Stuck pattern simplification" $ do
         -- Target: 1
         -- Coinductive axioms: none
         -- Normal axiom: x => 1 if x<2
         -- Start pattern: 0
-        [ _actual ] <-
+        Right [ _actual ] <-
             runOnePathSteps
                 metadataTools
                 (Limit 2)
@@ -374,9 +366,7 @@ test_onePathStrategy =
                         (Mock.builtinBool True)
                     )
                 ]
-        assertEqualWithExplanation ""
-            Bottom
-            _actual
+        assertEqualWithExplanation "" Bottom _actual
     ]
   where
     metadataTools :: SmtMetadataTools StepperAttributes
@@ -426,11 +416,12 @@ runSteps
     -> Pattern Variable
     -- ^left-hand-side of unification
     -> [Strategy (Prim (Pattern Variable) (RewriteRule Variable))]
-    -> IO a
+    -> IO (Either (Pattern Variable) a)
 runSteps metadataTools graphFilter picker configuration strategy =
-    (<$>) picker
+    (<$>) (Bifunctor.second picker)
     $ SMT.runSMT SMT.defaultConfig
     $ evalSimplifier emptyLogger
+    $ runExceptT
     $ (fromMaybe (error "Unexpected missing tree") . graphFilter)
     <$> runStrategy
         (transitionRule
@@ -453,7 +444,7 @@ runOnePathSteps
     -> TermLike Variable
     -> [RewriteRule Variable]
     -> [RewriteRule Variable]
-    -> IO [CommonStrategyPattern]
+    -> IO (Either (Pattern Variable) [CommonStrategyPattern])
 runOnePathSteps
     metadataTools
     stepLimit
@@ -478,6 +469,6 @@ runOnePathSteps
                 )
             )
         )
-    return (sort $ nub result)
+    return (Bifunctor.second (sort . nub) result)
   where
     expandedTarget = Pattern.fromTermLike target

--- a/kore/test/Test/Kore/OnePath/Verification.hs
+++ b/kore/test/Test/Kore/OnePath/Verification.hs
@@ -23,9 +23,6 @@ import qualified Kore.Attribute.Axiom as Attribute
 import           Kore.Attribute.Symbol
 import           Kore.IndexedModule.MetadataTools
                  ( SmtMetadataTools )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
-import qualified Kore.Internal.OrPattern as OrPattern
 import           Kore.Internal.Pattern
                  ( Conditional (Conditional) )
 import           Kore.Internal.Pattern as Conditional
@@ -67,7 +64,7 @@ test_onePathVerification =
             [simpleAxiom Mock.a Mock.b]
             [simpleClaim Mock.a Mock.b]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.a)
+            (Left $ Pattern.fromTermLike Mock.a)
             actual
     , testCase "Runs one step" $ do
         -- Axiom: a => b
@@ -84,7 +81,7 @@ test_onePathVerification =
             [simpleAxiom Mock.a Mock.b]
             [simpleClaim Mock.a Mock.b]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.b)
+            (Left $ Pattern.fromTermLike Mock.b)
             actual
     , testCase "Returns multiple results" $ do
         -- Axiom: a => b or c
@@ -96,8 +93,7 @@ test_onePathVerification =
             [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
             [simpleClaim Mock.a Mock.d]
         assertEqualWithExplanation ""
-            (Left . OrPattern.fromPatterns $
-                Pattern.fromTermLike <$> [Mock.b, Mock.c]
+            (Left $ Pattern.fromTermLike Mock.b
             )
             actual
     , testCase "Verifies one claim" $ do
@@ -123,7 +119,7 @@ test_onePathVerification =
             , simpleClaim Mock.a Mock.b
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.a)
+            (Left $ Pattern.fromTermLike Mock.a)
             actual
     , testCase "Verifies one claim multiple steps" $ do
         -- Axiom: a => b
@@ -189,14 +185,12 @@ test_onePathVerification =
             ]
             [simpleClaim (Mock.functionalConstr10 (mkVar Mock.x)) Mock.b]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromPattern
-                Conditional
-                    { term = Mock.functionalConstr11 (mkVar Mock.x)
-                    , predicate =
-                        makeNotPredicate
-                            (makeEqualsPredicate (mkVar Mock.x) Mock.a)
-                    , substitution = mempty
-                    }
+            (Left Conditional
+                { term = Mock.functionalConstr11 (mkVar Mock.x)
+                , predicate =
+                    makeNotPredicate $ makeEqualsPredicate (mkVar Mock.x) Mock.a
+                , substitution = mempty
+                }
             )
             actual
     , testCase "Verifies two claims" $ do
@@ -237,7 +231,7 @@ test_onePathVerification =
             , simpleClaim Mock.d Mock.e
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.c)
+            (Left $ Pattern.fromTermLike Mock.c)
             actual
     , testCase "fails second of two claims" $ do
         -- Axiom: a => b
@@ -257,7 +251,7 @@ test_onePathVerification =
             , simpleClaim Mock.d Mock.c
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.e)
+            (Left $ Pattern.fromTermLike Mock.e)
             actual
     , testCase "second proves first but fails" $ do
         -- Axiom: a => b
@@ -275,7 +269,7 @@ test_onePathVerification =
             , simpleClaim Mock.b Mock.c
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.b)
+            (Left $ Pattern.fromTermLike Mock.b)
             actual
     , testCase "first proves second but fails" $ do
         -- Axiom: a => b
@@ -293,7 +287,7 @@ test_onePathVerification =
             , simpleClaim Mock.a Mock.d
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.b)
+            (Left $ Pattern.fromTermLike Mock.b)
             actual
     , testCase "trusted second proves first" $ do
         -- Axiom: a => b
@@ -352,7 +346,7 @@ test_onePathVerification =
             , simpleClaim Mock.b Mock.e
             ]
         assertEqualWithExplanation ""
-            (Left $ OrPattern.fromTermLike Mock.e)
+            (Left $ Pattern.fromTermLike Mock.e)
             actual
     ]
   where
@@ -415,7 +409,7 @@ runVerification
     -> Limit Natural
     -> [OnePath.Axiom]
     -> [claim]
-    -> IO (Either (OrPattern Variable) ())
+    -> IO (Either (Pattern Variable) ())
 runVerification
     metadataTools
     stepLimit

--- a/kore/test/Test/Kore/OnePath/Verification.hs
+++ b/kore/test/Test/Kore/OnePath/Verification.hs
@@ -159,7 +159,7 @@ test_onePathVerification =
         -- Expected: success
         actual <- runVerification
             metadataTools
-            (Limit 3)
+            (Limit 4)
             [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
             , simpleAxiom (Mock.functionalConstr11 (mkVar Mock.x)) Mock.b
             , simpleAxiom
@@ -167,9 +167,7 @@ test_onePathVerification =
                 (Mock.functionalConstr11 (mkVar Mock.x))
             ]
             [simpleClaim (Mock.functionalConstr10 (mkVar Mock.x)) Mock.b]
-        assertEqualWithExplanation ""
-            (Right ())
-            actual
+        assertEqualWithExplanation "" (Right ()) actual
     , testCase "Partial verification failure" $ do
         -- Axiom: constr11(a) => b
         -- Axiom: constr10(x) => constr11(x)

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -284,7 +284,7 @@ test_equalsSimplification_Or_Pattern =
         let message1 =
                 unlines
                     [ "Expected"
-                    , unparseToString (OrPattern.toExpandedPattern <$> test1)
+                    , unparseToString (OrPattern.toPattern <$> test1)
                     , "would simplify to:"
                     , unlines (unparseToString <$> Foldable.toList expect)
                     , "but instead found:"

--- a/kore/test/Test/Kore/Step/Simplification/Or.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Or.hs
@@ -254,7 +254,7 @@ becomes
         (stateIntention
             [ prettyOr or1 or2
             , "to become:"
-            , Unparser.unparse $ OrPattern.toExpandedPattern expected
+            , Unparser.unparse $ OrPattern.toPattern expected
             ]
         )
 


### PR DESCRIPTION
This pull request causes one-path reachability proofs to fail at the first stuck remainder. Such proofs can loop if we fail to apply a circularity (for example) and this makes such a failure easier to debug.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

