### PR TITLE
Test.Kore.Step.Substitution: Check for normalization

### DIFF
--- a/kore/test/Test/Kore/Step/Substitution.hs
+++ b/kore/test/Test/Kore/Step/Substitution.hs
@@ -1,22 +1,21 @@
-module Test.Kore.Step.Substitution
+ module Test.Kore.Step.Substitution
     ( test_mergeAndNormalizeSubstitutions
     , test_normalize
     ) where
 
 import Test.Tasty
-       ( TestTree )
 import Test.Tasty.HUnit
-       ( assertEqual, testCase )
 
+import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
 
 import           Kore.Attribute.Symbol
                  ( StepperAttributes )
 import           Kore.IndexedModule.MetadataTools
                  ( SmtMetadataTools )
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
 import qualified Kore.Internal.MultiOr as MultiOr
+import           Kore.Internal.OrPredicate
+                 ( OrPredicate )
 import           Kore.Internal.Predicate
                  ( Conditional (..), Predicate )
 import qualified Kore.Internal.Predicate as Predicate
@@ -48,6 +47,7 @@ test_normalize =
         let expect = mempty
         actual <- normalize Predicate.bottomPredicate
         assertEqual "Expected empty result" expect actual
+        assertNormalizedPredicates actual
     , testCase "∃ y z. x = σ(y, z)" $ do
         let expect =
                 Predicate.fromPredicate
@@ -60,6 +60,7 @@ test_normalize =
             "Expected original result"
             (Right $ MultiOr.make [expect])
             actual
+        Foldable.traverse_ assertNormalizedPredicates actual
     , testCase "¬∃ y z. x = σ(y, z)" $ do
         let expect =
                 Predicate.fromPredicate
@@ -73,6 +74,7 @@ test_normalize =
             "Expected original result"
             (Right $ MultiOr.make [expect])
             actual
+        Foldable.traverse_ assertNormalizedPredicates actual
     ]
 
 test_mergeAndNormalizeSubstitutions :: [TestTree]
@@ -94,6 +96,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Constructor normalization with variables"
         -- [x=constructor(y)] + [x=constructor(y)]  === [x=constructor(y)]
@@ -112,6 +115,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Double constructor is bottom"
         -- [x=constructor(a)] + [x=constructor(constructor(a))]  === bottom?
@@ -128,6 +132,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Double constructor is bottom with variables"
         -- [x=constructor(y)] + [x=constructor(constructor(y))]  === bottom?
@@ -144,6 +149,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Constructor and constructor of function"
         -- [x=constructor(a)] + [x=constructor(f(a))]
@@ -172,6 +178,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Constructor and constructor of function with variables"
         -- [x=constructor(y)] + [x=constructor(f(y))]
@@ -191,6 +198,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Constructor and constructor of functional symbol"
         -- [x=constructor(y)] + [x=constructor(functional(y))]
@@ -210,6 +218,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Constructor circular dependency?"
         -- [x=y] + [y=constructor(x)]  === error
@@ -226,6 +235,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Non-ctor circular dependency"
         -- [x=y] + [y=f(x)]  === error
@@ -245,6 +255,7 @@ test_mergeAndNormalizeSubstitutions =
                         )
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Normalizes substitution"
         $ do
@@ -261,6 +272,7 @@ test_mergeAndNormalizeSubstitutions =
                     , (Mock.x, Mock.constr10 (mkVar Mock.y))
                     ]
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Predicate from normalizing substitution"
         $ do
@@ -284,6 +296,7 @@ test_mergeAndNormalizeSubstitutions =
                             ]
                         }
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
 
     , testCase "Normalizes substitution and substitutes in predicate"
         $ do
@@ -312,6 +325,7 @@ test_mergeAndNormalizeSubstitutions =
                             ]
                         }
             assertEqualWithExplanation "" expect actual
+            assertNormalizedPredicates actual
     ]
 
 mockMetadataTools :: SmtMetadataTools StepperAttributes
@@ -356,7 +370,7 @@ normalize predicated =
 
 normalizeExcept
     :: Conditional Variable ()
-    -> IO (Either UnificationOrSubstitutionError (MultiOr (Conditional Variable ())))
+    -> IO (Either UnificationOrSubstitutionError (OrPredicate Variable))
 normalizeExcept predicated =
     runSMT
     $ evalSimplifier emptyLogger
@@ -373,3 +387,11 @@ normalizeExcept predicated =
 -- | Run an 'SMT' computation with the default configuration.
 runSMT :: SMT a -> IO a
 runSMT = SMT.runSMT SMT.defaultConfig
+
+-- | Check that 'Predicate.substitution' is normalized for all arguments.
+assertNormalizedPredicates :: Foldable f => f (Predicate Variable) -> Assertion
+assertNormalizedPredicates =
+    Foldable.traverse_
+    $ assertBool "Substitution is normalized"
+    . Substitution.isNormalized
+    . Predicate.substitution

--- a/kore/test/Test/Kore/Step/Substitution.hs
+++ b/kore/test/Test/Kore/Step/Substitution.hs
@@ -1,4 +1,4 @@
- module Test.Kore.Step.Substitution
+module Test.Kore.Step.Substitution
     ( test_mergeAndNormalizeSubstitutions
     , test_normalize
     ) where


### PR DESCRIPTION
Follow-up to #616. As discussed, this explicitly checks that the substitution is normalized by the functions which specifically normalize the substitution.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

