### PR TITLE
patternToAxiomPattern: Recognize \ceil axioms

### DIFF
--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -26,6 +26,7 @@ module Kore.Step.Rule
     , extractImplicationClaims
     , mkRewriteAxiom
     , mkEqualityAxiom
+    , mkCeilAxiom
     , refreshRulePattern
     , Kore.Step.Rule.freeVariables
     , Kore.Step.Rule.mapVariables
@@ -368,6 +369,15 @@ patternToAxiomPattern attributes pat =
                 , ensures = Predicate.makeTruePredicate
                 , attributes
                 }
+        -- definedness axioms
+        ceil@(Ceil_ _ resultSort _) ->
+            pure $ FunctionAxiomPattern $ EqualityRule RulePattern
+                { left = ceil
+                , right = mkTop resultSort
+                , requires = Predicate.makeTruePredicate
+                , ensures = Predicate.makeTruePredicate
+                , attributes
+                }
         Forall_ _ _ child -> patternToAxiomPattern attributes child
         -- implication axioms:
         -- init -> modal_op ( prop )
@@ -428,6 +438,20 @@ mkEqualityAxiom lhs rhs requires =
     sortVariableR = SortVariable "R"
     sortR = SortVariableSort sortVariableR
     function = mkEquals sortR lhs rhs
+
+{- | Construct a 'VerifiedKoreSentence' corresponding to a 'Ceil' axiom.
+
+ -}
+mkCeilAxiom
+    :: TermLike Variable  -- ^ the child of 'Ceil'
+    -> Verified.Sentence
+mkCeilAxiom child =
+    SentenceAxiomSentence
+    $ mkAxiom [sortVariableR]
+    $ mkCeil sortR child
+  where
+    sortVariableR = SortVariable "R"
+    sortR = SortVariableSort sortVariableR
 
 {- | Refresh the variables of a 'RulePattern'.
 

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -109,6 +109,19 @@ axiomPatternsUnitTests =
                     (extractRewriteAxioms
                         (extractIndexedModule "TEST" indexedDefinition)
                     )
+        , testCase "\\ceil(I1:AInt <= I2:AInt)" $ do
+            let term = applyLeqAInt varI1 varI2
+                sortR = mkSortVariable (testId "R")
+            assertEqual ""
+                (Right $ FunctionAxiomPattern $ EqualityRule RulePattern
+                    { left = mkCeil sortR term
+                    , right = mkTop sortR
+                    , requires = Predicate.makeTruePredicate
+                    , ensures = Predicate.makeTruePredicate
+                    , attributes = def
+                    }
+                )
+                (Rule.fromSentence $ mkCeilAxiom term)
         , testCase "(I1:AInt => I2:AInt)::KItem"
             (assertEqual ""
                 (koreFail "Unsupported pattern type in axiom")


### PR DESCRIPTION
In the future, we expect to need many such defined-ness axioms.

It would also be nice if we could specify these axioms in the frontend, but for now this will do.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

