### PR TITLE
Pattern.simplify: Use filterOr

### DIFF
--- a/kore/src/Kore/Internal/MultiOr.hs
+++ b/kore/src/Kore/Internal/MultiOr.hs
@@ -88,8 +88,7 @@ uncheckedMerge (MultiOr a) (MultiOr b) = MultiOr (a <> b)
 
 instance NFData child => NFData (MultiOr child)
 
-instance TopBottom child => TopBottom (MultiOr child)
-  where
+instance TopBottom child => TopBottom (MultiOr child) where
     isTop (MultiOr [child]) = isTop child
     isTop _ = False
     isBottom (MultiOr []) = True
@@ -113,8 +112,7 @@ filterOr
     :: (Ord term, TopBottom term)
     => MultiOr term
     -> MultiOr term
-filterOr =
-    filterGeneric patternToOrBool . filterUnique
+filterOr = filterGeneric patternToOrBool . filterUnique
 
 {- | Simplify the disjunction by eliminating duplicate elements.
 

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -15,6 +15,7 @@ module Kore.Internal.OrPattern
     , toPattern
     , toTermLike
     , MultiOr.flatten
+    , MultiOr.filterOr
     ) where
 
 import qualified Data.Foldable as Foldable

--- a/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -15,6 +15,7 @@ import           Kore.IndexedModule.MetadataTools
                  ( SmtMetadataTools )
 import           Kore.Internal.OrPattern
                  ( OrPattern )
+import qualified Kore.Internal.OrPattern as OrPattern
 import           Kore.Internal.Pattern
                  ( Conditional (..), Pattern )
 import qualified Kore.Internal.Pattern as Pattern
@@ -58,7 +59,7 @@ simplify
     Conditional {term, predicate, substitution}
   = do
     simplifiedTerm <- simplifyTerm' term
-    traverse
+    OrPattern.filterOr <$> traverse
         (give tools $ Pattern.mergeWithPredicate
             tools
             substitutionSimplifier

--- a/kore/test/Test/Kore/Builtin/List.hs
+++ b/kore/test/Test/Kore/Builtin/List.hs
@@ -14,8 +14,6 @@ import qualified Data.Sequence as Seq
 
 import           Kore.Attribute.Hook
                  ( Hook )
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Attribute.Symbol as StepperAttributes
 import qualified Kore.Builtin.List as List
 import           Kore.IndexedModule.MetadataTools
@@ -28,8 +26,6 @@ import           Test.Kore
 import           Test.Kore.Builtin.Builtin
 import           Test.Kore.Builtin.Definition
 import qualified Test.Kore.Builtin.Int as Test.Int
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.SMT
 
@@ -182,18 +178,8 @@ test_isBuiltin =
             (not (List.isSymbolUnit mockHookTools Mock.concatListSymbol))
     ]
 
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 mockHookTools :: SmtMetadataTools Hook
-mockHookTools = StepperAttributes.hook <$> mockMetadataTools
+mockHookTools = StepperAttributes.hook <$> Mock.metadataTools
 
 -- | Specialize 'List.asPattern' to the builtin sort 'listSort'.
 asTermLike

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -19,8 +19,6 @@ import           Prelude hiding
 
 import           Kore.Attribute.Hook
                  ( Hook )
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Attribute.Symbol as StepperAttributes
 import qualified Kore.Builtin.Map as Map
 import           Kore.IndexedModule.MetadataTools
@@ -44,8 +42,6 @@ import           Test.Kore.Builtin.Int
 import qualified Test.Kore.Builtin.Int as Test.Int
 import qualified Test.Kore.Builtin.Set as Test.Set
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.SMT
 import           Test.Tasty.HUnit.Extensions
@@ -325,18 +321,8 @@ test_isBuiltin =
             (not (Map.isSymbolUnit mockHookTools Mock.concatMapSymbol))
     ]
 
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 mockHookTools :: SmtMetadataTools Hook
-mockHookTools = StepperAttributes.hook <$> mockMetadataTools
+mockHookTools = StepperAttributes.hook <$> Mock.metadataTools
 
 -- | Construct a pattern for a map which may have symbolic keys.
 asSymbolicPattern

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -20,8 +20,6 @@ import qualified Data.Set as Set
 
 import           Kore.Attribute.Hook
                  ( Hook )
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Attribute.Symbol as StepperAttributes
 import qualified Kore.Builtin.Set as Set
 import           Kore.IndexedModule.MetadataTools
@@ -48,8 +46,6 @@ import           Test.Kore.Builtin.Int
 import qualified Test.Kore.Builtin.Int as Test.Int
 import qualified Test.Kore.Builtin.List as Test.List
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.SMT
 import           Test.Tasty.HUnit.Extensions
@@ -577,18 +573,8 @@ test_isBuiltin =
 hprop_unparse :: Property
 hprop_unparse = hpropUnparse (asInternal <$> genConcreteSet)
 
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 mockHookTools :: SmtMetadataTools Hook
-mockHookTools = StepperAttributes.hook <$> mockMetadataTools
+mockHookTools = StepperAttributes.hook <$> Mock.metadataTools
 
 -- | Specialize 'Set.asTermLike' to the builtin sort 'setSort'.
 asTermLike

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -51,15 +51,11 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
-type ExecutionGraph a =
-    Strategy.ExecutionGraph
-        (a)
-        (RewriteRule Variable)
+type ExecutionGraph a = Strategy.ExecutionGraph a (RewriteRule Variable)
 
 test_onePathStrategy :: [TestTree]
 test_onePathStrategy =
@@ -70,7 +66,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: a
         [ actual ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 0)
             (Pattern.fromTermLike Mock.a)
             Mock.a
@@ -86,7 +82,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: bottom, since a->bottom
         [ _actual ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 1)
             (Pattern.fromTermLike Mock.a)
             Mock.a
@@ -101,7 +97,7 @@ test_onePathStrategy =
         -- Expected: c, since coinductive axioms are applied only at the second
         -- step
         [ _actual ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 1)
             (Pattern.fromTermLike Mock.a)
             Mock.d
@@ -118,7 +114,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: bottom, since a->b = target
         [ _actual ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
             Mock.b
@@ -137,7 +133,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: c, since a->b->c and b->d is ignored
         [ _actual1 ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
             Mock.e
@@ -162,7 +158,7 @@ test_onePathStrategy =
         -- Start pattern: a
         -- Expected: d, since a->b->d
         [ _actual ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 2)
             (Pattern.fromTermLike Mock.a)
             Mock.e
@@ -196,7 +192,7 @@ test_onePathStrategy =
         --   or (h(x) and x!=a and x!=b and x!=c )
         [ _actual1, _actual2, _actual3, _actual4 ] <-
             runOnePathSteps
-                metadataTools
+                Mock.metadataTools
                 (Limit 2)
                 (Pattern.fromTermLike
                     (Mock.functionalConstr10 (mkVar Mock.x))
@@ -267,7 +263,7 @@ test_onePathStrategy =
         --   Stuck (functionalConstr11(x) and x!=a and x!=b and x!=c )
         [ _actual1, _actual2, _actual3 ] <-
             runOnePathSteps
-                metadataTools
+                Mock.metadataTools
                 (Limit 2)
                 (Pattern.fromTermLike
                     (Mock.functionalConstr10 (mkVar Mock.x))
@@ -324,7 +320,7 @@ test_onePathStrategy =
         -- Start pattern: constr10(b)
         -- Expected: a | f(b) == c
         [ _actual1, _actual2 ] <- runOnePathSteps
-            metadataTools
+            Mock.metadataTools
             (Limit 2)
             (Pattern.fromTermLike
                 (Mock.functionalConstr10 Mock.b)
@@ -360,7 +356,7 @@ test_onePathStrategy =
         -- Start pattern: 0
         [ _actual ] <-
             runOnePathSteps
-                metadataTools
+                Mock.metadataTools
                 (Limit 2)
                 (Pattern.fromTermLike (Mock.builtinInt 0))
                 (Mock.builtinInt 1)
@@ -379,16 +375,6 @@ test_onePathStrategy =
             Bottom
             _actual
     ]
-  where
-    metadataTools :: SmtMetadataTools StepperAttributes
-    metadataTools =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
 
 simpleRewrite
     :: TermLike Variable

--- a/kore/test/Test/Kore/OnePath/Verification.hs
+++ b/kore/test/Test/Kore/OnePath/Verification.hs
@@ -47,7 +47,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -59,7 +58,7 @@ test_onePathVerification =
         -- Claim: a => b
         -- Expected: error a
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 0)
             [simpleAxiom Mock.a Mock.b]
             [simpleClaim Mock.a Mock.b]
@@ -76,7 +75,7 @@ test_onePathVerification =
         -- the rewrite transforms 'a' into 'b'. We detect the success at the
         -- beginning of the second step, which does not run here.
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 1)
             [simpleAxiom Mock.a Mock.b]
             [simpleClaim Mock.a Mock.b]
@@ -88,7 +87,7 @@ test_onePathVerification =
         -- Claim: a => d
         -- Expected: error [b, c]
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 1)
             [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
             [simpleClaim Mock.a Mock.d]
@@ -101,7 +100,7 @@ test_onePathVerification =
         -- Claim: a => b
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 2)
             [simpleAxiom Mock.a Mock.b]
             [simpleClaim Mock.a Mock.b]
@@ -112,7 +111,7 @@ test_onePathVerification =
         -- Trusted Claim: a => b
         -- Expected: error a
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             []
             [ simpleTrustedClaim Mock.a Mock.b
@@ -127,7 +126,7 @@ test_onePathVerification =
         -- Claim: a => c
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -142,7 +141,7 @@ test_onePathVerification =
         -- Claim: a => b
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -158,7 +157,7 @@ test_onePathVerification =
         -- Claim: constr10(x) => b
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
             , simpleAxiom (Mock.functionalConstr11 (mkVar Mock.x)) Mock.b
@@ -174,7 +173,7 @@ test_onePathVerification =
         -- Claim: constr10(x) => b
         -- Expected: error constr11(x) and x != a
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
             , simpleAxiom
@@ -199,7 +198,7 @@ test_onePathVerification =
         -- Claim: d => e
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -219,7 +218,7 @@ test_onePathVerification =
         -- Claim: d => e
         -- Expected: error c
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -239,7 +238,7 @@ test_onePathVerification =
         -- Claim: d => c
         -- Expected: error e
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 3)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -258,7 +257,7 @@ test_onePathVerification =
         -- Claim: b => c
         -- Expected: error b
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.c Mock.d
@@ -276,7 +275,7 @@ test_onePathVerification =
         -- Claim: a => d
         -- Expected: error b
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.c Mock.d
@@ -294,7 +293,7 @@ test_onePathVerification =
         -- Trusted Claim: b => c
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.c Mock.d
@@ -312,7 +311,7 @@ test_onePathVerification =
         -- Claim: a => d
         -- Expected: success
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.c Mock.d
@@ -334,7 +333,7 @@ test_onePathVerification =
         --        without second claim would be: a=>b=>c=>d
         --    second verification: b=>c=>d, not visible here
         actual <- runVerification
-            metadataTools
+            Mock.metadataTools
             (Limit 4)
             [ simpleAxiom Mock.a Mock.b
             , simpleAxiom Mock.b Mock.c
@@ -347,16 +346,6 @@ test_onePathVerification =
             (Left $ Pattern.fromTermLike Mock.e)
             actual
     ]
-  where
-    metadataTools :: SmtMetadataTools StepperAttributes
-    metadataTools =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
 
 simpleAxiom
     :: TermLike Variable

--- a/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -47,8 +47,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
@@ -69,7 +67,7 @@ test_definitionEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (definitionEvaluation
                     [ axiom
                         (Mock.functionalConstr10 (mkVar Mock.x))
@@ -106,7 +104,7 @@ test_definitionEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (definitionEvaluation
                     [ axiom
                         (Mock.functionalConstr10 Mock.a)
@@ -131,7 +129,7 @@ test_definitionEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (definitionEvaluation
                     [ axiom
                         (Mock.functionalConstr10 Mock.a)
@@ -181,7 +179,7 @@ test_definitionEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (definitionEvaluation
                     [ axiom
                         (Mock.functionalConstr10 Mock.a)
@@ -214,7 +212,7 @@ test_firstFullEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ axiomEvaluator
                         (Mock.functionalConstr10 (mkVar Mock.x))
@@ -238,7 +236,7 @@ test_firstFullEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ axiomEvaluator
                         (Mock.functionalConstr10 Mock.b)
@@ -268,7 +266,7 @@ test_firstFullEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ axiomEvaluator
                         (Mock.functionalConstr10 Mock.b)
@@ -288,7 +286,7 @@ test_firstFullEvaluation =
             expect = AttemptedAxiom.NotApplicable
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ axiomEvaluator
                         (Mock.functionalConstr10 Mock.b)
@@ -306,7 +304,7 @@ test_firstFullEvaluation =
                 "Unexpected simplification result with remainder"
             )
             (evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ axiomEvaluatorWithRemainder
                         (Mock.functionalConstr10 Mock.b)
@@ -324,7 +322,7 @@ test_firstFullEvaluation =
                 )
             )
             (evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (firstFullEvaluation
                     [ definitionEvaluation
                         [ axiom
@@ -360,7 +358,7 @@ test_simplifierWithFallback =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (simplifierWithFallback
                     (axiomEvaluator
                         (Mock.functionalConstr10 Mock.a)
@@ -400,7 +398,7 @@ test_simplifierWithFallback =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (simplifierWithFallback
                     (axiomEvaluatorWithRemainder
                         (Mock.functionalConstr10 Mock.b)
@@ -428,7 +426,7 @@ test_simplifierWithFallback =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (simplifierWithFallback
                     (axiomEvaluator
                         (Mock.functionalConstr10 Mock.a)
@@ -446,7 +444,7 @@ test_simplifierWithFallback =
             expect = AttemptedAxiom.NotApplicable
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (simplifierWithFallback
                     (axiomEvaluator
                         (Mock.functionalConstr10 Mock.a)
@@ -479,7 +477,7 @@ test_builtinEvaluation =
                         }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (builtinEvaluation
                     (axiomEvaluator
                         (Mock.functionalConstr10 Mock.a)
@@ -494,7 +492,7 @@ test_builtinEvaluation =
                 "Expecting hook MAP.unit to reduce concrete pattern"
             )
             (evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (builtinEvaluation failingEvaluator)
                 Mock.unitMap
             )
@@ -534,16 +532,6 @@ axiom left right predicate =
         , ensures = makeTruePredicate
         , attributes = def
         }
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
 
 evaluate
     :: SmtMetadataTools StepperAttributes

--- a/kore/test/Test/Kore/Step/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Matcher.hs
@@ -43,8 +43,6 @@ import qualified SMT
 import           Test.Kore
                  ( emptyLogger, testId )
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -60,7 +58,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkAnd (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkAnd (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -76,7 +74,7 @@ test_matcherEqualHeads =
                         }
                     ]
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.plain10 (mkVar Mock.x))
                     (Mock.plain10 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -84,7 +82,7 @@ test_matcherEqualHeads =
         , testCase "different constructors" $ do
             let expect = Nothing
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.constr10 (mkVar Mock.x))
                     (Mock.constr11 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -92,7 +90,7 @@ test_matcherEqualHeads =
         , testCase "different functions" $ do
             let expect = Nothing
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.f Mock.b)
                     (Mock.g Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -100,7 +98,7 @@ test_matcherEqualHeads =
         , testCase "different functions with variable" $ do
             let expect = Nothing
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.f (mkVar Mock.x))
                     (Mock.g Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -108,7 +106,7 @@ test_matcherEqualHeads =
         , testCase "different symbols" $ do
             let expect = Nothing
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.plain10 Mock.b)
                     (Mock.plain11 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -117,7 +115,7 @@ test_matcherEqualHeads =
         , testCase "different symbols with variable" $ do
             let expect = Nothing
             actual <-
-                matchDefinition mockMetadataTools
+                matchDefinition Mock.metadataTools
                     (Mock.plain10 (mkVar Mock.x))
                     (Mock.plain11 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -126,7 +124,7 @@ test_matcherEqualHeads =
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
             matchDefinition
-                mockMetadataTools
+                Mock.metadataTools
                 mkBottom_
                 mkBottom_
         assertEqualWithExplanation "" expect actual
@@ -140,7 +138,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkCeil_ (Mock.plain10 (mkVar Mock.x)))
                 (mkCeil_ (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -148,7 +146,7 @@ test_matcherEqualHeads =
     , testCase "CharLiteral" $ do
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
-            matchDefinition mockMetaMetadataTools
+            matchDefinition Mock.emptyMetadataTools
                 (mkCharLiteral 'a')
                 (mkCharLiteral 'a')
         assertEqualWithExplanation "" expect actual
@@ -156,7 +154,7 @@ test_matcherEqualHeads =
     , testCase "DomainValue" $ do
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkDomainValue $ Domain.BuiltinExternal Domain.External
                     { domainValueSort = Mock.testSort1
                     , domainValueChild =
@@ -180,7 +178,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkEquals_ (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkEquals_ (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -194,7 +192,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkExists Mock.x (Mock.plain10 (mkVar Mock.y)))
                 (mkExists Mock.z (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -208,7 +206,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkFloor_ (Mock.plain10 (mkVar Mock.x)))
                 (mkFloor_ (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -222,7 +220,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkForall Mock.x (Mock.plain10 (mkVar Mock.y)))
                 (mkForall Mock.z (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -236,7 +234,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkIff (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkIff (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -250,7 +248,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkImplies (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkImplies (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -264,7 +262,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkIn_ (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkIn_ (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -278,7 +276,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkNext (Mock.plain10 (mkVar Mock.x)))
                 (mkNext (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -292,7 +290,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkNot (Mock.plain10 (mkVar Mock.x)))
                 (mkNot (Mock.plain10 Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -306,7 +304,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkOr (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkOr (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -320,7 +318,7 @@ test_matcherEqualHeads =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkRewrites (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkRewrites (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -328,7 +326,7 @@ test_matcherEqualHeads =
     , testCase "StringLiteral" $ do
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
-            matchDefinition mockMetaMetadataTools
+            matchDefinition Mock.emptyMetadataTools
                 (mkStringLiteral "10")
                 (mkStringLiteral "10")
         assertEqualWithExplanation "" expect actual
@@ -336,7 +334,7 @@ test_matcherEqualHeads =
     , testCase "Top" $ do
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 mkTop_
                 mkTop_
         assertEqualWithExplanation "" expect actual
@@ -344,7 +342,7 @@ test_matcherEqualHeads =
     , testCase "Variable (quantified)" $ do
         let expect = Just $ MultiOr.make [Conditional.topPredicate]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkExists Mock.x (Mock.plain10 (mkVar Mock.x)))
                 (mkExists Mock.y (Mock.plain10 (mkVar Mock.y)))
         assertEqualWithExplanation "" expect actual
@@ -352,7 +350,7 @@ test_matcherEqualHeads =
     , testCase "Iff vs Or" $ do
         let expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkIff (Mock.plain10 Mock.a) (mkVar Mock.x))
                 (mkOr (Mock.plain10 Mock.a) Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -368,7 +366,7 @@ test_matcherEqualHeads =
                         }
                     ]
             actual <-
-                matchSimplification mockMetadataTools
+                matchSimplification Mock.metadataTools
                     (Mock.plain10 (mkVar Mock.x))
                     (Mock.plain10 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -376,7 +374,7 @@ test_matcherEqualHeads =
         , testCase "different constructors" $ do
             let expect = Nothing
             actual <-
-                matchSimplification mockMetadataTools
+                matchSimplification Mock.metadataTools
                     (Mock.constr10 (mkVar Mock.x))
                     (Mock.constr11 Mock.a)
             assertEqualWithExplanation "" expect actual
@@ -395,7 +393,7 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkVar Mock.x)
                 Mock.functional00
         assertEqualWithExplanation "" expect actual
@@ -409,7 +407,7 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkVar Mock.x)
                 Mock.cf
         assertEqualWithExplanation "" expect actual
@@ -417,7 +415,7 @@ test_matcherVariableFunction =
     , testCase "Non-functional" $ do
         let expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkVar Mock.x)
                 (Mock.constr10 Mock.cf)
         assertEqualWithExplanation "" expect actual
@@ -425,7 +423,7 @@ test_matcherVariableFunction =
     , testCase "Unidirectional" $ do
         let expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.functional10 (mkVar Mock.y))
                 (mkVar Mock.x)
         assertEqualWithExplanation "" expect actual
@@ -443,7 +441,7 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.sortInjectionSubToTop (mkVar x))
                 (Mock.sortInjectionSubSubToTop a)
         assertEqualWithExplanation "" expect actual
@@ -454,7 +452,7 @@ test_matcherVariableFunction =
             x = Variable (testId "x") mempty Mock.subSort
             expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.sortInjectionSubSubToTop a)
                 (Mock.sortInjectionSubToTop (mkVar x))
         assertEqualWithExplanation "" expect actual
@@ -474,7 +472,7 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.functionalTopConstr20
                     (Mock.sortInjectionSubToTop (mkVar xSub))
                     (mkVar Mock.x)
@@ -500,7 +498,7 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.functionalTopConstr21
                     (mkVar Mock.x)
                     (Mock.sortInjectionSubToTop (mkVar xSub))
@@ -520,14 +518,14 @@ test_matcherVariableFunction =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkExists Mock.y (Mock.constr20 (mkVar Mock.x) (mkVar Mock.y)))
                 (mkExists Mock.z (Mock.constr20 Mock.a (mkVar Mock.z)))
         assertEqualWithExplanation "" expect actual
     , testCase "Quantified no match on variable" $ do
         let expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkExists Mock.y (Mock.constr20 (mkVar Mock.x) (mkVar Mock.y)))
                 (mkExists Mock.z (Mock.constr20 Mock.a Mock.a))
         assertEqualWithExplanation "" expect actual
@@ -542,7 +540,7 @@ test_matcherVariableFunction =
                         }
                     ]
             actual <-
-                matchSimplification mockMetadataTools
+                matchSimplification Mock.metadataTools
                     (mkVar Mock.x)
                     Mock.cf
             assertEqualWithExplanation "" expect actual
@@ -550,7 +548,7 @@ test_matcherVariableFunction =
         , testCase "Non-function" $ do
             let expect = Nothing
             actual <-
-                matchSimplification mockMetadataTools
+                matchSimplification Mock.metadataTools
                     (mkVar Mock.x)
                     (Mock.constr10 Mock.cf)
             assertEqualWithExplanation "" expect actual
@@ -562,7 +560,7 @@ test_matcherNonVarToPattern =
     [ testCase "no-var - no-var" $ do
         let expect = Nothing
         actual <-
-            matchSimplification mockMetadataTools
+            matchSimplification Mock.metadataTools
             (Mock.plain10 Mock.a)
             (Mock.plain11 Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -570,7 +568,7 @@ test_matcherNonVarToPattern =
     , testCase "var - no-var" $ do
         let expect = Nothing
         actual <-
-            matchSimplification mockMetadataTools
+            matchSimplification Mock.metadataTools
             (Mock.plain10 (mkVar Mock.x))
             (Mock.plain11 Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -578,7 +576,7 @@ test_matcherNonVarToPattern =
     , testCase "no-var - var" $ do
         let expect = Nothing
         actual <-
-            matchSimplification mockMetadataTools
+            matchSimplification Mock.metadataTools
             (Mock.plain10 Mock.a)
             (Mock.plain11 (mkVar Mock.x))
         assertEqualWithExplanation "" expect actual
@@ -586,7 +584,7 @@ test_matcherNonVarToPattern =
     , testCase "var - var" $ do
         let expect = Nothing
         actual <-
-            matchSimplification mockMetadataTools
+            matchSimplification Mock.metadataTools
             (Mock.plain10 (mkVar Mock.x))
             (Mock.plain11 (mkVar Mock.y))
         assertEqualWithExplanation "" expect actual
@@ -604,7 +602,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkAnd (mkVar Mock.x) (Mock.constr20 Mock.cf (mkVar Mock.y)))
                 (mkAnd    Mock.cf     (Mock.constr20 Mock.cf    Mock.b))
         assertEqualWithExplanation "" expect actual
@@ -619,7 +617,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (Mock.plain20
                     (mkVar Mock.x)
                     (Mock.constr20 Mock.cf (mkVar Mock.y))
@@ -640,7 +638,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkEquals_
                     (mkVar Mock.x)
                     (Mock.constr20 Mock.cf (mkVar Mock.y))
@@ -658,7 +656,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkIff (mkVar Mock.x) (Mock.constr20 Mock.cf (mkVar Mock.y)))
                 (mkIff    Mock.cf     (Mock.constr20 Mock.cf    Mock.b))
         assertEqualWithExplanation "" expect actual
@@ -673,7 +671,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkImplies
                     (mkVar Mock.x)
                     (Mock.constr20 Mock.cf (mkVar Mock.y))
@@ -694,7 +692,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkIn_ (mkVar Mock.x) (Mock.constr20 Mock.cf (mkVar Mock.y)))
                 (mkIn_    Mock.cf     (Mock.constr20 Mock.cf    Mock.b))
         assertEqualWithExplanation "" expect actual
@@ -709,7 +707,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkOr (mkVar Mock.x) (Mock.constr20 Mock.cf (mkVar Mock.y)))
                 (mkOr    Mock.cf     (Mock.constr20 Mock.cf    Mock.b))
         assertEqualWithExplanation "" expect actual
@@ -724,7 +722,7 @@ test_matcherMergeSubresults =
                     }
                 ]
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkRewrites
                     (mkVar Mock.x)
                     (Mock.constr20 Mock.cg (mkVar Mock.y))
@@ -738,7 +736,7 @@ test_matcherMergeSubresults =
     , testCase "Merge conflict" $ do
         let expect = Just (MultiOr.make [])
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkAnd (mkVar Mock.x) (mkVar Mock.x))
                 (mkAnd    Mock.a         Mock.b)
         assertEqualWithExplanation "" expect actual
@@ -746,7 +744,7 @@ test_matcherMergeSubresults =
     , testCase "Merge error" $ do
         let expect = Nothing
         actual <-
-            matchDefinition mockMetadataTools
+            matchDefinition Mock.metadataTools
                 (mkAnd (mkVar Mock.x) (mkVar Mock.x))
                 (mkAnd (mkVar Mock.y) (Mock.f (mkVar Mock.y)))
         assertEqualWithExplanation "" expect actual
@@ -758,7 +756,7 @@ test_unificationWithAppMatchOnTop =
         let
             expect = Just (MultiOr.make [Conditional.topPredicate])
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             Mock.cg
             Mock.cg
         assertEqualWithExplanation "" expect actual
@@ -775,7 +773,7 @@ test_unificationWithAppMatchOnTop =
                     ]
                 )
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.f (mkVar Mock.x))
             (Mock.f Mock.cf)
         assertEqualWithExplanation "" expect actual
@@ -792,7 +790,7 @@ test_unificationWithAppMatchOnTop =
                     ]
                 )
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.f Mock.cf)
             (Mock.f (mkVar Mock.x))
         assertEqualWithExplanation "" expect actual
@@ -809,7 +807,7 @@ test_unificationWithAppMatchOnTop =
                     ]
                 )
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.f (Mock.functionalConstr10 (mkVar Mock.x)))
             (Mock.f (Mock.functionalConstr10 Mock.cf))
         assertEqualWithExplanation "" expect actual
@@ -827,7 +825,7 @@ test_unificationWithAppMatchOnTop =
                     ]
                 )
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.f Mock.a)
             (Mock.f (Mock.g (mkVar Mock.x)))
         assertEqualWithExplanation "" expect actual
@@ -849,7 +847,7 @@ test_unificationWithAppMatchOnTop =
                     ]
                 )
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.functional20 Mock.a Mock.cf)
             (Mock.functional20 (Mock.g (mkVar Mock.x)) (mkVar Mock.y))
         assertEqualWithExplanation "" expect actual
@@ -858,25 +856,11 @@ test_unificationWithAppMatchOnTop =
             expect = Just
                 (MultiOr.make [])
         actual <-
-            unificationWithMatch mockMetadataTools
+            unificationWithMatch Mock.metadataTools
             (Mock.f Mock.a)
             (Mock.f Mock.b)
         assertEqualWithExplanation "" expect actual
     ]
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
-mockMetaMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetaMetadataTools =
-    Mock.makeMetadataTools [] [] [] [] [] Mock.emptySmtDeclarations
 
 matchDefinition
     :: SmtMetadataTools StepperAttributes

--- a/kore/test/Test/Kore/Step/Axiom/UserDefined.hs
+++ b/kore/test/Test/Kore/Step/Axiom/UserDefined.hs
@@ -43,8 +43,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Kore.Step.Simplifier
@@ -67,7 +65,7 @@ test_userDefinedFunction =
                     }
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left = Mock.functionalConstr10 (mkVar Mock.x)
                     , right = Mock.functionalConstr11 (mkVar Mock.x)
@@ -84,7 +82,7 @@ test_userDefinedFunction =
                 AttemptedAxiom.NotApplicable
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left = Mock.functionalConstr10 (mkVar Mock.x)
                     , right = Mock.functionalConstr11 (mkVar Mock.x)
@@ -101,7 +99,7 @@ test_userDefinedFunction =
                 AttemptedAxiom.NotApplicable
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left = Mock.functionalConstr10 Mock.a
                     , right = Mock.functionalConstr11 Mock.a
@@ -127,7 +125,7 @@ test_userDefinedFunction =
                     }
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left = Mock.functionalConstr10 (mkVar Mock.x)
                     , right = Mock.functionalConstr11 (mkVar Mock.x)
@@ -149,7 +147,7 @@ test_userDefinedFunction =
                     }
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left = Mock.functionalConstr10 (mkVar Mock.x)
                     , right = Mock.functionalConstr11 (mkVar Mock.x)
@@ -192,7 +190,7 @@ test_userDefinedFunction =
                     }
         actual <-
             evaluateWithAxiom
-                mockMetadataTools
+                Mock.metadataTools
                 (EqualityRule RulePattern
                     { left  =
                         Mock.functionalConstr20
@@ -225,16 +223,6 @@ asSimplification
     :: [(TermLike Variable, [Pattern Variable])]
     -> [(TermLike Variable, [Pattern Variable])]
 asSimplification = id
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
 
 evaluateWithAxiom
     :: SmtMetadataTools StepperAttributes

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -49,8 +49,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
@@ -65,7 +63,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     (axiomEvaluator
@@ -85,7 +83,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     (builtinEvaluation $ axiomEvaluator
@@ -106,7 +104,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     (simplifierWithFallback
@@ -133,7 +131,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     (simplifierWithFallback
@@ -158,7 +156,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     ( axiomEvaluator
@@ -181,7 +179,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     ( axiomEvaluator
@@ -211,7 +209,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.functionalConstr10Id)
                     ( axiomEvaluator
@@ -236,7 +234,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.cId)
                     ( appliedMockEvaluator Conditional
@@ -261,7 +259,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.cId
                         , appliedMockEvaluator Conditional
@@ -296,7 +294,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.cId
                         , axiomEvaluator Mock.c Mock.d
@@ -330,7 +328,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.cId
                         , appliedMockEvaluator Conditional
@@ -375,7 +373,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , appliedMockEvaluator Conditional
@@ -410,7 +408,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , simplifierWithFallback
@@ -442,7 +440,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , simplifierWithFallback
@@ -484,7 +482,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , simplifierWithFallback
@@ -516,7 +514,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , simplifierWithFallback
@@ -560,7 +558,7 @@ test_functionIntegration =
                     }
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Map.fromList
                     [   ( AxiomIdentifier.Application Mock.fId
                         , definitionEvaluation
@@ -644,13 +642,3 @@ evaluate metadataTools functionIdToEvaluator patt =
             metadataTools patternSimplifier functionIdToEvaluator
     patternSimplifier :: TermLikeSimplifier
     patternSimplifier = Simplifier.create metadataTools functionIdToEvaluator
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -39,11 +39,12 @@ import qualified Kore.Attribute.Sort.Concat as Attribute
 import qualified Kore.Attribute.Sort.Element as Attribute
 import qualified Kore.Attribute.Sort.Unit as Attribute
 import           Kore.Attribute.Symbol
+import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Int as Builtin.Int
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.MetadataTools
-                 ( HeadType )
+                 ( HeadType, SmtMetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as HeadType
                  ( HeadType (..) )
 import           Kore.Internal.TermLike
@@ -1962,3 +1963,23 @@ builtinBool
     => Bool
     -> TermLike variable
 builtinBool = Builtin.Bool.asInternal boolSort
+
+emptyMetadataTools :: SmtMetadataTools Attribute.Symbol
+emptyMetadataTools =
+    Mock.makeMetadataTools
+        [] -- attributesMapping
+        [] -- headTypeMapping
+        [] -- sortAttributesMapping
+        [] -- subsorts
+        [] -- headSortsMapping
+        emptySmtDeclarations
+
+metadataTools :: SmtMetadataTools Attribute.Symbol
+metadataTools =
+    Mock.makeMetadataTools
+        attributesMapping
+        headTypeMapping
+        sortAttributesMapping
+        subsorts
+        headSortsMapping
+        smtDeclarations

--- a/kore/test/Test/Kore/Step/PatternAttributes.hs
+++ b/kore/test/Test/Kore/Step/PatternAttributes.hs
@@ -7,11 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( testCase )
 
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.TermLike
 import           Kore.Proof.Functional
 import           Kore.Step.PatternAttributes
@@ -22,8 +18,6 @@ import           Kore.Syntax.CharLiteral
 import           Kore.Syntax.StringLiteral
 
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as MockSymbols
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -82,7 +76,7 @@ test_patternAttributes =
             assertEqualWithExplanation "variables are functional"
                 (Right [FunctionalVariable Mock.x])
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mkVar Mock.x)
                 )
             let
@@ -91,7 +85,7 @@ test_patternAttributes =
             assertEqualWithExplanation "functional symbols are functional"
                 (Right [FunctionalHead Mock.functional00Symbol])
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionalConstant
                 )
             let
@@ -100,7 +94,7 @@ test_patternAttributes =
             assertEqualWithExplanation "string literals are functional"
                 (Right [FunctionalStringLiteral (StringLiteral "10")])
                 (isFunctionalPattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     str
                 )
             let
@@ -109,7 +103,7 @@ test_patternAttributes =
             assertEqualWithExplanation "char literals are functional"
                 (Right [FunctionalCharLiteral (CharLiteral 'a')])
                 (isFunctionalPattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     chr
                 )
             let
@@ -118,7 +112,7 @@ test_patternAttributes =
             assertEqualWithExplanation "function symbols are not functional"
                 (Left (NonFunctionalHead Mock.cfSymbol))
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionConstant
                 )
             let
@@ -127,7 +121,7 @@ test_patternAttributes =
             assertEqualWithExplanation "plain symbols are not functional"
                 (Left (NonFunctionalHead Mock.plain00Symbol))
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     plainConstant
                 )
             let
@@ -140,7 +134,7 @@ test_patternAttributes =
                     ]
                 )
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionalPatt
                 )
             let
@@ -150,7 +144,7 @@ test_patternAttributes =
             assertEqualWithExplanation "or is not functional"
                 (Left NonFunctionalPattern)
                 (isFunctionalPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     nonFunctionalPatt
                 )
         )
@@ -159,7 +153,7 @@ test_patternAttributes =
             assertEqualWithExplanation "variables are function-like"
                 (Right [FunctionProofFunctional (FunctionalVariable Mock.x)])
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mkVar Mock.x)
                 )
             let
@@ -171,7 +165,7 @@ test_patternAttributes =
                     ]
                 )
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionalConstant
                 )
             let
@@ -184,7 +178,7 @@ test_patternAttributes =
                     ]
                 )
                 (isFunctionPattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     str
                 )
             let
@@ -197,7 +191,7 @@ test_patternAttributes =
                     ]
                 )
                 (isFunctionPattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     chr
                 )
             let
@@ -206,7 +200,7 @@ test_patternAttributes =
             assertEqualWithExplanation "function symbols are function-like"
                 (Right [FunctionHead Mock.cfSymbol])
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionConstant
                 )
             let
@@ -215,7 +209,7 @@ test_patternAttributes =
             assertEqualWithExplanation "plain symbols are not function-like"
                 (Left (NonFunctionHead Mock.plain00Symbol))
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     plainConstant
                 )
             let
@@ -228,7 +222,7 @@ test_patternAttributes =
                     ]
                 )
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionalPatt
                 )
             let
@@ -238,7 +232,7 @@ test_patternAttributes =
             assertEqualWithExplanation "or is not function-like"
                 (Left NonFunctionPattern)
                 (isFunctionPattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     nonFunctionPatt
                 )
         )
@@ -247,7 +241,7 @@ test_patternAttributes =
             assertEqualWithExplanation "variables are constructor-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mkVar Mock.x)
                 )
             let
@@ -256,7 +250,7 @@ test_patternAttributes =
             assertEqualWithExplanation "constructors are constructor-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     constructor
                 )
             let
@@ -265,7 +259,7 @@ test_patternAttributes =
             assertEqualWithExplanation "sort injections are constructor-like"
                 (Right [ConstructorLikeProof, ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     sortInjection
                 )
             let
@@ -275,7 +269,7 @@ test_patternAttributes =
                 "constructors-modulo are not constructor-like"
                 (Left NonConstructorLikeHead)
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     mapElement
                 )
             let
@@ -284,7 +278,7 @@ test_patternAttributes =
             assertEqualWithExplanation "string literals are constructor-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     str
                 )
             let
@@ -293,7 +287,7 @@ test_patternAttributes =
             assertEqualWithExplanation "char literals are constructor-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     chr
                 )
             let
@@ -308,7 +302,7 @@ test_patternAttributes =
             assertEqualWithExplanation "domain values are constructor-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     dv
                 )
 
@@ -319,7 +313,7 @@ test_patternAttributes =
                 "function symbols are not constructor-like"
                 (Left NonConstructorLikeHead)
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionConstant
                 )
             let
@@ -328,7 +322,7 @@ test_patternAttributes =
             assertEqualWithExplanation "injections are not constructor-like"
                 (Left NonConstructorLikeHead)
                 (isConstructorLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     injectionConstant
                 )
         )
@@ -337,7 +331,7 @@ test_patternAttributes =
             assertEqualWithExplanation "variables are constructor-modulo-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mkVar Mock.x)
                 )
             let
@@ -347,7 +341,7 @@ test_patternAttributes =
                 "constructors are constructor-modulo-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     constructor
                 )
             let
@@ -357,7 +351,7 @@ test_patternAttributes =
                 "sort injections are constructor-modulo-like"
                 (Right [ConstructorLikeProof, ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     sortInjection
                 )
             let
@@ -372,7 +366,7 @@ test_patternAttributes =
                     ]
                 )
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     mapElement
                 )
             let
@@ -382,7 +376,7 @@ test_patternAttributes =
                 "string literals are constructor-modulo-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     str
                 )
             let
@@ -392,7 +386,7 @@ test_patternAttributes =
                 "char literals are constructor-modulo-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetaMetadataTools
+                    Mock.metadataTools
                     chr
                 )
             let
@@ -408,7 +402,7 @@ test_patternAttributes =
                 "domain values are constructor-modulo-like"
                 (Right [ConstructorLikeProof])
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     dv
                 )
 
@@ -419,7 +413,7 @@ test_patternAttributes =
                 "function symbols are not constructor-modulo-like"
                 (Left NonConstructorLikeHead)
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     functionConstant
                 )
             let
@@ -429,22 +423,8 @@ test_patternAttributes =
                 "injections are not constructor-modulo-like"
                 (Left NonConstructorLikeHead)
                 (isConstructorModuloLikePattern
-                    mockMetadataTools
+                    Mock.metadataTools
                     injectionConstant
                 )
         )
     ]
-  where
-    mockMetadataTools :: SmtMetadataTools StepperAttributes
-    mockMetadataTools =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
-
-    mockMetaMetadataTools :: SmtMetadataTools StepperAttributes
-    mockMetaMetadataTools =
-        Mock.makeMetadataTools [] [] [] [] [] Mock.emptySmtDeclarations

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -7,10 +7,6 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map as Map
 
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.MultiOr
                  ( MultiOr (MultiOr) )
 import           Kore.Internal.OrPattern
@@ -31,8 +27,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import           Test.Kore.Step.MockSymbols
                  ( testSort )
@@ -420,9 +414,9 @@ evaluate patt =
     SMT.runSMT SMT.defaultConfig
     $ evalSimplifier emptyLogger
     $ simplify
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         patt
 
@@ -436,19 +430,9 @@ evaluatePatterns first second =
     $ evalSimplifier emptyLogger
     $ gather
     $ makeEvaluate
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         first
         second
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -34,8 +34,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -50,7 +48,7 @@ test_andTermsSimplification =
                         , predicate = makeTruePredicate
                         , substitution = mempty
                         }
-            actual <- simplifyUnify mockMetadataTools fOfA mkTop_
+            actual <- simplifyUnify Mock.metadataTools fOfA mkTop_
             assertEqualWithExplanation "" (expected, Just expected) actual
 
         , testCase "\\and{s}(\\top{s}(), f{}(a))" $ do
@@ -60,7 +58,7 @@ test_andTermsSimplification =
                         , predicate = makeTruePredicate
                         , substitution = mempty
                         }
-            actual <- simplifyUnify mockMetadataTools mkTop_ fOfA
+            actual <- simplifyUnify Mock.metadataTools mkTop_ fOfA
             assertEqualWithExplanation "" (expected, Just expected) actual
 
         , testCase "\\and{s}(f{}(a), \\bottom{s}())" $ do
@@ -68,7 +66,7 @@ test_andTermsSimplification =
                     ( Pattern.bottom
                     , Just Pattern.bottom
                     )
-            actual <- simplifyUnify mockMetadataTools fOfA mkBottom_
+            actual <- simplifyUnify Mock.metadataTools fOfA mkBottom_
             assertEqualWithExplanation "" expect actual
 
         , testCase "\\and{s}(\\bottom{s}(), f{}(a))" $ do
@@ -78,7 +76,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     mkBottom_
                     fOfA
             assertEqualWithExplanation "" expect actual
@@ -93,7 +91,7 @@ test_andTermsSimplification =
                     }
         actual <-
             simplifyUnify
-                mockMetadataTools
+                Mock.metadataTools
                 fOfA fOfA
         assertEqualWithExplanation "" (expect, Just expect) actual
 
@@ -108,7 +106,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mkVar Mock.x) fOfA
             assertEqualWithExplanation "" (expect, Just expect) actual
 
@@ -122,7 +120,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     fOfA (mkVar Mock.x)
             assertEqualWithExplanation "" (expect, Just expect) actual
         ]
@@ -137,7 +135,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.injective10 fOfA) (Mock.injective10 gOfA)
             assertEqualWithExplanation "" (expect, Just expect) actual
         , testCase "same head, same child" $ do
@@ -149,7 +147,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.injective10 fOfA) (Mock.injective10 fOfA)
             assertEqualWithExplanation "" (expected, Just expected) actual
         , testCase "different head" $ do
@@ -166,7 +164,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.injective10 fOfA) (Mock.injective11 gOfA)
             assertEqualWithExplanation "" expect actual
         ]
@@ -182,7 +180,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjection10 Mock.cfSort0)
                     (Mock.sortInjection10 Mock.cgSort0)
             assertEqualWithExplanation "" (expect, Just expect) actual
@@ -196,7 +194,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjection10 Mock.cfSort0)
                     (Mock.sortInjection10 Mock.cfSort0)
             assertEqualWithExplanation "" (expect, Just expect) actual
@@ -205,7 +203,7 @@ test_andTermsSimplification =
                     (Pattern.bottom, Just Pattern.bottom)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionSubToTop Mock.plain00Subsort)
                     (Mock.sortInjection0ToTop Mock.plain00Sort0)
             assertEqualWithExplanation "" expect actual
@@ -227,7 +225,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionSubSubToTop Mock.plain00SubSubsort)
                     (Mock.sortInjectionSubToTop Mock.plain00Subsort)
             assertEqualWithExplanation "" expect actual
@@ -249,7 +247,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionSubToTop Mock.plain00Subsort)
                     (Mock.sortInjectionSubSubToTop Mock.plain00SubSubsort)
             assertEqualWithExplanation "" expect actual
@@ -260,7 +258,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjection10 Mock.aSort0)
                     (Mock.sortInjection11 Mock.aSort1)
             assertEqualWithExplanation "" expect actual
@@ -271,7 +269,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionSubToTop Mock.aSubsort)
                     (Mock.sortInjectionSubSubToTop Mock.aSubSubsort)
             assertEqualWithExplanation "" expect actual
@@ -282,7 +280,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionOtherToTop Mock.aOtherSort)
                     (Mock.sortInjectionSubToTop Mock.aSubsort)
             assertEqualWithExplanation "" expect actual
@@ -293,7 +291,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.sortInjectionSubToTop Mock.aSubsort)
                     (Mock.sortInjectionOtherToTop Mock.aOtherSort)
             assertEqualWithExplanation "" expect actual
@@ -311,7 +309,7 @@ test_andTermsSimplification =
                     in (expected, Just expected)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.constr10 Mock.cf)
                     (Mock.constr10 Mock.cg)
             assertEqualWithExplanation "" expect actual
@@ -327,7 +325,7 @@ test_andTermsSimplification =
                     in (expected, Just expected)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.constr10 Mock.cf)
                     (Mock.constr10 Mock.cf)
             assertEqualWithExplanation "" expect actual
@@ -339,7 +337,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.constr10 Mock.cf)
                     (Mock.constr11 Mock.cf)
             assertEqualWithExplanation "" expect actual
@@ -352,7 +350,7 @@ test_andTermsSimplification =
                 )
         actual <-
             simplifyUnify
-                mockMetadataTools
+                Mock.metadataTools
                 (Mock.constr10 Mock.cf)
                 (Mock.sortInjection11 Mock.cfSort1)
         assertEqualWithExplanation "" expect actual
@@ -369,7 +367,7 @@ test_andTermsSimplification =
                     in (expected, Just expected)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     aDomainValue aDomainValue
             assertEqualWithExplanation "" expect actual
 
@@ -380,7 +378,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     aDomainValue bDomainValue
             assertEqualWithExplanation "" expect actual
         ]
@@ -397,7 +395,7 @@ test_andTermsSimplification =
                     in (expected, Just expected)
             actual <-
                 simplifyUnify
-                    mockMetaMetadataTools
+                    Mock.emptyMetadataTools
                     (mkStringLiteral "a")
                     (mkStringLiteral "a")
             assertEqualWithExplanation "" expect actual
@@ -409,7 +407,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetaMetadataTools
+                    Mock.emptyMetadataTools
                     (mkStringLiteral "a")
                     (mkStringLiteral "b")
             assertEqualWithExplanation "" expect actual
@@ -427,7 +425,7 @@ test_andTermsSimplification =
                     in (expected, Just expected)
             actual <-
                 simplifyUnify
-                    mockMetaMetadataTools
+                    Mock.emptyMetadataTools
                     (mkCharLiteral 'a')
                     (mkCharLiteral 'a')
             assertEqualWithExplanation "" expect actual
@@ -439,7 +437,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetaMetadataTools
+                    Mock.emptyMetadataTools
                     (mkCharLiteral 'a')
                     (mkCharLiteral 'b')
             assertEqualWithExplanation "" expect actual
@@ -457,7 +455,7 @@ test_andTermsSimplification =
                     in (expanded, Just expanded)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     fOfA fOfA
             assertEqualWithExplanation "" expect actual
 
@@ -472,7 +470,7 @@ test_andTermsSimplification =
                     in (expanded, Just expanded)
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     fOfA gOfA
             assertEqualWithExplanation "" expect actual
         ]
@@ -489,7 +487,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     plain0OfA plain1OfA
             assertEqualWithExplanation "" expect actual
 
@@ -504,7 +502,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.constr10 plain0OfA) (Mock.constr10 plain1OfA)
             assertEqualWithExplanation "" expect actual
 
@@ -521,7 +519,7 @@ test_andTermsSimplification =
                     )
             actual <-
                 simplifyUnify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.constr10 (Mock.constr10 plain0OfA))
                     (Mock.constr10 (Mock.constr10 plain1OfA))
             assertEqualWithExplanation "" expect actual
@@ -541,7 +539,7 @@ test_andTermsSimplification =
                 )
         actual <-
             simplifyUnify
-                mockMetadataTools
+                Mock.metadataTools
                 (Mock.functionalConstr20 plain0OfA plain0OfB)
                 (Mock.functionalConstr20 plain1OfA plain1OfB)
         assertEqualWithExplanation "" expect actual
@@ -557,7 +555,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
                     (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
             assertEqualWithExplanation "" expect actual
@@ -566,7 +564,7 @@ test_andTermsSimplification =
             let expect = Just Pattern.bottom
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
                     (Mock.builtinMap [(Mock.bConcrete, mkVar Mock.x)])
             assertEqualWithExplanation "" expect actual
@@ -587,7 +585,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.builtinMap
                         [ (Mock.aConcrete, fOfA)
                         , (Mock.bConcrete, fOfB)
@@ -615,7 +613,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.builtinMap
                         [ (Mock.aConcrete, fOfA)
                         , (Mock.bConcrete, fOfB)
@@ -643,7 +641,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.concatMap
                         (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
                         (mkVar Mock.m)
@@ -671,7 +669,7 @@ test_andTermsSimplification =
                         }
             actual <-
                 unify
-                    mockMetadataTools
+                    Mock.metadataTools
                     (Mock.concatMap
                         (mkVar Mock.m)
                         (Mock.builtinMap [(Mock.aConcrete, mkVar Mock.x)])
@@ -698,7 +696,7 @@ test_andTermsSimplification =
                         , predicate = makeTruePredicate
                         , substitution = mempty
                         }
-            actual <- unify mockMetadataTools term1 term1
+            actual <- unify Mock.metadataTools term1 term1
             assertEqualWithExplanation "" expect actual
 
         , testCase "[same head, different head]" $ do
@@ -710,7 +708,7 @@ test_andTermsSimplification =
                         , predicate = makeFalsePredicate
                         , substitution = mempty
                         }
-            actual <- unify mockMetadataTools term3 term4
+            actual <- unify Mock.metadataTools term3 term4
             assertEqualWithExplanation "" expect actual
 
         , testCase "[a] `concat` x /\\ [a, b] " $ do
@@ -725,14 +723,14 @@ test_andTermsSimplification =
                         , substitution = Substitution.unsafeWrap
                             [(Mock.x, Mock.builtinList [Mock.b])]
                         }
-            actual <- unify mockMetadataTools term5 term6
+            actual <- unify Mock.metadataTools term5 term6
             assertEqualWithExplanation "" expect actual
 
         , testCase "different lengths" $ do
             let term7 = Mock.builtinList [Mock.a, Mock.a]
                 term8 = Mock.builtinList [Mock.a]
                 expect = Just Pattern.bottom
-            actual <- unify mockMetadataTools term7 term8
+            actual <- unify Mock.metadataTools term7 term8
             assertEqualWithExplanation "" expect actual
 
         -- TODO: Add tests with non-trivial unifications and predicates.
@@ -760,20 +758,6 @@ plain0OfB = Mock.plain10 Mock.b
 
 plain1OfB :: TermLike Variable
 plain1OfB = Mock.plain11 Mock.b
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
-mockMetaMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetaMetadataTools =
-    Mock.makeMetadataTools [] [] [] [] [] Mock.emptySmtDeclarations
 
 aDomainValue :: TermLike Variable
 aDomainValue =

--- a/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -42,8 +42,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import           Test.Kore.Step.MockSymbols
                  ( testSort )
@@ -82,7 +80,7 @@ test_applicationSimplification =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (mockSimplifier noSimplification)
                 Map.empty
                 (makeApplication
@@ -99,7 +97,7 @@ test_applicationSimplification =
         let expect = OrPattern.fromPatterns [ Pattern.bottom ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (mockSimplifier noSimplification)
                 Map.empty
                 (makeApplication
@@ -116,7 +114,7 @@ test_applicationSimplification =
         let expect = OrPattern.fromPatterns [ gOfAExpanded ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (mockSimplifier noSimplification)
                 (Map.singleton
                     (AxiomIdentifier.Application Mock.fId)
@@ -156,7 +154,7 @@ test_applicationSimplification =
                         ]
             actual <-
                 evaluate
-                    mockMetadataTools
+                    Mock.metadataTools
                     (mockSimplifier noSimplification)
                     Map.empty
                     (makeApplication
@@ -240,7 +238,7 @@ test_applicationSimplification =
                         }
                 in
                     evaluate
-                        mockMetadataTools
+                        Mock.metadataTools
                         (mockSimplifier noSimplification)
                         (Map.singleton
                             (AxiomIdentifier.Application Mock.sigmaId)
@@ -308,15 +306,6 @@ test_applicationSimplification =
         , predicate = makeTruePredicate
         , substitution = mempty
         }
-
-    mockMetadataTools =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
 
     noSimplification :: [(TermLike Variable, [Pattern Variable])]
     noSimplification = []

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -50,8 +50,6 @@ import           Kore.Variables.Fresh
 import qualified SMT
 
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import           Test.Kore.Step.MockSymbols
                  ( testSort )
@@ -75,7 +73,7 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-        actual <- evaluate mockMetadataTools
+        actual <- evaluate Mock.metadataTools
             (makeCeil
                 [somethingOfAExpanded, somethingOfBExpanded]
             )
@@ -83,7 +81,7 @@ test_ceilSimplification =
     , testCase "Ceil - bool operations"
         (do
             -- ceil(top) = top
-            actual1 <- evaluate mockMetadataTools
+            actual1 <- evaluate Mock.metadataTools
                 (makeCeil
                     [Pattern.top]
                 )
@@ -93,7 +91,7 @@ test_ceilSimplification =
                 )
                 actual1
             -- ceil(bottom) = bottom
-            actual2 <- evaluate mockMetadataTools
+            actual2 <- evaluate Mock.metadataTools
                 (makeCeil
                     []
                 )
@@ -106,7 +104,7 @@ test_ceilSimplification =
     , testCase "expanded Ceil - bool operations"
         (do
             -- ceil(top) = top
-            actual1 <- makeEvaluate mockMetadataTools
+            actual1 <- makeEvaluate Mock.metadataTools
                 (Pattern.top :: Pattern Variable)
             assertEqualWithExplanation "ceil(top)"
                 (OrPattern.fromPatterns
@@ -114,7 +112,7 @@ test_ceilSimplification =
                 )
                 actual1
             -- ceil(bottom) = bottom
-            actual2 <- makeEvaluate mockMetadataTools
+            actual2 <- makeEvaluate Mock.metadataTools
                 (Pattern.bottom :: Pattern Variable)
             assertEqualWithExplanation "ceil(bottom)"
                 (OrPattern.fromPatterns
@@ -137,7 +135,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = somethingOfA
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -168,7 +166,7 @@ test_ceilSimplification =
                             Substitution.unsafeWrap [(Mock.x, fOfB)]
                         }
                     ]
-            actual <- makeEvaluate mockMetadataTools
+            actual <- makeEvaluate Mock.metadataTools
                 Conditional
                     { term = constructorTerm
                     , predicate = makeEqualsPredicate fOfA gOfA
@@ -181,7 +179,7 @@ test_ceilSimplification =
     , testCase "ceil of constructors is top" $ do
         let
             expected = OrPattern.fromPatterns [Pattern.top]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.constr10 Mock.a
                 , predicate = makeTruePredicate
@@ -206,7 +204,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.functional20 somethingOfA somethingOfB
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -231,7 +229,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = fOfA
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -256,7 +254,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = fOfA
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -278,7 +276,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.a
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -308,7 +306,7 @@ test_ceilSimplification =
                     , substitution = Substitution.unsafeWrap [(Mock.x, fOfB)]
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.functional20 fOfA fOfB
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -336,7 +334,7 @@ test_ceilSimplification =
                     }
                 ]
         actual <- makeEvaluateWithAxioms
-            mockMetadataTools
+            Mock.metadataTools
             (Map.singleton
                 (AxiomIdentifier.Ceil
                     (AxiomIdentifier.Application Mock.fId)
@@ -368,7 +366,7 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term =
                     mkDomainValue
@@ -396,7 +394,7 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term =
                     Mock.builtinMap
@@ -418,7 +416,7 @@ test_ceilSimplification =
                     , substitution = mempty
                     }
                 ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.builtinList [fOfA, fOfB]
                 , predicate = makeTruePredicate
@@ -430,7 +428,7 @@ test_ceilSimplification =
         -- so ceil({a, b}) = top
         let
             expected = OrPattern.fromPatterns [ Pattern.top ]
-        actual <- makeEvaluate mockMetadataTools
+        actual <- makeEvaluate Mock.metadataTools
             Conditional
                 { term = Mock.builtinSet [asConcrete fOfA, asConcrete fOfB]
                 , predicate = makeTruePredicate
@@ -457,14 +455,6 @@ test_ceilSimplification =
         , predicate = makeTruePredicate
         , substitution = mempty
         }
-    mockMetadataTools =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
     asConcrete p =
         let Just r = asConcreteStepPattern p in r
 

--- a/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
+++ b/kore/test/Test/Kore/Step/Simplification/DomainValue.hs
@@ -10,8 +10,6 @@ import Test.Tasty.HUnit
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.MetadataTools
                  ( SmtMetadataTools )
@@ -28,7 +26,6 @@ import           Kore.Step.Simplification.DomainValue
                  ( simplify )
 
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import           Test.Kore.Step.MockSymbols
                  ( testSort )
 import qualified Test.Kore.Step.MockSymbols as Mock
@@ -54,7 +51,7 @@ test_domainValueSimplification =
                 ]
             )
             (evaluate
-                mockMetadataTools
+                Mock.emptyMetadataTools
                 (Domain.BuiltinExternal Domain.External
                     { domainValueSort = testSort
                     , domainValueChild =
@@ -68,7 +65,7 @@ test_domainValueSimplification =
             "Expected \\bottom to propagate to the top level"
             (OrPattern.fromPatterns [])
             (evaluate
-                mockMetadataTools
+                Mock.emptyMetadataTools
                 (mkMapDomainValue [(Mock.aConcrete, bottom)])
             )
         )
@@ -77,7 +74,7 @@ test_domainValueSimplification =
             "Expected \\bottom to propagate to the top level"
             (OrPattern.fromPatterns [])
             (evaluate
-                mockMetadataTools
+                Mock.emptyMetadataTools
                 (mkListDomainValue [bottom])
             )
         )
@@ -106,10 +103,6 @@ mkListDomainValue children =
         , builtinListConcat = Mock.concatListSymbol
         , builtinListChild = Seq.fromList children
         }
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools [] [] [] [] [] Mock.emptySmtDeclarations
 
 evaluate
     :: SmtMetadataTools attrs

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -46,8 +46,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -58,7 +56,7 @@ test_equalsSimplification_Or_Pattern =
         let expect = OrPattern.fromPatterns [ Conditional.top ]
         actual <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -71,7 +69,7 @@ test_equalsSimplification_Or_Pattern =
         let expect = OrPattern.fromPatterns [ Conditional.top ]
         actual <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -96,7 +94,7 @@ test_equalsSimplification_Or_Pattern =
         let expect = OrPattern.fromPatterns []
         actual <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -122,7 +120,7 @@ test_equalsSimplification_Or_Pattern =
                     ]
         actual <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -197,7 +195,7 @@ test_equalsSimplification_Or_Pattern =
                     ]
         actual1 <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -207,7 +205,7 @@ test_equalsSimplification_Or_Pattern =
         assertEqualWithExplanation "f vs g or h" expect actual1
         actual2 <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -280,7 +278,7 @@ test_equalsSimplification_Or_Pattern =
                     , equalsFirst = first
                     , equalsSecond = second
                     }
-        actual1 <- evaluateOr mockMetadataTools test1
+        actual1 <- evaluateOr Mock.metadataTools test1
         let message1 =
                 unlines
                     [ "Expected"
@@ -293,7 +291,7 @@ test_equalsSimplification_Or_Pattern =
         assertEqual message1 expect actual1
         actual2 <-
             evaluateOr
-                mockMetadataTools
+                Mock.metadataTools
                 Equals
                     { equalsOperandSort = testSort
                     , equalsResultSort = testSort
@@ -319,7 +317,7 @@ test_equalsSimplification_Pattern =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = mkTop_
                     , predicate = makeEqualsPredicate fOfA fOfB
@@ -371,7 +369,7 @@ test_equalsSimplification_Pattern =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = Mock.functionalConstr10 hOfA
                     , predicate = makeEqualsPredicate fOfA fOfB
@@ -389,14 +387,14 @@ test_equalsSimplification_TermLike :: [TestTree]
 test_equalsSimplification_TermLike =
     [ testCase "bottom == bottom"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             mkBottom_
             mkBottom_
         )
     , testCase "domain-value == domain-value"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             (mkDomainValue
                 (Domain.BuiltinExternal Domain.External
@@ -415,7 +413,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "domain-value != domain-value"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             (mkDomainValue
                 (Domain.BuiltinExternal Domain.External
@@ -434,7 +432,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "domain-value != domain-value because of sorts"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             (mkDomainValue
                 (Domain.BuiltinExternal Domain.External
@@ -453,49 +451,49 @@ test_equalsSimplification_TermLike =
         )
     , testCase "\"a\" == \"a\""
         (assertTermEqualsGeneric
-            mockMetaMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             (mkStringLiteral "a")
             (mkStringLiteral "a")
         )
     , testCase "\"a\" != \"b\""
         (assertTermEqualsGeneric
-            mockMetaMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             (mkStringLiteral "a")
             (mkStringLiteral "b")
         )
     , testCase "'a' == 'a'"
         (assertTermEqualsGeneric
-            mockMetaMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             (mkCharLiteral 'a')
             (mkCharLiteral 'a')
         )
     , testCase "'a' != 'b'"
         (assertTermEqualsGeneric
-            mockMetaMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             (mkCharLiteral 'a')
             (mkCharLiteral 'b')
         )
     , testCase "a != bottom"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             mkBottom_
             Mock.a
         )
     , testCase "a == a"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             Mock.a
             Mock.a
         )
     , testCase "f(a) vs g(a)"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate fOfA gOfA
@@ -506,7 +504,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "constructor1(a) vs constructor1(a)"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             constructor1OfA
             constructor1OfA
@@ -514,28 +512,28 @@ test_equalsSimplification_TermLike =
     , testCase
         "functionalconstructor1(a) vs functionalconstructor2(a)"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             functionalConstructor1OfA
             functionalConstructor2OfA
         )
     , testCase "constructor1(a) vs constructor2(a)"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.bottomPredicate
             constructor1OfA
             constructor2OfA
         )
     , testCase "constructor1(f(a)) vs constructor1(f(a))"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Predicate.topPredicate
             (Mock.constr10 fOfA)
             (Mock.constr10 fOfA)
         )
     , testCase "sigma(f(a), f(b)) vs sigma(g(a), g(b))"
         (assertTermEqualsMulti
-            mockMetadataTools
+            Mock.metadataTools
             [ Conditional
                 { term = ()
                 , predicate =
@@ -568,7 +566,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(x, functional) becomes a substitution"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeTruePredicate
@@ -580,7 +578,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(functional, x) becomes a substitution"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeTruePredicate
@@ -592,7 +590,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(x, function) becomes a substitution + ceil"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeCeilPredicate fOfA
@@ -603,7 +601,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(function, x) becomes a substitution + ceil"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeCeilPredicate fOfA
@@ -614,7 +612,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(x, constructor) becomes a predicate"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate (mkVar Mock.x) constructor1OfA
@@ -625,7 +623,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(constructor, x) becomes a predicate"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate constructor1OfA (mkVar Mock.x)
@@ -636,7 +634,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(x, something) becomes a predicate"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate (mkVar Mock.x) plain1OfA
@@ -647,7 +645,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(something, x) becomes a predicate"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate plain1OfA (mkVar Mock.x)
@@ -658,7 +656,7 @@ test_equalsSimplification_TermLike =
         )
     , testCase "equals(function, constructor) is not simplifiable"
         (assertTermEquals
-            mockMetadataTools
+            Mock.metadataTools
             Conditional
                 { term = ()
                 , predicate = makeEqualsPredicate (Mock.f Mock.a) Mock.a
@@ -670,7 +668,7 @@ test_equalsSimplification_TermLike =
     , testGroup "builtin Map domain"
         [ testCase "concrete Map, same keys"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = ()
                     , predicate = makeTruePredicate
@@ -681,14 +679,14 @@ test_equalsSimplification_TermLike =
             )
         , testCase "concrete Map, different keys"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Predicate.bottomPredicate
                 (Mock.builtinMap [(Mock.aConcrete, Mock.b)])
                 (Mock.builtinMap [(Mock.bConcrete, mkVar Mock.x)])
             )
         , testCase "concrete Map with framed Map"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = ()
                     , predicate =
@@ -712,7 +710,7 @@ test_equalsSimplification_TermLike =
             )
         , testCase "concrete Map with framed Map"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = ()
                     , predicate =
@@ -736,7 +734,7 @@ test_equalsSimplification_TermLike =
             )
         , testCase "framed Map with concrete Map"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = ()
                     , predicate =
@@ -760,7 +758,7 @@ test_equalsSimplification_TermLike =
             )
         , testCase "framed Map with concrete Map"
             (assertTermEquals
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = ()
                     , predicate =
@@ -794,7 +792,7 @@ test_equalsSimplification_TermLike =
             in
                 testCase "[same head, same head]"
                     (assertTermEquals
-                        mockMetadataTools
+                        Mock.metadataTools
                         Conditional
                             { term = ()
                             , predicate = makeTruePredicate
@@ -810,7 +808,7 @@ test_equalsSimplification_TermLike =
             in
                 testCase "[same head, different head]"
                     (assertTermEquals
-                        mockMetadataTools
+                        Mock.metadataTools
                         unified34
                         term3
                         term4
@@ -823,7 +821,7 @@ test_equalsSimplification_TermLike =
             in
                 testCase "[a] `concat` x /\\ [a, b] "
                     (assertTermEquals
-                        mockMetadataTools
+                        Mock.metadataTools
                         Conditional
                             { term = ()
                             , predicate = makeTruePredicate
@@ -839,7 +837,7 @@ test_equalsSimplification_TermLike =
             in
                 testCase "different lengths"
                     (assertTermEquals
-                        mockMetadataTools
+                        Mock.metadataTools
                         Predicate.bottomPredicate
                         term7
                         term8
@@ -962,20 +960,6 @@ functionalConstructor2OfA = Mock.functionalConstr11 Mock.a
 
 plain1OfA :: TermLike Variable
 plain1OfA = Mock.plain10 Mock.a
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
-mockMetaMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetaMetadataTools =
-    Mock.makeMetadataTools [] [] [] [] [] Mock.emptySmtDeclarations
 
 testSort :: Sort
 testSort = Mock.testSort

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -32,8 +32,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -90,7 +88,7 @@ test_simplify =
         -> TestTree
     simplifies original expected message =
         testCase message $ do
-            actual <- simplify mockMetadataTools (makeExists Mock.x original)
+            actual <- simplify Mock.metadataTools (makeExists Mock.x original)
             assertEqualWithExplanation "expected simplification"
                 (OrPattern.fromPatterns expected) actual
 
@@ -100,7 +98,7 @@ test_makeEvaluate =
         [ testCase "Top" $ do
             let expect = OrPattern.fromPatterns [ Pattern.top ]
             actual <-
-                makeEvaluate mockMetadataTools
+                makeEvaluate Mock.metadataTools
                     Mock.x
                     (Pattern.top :: Pattern Variable)
             assertEqualWithExplanation "" expect actual
@@ -108,7 +106,7 @@ test_makeEvaluate =
         , testCase " Bottom" $ do
             let expect = OrPattern.fromPatterns []
             actual <-
-                makeEvaluate mockMetadataTools
+                makeEvaluate Mock.metadataTools
                     Mock.x
                     (Pattern.bottom :: Pattern Variable)
             assertEqualWithExplanation "" expect actual
@@ -128,7 +126,7 @@ test_makeEvaluate =
                         }
                     ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = Mock.f (mkVar Mock.x)
@@ -151,7 +149,7 @@ test_makeEvaluate =
                         }
                     ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = fOfA
@@ -173,7 +171,7 @@ test_makeEvaluate =
                         }
                     ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = fOfX
@@ -196,7 +194,7 @@ test_makeEvaluate =
                         }
                     ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = fOfA
@@ -220,7 +218,7 @@ test_makeEvaluate =
                         }
                     ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = fOfX
@@ -234,7 +232,7 @@ test_makeEvaluate =
         --    = top.s
         let expect = OrPattern.fromPatterns [ Pattern.top ]
         actual <-
-            makeEvaluate mockMetadataTools
+            makeEvaluate Mock.metadataTools
                 Mock.x
                 Conditional
                     { term = mkTop_
@@ -248,16 +246,6 @@ test_makeEvaluate =
     fOfX = Mock.f (mkVar Mock.x)
     gOfA = Mock.g Mock.a
     hOfA = Mock.h Mock.a
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
 
 makeExists
     :: Ord variable

--- a/kore/test/Test/Kore/Step/Simplification/Iff.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Iff.hs
@@ -9,9 +9,6 @@ import Test.Tasty.HUnit
 import qualified Data.Function as Function
 import qualified Data.Map.Strict as Map
 
-import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.OrPattern
                  ( OrPattern )
 import qualified Kore.Internal.OrPattern as OrPattern
@@ -31,7 +28,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -204,9 +200,9 @@ simplify iff0 =
     SMT.runSMT SMT.defaultConfig
     $ evalSimplifier emptyLogger
     $ Iff.simplify
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         iff0
 
@@ -215,13 +211,3 @@ makeEvaluate
     -> Pattern Variable
     -> OrPattern Variable
 makeEvaluate = Iff.makeEvaluate
-
-mockMetadataTools :: SmtMetadataTools Attribute.Symbol
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -49,8 +49,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
@@ -60,7 +58,7 @@ test_simplificationIntegration =
         let expect = OrPattern.fromPatterns []
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term =
                         -- Use the exact form we expect from an owise condition
@@ -98,7 +96,7 @@ test_simplificationIntegration =
         let expect = OrPattern.fromPatterns [Pattern.top]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term =
                         -- Use the exact form we expect from an owise condition
@@ -148,7 +146,7 @@ test_simplificationIntegration =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 Conditional
                     { term = mkCeil_
                         (mkAnd
@@ -176,7 +174,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                mockMetadataTools
+                Mock.metadataTools
                 (axiomPatternsToEvaluators
                     (Map.fromList
                         [   ( AxiomIdentifier.Application
@@ -219,7 +217,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                mockMetadataTools
+                Mock.metadataTools
                 (axiomPatternsToEvaluators
                     (Map.fromList
                         [   ( AxiomIdentifier.Application
@@ -274,7 +272,7 @@ test_substitute =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Pattern.fromTermLike
                     (mkAnd
                         (Mock.functionalConstr20
@@ -303,7 +301,7 @@ test_substitute =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Pattern.fromTermLike
                     (mkAnd
                         (Mock.functionalConstr20
@@ -335,7 +333,7 @@ test_substituteMap =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 (Pattern.fromTermLike
                     (mkAnd
                         (Mock.functionalConstr20
@@ -372,7 +370,7 @@ test_substituteList =
                     ]
         actual <-
             evaluate
-                mockMetadataTools
+                Mock.metadataTools
                 ( Pattern.fromTermLike
                     (mkAnd
                         (Mock.functionalConstr20
@@ -389,16 +387,6 @@ test_substituteList =
     ]
   where
     mkDomainBuiltinList = Mock.builtinList
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
 
 evaluate
     :: SmtMetadataTools StepperAttributes

--- a/kore/test/Test/Kore/Step/Simplification/Not.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Not.hs
@@ -7,9 +7,6 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map.Strict as Map
 
-import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.OrPattern
                  ( OrPattern )
 import qualified Kore.Internal.OrPattern as OrPattern
@@ -32,7 +29,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -99,17 +95,7 @@ simplifyEvaluated =
     SMT.runSMT SMT.defaultConfig
     . evalSimplifier emptyLogger
     . Not.simplifyEvaluated
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
-
-mockMetadataTools :: SmtMetadataTools Attribute.Symbol
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations

--- a/kore/test/Test/Kore/Step/Simplification/Pattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Pattern.hs
@@ -32,7 +32,7 @@ test_Pattern_simplify :: [TestTree]
 test_Pattern_simplify =
     [ notTop     `becomes` OrPattern.bottom              $ "\\not(\\top)"
     , orAs       `becomes` OrPattern.fromTermLike Mock.a $ "\\or(a, a)"
-    , bottomLike `becomes` OrPattern.bottom              $ "\\and(a, \bottom)"
+    , bottomLike `becomes` OrPattern.bottom              $ "\\and(a, \\bottom)"
     ]
   where
     termLike = Pattern.fromTermLike

--- a/kore/test/Test/Kore/Step/Simplification/Pattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Pattern.hs
@@ -32,7 +32,7 @@ test_Pattern_simplify :: [TestTree]
 test_Pattern_simplify =
     [ notTop     `becomes` OrPattern.bottom              $ "\\not(\\top)"
     , orAs       `becomes` OrPattern.fromTermLike Mock.a $ "\\or(a, a)"
-    , bottomLike `becomes` OrPattern.bottom              $ "a ∧ \bottom"
+    , bottomLike `becomes` OrPattern.bottom              $ "\\and(a, \bottom)"
     ]
   where
     termLike = Pattern.fromTermLike

--- a/kore/test/Test/Kore/Step/Simplification/Pattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Pattern.hs
@@ -7,10 +7,6 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map as Map
 
-import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.OrPattern
                  ( OrPattern )
 import qualified Kore.Internal.OrPattern as OrPattern
@@ -28,7 +24,6 @@ import qualified Kore.Step.Simplification.Simplifier as Simplifier
 import qualified SMT
 
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -53,27 +48,17 @@ test_Pattern_simplify =
             actual <- simplify original
             assertEqualWithExplanation "" expect actual
 
-metadataTools :: SmtMetadataTools Attribute.Symbol
-metadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 simplify :: Pattern Variable -> IO (OrPattern Variable)
 simplify original =
     SMT.runSMT SMT.defaultConfig
     $ evalSimplifier emptyLogger
     $ Pattern.simplify
-        metadataTools
+        Mock.metadataTools
         predicateSimplifier
         termLikeSimplifier
         axiomSimplifiers
         original
   where
-    predicateSimplifier = Mock.substitutionSimplifier metadataTools
-    termLikeSimplifier = Simplifier.create metadataTools axiomSimplifiers
+    predicateSimplifier = Mock.substitutionSimplifier Mock.metadataTools
+    termLikeSimplifier = Simplifier.create Mock.metadataTools axiomSimplifiers
     axiomSimplifiers = Map.empty

--- a/kore/test/Test/Kore/Step/Simplification/Pattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Pattern.hs
@@ -1,0 +1,79 @@
+module Test.Kore.Step.Simplification.Pattern
+    ( test_Pattern_simplify
+    ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.Map as Map
+
+import qualified Kore.Attribute.Symbol as Attribute
+                 ( Symbol )
+import           Kore.IndexedModule.MetadataTools
+                 ( SmtMetadataTools )
+import           Kore.Internal.OrPattern
+                 ( OrPattern )
+import qualified Kore.Internal.OrPattern as OrPattern
+import           Kore.Internal.Pattern
+                 ( Pattern )
+import qualified Kore.Internal.Pattern as Pattern
+import           Kore.Internal.TermLike
+import           Kore.Logger.Output
+                 ( emptyLogger )
+import qualified Kore.Predicate.Predicate as Predicate
+import           Kore.Step.Simplification.Data
+                 ( evalSimplifier )
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import qualified Kore.Step.Simplification.Simplifier as Simplifier
+import qualified SMT
+
+import           Test.Kore.Comparators ()
+import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
+import qualified Test.Kore.Step.MockSimplifiers as Mock
+import qualified Test.Kore.Step.MockSymbols as Mock
+import           Test.Tasty.HUnit.Extensions
+
+test_Pattern_simplify :: [TestTree]
+test_Pattern_simplify =
+    [ notTop     `becomes` OrPattern.bottom              $ "\\not(\\top)"
+    , orAs       `becomes` OrPattern.fromTermLike Mock.a $ "\\or(a, a)"
+    , bottomLike `becomes` OrPattern.bottom              $ "a ∧ \bottom"
+    ]
+  where
+    termLike = Pattern.fromTermLike
+    -- | Term is \bottom, but not in a trivial way.
+    notTop = termLike (mkNot mkTop_)
+    -- | Lifting disjunction to the top would duplicate terms.
+    orAs = termLike (mkOr Mock.a Mock.a)
+    -- | Term is defined, but predicate is \bottom.
+    bottomLike =
+        (termLike Mock.a) { Pattern.predicate = Predicate.makeFalsePredicate }
+    becomes original expect name =
+        testCase name $ do
+            actual <- simplify original
+            assertEqualWithExplanation "" expect actual
+
+metadataTools :: SmtMetadataTools Attribute.Symbol
+metadataTools =
+    Mock.makeMetadataTools
+        Mock.attributesMapping
+        Mock.headTypeMapping
+        Mock.sortAttributesMapping
+        Mock.subsorts
+        Mock.headSortsMapping
+        Mock.smtDeclarations
+
+simplify :: Pattern Variable -> IO (OrPattern Variable)
+simplify original =
+    SMT.runSMT SMT.defaultConfig
+    $ evalSimplifier emptyLogger
+    $ Pattern.simplify
+        metadataTools
+        predicateSimplifier
+        termLikeSimplifier
+        axiomSimplifiers
+        original
+  where
+    predicateSimplifier = Mock.substitutionSimplifier metadataTools
+    termLikeSimplifier = Simplifier.create metadataTools axiomSimplifiers
+    axiomSimplifiers = Map.empty

--- a/kore/test/Test/Kore/Step/Simplification/Predicate.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Predicate.hs
@@ -9,10 +9,6 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map as Map
 
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import qualified Kore.Internal.MultiOr as MultiOr
 import qualified Kore.Internal.OrPattern as OrPattern
 import           Kore.Internal.OrPredicate
@@ -41,8 +37,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
 
@@ -272,16 +266,6 @@ test_predicateSimplification =
         assertEqualWithExplanation "" (MultiOr.singleton expect) actual
     ]
 
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 runSimplifier
     :: BuiltinAndAxiomSimplifierMap
     -> Predicate Variable
@@ -295,8 +279,8 @@ runSimplifier patternSimplifierMap predicate =
   where
     PredicateSimplifier simplifier =
         PSSimplifier.create
-            mockMetadataTools
-            (Simplifier.create mockMetadataTools patternSimplifierMap)
+            Mock.metadataTools
+            (Simplifier.create Mock.metadataTools patternSimplifierMap)
             patternSimplifierMap
 
 simplificationEvaluator

--- a/kore/test/Test/Kore/Step/Step.hs
+++ b/kore/test/Test/Kore/Step/Step.hs
@@ -16,9 +16,6 @@ import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-import           Kore.Attribute.Symbol
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import qualified Kore.Internal.Conditional as Conditional
 import           Kore.Internal.MultiOr
                  ( MultiOr )
@@ -63,20 +60,8 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
-
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
 
 evalUnifier
     :: BranchT Unifier a
@@ -102,7 +87,7 @@ applyInitialConditions initial unification =
         initial
         unification
   where
-    metadataTools = mockMetadataTools
+    metadataTools = Mock.metadataTools
     predicateSimplifier =
         Predicate.create
             metadataTools
@@ -183,7 +168,7 @@ unifyRule initial rule =
         initial
         rule
   where
-    metadataTools = mockMetadataTools
+    metadataTools = Mock.metadataTools
     unificationProcedure = UnificationProcedure Unification.unificationProcedure
     predicateSimplifier =
         Predicate.create
@@ -692,7 +677,7 @@ applyRewriteRules initial rules =
         rules
         initial
   where
-    metadataTools = mockMetadataTools
+    metadataTools = Mock.metadataTools
     predicateSimplifier =
         Predicate.create
             metadataTools
@@ -1064,7 +1049,7 @@ sequenceRewriteRules initial rules =
         initial
         rules
   where
-    metadataTools = mockMetadataTools
+    metadataTools = Mock.metadataTools
     predicateSimplifier =
         Predicate.create
             metadataTools
@@ -1184,7 +1169,7 @@ sequenceMatchingRules initial rules =
         initial
         (getEqualityRule <$> rules)
   where
-    metadataTools = mockMetadataTools
+    metadataTools = Mock.metadataTools
     predicateSimplifier =
         Predicate.create
             metadataTools

--- a/kore/test/Test/Kore/Step/Substitution.hs
+++ b/kore/test/Test/Kore/Step/Substitution.hs
@@ -10,10 +10,6 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map as Map
 
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.MultiOr
                  ( MultiOr )
 import qualified Kore.Internal.MultiOr as MultiOr
@@ -36,8 +32,6 @@ import qualified SMT
 
 import           Test.Kore
 import           Test.Kore.Comparators ()
-import qualified Test.Kore.IndexedModule.MockMetadataTools as Mock
-                 ( makeMetadataTools )
 import qualified Test.Kore.Step.MockSimplifiers as Mock
 import qualified Test.Kore.Step.MockSymbols as Mock
 import           Test.Tasty.HUnit.Extensions
@@ -314,16 +308,6 @@ test_mergeAndNormalizeSubstitutions =
             assertEqualWithExplanation "" expect actual
     ]
 
-mockMetadataTools :: SmtMetadataTools StepperAttributes
-mockMetadataTools =
-    Mock.makeMetadataTools
-        Mock.attributesMapping
-        Mock.headTypeMapping
-        Mock.sortAttributesMapping
-        Mock.subsorts
-        Mock.headSortsMapping
-        Mock.smtDeclarations
-
 merge
     :: [(Variable, TermLike Variable)]
     -> [(Variable, TermLike Variable)]
@@ -333,9 +317,9 @@ merge s1 s2 =
     $ evalSimplifier emptyLogger
     $ Monad.Unify.runUnifier
     $ mergePredicatesAndSubstitutionsExcept
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         []
         $ Substitution.wrap <$> [s1, s2]
@@ -348,9 +332,9 @@ normalize predicated =
     $ evalSimplifier emptyLogger
     $ gather
     $ Substitution.normalize
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         predicated
 
@@ -364,9 +348,9 @@ normalizeExcept predicated =
     $ fmap MultiOr.make
     $ gather
     $ Substitution.normalizeExcept
-        mockMetadataTools
-        (Mock.substitutionSimplifier mockMetadataTools)
-        (Simplifier.create mockMetadataTools Map.empty)
+        Mock.metadataTools
+        (Mock.substitutionSimplifier Mock.metadataTools)
+        (Simplifier.create Mock.metadataTools Map.empty)
         Map.empty
         predicated
 

--- a/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
+++ b/kore/test/Test/Kore/Unification/SubstitutionNormalization.hs
@@ -194,17 +194,7 @@ runNormalizeSubstitutionObject
 runNormalizeSubstitutionObject substitution =
     fmap (Substitution.unwrap . Conditional.substitution)
     . Except.runExcept
-    $ normalizeSubstitution mockMetadataToolsO (Map.fromList substitution)
-  where
-    mockMetadataToolsO :: SmtMetadataTools StepperAttributes
-    mockMetadataToolsO =
-        Mock.makeMetadataTools
-            Mock.attributesMapping
-            Mock.headTypeMapping
-            Mock.sortAttributesMapping
-            Mock.subsorts
-            Mock.headSortsMapping
-            Mock.smtDeclarations
+    $ normalizeSubstitution Mock.metadataTools (Map.fromList substitution)
 
 mockMetadataTools :: SmtMetadataTools StepperAttributes
 mockMetadataTools = MetadataTools


### PR DESCRIPTION
This fixes a bug in `Pattern` simplification related to a use of `traverse`. I also added a card to the story board to clean up other possibly-problematic uses.

Related: #635 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

