### PR TITLE
Repl: alias with arguments

### DIFF
--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -100,7 +100,7 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
         str <- prompt
         let command = maybe ShowUsage id $ parseMaybe commandParser str
         when (shouldStore command) $ lensCommands Lens.%= (Seq.|> str)
-        replInterpreter putStrLn command
+        replInterpreter printIfNotEmpty command
 
     state :: ReplState claim
     state =

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -117,6 +117,7 @@ runRepl tools simplifier predicateSimplifier axiomToIdSimplifier axioms' claims'
             , stepper = stepper0
             , unifier = unifier0
             , labels  = Map.empty
+            , aliases = Map.empty
             }
 
     addIndexesToAxioms

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -178,7 +178,7 @@ helpText =
     \prove <n>                             initializes proof mode for the nth \
                                            \claim\n\
     \graph [file]                          shows the current proof graph (*)\n\
-                                           \ (saves image if file argument is\
+    \                                      (saves image if file argument is\
                                            \ given)\n\
     \step [n]                              attempts to run 'n' proof steps at\
                                            \the current node (n=1 by default)\n\
@@ -207,8 +207,9 @@ helpText =
                                            \ index <num>.\n\
     \clear [n]                             removes all node children from the\
                                            \ proof graph\n\
-                                           \ (defaults to current node)\n\
+    \                                      (defaults to current node)\n\
     \alias <name> = <command>              adds as an alias for <command>\n\
+    \<alias>                               runs an existing alias\n\
     \exit                                  exits the repl\
     \\n\
     \Available modifiers:\n\

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -563,7 +563,10 @@ substituteAlias
       $ command
   where
     values :: Map String AliasArgument
-    values = Map.fromList $ zip arguments actualArguments
+    values
+      | length arguments == length actualArguments
+        = Map.fromList $ zip arguments actualArguments
+      | otherwise = Map.empty
 
     replaceArguments :: String -> String
     replaceArguments s = maybe s toString $ Map.lookup s values

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -16,7 +16,7 @@ module Kore.Repl.Data
     , ReplNode (..)
     , ReplState (..)
     , NodeState (..)
-    , AliasDefinition (..), ReplAlias (..)
+    , AliasDefinition (..), ReplAlias (..), AliasArgument(..)
     , getNodeState
     , InnerGraph
     , lensAxioms, lensClaims, lensClaim
@@ -110,9 +110,14 @@ data AliasDefinition = AliasDefinition
     , command   :: String
     } deriving (Eq, Show)
 
+data AliasArgument
+  = SimpleArgument String
+  | QuotedArgument String
+  deriving (Eq, Show)
+
 data ReplAlias = ReplAlias
     { name      :: String
-    , arguments :: [String]
+    , arguments :: [AliasArgument]
     } deriving (Eq, Show)
 
 -- | List of available commands for the Repl. Note that we are always in a proof
@@ -556,8 +561,13 @@ substituteAlias
       . words
       $ command
   where
-    values :: Map String String
+    values :: Map String AliasArgument
     values = Map.fromList $ zip arguments actualArguments
 
     replaceArguments :: String -> String
-    replaceArguments s = maybe s id $ Map.lookup s values
+    replaceArguments s = maybe s toString $ Map.lookup s values
+
+    toString :: AliasArgument -> String
+    toString = \case
+        SimpleArgument str -> str
+        QuotedArgument str -> "\"" <> str <> "\""

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -16,6 +16,7 @@ module Kore.Repl.Data
     , ReplNode (..)
     , ReplState (..)
     , NodeState (..)
+    , ReplAlias (..)
     , getNodeState
     , InnerGraph
     , lensAxioms, lensClaims, lensClaim
@@ -104,6 +105,11 @@ newtype ReplNode = ReplNode
     { unReplNode :: Graph.Node
     } deriving (Eq, Show)
 
+data ReplAlias = ReplAlias
+    { name    :: String
+    , command :: ReplCommand
+    } deriving (Eq, Show)
+
 -- | List of available commands for the Repl. Note that we are always in a proof
 -- state. We pick the first available Claim when we initialize the state.
 data ReplCommand
@@ -155,6 +161,8 @@ data ReplCommand
     -- ^ Writes all commands executed in this session to a file on disk.
     | AppendTo ReplCommand FilePath
     -- ^ Appends the output of a command to a file.
+    | Alias ReplAlias
+    -- ^ Alias a command.
     | Exit
     -- ^ Exit the repl.
     deriving (Eq, Show)

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -10,6 +10,7 @@ module Kore.Repl.Interpreter
     ( replInterpreter
     , showUsageMessage
     , showStepStoppedMessage
+    , printIfNotEmpty
     ) where
 
 import           Control.Comonad.Trans.Cofree
@@ -700,7 +701,7 @@ tryAlias name = do
         -> ReplState claim
         -> ReplM claim (Bool, ReplState claim)
     runInterpreter cmd =
-        lift . runStateT (replInterpreter putStrLn cmd)
+        lift . runStateT (replInterpreter printIfNotEmpty cmd)
 
 
 -- | Performs n proof steps, picking the next node unless branching occurs.
@@ -795,6 +796,12 @@ unparseStrategy omitList =
 
 putStrLn' :: MonadWriter String m => String -> m ()
 putStrLn' str = tell $ str <> "\n"
+
+printIfNotEmpty :: String -> IO ()
+printIfNotEmpty =
+    \case
+        "" -> pure ()
+        xs -> putStrLn xs
 
 printNotFound :: MonadWriter String m => m ()
 printNotFound = putStrLn' "Variable or index not found"

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -140,7 +140,7 @@ replInterpreter printFn replCmd = do
                 Pipe inn file args -> pipe inn file args $> True
                 AppendTo inn file  -> appendTo inn file  $> True
                 Alias a            -> alias a            $> True
-                TryAlias name      -> tryAlias name
+                TryAlias name      -> tryAlias name printFn
                 Exit               -> pure                  False
     (output, shouldContinue) <- evaluateCommand command
     liftIO $ printFn output
@@ -686,8 +686,9 @@ tryAlias
     :: forall claim
     .  Claim claim
     => String
+    -> (String -> IO ())
     -> ReplM claim Bool
-tryAlias name = do
+tryAlias name printFn = do
     res <- findAlias name
     case res of
         Nothing  -> showUsage $> True
@@ -701,7 +702,7 @@ tryAlias name = do
         -> ReplState claim
         -> ReplM claim (Bool, ReplState claim)
     runInterpreter cmd =
-        lift . runStateT (replInterpreter printIfNotEmpty cmd)
+        lift . runStateT (replInterpreter printFn cmd)
 
 
 -- | Performs n proof steps, picking the next node unless branching occurs.

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -34,9 +34,7 @@ import           Control.Monad.State.Strict
                  ( MonadState, StateT (..), execStateT )
 import qualified Control.Monad.Trans.Class as Monad.Trans
 import           Data.Coerce
-                 ( Coercible (..) )
-import           Data.Coerce
-                 ( coerce )
+                 ( Coercible, coerce )
 import           Data.Foldable
                  ( traverse_ )
 import           Data.Functor
@@ -699,9 +697,9 @@ tryAlias replAlias@ReplAlias { name } printFn = do
     res <- findAlias name
     case res of
         Nothing  -> showUsage $> True
-        Just alias -> do
+        Just aliasDef -> do
             let
-                command = substituteAlias alias replAlias
+                command = substituteAlias aliasDef replAlias
                 parsedCommand =
                     maybe ShowUsage id $ parseMaybe commandParser command
             (cont, st') <- get >>= runInterpreter parsedCommand

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -773,7 +773,6 @@ showRewriteRule rule =
         (RewriteRule (RulePattern{ Axiom.attributes })) =
             Attribute.sourceLocation attributes
 
-
 -- | Unparses a strategy node, using an omit list to hide specified children.
 unparseStrategy
     :: [String]

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -193,7 +193,7 @@ alias = do
 tryAlias :: Parser ReplCommand
 tryAlias = do
     name <- word
-    arguments <- some $ quotedOrWordWithout ""
+    arguments <- some (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
     return . TryAlias $ ReplAlias { name, arguments }
 
 infixr 2 <$$>

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -193,7 +193,7 @@ alias = do
 tryAlias :: Parser ReplCommand
 tryAlias = do
     name <- word
-    arguments <- some (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
+    arguments <- many (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
     return . TryAlias $ ReplAlias { name, arguments }
 
 infixr 2 <$$>

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -192,7 +192,7 @@ alias = do
 
 tryAlias :: Parser ReplCommand
 tryAlias = do
-    name <- word
+    name <- some (noneOf [' ']) <* Char.space
     arguments <- many (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
     return . TryAlias $ ReplAlias { name, arguments }
 

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -185,12 +185,16 @@ alias :: Parser ReplCommand
 alias = do
     literal "alias"
     name <- word
+    arguments <- many $ wordWithout "="
     literal "="
-    cmd  <- commandParserExceptAlias
-    return . Alias $ ReplAlias name cmd
+    command <- some L.charLiteral
+    return . Alias $ AliasDefinition { name, arguments, command }
 
 tryAlias :: Parser ReplCommand
-tryAlias = TryAlias <$$> word
+tryAlias = do
+    name <- word
+    arguments <- some $ quotedOrWordWithout ""
+    return . TryAlias $ ReplAlias { name, arguments }
 
 infixr 2 <$$>
 infixr 1 <**>

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -66,6 +66,7 @@ nonRecursiveCommand =
         , clear
         , saveSession
         , exit
+        , tryAlias
         ]
 
 pipeWith
@@ -188,6 +189,9 @@ alias = do
     literal "="
     cmd  <- commandParserExceptAlias
     return . Alias $ ReplAlias name cmd
+
+tryAlias :: Parser ReplCommand
+tryAlias = TryAlias <$$> word
 
 infixr 2 <$$>
 infixr 1 <**>

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -21,7 +21,6 @@ import qualified Text.Megaparsec.Char as Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
 import Kore.Repl.Data
-       ( AxiomIndex (..), ClaimIndex (..), ReplCommand (..), ReplNode (..) )
 
 type Parser = Parsec String String
 
@@ -30,7 +29,11 @@ type Parser = Parsec String String
 -- maybe ShowUsage id . Text.Megaparsec.parseMaybe commandParser
 -- @
 commandParser :: Parser ReplCommand
-commandParser = do
+commandParser =
+    alias <|> commandParserExceptAlias
+
+commandParserExceptAlias :: Parser ReplCommand
+commandParserExceptAlias = do
     cmd <- nonRecursiveCommand
     endOfInput cmd
         <|> pipeWith appendTo cmd
@@ -177,6 +180,14 @@ appendTo cmd =
     AppendTo cmd
     <$$> literal ">>"
     *> quotedOrWordWithout ""
+
+alias :: Parser ReplCommand
+alias = do
+    literal "alias"
+    name <- word
+    literal "="
+    cmd  <- commandParserExceptAlias
+    return . Alias $ ReplAlias name cmd
 
 infixr 2 <$$>
 infixr 1 <**>

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -30,7 +30,7 @@ type Parser = Parsec String String
 -- @
 commandParser :: Parser ReplCommand
 commandParser =
-    alias <|> commandParserExceptAlias
+    alias <|> commandParserExceptAlias <|> tryAlias
 
 commandParserExceptAlias :: Parser ReplCommand
 commandParserExceptAlias = do
@@ -66,7 +66,6 @@ nonRecursiveCommand =
         , clear
         , saveSession
         , exit
-        , tryAlias
         ]
 
 pipeWith

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -16,9 +16,11 @@ import           Control.Applicative
 import qualified Data.Foldable as Foldable
 import           Data.Functor
                  ( void, ($>) )
+import           Data.List
+                 ( nub )
 import           Text.Megaparsec
-                 ( Parsec, eof, many, manyTill, noneOf, oneOf, option,
-                 optional, try )
+                 ( Parsec, customFailure, eof, many, manyTill, noneOf, oneOf,
+                 option, optional, try )
 import qualified Text.Megaparsec.Char as Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
@@ -205,6 +207,9 @@ alias = do
     literal "alias"
     name <- word
     arguments <- many $ wordWithout "="
+    if nub arguments /= arguments
+        then customFailure "Error when parsing alias: duplicate argument name."
+        else pure ()
     literal "="
     command <- some L.charLiteral
     return . Alias $ AliasDefinition { name, arguments, command }

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -44,6 +44,7 @@ scriptParser =
     skipSpacesAndComments =
         optional $ spaceConsumer <* Char.newline
 
+commandParser :: Parser ReplCommand
 commandParser = commandParser0 eof
 
 commandParser0 :: Parser () -> Parser ReplCommand

--- a/kore/test/Test/Kore/Parser.hs
+++ b/kore/test/Test/Kore/Parser.hs
@@ -44,8 +44,8 @@ failure input expected = Failure FailureTest
     , failureExpected = expected
     }
 
-fails :: String -> String -> ParserTest a
-fails input details = FailureWithoutMessage [input, details]
+fails :: String -> () -> ParserTest a
+fails input _ = FailureWithoutMessage [input]
 
 parseTree
     :: (HasCallStack, Show a, Eq a)

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -116,7 +116,7 @@ tryAlias =
         stateT  = \st -> st { aliases = Map.insert name alias (aliases st) }
         command = TryAlias "h"
     in do
-        Result { output, continue, state } <-
+        Result { output, continue } <-
             runWithState command axioms claim stateT
         output   `equalsOutput` helpText
         continue `equals` True

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -43,6 +43,8 @@ test_replInterpreter =
     , help      `tests` "Showing the help message"
     , step5     `tests` "Performing 5 steps"
     , step100   `tests` "Stepping over proof completion"
+    , makeAlias `tests` "Creating an alias"
+    , tryAlias  `tests` "Executing an existing alias"
     ]
 
 showUsage :: IO ()
@@ -91,6 +93,35 @@ step100 =
         continue   `equals`         True
         state      `hasCurrentNode` ReplNode 10
 
+makeAlias :: IO ()
+makeAlias =
+    let
+        axioms  = []
+        claim   = emptyClaim
+        alias   = ReplAlias { name = "a", command = Help }
+        command = Alias alias
+    in do
+        Result { output, continue, state } <- run command axioms claim
+        output   `equalsOutput` ""
+        continue `equals`       True
+        state    `hasAlias`     alias
+
+tryAlias :: IO ()
+tryAlias =
+    let
+        axioms  = []
+        claim   = emptyClaim
+        name    = "h"
+        alias   = ReplAlias { name, command = Help }
+        stateT  = \st -> st { aliases = Map.insert name alias (aliases st) }
+        command = TryAlias "h"
+    in do
+        Result { output, continue, state } <-
+            runWithState command axioms claim stateT
+        output   `equalsOutput` helpText
+        continue `equals` True
+
+
 add1 :: Axiom
 add1 = coerce $ rulePattern n plusOne
   where
@@ -108,15 +139,27 @@ emptyClaim :: Claim
 emptyClaim = coerce $ rulePattern mkBottom_ mkBottom_
 
 run :: ReplCommand -> [Axiom] -> Claim -> IO Result
-run command axioms claim =  do
+run command axioms claim =  runWithState command axioms claim id
+
+runWithState
+    :: ReplCommand
+    -> [Axiom]
+    -> Claim
+    -> (ReplState Claim -> ReplState Claim)
+    -> IO Result
+runWithState command axioms claim stateTransformer = do
     output <- newIORef ""
     (c, s) <- liftSimplifier $
-        replInterpreter (writeIORef output) command `runStateT` state
+        replInterpreter (writeIORefIfNotEmpty output) command `runStateT` state
     output' <- readIORef output
     return $ Result output' c s
   where
     liftSimplifier = SMT.runSMT SMT.defaultConfig . evalSimplifier emptyLogger
-    state = mkState axioms claim
+    state = stateTransformer $ mkState axioms claim
+    writeIORefIfNotEmpty out =
+        \case
+            "" -> pure ()
+            xs -> writeIORef out xs
 
 data Result = Result
     { output   :: String
@@ -124,17 +167,10 @@ data Result = Result
     , state    :: ReplState Claim
     }
 
-equals
-    :: (Eq a, Show a)
-    => a
-    -> a
-    -> Assertion
+equals :: (Eq a, Show a) => a -> a -> Assertion
 equals = (@?=)
 
-equalsOutput
-    :: String
-    -> String
-    -> Assertion
+equalsOutput :: String -> String -> Assertion
 equalsOutput "" expected     = "" @?= expected
 equalsOutput actual expected = actual @?= expected <> "\n"
 
@@ -145,6 +181,14 @@ hasCurrentNode st n = do
     graphNode `equals` justNode
   where
     justNode = Just n
+
+hasAlias :: ReplState Claim -> ReplAlias -> IO ()
+hasAlias st alias =
+    let
+        aliasMap = aliases st
+        actual   = name alias `Map.lookup` aliasMap
+    in
+        actual `equals` Just alias
 
 tests :: IO () -> String -> TestTree
 tests = flip testCase

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -158,10 +158,11 @@ mkState axioms claim =
         , graph    = graph'
         , node     = ReplNode 0
         , commands = Seq.empty
-        , omit    = []
-        , stepper = stepper0
-        , unifier = unifier0
-        , labels  = Map.empty
+        , omit     = []
+        , stepper  = stepper0
+        , unifier  = unifier0
+        , labels   = Map.empty
+        , aliases  = Map.empty
         }
   where
     graph' = emptyExecutionGraph claim

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -98,7 +98,7 @@ makeAlias =
     let
         axioms  = []
         claim   = emptyClaim
-        alias   = ReplAlias { name = "a", command = Help }
+        alias   = AliasDefinition { name = "a", arguments = [], command = "help" }
         command = Alias alias
     in do
         Result { output, continue, state } <- run command axioms claim
@@ -112,9 +112,9 @@ tryAlias =
         axioms  = []
         claim   = emptyClaim
         name    = "h"
-        alias   = ReplAlias { name, command = Help }
+        alias   = AliasDefinition { name, arguments = [], command = "help" }
         stateT  = \st -> st { aliases = Map.insert name alias (aliases st) }
-        command = TryAlias "h"
+        command = TryAlias $ ReplAlias "h" []
     in do
         Result { output, continue } <-
             runWithState command axioms claim stateT
@@ -182,11 +182,11 @@ hasCurrentNode st n = do
   where
     justNode = Just n
 
-hasAlias :: ReplState Claim -> ReplAlias -> IO ()
-hasAlias st alias =
+hasAlias :: ReplState Claim -> AliasDefinition -> IO ()
+hasAlias st alias@AliasDefinition { name } =
     let
         aliasMap = aliases st
-        actual   = name alias `Map.lookup` aliasMap
+        actual   = name `Map.lookup` aliasMap
     in
         actual `equals` Just alias
 

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -60,8 +60,6 @@ claimTests =
     [ "claim 0"  `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 0 " `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 5"  `parsesTo_` ShowClaim (ClaimIndex 5)
-    , "claim"    `fails`     "needs parameters"
-    , "claim -5" `fails`     "no negative numbers"
     ]
 
 axiomTests :: [ParserTest ReplCommand]
@@ -69,8 +67,6 @@ axiomTests =
     [ "axiom 0"  `parsesTo_` ShowAxiom (AxiomIndex 0)
     , "axiom 0 " `parsesTo_` ShowAxiom (AxiomIndex 0)
     , "axiom 5"  `parsesTo_` ShowAxiom (AxiomIndex 5)
-    , "axiom"    `fails`     "needs parameters"
-    , "axiom -5" `fails`     "no negative numbers"
     ]
 
 proveTests :: [ParserTest ReplCommand]
@@ -78,8 +74,6 @@ proveTests =
     [ "prove 0"  `parsesTo_` Prove (ClaimIndex 0)
     , "prove 0 " `parsesTo_` Prove (ClaimIndex 0)
     , "prove 5"  `parsesTo_` Prove (ClaimIndex 5)
-    , "prove"    `fails`     "needs parameters"
-    , "prove -5" `fails`     "no negative numbers"
     ]
 
 graphTests :: [ParserTest ReplCommand]
@@ -88,7 +82,6 @@ graphTests =
     , "graph "          `parsesTo_` ShowGraph Nothing
     , "graph file"      `parsesTo_` ShowGraph (Just "file")
     , "graph \"f ile\"" `parsesTo_` ShowGraph (Just "f ile")
-    , "graph f ile"     `fails`     "graph doesn't take 2 args"
     ]
 
 stepTests :: [ParserTest ReplCommand]
@@ -97,7 +90,6 @@ stepTests =
     , "step "   `parsesTo_` ProveSteps 1
     , "step 5"  `parsesTo_` ProveSteps 5
     , "step 5 " `parsesTo_` ProveSteps 5
-    , "step -5" `fails`     "no negative numbers"
     ]
 
 stepfTests :: [ParserTest ReplCommand]
@@ -106,14 +98,12 @@ stepfTests =
     , "stepf "   `parsesTo_` ProveStepsF 1
     , "stepf 5"  `parsesTo_` ProveStepsF 5
     , "stepf 5 " `parsesTo_` ProveStepsF 5
-    , "stepf -5" `fails`     "no negative numbers"
     ]
 
 selectTests :: [ParserTest ReplCommand]
 selectTests =
     [ "select 5"  `parsesTo_` SelectNode (ReplNode 5)
     , "select 5 " `parsesTo_` SelectNode (ReplNode 5)
-    , "select -5" `fails`     "no negative numbers"
     ]
 
 configTests :: [ParserTest ReplCommand]
@@ -121,7 +111,6 @@ configTests =
     [ "config"    `parsesTo_` ShowConfig Nothing
     , "config "   `parsesTo_` ShowConfig Nothing
     , "config 5"  `parsesTo_` ShowConfig (Just (ReplNode 5))
-    , "config -5" `fails`     "no negative numbers"
     ]
 
 omitTests :: [ParserTest ReplCommand]
@@ -146,7 +135,6 @@ precBranchTests =
     [ "prec-branch"    `parsesTo_` ShowPrecBranch Nothing
     , "prec-branch "   `parsesTo_` ShowPrecBranch Nothing
     , "prec-branch 5"  `parsesTo_` ShowPrecBranch (Just (ReplNode 5))
-    , "prec-branch -5" `fails`     "no negative numbers"
     ]
 
 childrenTests :: [ParserTest ReplCommand]
@@ -154,7 +142,6 @@ childrenTests =
     [ "children"    `parsesTo_` ShowChildren Nothing
     , "children "   `parsesTo_` ShowChildren Nothing
     , "children 5"  `parsesTo_` ShowChildren (Just (ReplNode 5))
-    , "children -5" `fails`     "no negative numbers"
     ]
 
 labelTests :: [ParserTest ReplCommand]
@@ -170,17 +157,12 @@ labelTests =
     , "label +1ab31 5"  `parsesTo_` LabelAdd "1ab31" (Just (ReplNode 5))
     , "label -label"    `parsesTo_` LabelDel "label"
     , "label -1ab31"    `parsesTo_` LabelDel "1ab31"
-    , "label +label -5" `fails`     "no negative numbers"
     ]
 
 tryTests :: [ParserTest ReplCommand]
 tryTests =
     [ "try a5"  `parsesTo_` tryAxiom 5
     , "try c5"  `parsesTo_` tryClaim 5
-    , "try"     `fails`     "empty try"
-    , "try 5"   `fails`     "need to specify axiom or claim"
-    , "try a 5" `fails`     "can't separate specifier and id"
-    , "try a"   `fails`     "must specify identifier"
     ]
   where
     tryAxiom :: Int -> ReplCommand
@@ -202,7 +184,6 @@ redirectTests =
     , "config 5 > file"   `parsesTo_` Redirect (ShowConfig (Just (ReplNode 5))) "file"
     , "claim 3 > cf"      `parsesTo_` Redirect (ShowClaim (ClaimIndex 3)) "cf"
     , "claim 3 > \"c f\"" `parsesTo_` Redirect (ShowClaim (ClaimIndex 3)) "c f"
-    , "config 5 > "       `fails`     "no file name"
     ]
 
 pipeTests :: [ParserTest ReplCommand]
@@ -212,7 +193,6 @@ pipeTests =
     , "config 5 | script \"arg1\" \"arg2\"" `parsesTo_` pipeConfig (Just (ReplNode 5)) "script" ["arg1", "arg2"]
     , "step 5 | script"                     `parsesTo_` pipeStep 5 "script" []
     , "step 5 | \"s c ri p t\""             `parsesTo_` pipeStep 5 "s c ri p t" []
-    , "config 5 | "                         `fails`     "no script name"
     ]
   where
     pipeConfig
@@ -239,9 +219,6 @@ pipeRedirectTests =
         `parsesTo_` pipeRedirectConfig Nothing "s cript" ["arg 1", "arg2"] "f ile"
     , "config 5 | script \"a r g 1\" arg2 > file"
         `parsesTo_` pipeRedirectConfig (Just (ReplNode 5)) "script" ["a r g 1", "arg2"] "file"
-    , "config 5 | > "        `fails`     "no script or file name"
-    , "config 5 | script > " `fails`     "no file name"
-    , "config 5 | > file"    `fails`     "no script name"
     ]
   where
     pipeRedirectConfig
@@ -257,7 +234,6 @@ appendTests :: [ParserTest ReplCommand]
 appendTests =
     [ "config >> file"        `parsesTo_` AppendTo (ShowConfig Nothing) "file"
     , "config >> \"f i l e\"" `parsesTo_` AppendTo (ShowConfig Nothing) "f i l e"
-    , "config >> "            `fails`     "no file name"
     ]
 
 pipeAppendTests :: [ParserTest ReplCommand]
@@ -266,8 +242,6 @@ pipeAppendTests =
         `parsesTo_` pipeAppendConfig Nothing "script" [] "file"
     , "config 5 | \"sc ript\" arg1 \"a rg\" >> \"f ile\""
         `parsesTo_` pipeAppendConfig (Just (ReplNode 5)) "sc ript" ["arg1", "a rg"] "f ile"
-    , "config | > >> file" `fails` "incorrect script name"
-    , "config | s >> "     `fails` "no file name"
     ]
   where
     pipeAppendConfig
@@ -285,7 +259,6 @@ ruleTests =
     , "rule "   `parsesTo_` ShowRule Nothing
     , "rule 5"  `parsesTo_` ShowRule (Just (ReplNode 5))
     , "rule 5 " `parsesTo_` ShowRule (Just (ReplNode 5))
-    , "rule -5" `fails`     "no negative numbers"
     ]
 
 clearTests :: [ParserTest ReplCommand]
@@ -294,14 +267,12 @@ clearTests =
     , "clear "   `parsesTo_` Clear Nothing
     , "clear 5"  `parsesTo_` Clear (Just (ReplNode 5))
     , "clear 5 " `parsesTo_` Clear (Just (ReplNode 5))
-    , "clear -5" `fails`     "no negative numbers"
     ]
 
 saveSessionTests :: [ParserTest ReplCommand]
 saveSessionTests =
     [ "save-session file"  `parsesTo_` SaveSession "file"
     , "save-session file " `parsesTo_` SaveSession "file"
-    , "save-session"       `fails`     "need to supply file name"
     ]
 
 noArgsAliasTests :: [ParserTest ReplCommand]
@@ -318,12 +289,14 @@ noArgsAliasTests =
 tryAliasTests :: [ParserTest ReplCommand]
 tryAliasTests =
     [ "whatever"           `parsesTo_` TryAlias (ReplAlias "whatever" [])
-    , "whatever with args" `fails`     "arguments not yet supported"
     ]
 
 aliasesWithArgs :: [ParserTest ReplCommand]
 aliasesWithArgs =
-    [ "alias s n = step n" `parsesTo_` alias "s" ["n"] "step n"
+    [ "alias s n = step n"         `parsesTo_` alias "s" ["n"] "step n"
+    , "alias s = step 1 > \"a b\"" `parsesTo_` alias "s" [] "step 1 > \"a b\""
+    , "alias c n s = config n | echo \"hello world\" > s"
+            `parsesTo_` alias "c" ["n", "s"] "config n | echo \"hello world\" > s"
     ]
   where
     alias name arguments command =

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -38,6 +38,7 @@ test_replParser =
     , appendTests       `tests` "append"
     , pipeAppendTests   `tests` "pipe append"
     , noArgsAliasTests  `tests` "no arguments alias tests"
+    , tryAliasTests     `tests` "try alias"
     ]
 
 tests :: [ParserTest ReplCommand] -> String -> TestTree
@@ -311,8 +312,14 @@ noArgsAliasTests =
     , "alias a = config 10 | cmd > file" `parsesTo_` alias pipeRedirect
     ]
   where
-    alias = Alias . ReplAlias "a"
-    config10 = ShowConfig . Just . ReplNode $ 10
+    alias        = Alias . ReplAlias "a"
+    config10     = ShowConfig . Just . ReplNode $ 10
     pipeCmd      = Pipe config10 "cmd" []
     redirectFile = Redirect config10 "file"
     pipeRedirect = Redirect pipeCmd "file"
+
+tryAliasTests :: [ParserTest ReplCommand]
+tryAliasTests =
+    [ "whatever"           `parsesTo_` TryAlias "whatever"
+    , "whatever with args" `fails`     "arguments not yet supported"
+    ]

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -37,6 +37,7 @@ test_replParser =
     , saveSessionTests  `tests` "save-session"
     , appendTests       `tests` "append"
     , pipeAppendTests   `tests` "pipe append"
+    , aliasTests        `tests` "alias tests"
     ]
 
 tests :: [ParserTest ReplCommand] -> String -> TestTree
@@ -299,4 +300,9 @@ saveSessionTests =
     [ "save-session file"  `parsesTo_` SaveSession "file"
     , "save-session file " `parsesTo_` SaveSession "file"
     , "save-session"       `fails`     "need to supply file name"
+    ]
+
+aliasTests :: [ParserTest ReplCommand]
+aliasTests =
+    [ "alias help' = help" `fails` "not implemented"
     ]

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -37,7 +37,7 @@ test_replParser =
     , saveSessionTests  `tests` "save-session"
     , appendTests       `tests` "append"
     , pipeAppendTests   `tests` "pipe append"
-    , aliasTests        `tests` "alias tests"
+    , noArgsAliasTests  `tests` "no arguments alias tests"
     ]
 
 tests :: [ParserTest ReplCommand] -> String -> TestTree
@@ -302,7 +302,17 @@ saveSessionTests =
     , "save-session"       `fails`     "need to supply file name"
     ]
 
-aliasTests :: [ParserTest ReplCommand]
-aliasTests =
-    [ "alias help' = help" `fails` "not implemented"
+noArgsAliasTests :: [ParserTest ReplCommand]
+noArgsAliasTests =
+    [ "alias a = help"                   `parsesTo_` alias Help
+    , "alias a = config 10"              `parsesTo_` alias config10
+    , "alias a = config 10 | cmd"        `parsesTo_` alias pipeCmd
+    , "alias a = config 10 > file"       `parsesTo_` alias redirectFile
+    , "alias a = config 10 | cmd > file" `parsesTo_` alias pipeRedirect
     ]
+  where
+    alias = Alias . ReplAlias "a"
+    config10 = ShowConfig . Just . ReplNode $ 10
+    pipeCmd      = Pipe config10 "cmd" []
+    redirectFile = Redirect config10 "file"
+    pipeRedirect = Redirect pipeCmd "file"

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -68,7 +68,8 @@ claimTests =
     [ "claim 0"  `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 0 " `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 5"  `parsesTo_` ShowClaim (ClaimIndex 5)
-    , "claim"    `fails`     "wat"
+    , "claim"    `fails`     ()
+    , "claim -5" `fails`     ()
     ]
 
 axiomTests :: [ParserTest ReplCommand]
@@ -76,6 +77,8 @@ axiomTests =
     [ "axiom 0"  `parsesTo_` ShowAxiom (AxiomIndex 0)
     , "axiom 0 " `parsesTo_` ShowAxiom (AxiomIndex 0)
     , "axiom 5"  `parsesTo_` ShowAxiom (AxiomIndex 5)
+    , "axiom"    `fails`     ()
+    , "axiom -5" `fails`     ()
     ]
 
 proveTests :: [ParserTest ReplCommand]
@@ -83,6 +86,8 @@ proveTests =
     [ "prove 0"  `parsesTo_` Prove (ClaimIndex 0)
     , "prove 0 " `parsesTo_` Prove (ClaimIndex 0)
     , "prove 5"  `parsesTo_` Prove (ClaimIndex 5)
+    , "prove"    `fails`     ()
+    , "prove -5" `fails`     ()
     ]
 
 graphTests :: [ParserTest ReplCommand]
@@ -91,6 +96,7 @@ graphTests =
     , "graph "          `parsesTo_` ShowGraph Nothing
     , "graph file"      `parsesTo_` ShowGraph (Just "file")
     , "graph \"f ile\"" `parsesTo_` ShowGraph (Just "f ile")
+    , "graph f ile"     `fails`     ()
     ]
 
 stepTests :: [ParserTest ReplCommand]
@@ -99,6 +105,7 @@ stepTests =
     , "step "   `parsesTo_` ProveSteps 1
     , "step 5"  `parsesTo_` ProveSteps 5
     , "step 5 " `parsesTo_` ProveSteps 5
+    , "step -5" `fails`     ()
     ]
 
 stepfTests :: [ParserTest ReplCommand]
@@ -107,19 +114,24 @@ stepfTests =
     , "stepf "   `parsesTo_` ProveStepsF 1
     , "stepf 5"  `parsesTo_` ProveStepsF 5
     , "stepf 5 " `parsesTo_` ProveStepsF 5
+    , "stepf -5" `fails`     ()
     ]
 
 selectTests :: [ParserTest ReplCommand]
 selectTests =
     [ "select 5"  `parsesTo_` SelectNode (ReplNode 5)
     , "select 5 " `parsesTo_` SelectNode (ReplNode 5)
+    , "select -5" `fails`     ()
     ]
 
 configTests :: [ParserTest ReplCommand]
 configTests =
-    [ "config"    `parsesTo_` ShowConfig Nothing
-    , "config "   `parsesTo_` ShowConfig Nothing
-    , "config 5"  `parsesTo_` ShowConfig (Just (ReplNode 5))
+    [ "config"             `parsesTo_` ShowConfig Nothing
+    , "config "            `parsesTo_` ShowConfig Nothing
+    , "config 5"           `parsesTo_` ShowConfig (Just (ReplNode 5))
+    , "config -5"          `fails`     ()
+    , "config | > >> file" `fails`     ()
+    , "config | s >> "     `fails`     ()
     ]
 
 omitTests :: [ParserTest ReplCommand]
@@ -144,6 +156,7 @@ precBranchTests =
     [ "prec-branch"    `parsesTo_` ShowPrecBranch Nothing
     , "prec-branch "   `parsesTo_` ShowPrecBranch Nothing
     , "prec-branch 5"  `parsesTo_` ShowPrecBranch (Just (ReplNode 5))
+    , "prec-branch -5" `fails`     ()
     ]
 
 childrenTests :: [ParserTest ReplCommand]
@@ -151,6 +164,7 @@ childrenTests =
     [ "children"    `parsesTo_` ShowChildren Nothing
     , "children "   `parsesTo_` ShowChildren Nothing
     , "children 5"  `parsesTo_` ShowChildren (Just (ReplNode 5))
+    , "children -5" `fails`     ()
     ]
 
 labelTests :: [ParserTest ReplCommand]
@@ -188,12 +202,16 @@ exitTests =
 
 redirectTests :: [ParserTest ReplCommand]
 redirectTests =
-    [ "config > file"     `parsesTo_` Redirect (ShowConfig Nothing)  "file"
-    , "config 5 > file"   `parsesTo_` Redirect (ShowConfig (Just (ReplNode 5))) "file"
-    , "config 5 > file"   `parsesTo_` Redirect (ShowConfig (Just (ReplNode 5))) "file"
-    , "claim 3 > cf"      `parsesTo_` Redirect (ShowClaim (ClaimIndex 3)) "cf"
-    , "claim 3 > \"c f\"" `parsesTo_` Redirect (ShowClaim (ClaimIndex 3)) "c f"
+    [ "config > file"     `parsesTo_` redirectConfig Nothing "file"
+    , "config 5 > file"   `parsesTo_` redirectConfig (Just $ ReplNode 5) "file"
+    , "config 5 > file"   `parsesTo_` redirectConfig (Just $ ReplNode 5) "file"
+    , "claim 3 > cf"      `parsesTo_` redirectClaim (ClaimIndex 3) "cf"
+    , "claim 3 > \"c f\"" `parsesTo_` redirectClaim (ClaimIndex 3) "c f"
+    , "config 5 > "       `fails`     ()
     ]
+  where
+    redirectConfig maybeNode file  = Redirect (ShowConfig maybeNode) file
+    redirectClaim  maybeClaim file = Redirect (ShowClaim maybeClaim) file
 
 pipeTests :: [ParserTest ReplCommand]
 pipeTests =
@@ -202,6 +220,7 @@ pipeTests =
     , "config 5 | script \"arg1\" \"arg2\"" `parsesTo_` pipeConfig (Just (ReplNode 5)) "script" ["arg1", "arg2"]
     , "step 5 | script"                     `parsesTo_` pipeStep 5 "script" []
     , "step 5 | \"s c ri p t\""             `parsesTo_` pipeStep 5 "s c ri p t" []
+    , "config 5 | "                         `fails`     ()
     ]
   where
     pipeConfig
@@ -243,6 +262,7 @@ appendTests :: [ParserTest ReplCommand]
 appendTests =
     [ "config >> file"        `parsesTo_` AppendTo (ShowConfig Nothing) "file"
     , "config >> \"f i l e\"" `parsesTo_` AppendTo (ShowConfig Nothing) "f i l e"
+    , "config >> "            `fails`     ()
     ]
 
 pipeAppendTests :: [ParserTest ReplCommand]
@@ -268,6 +288,7 @@ ruleTests =
     , "rule "   `parsesTo_` ShowRule Nothing
     , "rule 5"  `parsesTo_` ShowRule (Just (ReplNode 5))
     , "rule 5 " `parsesTo_` ShowRule (Just (ReplNode 5))
+    , "rule -5" `fails`     ()
     ]
 
 clearTests :: [ParserTest ReplCommand]
@@ -276,12 +297,14 @@ clearTests =
     , "clear "   `parsesTo_` Clear Nothing
     , "clear 5"  `parsesTo_` Clear (Just (ReplNode 5))
     , "clear 5 " `parsesTo_` Clear (Just (ReplNode 5))
+    , "clear -5" `fails`     ()
     ]
 
 saveSessionTests :: [ParserTest ReplCommand]
 saveSessionTests =
     [ "save-session file"  `parsesTo_` SaveSession "file"
     , "save-session file " `parsesTo_` SaveSession "file"
+    , "save-session"       `fails`     ()
     ]
 
 noArgsAliasTests :: [ParserTest ReplCommand]

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -60,6 +60,7 @@ claimTests =
     [ "claim 0"  `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 0 " `parsesTo_` ShowClaim (ClaimIndex 0)
     , "claim 5"  `parsesTo_` ShowClaim (ClaimIndex 5)
+    , "claim"    `fails`     "wat"
     ]
 
 axiomTests :: [ParserTest ReplCommand]
@@ -288,8 +289,13 @@ noArgsAliasTests =
 
 tryAliasTests :: [ParserTest ReplCommand]
 tryAliasTests =
-    [ "whatever"           `parsesTo_` TryAlias (ReplAlias "whatever" [])
+    [ "whatever"    `parsesTo_` tryAlias "whatever" []
+    , "c 1 \"a b\"" `parsesTo_` tryAlias "c" [str "1", quoted "a b"]
     ]
+  where
+    tryAlias name = TryAlias . ReplAlias name
+    str = SimpleArgument
+    quoted = QuotedArgument
 
 aliasesWithArgs :: [ParserTest ReplCommand]
 aliasesWithArgs =


### PR DESCRIPTION
Limitations:
~- no parsing error when attempting to add an alias for an existing command (although it will have no real effect)~ fixed
- we don't have great errors (but this is a problem with the repl in general since we hide parsing errors)
~- no checking until we actually try running the alias, so the alias could be completely malformed~
- no checking that the alias is malformed, but we do check that at least the "verb" (first word in the command) is defined
~- you can create infinite loops:~

You can't create infinite loops because of the check above (first line would error because `ln` is not defined
```
> alias l0 = loop
Error: unknown command.
```