### PR TITLE
Fix a \not simplifier bug

### DIFF
--- a/kore/src/Kore/Step/Simplification/Not.hs
+++ b/kore/src/Kore/Step/Simplification/Not.hs
@@ -116,9 +116,7 @@ simplifyEvaluated
     termSimplifier
     axiomSimplifiers
     simplified
-  | OrPattern.isFalse simplified = return (OrPattern.fromPatterns [Pattern.top])
-  | OrPattern.isTrue  simplified = return (OrPattern.fromPatterns [])
-  | otherwise =
+  =
     fmap OrPattern.fromPatterns $ gather $ do
         let not' = Not { notChild = simplified, notSort = () }
         andPattern <- scatterAnd (evaluateNotPattern <$> distributeNot not')

--- a/kore/src/Kore/Step/Simplification/Not.hs
+++ b/kore/src/Kore/Step/Simplification/Not.hs
@@ -144,18 +144,7 @@ makeEvaluate
         )
     => Pattern variable
     -> OrPattern variable
-makeEvaluate Conditional { term, predicate, substitution } =
-    OrPattern.fromPatterns
-        [ Pattern.fromTermLike $ makeTermNot term
-        , Conditional
-            { term = mkTop (termLikeSort term)
-            , predicate =
-                makeNotPredicate
-                $ makeAndPredicate predicate
-                $ Predicate.fromSubstitution substitution
-            , substitution = mempty
-            }
-        ]
+makeEvaluate = evaluateNotPattern . Not ()
 
 makeTermNot
     ::  ( SortedVariable variable

--- a/kore/src/Kore/Syntax/Not.hs
+++ b/kore/src/Kore/Syntax/Not.hs
@@ -20,6 +20,7 @@ import qualified GHC.Generics as GHC
 
 import Kore.Debug
 import Kore.Sort
+import Kore.TopBottom
 import Kore.Unparser
 
 {-|'Not' corresponds to the @\not@ branches of the @object-pattern@ and
@@ -57,3 +58,7 @@ instance Unparse child => Unparse (Not Sort child) where
 
     unparse2 Not { notChild } =
         Pretty.parens (Pretty.fillSep ["\\not", unparse2 notChild])
+
+instance TopBottom child => TopBottom (Not sort child) where
+    isTop = isBottom . notChild
+    isBottom = isTop . notChild


### PR DESCRIPTION
This fixes a small bug in the \not simplifier. I can't seem to trigger this bug "in production," so I'm calling it "small".

In addition to adding a test and fixing the bug, I wrote the simplifier in a more type-ful way, so that I can make changes more confidently in the future.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

