### PR TITLE
Cleanup: Logging

### DIFF
--- a/kore/src/Control/Monad/Counter.hs
+++ b/kore/src/Control/Monad/Counter.hs
@@ -63,18 +63,24 @@ newtype CounterT m a =
 
 instance Monad m => MonadCounter (CounterT m) where
     increment = CounterT incrementState
+    {-# INLINE increment #-}
 
 deriving instance Monad m => MonadState Natural (CounterT m)
 
 instance MonadIO m => MonadIO (CounterT m) where
     liftIO = CounterT . liftIO
+    {-# INLINE liftIO #-}
 
 instance MonadReader e m => MonadReader e (CounterT m) where
     ask = Monad.Trans.lift Monad.Reader.ask
+    {-# INLINE ask #-}
+
     local f =  CounterT . Monad.Reader.local f . getCounterT
+    {-# INLINE local #-}
 
 instance Morph.MFunctor CounterT where
     hoist f = CounterT . Morph.hoist f . getCounterT
+    {-# INLINE hoist #-}
 
 {- | Run a computation using a monotonic counter.
 

--- a/kore/src/Kore/Logger.hs
+++ b/kore/src/Kore/Logger.hs
@@ -116,11 +116,17 @@ hoistLogAction f (LogAction logger) = LogAction $ \msg -> f (logger msg)
 
 instance WithLog msg m => WithLog msg (Except.ExceptT e m) where
     askLogAction = Monad.Trans.lift (liftLogAction <$> askLogAction)
+    {-# INLINE askLogAction #-}
+
     withLog f = Monad.Morph.hoist (withLog f)
+    {-# INLINE withLog #-}
 
 instance WithLog msg m => WithLog msg (ListT m) where
     askLogAction = Monad.Trans.lift (liftLogAction <$> askLogAction)
+    {-# INLINE askLogAction #-}
+
     withLog f = Monad.Morph.hoist (withLog f)
+    {-# INLINE withLog #-}
 
 -- | Log any message.
 logMsg :: WithLog msg m => msg -> m ()

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -63,6 +63,7 @@ newtype TransitionT rule m a =
 
 instance MonadTrans (TransitionT rule) where
     lift = TransitionT . Monad.Trans.lift . Monad.Trans.lift
+    {-# INLINE lift #-}
 
 instance MonadError e m => MonadError e (TransitionT rule m) where
     throwError = Monad.Trans.lift . throwError
@@ -77,18 +78,19 @@ instance MonadError e m => MonadError e (TransitionT rule m) where
 
 instance MonadReader e m => MonadReader e (TransitionT rule m) where
     ask     = Monad.Trans.lift ask
+    {-# INLINE ask #-}
+
     local f = TransitionT . Accum.mapAccumT (local f) . getTransitionT
+    {-# INLINE local #-}
 
 instance Monad.Morph.MFunctor (TransitionT rule) where
     hoist morph =
         TransitionT
-            . Accum.mapAccumT (Monad.Morph.hoist morph)
-            . getTransitionT
+        . Accum.mapAccumT (Monad.Morph.hoist morph)
+        . getTransitionT
+    {-# INLINE hoist #-}
 
-instance
-    ( MonadSMT m
-    , MonadIO m
-    ) => MonadSMT (TransitionT rule m) where
+instance (MonadSMT m, MonadIO m) => MonadSMT (TransitionT rule m)
 
 runTransitionT :: Monad m => TransitionT rule m a -> m [(a, Seq rule)]
 runTransitionT (TransitionT edge) = ListT.gather (runAccumT edge mempty)

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -136,6 +136,7 @@ class Monad m => MonadSMT m where
         => m a
         -> m a
     withSolver action = Morph.hoist withSolver action
+    {-# INLINE withSolver #-}
 
     -- | Declares a general SExpr to SMT.
     declare :: Text -> SExpr -> m SExpr
@@ -145,6 +146,7 @@ class Monad m => MonadSMT m where
         -> SExpr
         -> m SExpr
     declare text = Trans.lift . declare text
+    {-# INLINE declare #-}
 
     -- | Declares a function symbol to SMT.
     declareFun :: SmtFunctionDeclaration -> m SExpr
@@ -153,6 +155,7 @@ class Monad m => MonadSMT m where
         => SmtFunctionDeclaration
         -> m SExpr
     declareFun = Trans.lift . declareFun
+    {-# INLINE declareFun #-}
 
     -- | Declares a sort to SMT.
     declareSort :: SmtSortDeclaration -> m SExpr
@@ -161,6 +164,7 @@ class Monad m => MonadSMT m where
         => SmtSortDeclaration
         -> m SExpr
     declareSort = Trans.lift . declareSort
+    {-# INLINE declareSort #-}
 
     -- | Declares a constructor-based sort to SMT.
     declareDatatype :: SmtDataTypeDeclaration -> m ()
@@ -169,6 +173,7 @@ class Monad m => MonadSMT m where
         => SmtDataTypeDeclaration
         -> m ()
     declareDatatype = Trans.lift . declareDatatype
+    {-# INLINE declareDatatype #-}
 
     -- | Declares a constructor-based sort to SMT.
     declareDatatypes ::  [SmtDataTypeDeclaration] -> m ()
@@ -177,6 +182,7 @@ class Monad m => MonadSMT m where
         => [SmtDataTypeDeclaration]
         -> m ()
     declareDatatypes = Trans.lift . declareDatatypes
+    {-# INLINE declareDatatypes #-}
 
     -- | Assume a fact.
     assert :: SExpr -> m ()
@@ -185,6 +191,7 @@ class Monad m => MonadSMT m where
         => SExpr
         -> m ()
     assert = Trans.lift . assert
+    {-# INLINE assert #-}
 
     {- | Check if the current set of assertions is satisfiable.
 
@@ -196,6 +203,7 @@ class Monad m => MonadSMT m where
         :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
         => m Result
     check = Trans.lift check
+    {-# INLINE check #-}
 
     -- | A command with an uninteresting result.
     ackCommand :: SExpr -> m ()
@@ -204,6 +212,7 @@ class Monad m => MonadSMT m where
         => SExpr
         -> m ()
     ackCommand = Trans.lift . ackCommand
+    {-# INLINE ackCommand #-}
 
     -- | Load a .smt2 file
     loadFile :: FilePath -> m ()
@@ -212,6 +221,7 @@ class Monad m => MonadSMT m where
         => FilePath
         -> m ()
     loadFile = Trans.lift . loadFile
+    {-# INLINE loadFile #-}
 
 withSolver' :: (Solver -> IO a) -> SMT a
 withSolver' action = do
@@ -265,25 +275,13 @@ instance MonadSMT SMT where
     loadFile path =
         withSolver' $ \solver -> SimpleSMT.loadFile solver path
 
-instance
-    ( MonadSMT m
-    , MonadIO m
-    ) => MonadSMT (Maybe.MaybeT m) where
+instance (MonadSMT m, MonadIO m) => MonadSMT (Maybe.MaybeT m)
 
-instance
-    ( MonadSMT m
-    , MonadIO m
-    ) => MonadSMT (State.Lazy.StateT s m) where
+instance (MonadSMT m, MonadIO m) => MonadSMT (State.Lazy.StateT s m)
 
-instance
-    ( MonadSMT m
-    , MonadIO m
-    ) => MonadSMT (Counter.CounterT m) where
+instance (MonadSMT m, MonadIO m) => MonadSMT (Counter.CounterT m)
 
-instance
-    ( MonadSMT m
-    , MonadIO m
-    ) => MonadSMT (State.Strict.StateT s m) where
+instance (MonadSMT m, MonadIO m) => MonadSMT (State.Strict.StateT s m)
 
 {- | Initialize a new solver with the given 'Config'.
 

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -10,7 +10,7 @@ module Test.Kore.Builtin.Builtin
     , evaluateT
     , evaluateToList
     , indexedModule
-    , runStepWith
+    , runStep
     , runSMT
     ) where
 
@@ -218,36 +218,35 @@ evaluateToList =
 runSMT :: SMT a -> IO a
 runSMT = SMT.runSMT SMT.defaultConfig emptyLogger
 
-runStepWith
+runStep
     :: Pattern Variable
     -- ^ configuration
     -> RewriteRule Variable
     -- ^ axiom
-    -> IO (Either UnificationOrSubstitutionError (OrPattern Variable))
-runStepWith configuration axiom = do
-    result <- runStepResultWith configuration axiom
-    return (Step.gatherResults <$> result)
+    -> SMT (Either UnificationOrSubstitutionError (OrPattern Variable))
+runStep configuration axiom = do
+    results <- runStepResult configuration axiom
+    return (Step.gatherResults <$> results)
 
-runStepResultWith
+runStepResult
     :: Pattern Variable
     -- ^ configuration
     -> RewriteRule Variable
     -- ^ axiom
-    -> IO (Either UnificationOrSubstitutionError (Step.Results Variable))
-runStepResultWith configuration axiom =
-    let smt =
-            runSMT
-            $ evalSimplifier
-            $ Monad.Unify.runUnifier
-            $ Step.applyRewriteRules
-                testMetadataTools
-                testSubstitutionSimplifier
-                testTermLikeSimplifier
-                testEvaluators
-                (Step.UnificationProcedure Unification.unificationProcedure)
-                [axiom]
-                configuration
-    in fmap Result.mergeResults <$> smt
+    -> SMT (Either UnificationOrSubstitutionError (Step.Results Variable))
+runStepResult configuration axiom = do
+    results <-
+        evalSimplifier
+        $ Monad.Unify.runUnifier
+        $ Step.applyRewriteRules
+            testMetadataTools
+            testSubstitutionSimplifier
+            testTermLikeSimplifier
+            testEvaluators
+            (Step.UnificationProcedure Unification.unificationProcedure)
+            [axiom]
+            configuration
+    return (Result.mergeResults <$> results)
 
 
 -- | Test unparsing internalized patterns.

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -8,8 +8,6 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import qualified Control.Monad as Monad
-import           Control.Monad.IO.Class
-                 ( liftIO )
 import qualified Control.Monad.Trans as Trans
 import qualified Data.Default as Default
 import qualified Data.List as List
@@ -813,7 +811,7 @@ test_concretizeKeysAxiom =
                         symbolicKey
                         (asTermLike $ Map.fromList [(key, val)])
             config <- evaluate pair
-            actual <- liftIO $ runStepWith config axiom
+            actual <- runStep config axiom
             assertEqualWithExplanation "expected MAP.lookup" expected actual
   where
     x = mkIntVar (testId "x")

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -10,8 +10,6 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import qualified Control.Monad as Monad
-import           Control.Monad.IO.Class
-                 ( liftIO )
 import qualified Control.Monad.Trans as Trans
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
@@ -760,7 +758,7 @@ test_concretizeKeysAxiom =
     testCaseWithSMT "unify Set with symbolic keys in axiom" $ do
         let pair = mkPair intSort setSort symbolicKey concreteSet
         config <- evaluate pair
-        actual <- liftIO $ runStepWith config axiom
+        actual <- runStep config axiom
         assertEqualWithExplanation "" expected actual
   where
     x = mkIntVar (testId "x")


### PR DESCRIPTION
This is some cleanup I did while investigating the unit test performance regression. These changes themselves have a negligible impact on performance. Ultimately the regression is caused by spawning too many Z3 processes, which will be solved when @vladciobanu adds a dummy solver interface for the tests.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

