### PR TITLE
Refactor SMT logging

### DIFF
--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -5,6 +5,7 @@ module Main (main) where
 
 import           Control.Applicative
                  ( optional )
+import           Control.Concurrent.MVar
 import qualified Data.Bifunctor as Bifunctor
 import           Data.Semigroup
                  ( (<>) )
@@ -22,7 +23,7 @@ import           Kore.Exec
                  ( proveWithRepl )
 import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import           Kore.Logger.Output
-                 ( emptyLogger )
+                 ( emptyLogger, swappableLogger )
 import           Kore.Repl
 import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
@@ -186,15 +187,21 @@ mainWithOptions
                 , SMT.preludeFile = smtPrelude
                 }
     if replMode == RunScript && (unReplScript replScript) == Nothing
-       then do
-           putStrLn "You must supply the path to the repl script\
-                    \ in order to run the repl in run-script mode."
-           exitFailure
-       else do
-           SMT.runSMT smtConfig emptyLogger
+        then do
+            putStrLn
+                "You must supply the path to the repl script\
+                \ in order to run the repl in run-script mode."
+            exitFailure
+        else do
+            mLogger <- newMVar emptyLogger
+            SMT.runSMT smtConfig (swappableLogger mLogger)
                $ evalSimplifier
                $ proveWithRepl
-                    indexedModule specDefIndexedModule replScript replMode
+                    indexedModule
+                    specDefIndexedModule
+                    mLogger
+                    replScript
+                    replMode
 
   where
     mainModuleName :: ModuleName

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -19,6 +19,7 @@ module Kore.Exec
     , Equality
     ) where
 
+import           Control.Concurrent.MVar
 import qualified Control.Monad as Monad
 import           Control.Monad.Trans.Except
                  ( runExceptT )
@@ -244,12 +245,13 @@ proveWithRepl
     -- ^ The main module
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The spec module
+    -> MVar (Log.LogAction IO Log.LogMessage)
     -> Repl.ReplScript
     -- ^ Optional script
     -> Repl.ReplMode
     -- ^ Run in a specific repl mode
     -> Simplifier ()
-proveWithRepl definitionModule specModule replScript replMode = do
+proveWithRepl definitionModule specModule mvar replScript replMode = do
     let tools = MetadataTools.build definitionModule
     Initialized
         { rewriteRules
@@ -272,6 +274,7 @@ proveWithRepl definitionModule specModule replScript replMode = do
         axiomIdToSimplifier
         axioms
         claims
+        mvar
         replScript
         replMode
 

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -12,6 +12,7 @@ module Kore.Repl
     , ReplMode (..)
     ) where
 
+import           Control.Concurrent.MVar
 import           Control.Exception
                  ( AsyncException (UserInterrupt) )
 import qualified Control.Lens as Lens hiding
@@ -97,6 +98,7 @@ runRepl
     -- ^ list of axioms to used in the proof
     -> [claim]
     -- ^ list of claims to be proven
+    -> MVar (Logger.LogAction IO Logger.LogMessage)
     -> ReplScript
     -- ^ optional script
     -> ReplMode
@@ -104,7 +106,7 @@ runRepl
     -> Simplifier ()
 runRepl
     tools simplifier predicateSimplifier axiomToIdSimplifier
-    axioms' claims' replScript replMode
+    axioms' claims' logger replScript replMode
   = do
     mNewState <- evaluateScript replScript
     case replMode of
@@ -156,6 +158,7 @@ runRepl
             , labels     = Map.empty
             , aliases    = Map.empty
             , logging    = (Logger.Debug, NoLogging)
+            , logger
             }
 
     firstClaimIndex :: ClaimIndex

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -11,7 +11,6 @@ module Kore.Step.Simplification.Data
     ( Simplifier
     , runSimplifier
     , evalSimplifier
-    , withLogger
     , BranchT
     , evalSimplifierBranch
     , gather
@@ -57,7 +56,6 @@ import           Kore.Variables.Fresh
 import qualified ListT
 import           SMT
                  ( MonadSMT (..), SMT (..) )
-import qualified SMT
 
 {-| 'And' simplification is very similar to 'Equals' simplification.
 This type is used to distinguish between the two in the common code.
@@ -193,13 +191,6 @@ evalSimplifierBranch
     -- ^ simplifier computation
     -> SMT [a]
 evalSimplifierBranch = evalSimplifier . gather
-
--- | Use a different logger in the provided context.
-withLogger :: LogAction IO LogMessage -> Simplifier a  -> Simplifier a
-withLogger l =
-    Simplifier
-        . SMT.withLogger l
-        . getSimplifier
 
 {- | Run a simplification, returning the result of only one branch.
 

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -181,9 +181,9 @@ newtype Simplifier a = Simplifier
 
 instance WithLog LogMessage Simplifier where
     askLogAction = Simplifier $ hoistLogAction Simplifier <$> askLogAction
-    withLog mapping =
+    localLogAction mapping =
         Simplifier
-        . withLog mapping
+        . localLogAction mapping
         . getSimplifier
 
 {- | Run a simplification, returning the results along all branches.

--- a/kore/src/Kore/Unification/Unify.hs
+++ b/kore/src/Kore/Unification/Unify.hs
@@ -125,7 +125,7 @@ instance
             . Log.hoistLogAction liftSimplifier
             $ Log.LogAction logger
 
-    withLog f = UnifierTT . Log.withLog f . getUnifier
+    localLogAction f = UnifierTT . Log.localLogAction f . getUnifier
 
 -- | Lift an 'ExceptT' to a 'MonadUnify'.
 fromExceptT

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -10,7 +10,7 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 module SMT
     ( SMT, getSMT
     , Solver
-    , newSolver, stopSolver, withLogger
+    , newSolver, stopSolver
     , runSMT
     , MonadSMT (..)
     , Config (..)
@@ -364,12 +364,3 @@ getLoggerRef = do
     mvar <- SMT $ Reader.ask
     solver <- liftIO $ readMVar mvar
     return $ solver Lens.^. SimpleSMT.lensLogger
-
-withLogger :: Logger -> SMT a  -> SMT a
-withLogger l action = do
-    loggerRef <- getLoggerRef
-    originalLogger <- liftIO $ readIORef loggerRef
-    liftIO $ writeIORef loggerRef l
-    result <- action
-    liftIO $ writeIORef loggerRef originalLogger
-    return result

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -63,8 +63,6 @@ import qualified Control.Monad.State.Lazy as State.Lazy
 import qualified Control.Monad.State.Strict as State.Strict
 import qualified Control.Monad.Trans as Trans
 import qualified Control.Monad.Trans.Maybe as Maybe
-import           Data.IORef
-                 ( IORef, readIORef, writeIORef )
 import           Data.Limit
 import           Data.Text
                  ( Text )
@@ -224,22 +222,20 @@ class Monad m => MonadSMT m where
     {-# INLINE loadFile #-}
 
 withSolver' :: (Solver -> IO a) -> SMT a
-withSolver' action = do
-    mvar <- SMT $ Reader.ask
+withSolver' action = SMT $ do
+    mvar <- Reader.ask
     liftIO $ withMVar mvar action
 
 instance Logger.WithLog Logger.LogMessage SMT where
-    askLogAction = do
-        loggerRef <- getLoggerRef
-        originalLogger <- liftIO $ readIORef loggerRef
-        return (Logger.hoistLogAction liftIO originalLogger)
-    localLogAction mapping action = do
-        loggerRef <- getLoggerRef
-        originalLogger <- liftIO $ readIORef loggerRef
-        liftIO $ writeIORef loggerRef (mapping originalLogger)
-        result <- action
-        liftIO $ writeIORef loggerRef originalLogger
-        return result
+    askLogAction =
+        withSolver' (return . hoistLogAction . SimpleSMT.logger)
+      where
+        hoistLogAction = Logger.hoistLogAction (SMT . liftIO)
+
+    localLogAction mapping (SMT action) =
+        withSolver' $ \solver -> do
+            let solver' = Lens.over SimpleSMT.lensLogger mapping solver
+            runReaderT action =<< newMVar solver'
 
 instance MonadSMT SMT where
     withSolver (SMT action) = withSolver' $ \solver -> do
@@ -295,8 +291,6 @@ newSolver config logger = do
     runReaderT getSMT mvar
     return mvar
   where
-    -- TODO (thomas.tuegel): Set up logging using logFile.
-    -- TODO (thomas.tuegel): Initialize solver from preludeFile.
     Config { timeOut } = config
     Config { executable = exe, arguments = args } = config
     Config { preludeFile } = config
@@ -358,9 +352,3 @@ setTimeOut TimeOut { getTimeOut } =
             setInfo ":time" (SimpleSMT.int timeOut)
         Unlimited ->
             return ()
-
-getLoggerRef :: SMT (IORef Logger)
-getLoggerRef = do
-    mvar <- SMT $ Reader.ask
-    solver <- liftIO $ readMVar mvar
-    return $ solver Lens.^. SimpleSMT.lensLogger

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -233,7 +233,7 @@ instance Logger.WithLog Logger.LogMessage SMT where
         loggerRef <- getLoggerRef
         originalLogger <- liftIO $ readIORef loggerRef
         return (Logger.hoistLogAction liftIO originalLogger)
-    withLog mapping action = do
+    localLogAction mapping action = do
         loggerRef <- getLoggerRef
         originalLogger <- liftIO $ readIORef loggerRef
         liftIO $ writeIORef loggerRef (mapping originalLogger)

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -7,6 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( Assertion, testCase, (@?=) )
 
+import           Control.Concurrent.MVar
 import           Control.Monad.Trans.State.Strict
                  ( evalStateT, runStateT )
 import           Data.Coerce
@@ -336,16 +337,18 @@ runWithState
 runWithState command axioms claims claim stateTransformer
   = Logger.withLogger logOptions $ \logger -> do
         output <- newIORef ""
-        (c, s) <- liftSimplifier logger
+        mvar <- newMVar logger
+        let state = stateTransformer $ mkState axioms claims claim mvar
+        (c, s) <-
+            liftSimplifier (Logger.swappableLogger mvar)
+            $ flip runStateT state
             $ replInterpreter (writeIORefIfNotEmpty output) command
-                `runStateT` state
         output' <- readIORef output
         return $ Result output' c s
   where
     logOptions = Logger.KoreLogOptions Logger.LogNone Logger.Debug
     liftSimplifier logger =
         SMT.runSMT SMT.defaultConfig logger . evalSimplifier
-    state = stateTransformer $ mkState axioms claims claim
     writeIORefIfNotEmpty out =
         \case
             "" -> pure ()
@@ -390,8 +393,13 @@ hasLogging st expectedLogging =
 tests :: IO () -> String -> TestTree
 tests = flip testCase
 
-mkState :: [Axiom] -> [Claim] -> Claim -> ReplState Claim
-mkState axioms claims claim =
+mkState
+    :: [Axiom]
+    -> [Claim]
+    -> Claim
+    -> MVar (Logger.LogAction IO Logger.LogMessage)
+    -> ReplState Claim
+mkState axioms claims claim logger =
     ReplState
         { axioms      = axioms
         , claims      = claims
@@ -406,6 +414,7 @@ mkState axioms claims claim =
         , labels      = Map.singleton (ClaimIndex 0) Map.empty
         , aliases     = Map.empty
         , logging     = (Logger.Debug, NoLogging)
+        , logger
         }
   where
     graph' = emptyExecutionGraph claim


### PR DESCRIPTION
This gets rid of the hacky `IORef` thing. When you start to invert the `Simplifier` hierarchy, you should probably base it on this branch.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

