### PR TITLE
kore-repl: Do not run stepper for `try` command

### DIFF
--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -40,8 +40,6 @@ import           Text.Megaparsec
                  ( parseMaybe )
 
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Internal.TermLike
-                 ( TermLike, Variable )
 import qualified Kore.Logger as Logger
 import           Kore.OnePath.Verification
                  ( verifyClaimStep )
@@ -55,6 +53,7 @@ import qualified Kore.Step.Rule as Rule
 import           Kore.Step.Simplification.Data
                  ( Simplifier )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Syntax.Variable
 import           Kore.Unification.Procedure
                  ( unificationProcedure )
 import           Kore.Unparser
@@ -133,7 +132,7 @@ runRepl axioms' claims' logger replScript replMode = do
             -- the frontend via '--omit-labels'.
             , omit       = []
             , stepper    = stepper0
-            , unifier    = unifier0
+            , unifier    = unificationProcedure
             , labels     = Map.empty
             , aliases    = Map.empty
             , logging    = (Logger.Debug, NoLogging)
@@ -205,12 +204,6 @@ runRepl axioms' claims' logger replScript replMode = do
                 catchInterruptWithDefault graph
                 $ verifyClaimStep claim claims axioms graph node
             else pure graph
-
-    unifier0
-        :: TermLike Variable
-        -> TermLike Variable
-        -> UnifierWithExplanation ()
-    unifier0 first second = () <$ unificationProcedure first second
 
     catchInterruptWithDefault :: MonadCatch m => MonadIO m => a -> m a -> m a
     catchInterruptWithDefault def sa =

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -44,8 +44,6 @@ module Kore.Repl.Data
 import           Control.Applicative
                  ( Alternative )
 import           Control.Concurrent.MVar
-import           Control.Error
-                 ( hush )
 import qualified Control.Lens as Lens hiding
                  ( makeLenses )
 import qualified Control.Lens.TH.Rules as Lens
@@ -69,11 +67,13 @@ import           Data.Coerce
 import qualified Data.Graph.Inductive.Graph as Graph
 import           Data.Graph.Inductive.PatriciaTree
                  ( Gr )
+import           Data.List.NonEmpty
+                 ( NonEmpty (..) )
 import qualified Data.Map as Map
 import           Data.Map.Strict
                  ( Map )
 import           Data.Maybe
-                 ( listToMaybe )
+                 ( fromMaybe, listToMaybe )
 import           Data.Monoid
                  ( First (..) )
 import           Data.Sequence
@@ -92,8 +92,10 @@ import           Numeric.Natural
 import           System.IO
                  ( Handle, IOMode (AppendMode), hClose, openFile )
 
-import           Kore.Internal.Pattern
+import           Kore.Internal.Conditional
                  ( Conditional (..) )
+import           Kore.Internal.Predicate
+                 ( Predicate )
 import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Logger.Output as Logger
@@ -371,7 +373,7 @@ data ReplState claim = ReplState
     , unifier
         :: TermLike Variable
         -> TermLike Variable
-        -> UnifierWithExplanation ()
+        -> UnifierWithExplanation (Predicate Variable)
     -- ^ Unifier function, it is a partially applied 'unificationProcedure'
     --   where we discard the result since we are looking for unification
     --   failures
@@ -426,20 +428,27 @@ instance MonadUnify UnifierWithExplanation where
 runUnifierWithExplanation
     :: forall a
     .  UnifierWithExplanation a
-    -> Simplifier (Maybe (Doc ()))
-runUnifierWithExplanation (UnifierWithExplanation unifier)
-  =
-    join <$> fmap (fmap getFirst) unificationExplanations
-  where
-    unificationResults :: Simplifier (Maybe ([a], First (Doc ())))
-    unificationResults =
-        hush
-        <$> Monad.Unify.runUnifierT
+    -> Simplifier (Either (Doc ()) (NonEmpty a))
+runUnifierWithExplanation (UnifierWithExplanation unifier) =
+    either (Left . Pretty.pretty) failWithExplanation
+    <$> Monad.Unify.runUnifierT
             (\accum -> runAccumT accum mempty)
             unifier
-    unificationExplanations :: Simplifier (Maybe (First (Doc ())))
-    unificationExplanations =
-        fmap (fmap snd) unificationResults
+  where
+    failWithExplanation (results, explanation) =
+        case results of
+            [] -> Left $ fromMaybe "No explanation given" (getFirst explanation)
+            r : rs -> Right (r :| rs)
+  -- where
+  --   unificationResults :: Simplifier (Either Failure NonEmpty a)
+  --   unificationResults =
+  --       _
+  --       $   Monad.Unify.runUnifierT
+  --               (\accum -> runAccumT accum mempty)
+  --               unifier
+  --   unificationExplanations :: Simplifier (Maybe (First (Doc ())))
+  --   unificationExplanations =
+  --       fmap (fmap snd) unificationResults
 
 Lens.makeLenses ''ReplState
 
@@ -696,7 +705,7 @@ runUnifier
     => Monad.Trans.MonadTrans m
     => TermLike Variable
     -> TermLike Variable
-    -> m Simplifier (Maybe (Pretty.Doc ()))
+    -> m Simplifier (Either (Doc ()) (NonEmpty (Predicate Variable)))
 runUnifier first second = do
     unifier <- Lens.use lensUnifier
     mvar <- Lens.use lensLogger

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -439,16 +439,6 @@ runUnifierWithExplanation (UnifierWithExplanation unifier) =
         case results of
             [] -> Left $ fromMaybe "No explanation given" (getFirst explanation)
             r : rs -> Right (r :| rs)
-  -- where
-  --   unificationResults :: Simplifier (Either Failure NonEmpty a)
-  --   unificationResults =
-  --       _
-  --       $   Monad.Unify.runUnifierT
-  --               (\accum -> runAccumT accum mempty)
-  --               unifier
-  --   unificationExplanations :: Simplifier (Maybe (First (Doc ())))
-  --   unificationExplanations =
-  --       fmap (fmap snd) unificationResults
 
 Lens.makeLenses ''ReplState
 

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -985,7 +985,7 @@ parseEvalScript state file = do
         -> [ReplCommand]
         -> Simplifier (Maybe (ReplState claim))
     executeScript st cmds = do
-        newSt <- execStateT (executeCommands) st
+        newSt <- execStateT executeCommands st
         return . return $ newSt
       where
         executeCommands =

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -44,15 +44,17 @@ import           Control.Monad.Trans.Except
                  ( runExceptT )
 import           Data.Coerce
                  ( Coercible, coerce )
-import           Data.Foldable
-                 ( traverse_ )
+import qualified Data.Foldable as Foldable
 import           Data.Functor
                  ( ($>) )
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Graph.Inductive.Graph as Graph
 import qualified Data.GraphViz as Graph
+import qualified Data.List as List
 import           Data.List.Extra
                  ( groupSort )
+import           Data.List.NonEmpty
+                 ( NonEmpty )
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
                  ( catMaybes, listToMaybe )
@@ -72,14 +74,16 @@ import           Kore.Attribute.Axiom
 import qualified Kore.Attribute.Axiom as Attribute
                  ( Axiom (..), RuleIndex (..), sourceLocation )
 import           Kore.Attribute.RuleIndex
-import           Kore.Internal.Pattern
+import           Kore.Internal.Conditional
                  ( Conditional (..) )
+import           Kore.Internal.Predicate
+                 ( Predicate )
 import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Logger
 import           Kore.OnePath.StrategyPattern
-                 ( CommonStrategyPattern, StrategyPattern (..),
+                 ( CommonStrategyPattern,
                  StrategyPatternTransformer (StrategyPatternTransformer),
                  strategyPattern )
 import qualified Kore.OnePath.StrategyPattern as StrategyPatternTransformer
@@ -104,7 +108,7 @@ import qualified Kore.Syntax.Id as Id
 import           Kore.Syntax.Variable
                  ( Variable )
 import           Kore.Unparser
-                 ( unparseToString )
+                 ( unparse, unparseToString )
 import           Numeric.Natural
 import           System.Directory
                  ( doesFileExist, findExecutable )
@@ -383,7 +387,7 @@ omitCell =
         omitList <- Lens.use lensOmit
         case omitList of
             [] -> putStrLn' "Omit list is currently empty."
-            _  -> traverse_ putStrLn' omitList
+            _  -> Foldable.traverse_ putStrLn' omitList
 
     addOrRemove :: String -> ReplM claim ()
     addOrRemove str = lensOmit %= toggle str
@@ -617,42 +621,8 @@ tryAxiomClaim eac = do
         Nothing -> putStrLn' "Could not find axiom or claim."
         Just axiomOrClaim -> do
             node <- Lens.use lensNode
-            (graph, stepResult) <- runStepper'
-                (rightToList axiomOrClaim)
-                (leftToList  axiomOrClaim)
-                node
-            case stepResult of
-                NoResult ->
-                    showUnificationFailure axiomOrClaim node
-                SingleResult node' -> do
-                    lensNode .= node'
-                    updateExecutionGraph graph
-                    putStrLn' "Unification successful."
-                BranchResult nodes -> do
-                    stuckToUnstuck nodes graph
-                    putStrLn'
-                        $ "Unification successful with branching: "
-                            <> show nodes
+            showUnificationFailure axiomOrClaim node
   where
-    leftToList :: Either a b -> [a]
-    leftToList = either pure (const [])
-
-    rightToList :: Either a b -> [b]
-    rightToList = either (const []) pure
-
-    stuckToUnstuck :: [ReplNode] -> ExecutionGraph -> ReplM claim ()
-    stuckToUnstuck nodes Strategy.ExecutionGraph{ graph } =
-        updateInnerGraph
-        $ Graph.gmap (stuckToRewrite
-        $ fmap unReplNode nodes) graph
-
-    stuckToRewrite xs ct@(to, n, lab, from)
-        | n `elem` xs =
-            case lab of
-                Stuck patt -> (to, n, RewritePattern patt, from)
-                _ -> ct
-        | otherwise = ct
-
     showUnificationFailure
         :: Either (Axiom) claim
         -> ReplNode
@@ -670,6 +640,7 @@ tryAxiomClaim eac = do
                         , stuckTransformer   = runUnifier' first . term
                         }
                     second
+
     runUnifier' first second =
         runUnifier first second >>= putStrLn' . formatUnificationMessage
 
@@ -1014,12 +985,27 @@ parseEvalScript state file = do
         -> [ReplCommand]
         -> Simplifier (Maybe (ReplState claim))
     executeScript st cmds = do
-        newSt <- execStateT (traverse_ (replInterpreter $ \_ -> return () ) cmds) st
+        newSt <- execStateT (executeCommands) st
         return . return $ newSt
+      where
+        executeCommands =
+            Foldable.for_ cmds $ replInterpreter $ \_ -> return ()
 
-formatUnificationMessage :: Maybe (Pretty.Doc ()) -> String
+formatUnificationMessage
+    :: Either (Pretty.Doc ()) (NonEmpty (Predicate Variable))
+    -> String
 formatUnificationMessage =
-    maybe "No unification error found." show
+    show . either prettyFailure prettyUnifiers
+  where
+    prettyFailure =
+        (<>) "Failed: "
+    prettyUnifiers =
+        Pretty.vsep
+        . (:) "Succeeded with unifiers:"
+        . List.intersperse (Pretty.indent 2 "and")
+        . map (Pretty.indent 4 . unparseUnifier)
+        . Foldable.toList
+    unparseUnifier = unparse . (<$) (TermLike.mkTop_ :: TermLike Variable)
 
 findLeafNodes :: InnerGraph -> [Graph.Node]
 findLeafNodes graph =

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -7,6 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
        ( Assertion, testCase, (@?=) )
 
+import           Control.Applicative
 import           Control.Concurrent.MVar
 import           Control.Monad.Trans.State.Strict
                  ( evalStateT, runStateT )
@@ -14,12 +15,17 @@ import           Data.Coerce
                  ( coerce )
 import           Data.IORef
                  ( newIORef, readIORef, writeIORef )
+import           Data.List.NonEmpty
+                 ( NonEmpty (..) )
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
 import qualified Data.Map.Strict as StrictMap
 import qualified Kore.Builtin.Int as Int
+import           Kore.Internal.Predicate
+                 ( Predicate )
+import qualified Kore.Internal.Predicate as Predicate
 import           Kore.Internal.TermLike
                  ( TermLike, mkApp, mkBottom_, mkVar, varS )
 import qualified Kore.Logger.Output as Logger
@@ -61,7 +67,8 @@ test_replInterpreter =
     , aliasOfUnknownCommand  `tests` "Create alias of unknown command"
     , recursiveAlias         `tests` "Create alias of unknown command"
     , tryAlias               `tests` "Executing an existing alias with arguments"
-    , unificationFailure     `tests` "Force axiom that doesn't unify"
+    , unificationFailure     `tests` "Try axiom that doesn't unify"
+    , unificationSuccess     `tests` "Try axiom that does unify"
     , proofStatus            `tests` "Multi claim proof status"
     , logUpdatesState        `tests` "Log command updates the state"
     , showCurrentClaim       `tests` "Showing current claim"
@@ -238,10 +245,26 @@ unificationFailure =
     in do
         Result { output, continue, state } <- run command axioms [claim] claim
         expectedOutput <-
-            unificationErrorMessage cannotUnifyDistinctDomainValues one zero
+            formatUnificationError cannotUnifyDistinctDomainValues one zero
         output `equalsOutput` expectedOutput
         continue `equals` Continue
         state `hasCurrentNode` ReplNode 0
+
+unificationSuccess :: IO ()
+unificationSuccess = do
+    let
+        zero = Int.asInternal intSort 0
+        one = Int.asInternal intSort 1
+        impossibleAxiom = coerce $ rulePattern zero one
+        axioms = [ impossibleAxiom ]
+        claim = zeroToTen
+        command = Try . Left $ AxiomIndex 0
+        expectedOutput = formatUnifiers (Predicate.top :| [])
+
+    Result { output, continue, state } <- run command axioms [claim] claim
+    output `equalsOutput` expectedOutput
+    continue `equals` Continue
+    state `hasCurrentNode` ReplNode 0
 
 proofStatus :: IO ()
 proofStatus =
@@ -410,7 +433,7 @@ mkState axioms claims claim logger =
         , commands    = Seq.empty
         , omit        = []
         , stepper     = stepper0
-        , unifier     = unifier0
+        , unifier     = unificationProcedure
         , labels      = Map.singleton (ClaimIndex 0) Map.empty
         , aliases     = Map.empty
         , logging     = (Logger.Debug, NoLogging)
@@ -420,18 +443,17 @@ mkState axioms claims claim logger =
     graph' = emptyExecutionGraph claim
     stepper0 claim' claims' axioms' graph (ReplNode node) =
         verifyClaimStep claim' claims' axioms' graph node
-    unifier0
-        :: TermLike Variable
-        -> TermLike Variable
-        -> UnifierWithExplanation ()
-    unifier0 first second = () <$ unificationProcedure first second
 
-unificationErrorMessage
+formatUnificationError
     :: Pretty.Doc ()
     -> TermLike Variable
     -> TermLike Variable
     -> IO String
-unificationErrorMessage info first second = do
-    res <- runSimplifier . runUnifierWithExplanation
-        $ explainBottom info first second
+formatUnificationError info first second = do
+    res <- runSimplifier . runUnifierWithExplanation $ do
+        explainBottom info first second
+        empty
     return $ formatUnificationMessage res
+
+formatUnifiers :: NonEmpty (Predicate Variable) -> String
+formatUnifiers = formatUnificationMessage . Right


### PR DESCRIPTION
Running the `try` command through the stepper produces confusing output. Running unification directly makes the result clearer and also doesn't modify the execution graph.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

