### PR TITLE
Error on defining constructor for hooked sorts

### DIFF
--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -36,7 +36,6 @@ import qualified Kore.Builtin as Builtin
 import           Kore.Error
 import           Kore.IndexedModule.IndexedModule as IndexedModule
 import           Kore.IndexedModule.Resolvers
-import qualified Kore.Sort as Sort
 import           Kore.Syntax
 import           Kore.Syntax.Definition
 import qualified Kore.Verified as Verified

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -13,7 +13,7 @@ module Kore.ASTVerifier.SentenceVerifier
     ) where
 
 import           Control.Monad
-                 ( foldM, join )
+                 ( foldM )
 import           Data.Function
 import qualified Data.Map as Map
 import           Data.Maybe
@@ -274,16 +274,18 @@ verifySymbolSentence indexedModule sentence =
             resultSort = sentenceSymbolResultSort sentence
             resultSortId = getSortId resultSort
 
-            ctor =
+            -- TODO(vladimir.ciobanu): Lookup this attribute in the symbol
+            -- attribute record when it becomes available.
+            isCtor =
                 Attribute.constructorAttribute  `elem` getAttributes attributes
-            sort =
-                join
-                . fmap (Attribute.getHook . Attribute.hook . fst)
-                . Map.lookup resultSortId
-                $ indexedModuleSortDescriptions indexedModule
+            resultSortHook = do
+                (sortDescription, _) <-
+                    Map.lookup resultSortId
+                        $ indexedModuleSortDescriptions indexedModule
+                Attribute.getHook . Attribute.hook $ sortDescription
         in
             koreFailWhen
-                (ctor && isJust sort)
+                (isCtor && isJust resultSortHook)
                 ( "Cannot define constructor '"
                 ++ getIdForError symbol
                 ++ "' for hooked sort '"

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -13,9 +13,11 @@ module Kore.ASTVerifier.SentenceVerifier
     ) where
 
 import           Control.Monad
-                 ( foldM )
+                 ( foldM, join )
 import           Data.Function
 import qualified Data.Map as Map
+import           Data.Maybe
+                 ( isJust )
 import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
@@ -26,11 +28,15 @@ import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.PatternVerifier as PatternVerifier
 import           Kore.ASTVerifier.SortVerifier
+import qualified Kore.Attribute.Constructor as Attribute
+import qualified Kore.Attribute.Hook as Attribute
 import qualified Kore.Attribute.Parser as Attribute.Parser
+import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
 import           Kore.IndexedModule.IndexedModule as IndexedModule
 import           Kore.IndexedModule.Resolvers
+import qualified Kore.Sort as Sort
 import           Kore.Syntax
 import           Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
@@ -251,6 +257,7 @@ verifySymbolSentence indexedModule sentence =
         mapM_
             (verifySort findSort variables)
             (sentenceSymbolSorts sentence)
+        verifyConstructorNotInHookedSort
         verifySort
             findSort
             variables
@@ -259,6 +266,31 @@ verifySymbolSentence indexedModule sentence =
   where
     findSort = findIndexedSort indexedModule
     sortParams = (symbolParams . sentenceSymbolSymbol) sentence
+
+    verifyConstructorNotInHookedSort :: Either (Error VerifyError) ()
+    verifyConstructorNotInHookedSort =
+        let
+            symbol = symbolConstructor $ sentenceSymbolSymbol sentence
+            attributes = sentenceSymbolAttributes sentence
+            resultSort = sentenceSymbolResultSort sentence
+            resultSortId = getSortId resultSort
+
+            ctor =
+                Attribute.constructorAttribute  `elem` getAttributes attributes
+            sort =
+                join
+                . fmap (Attribute.getHook . Attribute.hook . fst)
+                . Map.lookup resultSortId
+                $ indexedModuleSortDescriptions indexedModule
+        in
+            koreFailWhen
+                (ctor && isJust sort)
+                ( "Cannot define constructor '"
+                ++ getIdForError symbol
+                ++ "' for hooked sort '"
+                ++ getIdForError resultSortId
+                ++ "'."
+                )
 
 verifyAliasSentence
     :: Builtin.Verifiers

--- a/kore/src/Kore/Sort.hs
+++ b/kore/src/Kore/Sort.hs
@@ -9,6 +9,7 @@ module Kore.Sort
     ( SortVariable (..)
     , SortActual (..)
     , Sort (..)
+    , getSortId
     , substituteSortVariables
     -- * Meta-sorts
     , MetaSortType (..)
@@ -127,6 +128,15 @@ instance Unparse Sort where
         \case
             SortVariableSort sortVariable -> unparse2 sortVariable
             SortActualSort sortActual -> unparse2 sortActual
+
+getSortId :: Sort -> Id
+getSortId =
+    \case
+        SortVariableSort SortVariable { getSortVariable } ->
+            getSortVariable
+        SortActualSort SortActual { sortActualName } ->
+            sortActualName
+
 {- | Substitute sort variables in a 'Sort'.
 
 Sort variables that are not in the substitution are not changed.

--- a/src/test/resources/test-hooks-ctor.kore
+++ b/src/test/resources/test-hooks-ctor.kore
@@ -1,0 +1,10 @@
+[]
+
+module TEST-HOOKS-CTOR
+
+  hooked-sort S{} [hook{}("S.S")]
+
+  // Verification failure: hooked sorts can't have additional constructors.
+  symbol sym{}() : S{} [functional{}(), constructor{}()]
+
+endmodule []

--- a/src/test/resources/test-hooks-ctor.kore.golden
+++ b/src/test/resources/test-hooks-ctor.kore.golden
@@ -1,0 +1,1 @@
+Error in module 'TEST-HOOKS-CTOR' -> symbol 'sym' declaration (../src/test/resources//test-hooks-ctor.kore 8:10): Cannot define constructor 'sym' for hooked sort 'S'.


### PR DESCRIPTION
Fixes #695 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

