### PR TITLE
Remove special handler for K constructors

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -6,7 +6,7 @@ UPSTREAM_BRANCH = origin/master
 
 BUILD_DIR = $(TOP)/.build
 K_NIGHTLY = $(BUILD_DIR)/nightly.tar.gz
-K_NIGHTLY_URL = https://github.com/kframework/k/releases/download/nightly-121d8e122/nightly.tar.gz
+K_NIGHTLY_URL = https://github.com/kframework/k/releases/download/nightly-23f76b81d/nightly.tar.gz
 K_DIST_DEFAULT = $(BUILD_DIR)/k
 K_DIST ?= $(K_DIST_DEFAULT)
 K_DIST_BIN = $(K_DIST)/bin


### PR DESCRIPTION
This is just waiting on a new K release.

Fixes: #725 
Related: kframework/k#535 kframework/k#543

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

