### PR TITLE
[kevm-integration] Update K to nightly-121d8e122

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -6,7 +6,7 @@ UPSTREAM_BRANCH = origin/master
 
 BUILD_DIR = $(TOP)/.build
 K_NIGHTLY = $(BUILD_DIR)/nightly.tar.gz
-K_NIGHTLY_URL = https://github.com/kframework/k/releases/download/nightly-302f3831b/nightly.tar.gz
+K_NIGHTLY_URL = https://github.com/kframework/k/releases/download/nightly-121d8e122/nightly.tar.gz
 K_DIST_DEFAULT = $(BUILD_DIR)/k
 K_DIST ?= $(K_DIST_DEFAULT)
 K_DIST_BIN = $(K_DIST)/bin


### PR DESCRIPTION
Related: kframework/k#534
Fixes: #727

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

