### PR TITLE
Set unit unification

### DIFF
--- a/kore/src/Kore/Unification/Substitution.hs
+++ b/kore/src/Kore/Unification/Substitution.hs
@@ -13,6 +13,7 @@ module Kore.Unification.Substitution
     , unwrap
     , toMap
     , fromMap
+    , singleton
     , wrap
     , modify
     , Kore.Unification.Substitution.mapVariables
@@ -141,6 +142,21 @@ fromMap
     => Map variable (TermLike variable)
     -> Substitution variable
 fromMap = wrap . Map.toList
+
+{- | Construct substitution for a single variable.
+
+The substitution is normalized if the variable does not occur free in the term.
+
+ -}
+singleton
+    :: Ord variable
+    => variable
+    -> TermLike variable
+    -> Substitution variable
+singleton var termLike
+  | TermLike.hasFreeVariable var termLike = Substitution [(var, termLike)]
+  | otherwise =
+    NormalizedSubstitution (Map.singleton var termLike)
 
 -- | Wrap the list of substitutions to an un-normalized substitution. Note that
 -- @wrap . unwrap@ is not @id@ because the normalization state is lost.

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -423,6 +423,12 @@ concatSetSymbol :: Internal.Symbol
 concatSetSymbol =
     binarySymbol "concatSet" setSort & hook "SET.concat" & functional
 
+concatSet
+    :: TermLike Variable
+    -> TermLike Variable
+    -> TermLike Variable
+concatSet s1 s2 = mkApplySymbol concatSetSymbol [s1, s2]
+
 inSetSymbol :: Internal.Symbol
 inSetSymbol =
     builtinSymbol "inSet" boolSort [intSort, setSort] & hook "SET.in"

--- a/kore/test/Test/SMT.hs
+++ b/kore/test/Test/SMT.hs
@@ -13,11 +13,15 @@ import           SMT
                  ( SMT )
 import qualified SMT
 
-testPropertyWithSolver :: String -> PropertyT SMT () -> TestTree
+testPropertyWithSolver
+    :: GHC.HasCallStack
+    => String
+    -> PropertyT SMT ()
+    -> TestTree
 testPropertyWithSolver str =
     testProperty str . Hedgehog.property . Morph.hoist runSMT
 
-testCaseWithSMT :: String -> SMT () -> TestTree
+testCaseWithSMT :: GHC.HasCallStack => String -> SMT () -> TestTree
 testCaseWithSMT str = testCase str . runSMT
 
 assertEqual'


### PR DESCRIPTION
@virgil-serbanuta I was able to re-create the integration test failure in a unit test. It only appears using `termUnification`, it doesn't happen when simplifying a `mkAnd` pattern, so I guess (?) we stopped running something through the simplifier before unification.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

