### PR TITLE
return the counterexample and enforce one rule in the spec module

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -400,8 +400,13 @@ mainWithOptions
                           where
                             failure pat = (ExitFailure 1, pat)
                             success = (ExitSuccess, mkTop $ mkSortVariable "R")
-                            unknown = (ExitSuccess,
-                                       mkTop $ mkSortVariable "Unknown")
+                            unknown =
+                                ( ExitSuccess
+                                , mkVar
+                                    $ varS
+                                        "Unkown"
+                                        (mkSort $ noLocationId "SortUnknown")
+                                )
                 )
         let unparsed = (unparse . externalizeFreshVariables) finalPattern
         case outputFileName of

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -40,6 +40,8 @@ import           Kore.Internal.Pattern
 import           Kore.Internal.TermLike
 import           Kore.Logger.Output
                  ( KoreLogOptions (..), parseKoreLogOptions, withLogger )
+import qualified Kore.ModelChecker.Bounded as Bounded
+                 ( CheckResult (..) )
 import           Kore.Parser
                  ( ParsedPattern, parseKorePattern )
 import           Kore.Predicate.Predicate
@@ -380,12 +382,15 @@ mainWithOptions
                                     return (ExitSuccess, pat)
                         Just (specIndexedModule, graphSearch, bmc)
                           | bmc -> do
-                            _ <- boundedModelCheck
-                                    stepLimit
-                                    indexedModule
-                                    specIndexedModule
-                                    graphSearch
-                            return success
+                            checkResult <- boundedModelCheck
+                                            stepLimit
+                                            indexedModule
+                                            specIndexedModule
+                                            graphSearch
+                            case checkResult of
+                                Bounded.Proved -> return success
+                                Bounded.Unknown -> return unknown
+                                Bounded.Failed pat -> return (failure pat)
                           | otherwise ->
                             either failure (const success)
                             <$> prove
@@ -395,6 +400,8 @@ mainWithOptions
                           where
                             failure pat = (ExitFailure 1, pat)
                             success = (ExitSuccess, mkTop $ mkSortVariable "R")
+                            unknown = (ExitSuccess,
+                                       mkTop $ mkSortVariable "Unknown")
                 )
         let unparsed = (unparse . externalizeFreshVariables) finalPattern
         case outputFileName of

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -69,10 +69,10 @@ import           Kore.Step.Axiom.Identifier
 import           Kore.Step.Axiom.Registry
                  ( axiomPatternsToEvaluators, extractEqualityAxioms )
 import           Kore.Step.Rule
-                 ( EqualityRule (EqualityRule), OnePathRule (..),
-                 RewriteRule (RewriteRule), RulePattern (RulePattern),
-                 extractImplicationClaims, extractOnePathClaims,
-                 extractRewriteAxioms, getRewriteRule )
+                 ( EqualityRule (EqualityRule), ImplicationRule (..),
+                 OnePathRule (..), RewriteRule (RewriteRule),
+                 RulePattern (RulePattern), extractImplicationClaims,
+                 extractOnePathClaims, extractRewriteAxioms, getRewriteRule )
 import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Search
@@ -298,18 +298,21 @@ boundedModelCheck
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The spec module
     -> Strategy.GraphSearchOrder
-    -> SMT [Bounded.CheckResult]
+    -> SMT (Bounded.CheckResult (TermLike Variable))
 boundedModelCheck limit definitionModule specModule searchOrder =
     evalSimplifier env $ initialize definitionModule $ \initialized -> do
         let Initialized { rewriteRules } = initialized
-
+            specClaims = extractImplicationClaims specModule
+        assertSomeClaims specClaims
+        assertSingleClaim specClaims
+        let
             axioms = fmap Axiom rewriteRules
-            specAxioms = fmap snd $ extractImplicationClaims specModule
+            claims = fmap makeClaim specClaims
 
-        Bounded.check
+        Bounded.checkClaim
             (Bounded.bmcStrategy axioms)
             searchOrder
-            (map (\x -> (x,limit)) specAxioms)
+            (head claims, limit)
   where
     metadataTools = MetadataTools.build definitionModule
     env =
@@ -319,6 +322,11 @@ boundedModelCheck limit definitionModule specModule searchOrder =
             , simplifierPredicate = emptyPredicateSimplifier
             , simplifierAxioms = emptyAxiomSimplifiers
             }
+
+assertSingleClaim :: Monad m => [claim] -> m ()
+assertSingleClaim claims =
+    Monad.when ((length claims) > 1) . error
+        $ "More than one claim is found in the module."
 
 assertSomeClaims :: Monad m => [claim] -> m ()
 assertSomeClaims claims =

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -161,6 +161,15 @@ deriving instance Eq variable => Eq (ImplicationRule variable)
 deriving instance Ord variable => Ord (ImplicationRule variable)
 deriving instance Show variable => Show (ImplicationRule variable)
 
+instance
+    (Ord variable, SortedVariable variable, Unparse variable)
+    => Unparse (ImplicationRule variable)
+  where
+    unparse (ImplicationRule RulePattern { left, right } ) =
+        unparse $ mkImplies left right
+    unparse2 (ImplicationRule RulePattern { left, right } ) =
+        unparse2 $ mkImplies left right
+
 -- | modalities
 weakExistsFinally :: Text
 weakExistsFinally = "weakExistsFinally"


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---
1) We return the counterexample to the frontend instead of using Debug.Trace to print it to the std output.
2) Currently we enforce only one rule in the spec module. If a spec module contains several rules to check, it is hard to present the final results to the user.