### PR TITLE
Refactor some of the error code to use text.

### DIFF
--- a/kore/src/Kore/AST/AstWithLocation.hs
+++ b/kore/src/Kore/AST/AstWithLocation.hs
@@ -12,6 +12,9 @@ module Kore.AST.AstWithLocation
     , prettyPrintLocationFromAst
     ) where
 
+import Data.Text
+       ( Text )
+
 import Kore.Syntax
 import Kore.Syntax.Definition
 import Kore.Syntax.PatternF
@@ -26,7 +29,7 @@ class AstWithLocation awl where
 
 prettyPrintLocationFromAst
     :: AstWithLocation astWithLocation
-    => astWithLocation -> String
+    => astWithLocation -> Text
 prettyPrintLocationFromAst = prettyPrintAstLocation . locationFromAst
 
 instance AstWithLocation AstLocation where

--- a/kore/src/Kore/AST/Error.hs
+++ b/kore/src/Kore/AST/Error.hs
@@ -22,8 +22,9 @@ module Kore.AST.Error
     , withSentenceContext
     ) where
 
-import Data.List
-       ( intercalate )
+import           Data.Text
+                 ( Text )
+import qualified Data.Text as Text
 
 import Kore.AST.AstWithLocation
 import Kore.Error
@@ -35,10 +36,10 @@ the provided locations. -}
 koreFailWithLocations
     :: (AstWithLocation astWithLocation, MonadError (Error e) m)
     => [astWithLocation]
-    -> String
+    -> Text
     -> m a
 koreFailWithLocations locations errorMessage =
-    withLocationsContext locations (koreFail errorMessage)
+    withLocationsContext locations (koreFailText errorMessage)
 
 {-|'koreFailWithLocationsWhen' produces an error result with a context
 containing the provided locations whenever the provided flag is true.
@@ -47,10 +48,10 @@ koreFailWithLocationsWhen
     :: (AstWithLocation astWithLocation, MonadError (Error e) m)
     => Bool
     -> [astWithLocation]
-    -> String
+    -> Text
     -> m ()
 koreFailWithLocationsWhen condition locations errorMessage =
-    withLocationsContext locations (koreFailWhen condition errorMessage)
+    withLocationsContext locations (koreFailWhenText condition errorMessage)
 
 {-|'withLocationsContext' prepends the given location to the error context
 whenever the given action fails.
@@ -61,10 +62,10 @@ withLocationsContext
     -> m result
     -> m result
 withLocationsContext locations =
-    withContext
+    withTextContext
         (  "("
-        ++ intercalate ", " (map prettyPrintLocationFromAst locations)
-        ++ ")"
+        <> Text.intercalate ", " (map prettyPrintLocationFromAst locations)
+        <> ")"
         )
 
 {-|'withLocationsContext' prepends the given message, associated with the
@@ -73,11 +74,12 @@ location, to the error context whenever the given action fails.
 withLocationAndContext
     :: (AstWithLocation astWithLocation, MonadError (Error e) m)
     => astWithLocation
-    -> String
+    -> Text
     -> m result
     -> m result
 withLocationAndContext location message =
-    withContext (message ++ " (" ++ prettyPrintLocationFromAst location ++ ")")
+    withTextContext
+        (message <> " (" <> prettyPrintLocationFromAst location <> ")")
 
 {- | Identify and locate the given symbol declaration in the error context.
  -}
@@ -90,7 +92,7 @@ withSentenceSymbolContext
     SentenceSymbol { sentenceSymbolSymbol = Symbol { symbolConstructor } }
   =
     withLocationAndContext symbolConstructor
-        ("symbol '" ++ getIdForError symbolConstructor ++ "' declaration")
+        ("symbol '" <> getId symbolConstructor <> "' declaration")
 
 {- | Identify and locate the given alias declaration in the error context.
  -}
@@ -102,7 +104,7 @@ withSentenceAliasContext
     SentenceAlias { sentenceAliasAlias = Alias { aliasConstructor } }
   =
     withLocationAndContext aliasConstructor
-        ("alias '" ++ getIdForError aliasConstructor ++ "' declaration")
+        ("alias '" <> getId aliasConstructor <> "' declaration")
 
 {- | Identify and locate the given axiom declaration in the error context.
  -}
@@ -130,7 +132,7 @@ withSentenceSortContext
     SentenceSort { sentenceSortName }
   =
     withLocationAndContext sentenceSortName
-        ("sort '" ++ getIdForError sentenceSortName ++ "' declaration")
+        ("sort '" <> getId sentenceSortName <> "' declaration")
 
 {- | Identify and locate the given hooked declaration in the error context.
  -}
@@ -143,16 +145,16 @@ withSentenceHookContext =
         SentenceHookedSort SentenceSort { sentenceSortName } ->
             withLocationAndContext sentenceSortName
                 (  "hooked-sort '"
-                ++ getIdForError sentenceSortName
-                ++ "' declaration"
+                <> getId sentenceSortName
+                <> "' declaration"
                 )
 
         SentenceHookedSymbol SentenceSymbol
             { sentenceSymbolSymbol = Symbol { symbolConstructor } } ->
             withLocationAndContext symbolConstructor
                 (  "hooked-symbol '"
-                ++ getIdForError symbolConstructor
-                ++ "' declaration"
+                <> getId symbolConstructor
+                <> "' declaration"
                 )
 
 {- | Locate the given import declaration in the error context.

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -39,11 +39,13 @@ import qualified Data.Map as Map
 import           Data.Set
                  ( Set )
 import qualified Data.Set as Set
+import           Data.Text
+                 ( Text )
 import           Data.Text.Prettyprint.Doc
                  ( (<+>) )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           Data.Text.Prettyprint.Doc.Render.String
-                 ( renderString )
+import           Data.Text.Prettyprint.Doc.Render.Text
+                 ( renderStrict )
 
 import qualified Control.Lens.TH.Rules as Lens
 import           Kore.AST.Error
@@ -166,7 +168,7 @@ lookupDeclaredVariable varId = do
     errorUnquantified :: PatternVerifier Variable
     errorUnquantified =
         koreFailWithLocations [varId]
-            ("Unquantified variable: '" ++ getIdForError varId ++ "'.")
+            ("Unquantified variable: '" <> getId varId <> "'.")
 
 addDeclaredVariable
     :: Variable
@@ -193,9 +195,9 @@ newDeclaredVariable declared variable@Variable { variableName } = do
     alreadyDeclared :: Variable -> PatternVerifier DeclaredVariables
     alreadyDeclared variable' =
         koreFailWithLocations [variable', variable]
-            ("Variable '"
-                ++ getIdForError variableName
-                ++ "' was already declared."
+            (  "Variable '"
+            <> getId variableName
+            <> "' was already declared."
             )
 
 {- | Collect 'DeclaredVariables'.
@@ -768,11 +770,11 @@ assertSameSort
     :: Sort
     -> Sort
     -> PatternVerifier ()
-assertSameSort expectedSort actualSort = do
+assertSameSort expectedSort actualSort =
     koreFailWithLocationsWhen
         (expectedSort /= actualSort)
         [expectedSort, actualSort]
-        ((renderString . Pretty.layoutCompact)
+        ((renderStrict . Pretty.layoutCompact)
          ("Expecting sort"
           <+> Pretty.squotes (unparse expectedSort)
           <+> "but got"
@@ -817,33 +819,33 @@ checkVariable var vars =
   where
     inconsistent v =
         koreFailWithLocations [v, var]
-        $ renderString $ Pretty.layoutCompact
+        $ renderStrict $ Pretty.layoutCompact
         $ "Inconsistent free variable usage:"
             <+> unparse v
             <+> "and"
             <+> unparse var
             <> Pretty.dot
 
-patternNameForContext :: PatternF Variable p -> String
+patternNameForContext :: PatternF Variable p -> Text
 patternNameForContext (AndF _) = "\\and"
 patternNameForContext (ApplicationF application) =
     "symbol or alias '"
-    ++ getIdForError
+    <> getId
         (symbolOrAliasConstructor (applicationSymbolOrAlias application))
-    ++ "'"
+    <> "'"
 patternNameForContext (BottomF _) = "\\bottom"
 patternNameForContext (CeilF _) = "\\ceil"
 patternNameForContext (DomainValueF _) = "\\dv"
 patternNameForContext (EqualsF _) = "\\equals"
 patternNameForContext (ExistsF exists) =
     "\\exists '"
-    ++ variableNameForContext (existsVariable exists)
-    ++ "'"
+    <> variableNameForContext (existsVariable exists)
+    <> "'"
 patternNameForContext (FloorF _) = "\\floor"
 patternNameForContext (ForallF forall) =
     "\\forall '"
-    ++ variableNameForContext (forallVariable forall)
-    ++ "'"
+    <> variableNameForContext (forallVariable forall)
+    <> "'"
 patternNameForContext (IffF _) = "\\iff"
 patternNameForContext (ImpliesF _) = "\\implies"
 patternNameForContext (InF _) = "\\in"
@@ -857,10 +859,10 @@ patternNameForContext (StringLiteralF _) = "<string>"
 patternNameForContext (CharLiteralF _) = "<char>"
 patternNameForContext (TopF _) = "\\top"
 patternNameForContext (VariableF variable) =
-    "variable '" ++ variableNameForContext variable ++ "'"
+    "variable '" <> variableNameForContext variable <> "'"
 patternNameForContext (InhabitantF _) = "\\inh"
 patternNameForContext (SetVariableF (SetVariable variable)) =
-    "set variable '" ++ variableNameForContext variable ++ "'"
+    "set variable '" <> variableNameForContext variable <> "'"
 
-variableNameForContext :: Variable -> String
-variableNameForContext variable = getIdForError (variableName variable)
+variableNameForContext :: Variable -> Text
+variableNameForContext variable = getId (variableName variable)

--- a/kore/src/Kore/ASTVerifier/SortVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SortVerifier.hs
@@ -31,7 +31,7 @@ verifySort _ declaredSortVariables (SortVariableSort variable)
     koreFailWithLocationsWhen
         (Set.notMember variable declaredSortVariables)
         [variableId]
-        ("Sort variable '" ++ getIdForError variableId ++ "' not declared.")
+        ("Sort variable '" <> getId variableId <> "' not declared.")
     verifySuccess
   where
     variableId = getSortVariable variable
@@ -39,7 +39,7 @@ verifySort findSortDescription declaredSortVariables (SortActualSort sort)
   = do
     withLocationAndContext
         sortName
-        ("sort '" ++ getIdForError (sortActualName sort) ++ "'")
+        ("sort '" <> getId (sortActualName sort) <> "'")
         ( do
             sortDescription <- findSortDescription sortName
             verifySortMatchesDeclaration
@@ -51,14 +51,14 @@ verifySort findSortDescription declaredSortVariables (SortActualSort sort)
         (sortIsMeta && sortActualSorts sort /= [])
         [sortName]
         (  "Malformed meta sort '"
-        ++ sortId
-        ++ "' with non-empty Parameter sorts."
+        <> sortId
+        <> "' with non-empty Parameter sorts."
         )
     verifySuccess
   where
     sortIsMeta = False
     sortName   = sortActualName sort
-    sortId     = getIdForError sortName
+    sortId     = getId sortName
 
 verifySortMatchesDeclaration
     :: MonadError (Error VerifyError) m

--- a/kore/src/Kore/Attribute/Parser.hs
+++ b/kore/src/Kore/Attribute/Parser.hs
@@ -169,7 +169,7 @@ withApplication ident go kore =
           | symbolOrAliasConstructor == ident -> \attrs ->
             Kore.Error.withLocationAndContext
                 symbol
-                ("attribute '" ++ show symbol ++ "'")
+                ("attribute '" <> Text.pack (show symbol) <> "'")
                 (go symbolOrAliasParams applicationChildren attrs)
           where
             Application { applicationSymbolOrAlias = symbol } = app
@@ -184,7 +184,7 @@ getZeroParams =
         [] -> return ()
         params ->
             Kore.Error.koreFailWithLocations params
-                ("expected zero parameters, found " ++ show arity)
+                ("expected zero parameters, found " <> Text.pack (show arity))
           where
             arity = length params
 
@@ -194,7 +194,7 @@ getTwoParams =
         [param1, param2] -> return (param1, param2)
         params ->
             Kore.Error.koreFailWithLocations params
-                ("expected two parameters, found " ++ show arity)
+                ("expected two parameters, found " <> Text.pack (show arity))
           where
             arity = length params
 
@@ -250,7 +250,7 @@ getSymbolOrAlias kore =
           | otherwise ->
             Kore.Error.withLocationAndContext
                 symbol
-                ("symbol '" ++ show symbol ++ "'")
+                ("symbol '" <> Text.pack (show symbol) <> "'")
                 (Kore.Error.koreFail "expected zero arguments")
           where
             Application { applicationSymbolOrAlias = symbol } = app

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -344,10 +344,7 @@ assertSymbolHook indexedModule symbolId expected = do
           | otherwise ->
             Kore.Error.koreFailWithLocations
                 [symbol]
-                ("Symbol is not hooked to builtin symbol '"
-                    ++ expectedForError ++ "'")
-          where
-            expectedForError = Text.unpack expected
+                ("Symbol is not hooked to builtin symbol '" <> expected <> "'")
         Nothing ->
             Kore.Error.koreFailWithLocations
                 [symbol]
@@ -374,7 +371,7 @@ assertSymbolResultSort indexedModule symbolId expectedSort = do
         $ Kore.Error.koreFailWithLocations
             [symbol]
             ("Symbol does not return sort '"
-                ++ unparseToString expectedSort ++ "'")
+                <> unparseToText expectedSort <> "'")
 
 {- | Verify the occurrence of a builtin sort.
 

--- a/kore/src/Kore/IndexedModule/Error.hs
+++ b/kore/src/Kore/IndexedModule/Error.hs
@@ -5,10 +5,17 @@ License     : NCSA
 
 module Kore.IndexedModule.Error
     ( noSort
+    , noSortText
     , noHead
     , noAlias
+    , noAliasText
     , noSymbol
+    , noSymbolText
     ) where
+
+import           Data.Text
+                 ( Text )
+import qualified Data.Text as Text
 
 import Kore.Syntax
 
@@ -16,6 +23,10 @@ import Kore.Syntax
 noSort :: Id -> String
 noSort sortId =
     notDefined "Sort" $ getIdForError sortId
+
+-- | A message declaring that a Sort is undefined
+noSortText :: Id -> Text
+noSortText sortId = Text.pack (noSort sortId)
 
 -- | A message declaring that a Head is undefined
 noHead :: SymbolOrAlias -> String
@@ -27,10 +38,18 @@ noAlias :: Id -> String
 noAlias identifier =
     notDefined "Alias" $ getIdForError identifier
 
+-- | A message declaring that a Alias is undefined
+noAliasText :: Id -> Text
+noAliasText identifier = Text.pack (noAlias identifier)
+
 -- | A message declaring that a Symbol is undefined
 noSymbol :: Id -> String
 noSymbol identifier =
     notDefined "Symbol" $ getIdForError identifier
+
+-- | A message declaring that a Symbol is undefined
+noSymbolText :: Id -> Text
+noSymbolText identifier = Text.pack (noSymbol identifier)
 
 -- | A message declaring that some `tag` is undefined.
 notDefined :: String -> String -> String

--- a/kore/src/Kore/IndexedModule/Resolvers.hs
+++ b/kore/src/Kore/IndexedModule/Resolvers.hs
@@ -41,7 +41,8 @@ import           Kore.AST.Error
 import qualified Kore.Attribute.Sort as Attribute
 import           Kore.Error
 import           Kore.IndexedModule.Error
-                 ( noAlias, noHead, noSort, noSymbol )
+                 ( noAliasText, noHead, noSort, noSortText, noSymbol,
+                 noSymbolText )
 import           Kore.IndexedModule.IndexedModule
                  ( IndexedModule (..), getIndexedSentence,
                  indexedModulesInScope )
@@ -169,7 +170,7 @@ resolveSymbol
 resolveSymbol m headId =
     case resolveThing symbolSentencesMap m headId of
         Nothing ->
-            koreFailWithLocations [headId] (noSymbol headId)
+            koreFailWithLocations [headId] (noSymbolText headId)
         Just result ->
             return result
 
@@ -184,7 +185,7 @@ resolveAlias
 resolveAlias m headId =
     case resolveThing aliasSentencesMap m headId of
         Nothing ->
-            koreFailWithLocations [headId] (noAlias headId)
+            koreFailWithLocations [headId] (noAliasText headId)
         Just result ->
             return result
 
@@ -201,7 +202,7 @@ resolveSort
 resolveSort m sortId =
     case resolveThing sortSentencesMap m sortId of
         Nothing ->
-            koreFailWithLocations [sortId] $ noSort sortId
+            koreFailWithLocations [sortId] $ noSortText sortId
         Just sortDescription ->
             return sortDescription
 

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -122,7 +122,7 @@ instance Debug AstLocation
 {-| 'prettyPrintAstLocation' displays an `AstLocation` in a way that's
 (sort of) user friendly.
 -}
-prettyPrintAstLocation :: AstLocation -> String
+prettyPrintAstLocation :: AstLocation -> Text
 prettyPrintAstLocation AstLocationNone = "<unknown location>"
 prettyPrintAstLocation AstLocationImplicit = "<implicitly defined entity>"
 prettyPrintAstLocation AstLocationGeneratedVariable =
@@ -135,7 +135,9 @@ prettyPrintAstLocation
         , column = column'
         }
     )
-    = name ++ " " ++ show line' ++ ":" ++ show column'
+  = Text.pack name <> " "
+    <> Text.pack (show line') <> ":"
+    <> Text.pack (show column')
 prettyPrintAstLocation AstLocationUnknown = "<unknown location>"
 
 {-| 'FileLocation' represents a position in a source file.


### PR DESCRIPTION
I meant this to be a part of the dv vs constructor verification PR, but it seems that I'll need some changes in that, so I'm sending this as a separate PR.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

