### PR TITLE
list-requires: Do not define symbol removeAs

### DIFF
--- a/src/main/k/working/tests/collections/list-requires/list-requires.k
+++ b/src/main/k/working/tests/collections/list-requires/list-requires.k
@@ -13,12 +13,12 @@ module LIST-REQUIRES
     </T>
 
 syntax Map ::= removeAs ( Map ) [function, functional]
-             | removeAs ( List , Map ) [function, functional]
+//             | removeAs ( List , Map ) [function, functional]
 // ------------------------------------------------------------------------------
-rule removeAs( M )                                   => removeAs(Set2List(keys(M)), M)
-rule removeAs( .List, .Map )                         => .Map
-rule removeAs( ListItem(KEY) L, KEY |-> 0 REST )     => removeAs(L, REST)
-rule removeAs( ListItem(KEY) L, KEY |-> VALUE REST ) => KEY |-> VALUE removeAs(L, REST) requires VALUE =/=K 0
+//rule removeAs( M )                                   => removeAs(Set2List(keys(M)), M)
+//rule removeAs( .List, .Map )                         => .Map
+//rule removeAs( ListItem(KEY) L, KEY |-> 0 REST )     => removeAs(L, REST)
+//rule removeAs( ListItem(KEY) L, KEY |-> VALUE REST ) => KEY |-> VALUE removeAs(L, REST) requires VALUE =/=K 0
 
 rule
     <k> a => b </k>


### PR DESCRIPTION
This will cause the backend to loop due to unifying `removeAs(a |-> 0 b |-> a)` with `b |-> a`. It should get stuck or report an error.
Reproduce:
```
cd src/main/k/working/tests/collections/list-requires
make test-k
```

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

