### PR TITLE
Internal representations

### DIFF
--- a/kore/src/Kore/Builtin.hs
+++ b/kore/src/Kore/Builtin.hs
@@ -30,8 +30,6 @@ module Kore.Builtin
     , internalize
     ) where
 
-import           Control.Category
-                 ( (>>>) )
 import qualified Control.Comonad.Trans.Cofree as Cofree
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.HashMap.Strict as HashMap
@@ -282,5 +280,5 @@ internalize tools =
   where
     internalize1 =
             List.internalize tools
-        >>> Map.internalize tools
-        >>> Set.internalize tools
+        .   Map.internalize tools
+        .   Set.internalize tools

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -57,7 +57,6 @@ import           GHC.Stack
 
 import qualified Kore.Attribute.Symbol as Attribute
                  ( Symbol )
-import qualified Kore.Attribute.Symbol as Attribute.Symbol
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.MapSymbols as Map
 import qualified Kore.Builtin.SetSymbols as Set
@@ -160,11 +159,11 @@ instance TermWrapper Domain.NormalizedMap Domain.Value where
         (Builtin_ (Domain.BuiltinMap Domain.InternalAc { builtinAcChild }))
       = Normalized (Domain.unwrapAc builtinAcChild)
     toNormalized tools (App_ symbol args)
-      | Map.isSymbolUnit hookTools symbol =
+      | Map.isSymbolUnit symbol =
         case args of
             [] -> Normalized Domain.emptyNormalizedAc
             _ -> Builtin.wrongArity "MAP.unit"
-      | Map.isSymbolElement hookTools symbol =
+      | Map.isSymbolElement symbol =
         case args of
             [key, value] ->
                 Normalized Domain.NormalizedAc
@@ -173,13 +172,11 @@ instance TermWrapper Domain.NormalizedMap Domain.Value where
                     , opaque = []
                     }
             _ -> Builtin.wrongArity "MAP.element"
-      | Map.isSymbolConcat hookTools symbol =
+      | Map.isSymbolConcat symbol =
         case args of
             [set1, set2] ->
                 toNormalized tools set1 <> toNormalized tools set2
             _ -> Builtin.wrongArity "MAP.concat"
-      where
-        hookTools = Attribute.Symbol.hook <$> tools
     toNormalized _ patt =
         Normalized Domain.NormalizedAc
             { elementsWithVariables = []
@@ -216,11 +213,11 @@ instance TermWrapper Domain.NormalizedSet Domain.NoValue where
         (Builtin_ (Domain.BuiltinSet Domain.InternalAc { builtinAcChild }))
       = Normalized (Domain.unwrapAc builtinAcChild)
     toNormalized tools (App_ symbol args)
-      | Set.isSymbolUnit hookTools symbol =
+      | Set.isSymbolUnit symbol =
         case args of
             [] -> Normalized Domain.emptyNormalizedAc
             _ -> Builtin.wrongArity "SET.unit"
-      | Set.isSymbolElement hookTools symbol =
+      | Set.isSymbolElement symbol =
         case args of
             [elem1] ->
                 Normalized Domain.NormalizedAc
@@ -229,13 +226,11 @@ instance TermWrapper Domain.NormalizedSet Domain.NoValue where
                     , opaque = []
                     }
             _ -> Builtin.wrongArity "SET.element"
-      | Set.isSymbolConcat hookTools symbol =
+      | Set.isSymbolConcat symbol =
         case args of
             [set1, set2] ->
                 toNormalized tools set1 <> toNormalized tools set2
             _ -> Builtin.wrongArity "SET.concat"
-      where
-        hookTools = Attribute.Symbol.hook <$> tools
     toNormalized _ patt =
         Normalized Domain.NormalizedAc
             { elementsWithVariables = []

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -165,7 +165,14 @@ instance TermWrapper Domain.NormalizedMap Domain.Value where
             _ -> Builtin.wrongArity "MAP.unit"
       | Map.isSymbolElement symbol =
         case args of
-            [key, value] ->
+            [key, value]
+              | Just key' <- Builtin.toKey key ->
+                Normalized Domain.NormalizedAc
+                    { elementsWithVariables = []
+                    , concreteElements = Map.singleton key' (Domain.Value value)
+                    , opaque = []
+                    }
+              | otherwise ->
                 Normalized Domain.NormalizedAc
                     { elementsWithVariables = [(key, Domain.Value value)]
                     , concreteElements = Map.empty

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -41,20 +41,15 @@ import           Control.Error
 import           Control.Monad
                  ( foldM, unless )
 import qualified Control.Monad.Trans as Monad.Trans
-import qualified Data.Either as Either
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
 import qualified Data.List
-import           Data.List.NonEmpty
-                 ( NonEmpty (..) )
 import           Data.Map.Strict
                  ( Map )
 import qualified Data.Map.Strict as Map
 import           Data.Reflection
                  ( Given )
 import qualified Data.Reflection as Reflection
-import           Data.Semigroup
-                 ( sconcat )
 import           Data.Text.Prettyprint.Doc
                  ( Doc )
 import           GHC.Stack
@@ -162,28 +157,7 @@ instance TermWrapper Domain.NormalizedMap Domain.Value where
     toNormalized
         _tools
         (Builtin_ (Domain.BuiltinMap Domain.InternalAc { builtinAcChild }))
-      = flatAc
-      where
-        normalizedAc = Domain.unwrapAc builtinAcChild
-        concreteAc =
-            Domain.emptyNormalizedAc
-                { Domain.concreteElements =
-                    Domain.concreteElements normalizedAc
-                , Domain.opaque = actuallyOpaque
-                }
-        opaqueAcs = Domain.opaque normalizedAc
-        (builtinChildren, actuallyOpaque) =
-            Either.partitionEithers (selectBuiltinChildren <$> opaqueAcs)
-        abstractAcs = asElement <$> Domain.elementsWithVariables normalizedAc
-        asElement element =
-            Domain.emptyNormalizedAc
-                { Domain.elementsWithVariables = [element] }
-        flatAc =
-            (sconcat . fmap Normalized)
-                (concreteAc :| (abstractAcs <> builtinChildren))
-        selectBuiltinChildren (TermLike.BuiltinMap_ internalMap) =
-            (Left . Domain.unwrapAc) (Domain.builtinAcChild internalMap)
-        selectBuiltinChildren other = Right other
+      = Normalized (Domain.unwrapAc builtinAcChild)
     toNormalized tools (App_ symbol args)
       | Map.isSymbolUnit symbol =
         case args of

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -226,7 +226,14 @@ instance TermWrapper Domain.NormalizedSet Domain.NoValue where
             _ -> Builtin.wrongArity "SET.unit"
       | Set.isSymbolElement symbol =
         case args of
-            [elem1] ->
+            [elem1]
+              | Just elem1' <- Builtin.toKey elem1 ->
+                Normalized Domain.NormalizedAc
+                    { elementsWithVariables = []
+                    , concreteElements = Map.singleton elem1' Domain.NoValue
+                    , opaque = []
+                    }
+              | otherwise ->
                 Normalized Domain.NormalizedAc
                     { elementsWithVariables = [(elem1, Domain.NoValue)]
                     , concreteElements = Map.empty

--- a/kore/src/Kore/Builtin/Attributes.hs
+++ b/kore/src/Kore/Builtin/Attributes.hs
@@ -17,37 +17,23 @@ module Kore.Builtin.Attributes
     , isConstructorModuloLike_
     ) where
 
-import Data.Reflection
-       ( Given, given )
-
-import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.MapSymbols as Map
 import qualified Kore.Builtin.SetSymbols as Set
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.Symbol
 
 -- | Is the symbol a constructor modulo associativity, commutativity and
 -- neutral element?
-isConstructorModulo_
-    :: Given (SmtMetadataTools Attribute.Symbol)
-    => Symbol
-    -> Bool
+isConstructorModulo_ :: Symbol -> Bool
 isConstructorModulo_ symbol =
-    any (apply given symbol)
+    any (apply symbol)
         [ List.isSymbolConcat, List.isSymbolElement, List.isSymbolUnit
         ,  Map.isSymbolConcat,  Map.isSymbolElement,  Map.isSymbolUnit
         ,  Set.isSymbolConcat,  Set.isSymbolElement,  Set.isSymbolUnit
         ]
   where
-    apply tools pattHead f = f (Attribute.hook <$> tools) pattHead
+    apply pattHead f = f pattHead
 
-isConstructorModuloLike_
-    :: Given (SmtMetadataTools Attribute.Symbol)
-    => Symbol
-    -> Bool
-isConstructorModuloLike_ appHead =
-    isConstructorModulo_ appHead
-        || isConstructor appHead
-        || isSortInjection appHead
+isConstructorModuloLike_ :: Symbol -> Bool
+isConstructorModuloLike_ =
+    or <$> sequence [isConstructorModulo_, isConstructor, isSortInjection]

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -58,7 +58,7 @@ module Kore.Builtin.Builtin
     , lookupSymbolConcat
     , isSymbol
     , isSort
-    , expectNormalConcreteTerm
+    , toKey
     , getAttemptedAxiom
       -- * Implementing builtin unification
     , unifyEqualsUnsolved
@@ -128,7 +128,6 @@ import           Kore.Step.Simplification.Data
                  BuiltinAndAxiomSimplifierMap, MonadSimplify,
                  PredicateSimplifier, SimplificationType, TermLikeSimplifier,
                  applicationAxiomSimplifier )
-import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as SimplificationType
                  ( SimplificationType (..) )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
@@ -875,23 +874,18 @@ isSort builtinName tools sort
     isPredicateSort = sort == predicateSort
 
 
-{- | Ensure that a 'StepPattern' is a concrete, normalized term.
+{- | Ensure that a 'TermLike' is a concrete, normalized term.
 
-    If the pattern is not concrete and normalized, the function is
-    'NotApplicable'.
+If the pattern is not concrete and normalized, the function is
+See also: 'Kore.Proof.Value.Value'
 
  -}
-expectNormalConcreteTerm
-    :: MonadSimplify m
-    => TermLike variable
-    -> MaybeT m (TermLike Concrete)
-expectNormalConcreteTerm purePattern = do
-    tools <- Simplifier.askMetadataTools
-    MaybeT $ return $ do
-        p <- TermLike.asConcrete purePattern
-        -- TODO (thomas.tuegel): Use the return value as the term.
-        _ <- Value.fromConcreteStepPattern tools p
-        return p
+toKey :: TermLike variable -> Maybe (TermLike Concrete)
+toKey purePattern = do
+    p <- TermLike.asConcrete purePattern
+    -- TODO (thomas.tuegel): Use the return value as the term.
+    _ <- Value.fromTermLike p
+    return p
 
 {- | Run a function evaluator that can terminate early.
  -}

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -865,9 +865,9 @@ Returns Just False if the sort is a variable.
 -}
 isSort :: Text -> SmtMetadataTools attr -> Sort -> Maybe Bool
 isSort builtinName tools sort
-  | isPredicateSort = Nothing
-  | otherwise =
-    Just (getHook hook == Just builtinName)
+  | isPredicateSort            = Nothing
+  | SortVariableSort _ <- sort = Nothing
+  | otherwise                  = Just (getHook hook == Just builtinName)
   where
     MetadataTools {sortAttributes} = tools
     Attribute.Sort {hook} = sortAttributes sort

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -854,10 +854,9 @@ lookupSymbolConcat tools builtinSort =
  -}
 isSymbol
     :: Text  -- ^ Builtin symbol
-    -> SmtMetadataTools Hook
     -> Symbol  -- ^ Kore symbol
     -> Bool
-isSymbol builtinName _ Symbol { symbolAttributes = Attribute.Symbol { hook } } =
+isSymbol builtinName Symbol { symbolAttributes = Attribute.Symbol { hook } } =
     getHook hook == Just builtinName
 
 {- | Is the given sort hooked to the named builtin?

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -352,8 +352,15 @@ internalize
 internalize tools termLike@(App_ symbol args)
   | isSymbolUnit    symbol , [ ] <- args = asInternal' (Seq.fromList args)
   | isSymbolElement symbol , [_] <- args = asInternal' (Seq.fromList args)
-  | isSymbolConcat  symbol , [BuiltinList_ list1, BuiltinList_ list2] <- args =
-    asInternal' (Function.on (<>) Domain.builtinListChild list1 list2)
+  | isSymbolConcat  symbol =
+    case args of
+        [BuiltinList_ list1, arg2              ]
+          | (null . Domain.builtinListChild) list1 -> arg2
+        [arg1              , BuiltinList_ list2]
+          | (null . Domain.builtinListChild) list2 -> arg1
+        [BuiltinList_ list1, BuiltinList_ list2] ->
+            asInternal' (Function.on (<>) Domain.builtinListChild list1 list2)
+        _ -> termLike
   where
     asInternal' = asInternal tools (termLikeSort termLike)
 internalize _ termLike = termLike

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -59,8 +59,6 @@ import           Data.Text
                  ( Text )
 import qualified Data.Text as Text
 
-import           Kore.Attribute.Hook
-                 ( Hook )
 import qualified Kore.Attribute.Symbol as Attribute
 import           Kore.Builtin.Builtin
                  ( acceptAnySort )
@@ -354,26 +352,17 @@ lookupSymbolGet = Builtin.lookupSymbol getKey
 
 {- | Check if the given symbol is hooked to @LIST.concat@.
 -}
-isSymbolConcat
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolConcat :: Symbol -> Bool
 isSymbolConcat = Builtin.isSymbol concatKey
 
 {- | Check if the given symbol is hooked to @LIST.element@.
 -}
-isSymbolElement
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolElement :: Symbol -> Bool
 isSymbolElement = Builtin.isSymbol elementKey
 
 {- | Check if the given symbol is hooked to @LIST.unit@.
 -}
-isSymbolUnit
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolUnit :: Symbol -> Bool
 isSymbolUnit = Builtin.isSymbol unitKey
 
 {- | Simplify the conjunction or equality of two concrete List domain values.
@@ -410,8 +399,6 @@ unifyEquals
   =
     unifyEquals0 first second
   where
-    hookTools = Attribute.hook <$> tools
-
     propagatePredicates
         :: Traversable t
         => t (Conditional variable a)
@@ -437,7 +424,7 @@ unifyEquals
                     , "This should have been a sort error."
                     ]
             app@(App_ symbol2 args2)
-              | isSymbolConcat hookTools symbol2 ->
+              | isSymbolConcat symbol2 ->
                 Monad.Trans.lift $ case args2 of
                     [ Builtin_ (Domain.BuiltinList builtin2), x@(Var_ _) ] ->
                         unifyEqualsFramedRight builtin1 builtin2 x

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -483,7 +483,15 @@ internalize tools termLike
   , isConstructorModulo_ symbol =
     case Ac.toNormalized @Domain.NormalizedMap tools termLike of
         Ac.Bottom                    -> TermLike.mkBottom sort'
-        Ac.Normalized termNormalized -> Ac.asInternal tools sort' termNormalized
+        Ac.Normalized termNormalized
+          | null (Domain.elementsWithVariables termNormalized)
+          , null (Domain.concreteElements termNormalized)
+          , [singleOpaqueTerm] <- Domain.opaque termNormalized
+          ->
+            -- When the 'normalized' term consists of a single opaque Map-sorted
+            -- term, we should prefer to return only that term.
+            singleOpaqueTerm
+          | otherwise -> Ac.asInternal tools sort' termNormalized
   | otherwise = termLike
   where
     sort' = termLikeSort termLike

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -29,7 +29,7 @@ module Kore.Builtin.Map
 import           Control.Applicative
                  ( Alternative (..) )
 import           Control.Error
-                 ( MaybeT (MaybeT), fromMaybe, runMaybeT )
+                 ( MaybeT (MaybeT), fromMaybe, hoistMaybe, runMaybeT )
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.HashMap.Strict as HashMap
 import           Data.Map.Strict
@@ -225,7 +225,7 @@ evalLookup =
                         then Builtin.appliedFunction Pattern.bottom
                         else empty
                 bothConcrete = do
-                    _key <- Builtin.expectNormalConcreteTerm _key
+                    _key <- hoistMaybe $ Builtin.toKey _key
                     _map <- expectConcreteBuiltinMap Map.lookupKey _map
                     Builtin.appliedFunction
                         $ maybeBottom
@@ -306,7 +306,7 @@ evalUpdate =
                     case arguments of
                         [_map, _key, value'] -> (_map, _key, value')
                         _ -> Builtin.wrongArity Map.updateKey
-            _key <- Builtin.expectNormalConcreteTerm _key
+            _key <- hoistMaybe $ Builtin.toKey _key
             _map <- expectConcreteBuiltinMap Map.updateKey _map
             returnConcreteMap
                 resultSort
@@ -322,7 +322,7 @@ evalInKeys =
                     case arguments of
                         [_key, _map] -> (_key, _map)
                         _ -> Builtin.wrongArity Map.in_keysKey
-            _key <- Builtin.expectNormalConcreteTerm _key
+            _key <- hoistMaybe $ Builtin.toKey _key
             _map <- expectConcreteBuiltinMap Map.in_keysKey _map
             Builtin.appliedFunction
                 $ Bool.asPattern resultSort
@@ -361,7 +361,7 @@ evalRemove =
                         else empty
                 bothConcrete = do
                     _map <- expectConcreteBuiltinMap Map.removeKey _map
-                    _key <- Builtin.expectNormalConcreteTerm _key
+                    _key <- hoistMaybe $ Builtin.toKey _key
                     returnConcreteMap resultSort $ Map.delete _key _map
             emptyMap <|> bothConcrete
 

--- a/kore/src/Kore/Builtin/MapSymbols.hs
+++ b/kore/src/Kore/Builtin/MapSymbols.hs
@@ -40,8 +40,6 @@ module Kore.Builtin.MapSymbols
 
 import           Data.String
                  ( IsString )
-import           Kore.Attribute.Hook
-                 ( Hook )
 import qualified Kore.Attribute.Symbol as Attribute
                  ( Symbol )
 import qualified Kore.Builtin.Builtin as Builtin
@@ -49,8 +47,6 @@ import qualified Kore.Error as Kore
                  ( Error )
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.Symbol
                  ( Symbol )
 import           Kore.Sort
@@ -133,40 +129,25 @@ lookupSymbolRemoveAll = Builtin.lookupSymbol removeAllKey
 
 {- | Check if the given symbol is hooked to @MAP.concat@.
  -}
-isSymbolConcat
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolConcat :: Symbol -> Bool
 isSymbolConcat = Builtin.isSymbol concatKey
 
 {- | Check if the given symbol is hooked to @MAP.element@.
  -}
-isSymbolElement
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolElement :: Symbol -> Bool
 isSymbolElement = Builtin.isSymbol elementKey
 
 {- | Check if the given symbol is hooked to @MAP.unit@.
 -}
-isSymbolUnit
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolUnit :: Symbol -> Bool
 isSymbolUnit = Builtin.isSymbol unitKey
 
 {- | Check if the given symbol is hooked to @MAP.remove@.
 -}
-isSymbolRemove
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolRemove :: Symbol -> Bool
 isSymbolRemove = Builtin.isSymbol removeKey
 
 {- | Check if the given symbol is hooked to @MAP.removeAll@.
 -}
-isSymbolRemoveAll
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolRemoveAll :: Symbol -> Bool
 isSymbolRemoveAll = Builtin.isSymbol removeAllKey

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -46,6 +46,8 @@ import qualified Data.Text as Text
 import qualified Kore.Attribute.Symbol as Attribute
                  ( Symbol )
 import qualified Kore.Builtin.AssociativeCommutative as Ac
+import           Kore.Builtin.Attributes
+                 ( isConstructorModulo_ )
 import qualified Kore.Builtin.Bool as Bool
 import           Kore.Builtin.Builtin
                  ( acceptAnySort )
@@ -454,7 +456,11 @@ internalize
     -> TermLike variable
     -> TermLike variable
 internalize tools termLike
-  | fromMaybe False (isSetSort tools sort') =
+  | fromMaybe False (isSetSort tools sort')
+  -- Ac.toNormalized is greedy about 'normalizing' opaque terms, we should only
+  -- apply it if we know the term head is a constructor-like symbol.
+  , App_ symbol _ <- termLike
+  , isConstructorModulo_ symbol =
     case Ac.toNormalized @Domain.NormalizedSet tools termLike of
         Ac.Bottom                    -> TermLike.mkBottom sort'
         Ac.Normalized termNormalized -> Ac.asInternal tools sort' termNormalized

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -32,7 +32,7 @@ module Kore.Builtin.Set
 import           Control.Applicative
                  ( Alternative (..) )
 import           Control.Error
-                 ( MaybeT (MaybeT), fromMaybe, runMaybeT )
+                 ( MaybeT (MaybeT), fromMaybe, hoistMaybe, runMaybeT )
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.HashMap.Strict as HashMap
 import           Data.Map.Strict
@@ -251,7 +251,7 @@ evalIn =
                     case arguments of
                         [_elem, _set] -> (_elem, _set)
                         _ -> Builtin.wrongArity Set.inKey
-            _elem <- Builtin.expectNormalConcreteTerm _elem
+            _elem <- hoistMaybe $ Builtin.toKey _elem
             _set <- expectConcreteBuiltinSet Set.inKey _set
             (Builtin.appliedFunction . asExpandedBoolPattern)
                 (Map.member _elem _set)

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -463,7 +463,15 @@ internalize tools termLike
   , isConstructorModulo_ symbol =
     case Ac.toNormalized @Domain.NormalizedSet tools termLike of
         Ac.Bottom                    -> TermLike.mkBottom sort'
-        Ac.Normalized termNormalized -> Ac.asInternal tools sort' termNormalized
+        Ac.Normalized termNormalized
+          | null (Domain.elementsWithVariables termNormalized)
+          , null (Domain.concreteElements termNormalized)
+          , [singleOpaqueTerm] <- Domain.opaque termNormalized
+          ->
+            -- When the 'normalized' term consists of a single opaque Map-sorted
+            -- term, we should prefer to return only that term.
+            singleOpaqueTerm
+          | otherwise -> Ac.asInternal tools sort' termNormalized
   | otherwise = termLike
   where
     sort' = termLikeSort termLike

--- a/kore/src/Kore/Builtin/SetSymbols.hs
+++ b/kore/src/Kore/Builtin/SetSymbols.hs
@@ -33,8 +33,6 @@ module Kore.Builtin.SetSymbols
 
 import           Data.String
                  ( IsString )
-import           Kore.Attribute.Hook
-                 ( Hook )
 import qualified Kore.Attribute.Symbol as Attribute
                  ( Symbol )
 import qualified Kore.Builtin.Builtin as Builtin
@@ -42,8 +40,6 @@ import qualified Kore.Error as Kore
                  ( Error )
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
 import           Kore.Internal.Symbol
                  ( Symbol )
 import           Kore.Sort
@@ -91,24 +87,15 @@ lookupSymbolDifference = Builtin.lookupSymbol differenceKey
 
 {- | Check if the given symbol is hooked to @SET.concat@.
  -}
-isSymbolConcat
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolConcat :: Symbol -> Bool
 isSymbolConcat = Builtin.isSymbol concatKey
 
 {- | Check if the given symbol is hooked to @SET.element@.
  -}
-isSymbolElement
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolElement :: Symbol -> Bool
 isSymbolElement = Builtin.isSymbol elementKey
 
 {- | Check if the given symbol is hooked to @SET.unit@.
 -}
-isSymbolUnit
-    :: SmtMetadataTools Hook
-    -> Symbol
-    -> Bool
+isSymbolUnit :: Symbol -> Bool
 isSymbolUnit = Builtin.isSymbol unitKey

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -39,7 +39,6 @@ import qualified Kore.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
-import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
                  ( build )
 import           Kore.IndexedModule.Resolvers
@@ -129,7 +128,7 @@ exec
     -> SMT (TermLike Variable)
 exec indexedModule strategy initialTerm =
     evalSimplifier env $ do
-        execution <- execute indexedModule' strategy initialTerm
+        execution <- execute indexedModule strategy initialTerm
         let
             Execution { executionGraph } = execution
             finalConfig = pickLongest executionGraph
@@ -138,13 +137,6 @@ exec indexedModule strategy initialTerm =
                 $ Pattern.toTermLike finalConfig
         return finalTerm
   where
-    indexedModule' =
-        IndexedModule.mapPatterns
-            (Builtin.internalize metadataTools)
-            indexedModule
-    -- It's safe to build the MetadataTools using the external IndexedModule
-    -- because MetadataTools doesn't retain any knowledge of the patterns which
-    -- are internalized.
     metadataTools = MetadataTools.build indexedModule
     env =
         Simplifier.Env

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -39,6 +39,7 @@ import qualified Kore.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
+import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
                  ( build )
 import           Kore.IndexedModule.Resolvers
@@ -128,7 +129,7 @@ exec
     -> SMT (TermLike Variable)
 exec indexedModule strategy initialTerm =
     evalSimplifier env $ do
-        execution <- execute indexedModule strategy initialTerm
+        execution <- execute indexedModule' strategy initialTerm
         let
             Execution { executionGraph } = execution
             finalConfig = pickLongest executionGraph
@@ -137,6 +138,13 @@ exec indexedModule strategy initialTerm =
                 $ Pattern.toTermLike finalConfig
         return finalTerm
   where
+    indexedModule' =
+        IndexedModule.mapPatterns
+            (Builtin.internalize metadataTools)
+            indexedModule
+    -- It's safe to build the MetadataTools using the external IndexedModule
+    -- because MetadataTools doesn't retain any knowledge of the patterns which
+    -- are internalized.
     metadataTools = MetadataTools.build indexedModule
     env =
         Simplifier.Env

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -84,6 +84,7 @@ module Kore.Internal.TermLike
     , pattern Bottom_
     , pattern Builtin_
     , pattern BuiltinList_
+    , pattern BuiltinMap_
     , pattern Ceil_
     , pattern DV_
     , pattern Equals_
@@ -1891,6 +1892,10 @@ pattern BuiltinList_
     :: Domain.InternalList (TermLike variable)
     -> TermLike variable
 
+pattern BuiltinMap_
+    :: Domain.InternalMap (TermLike Concrete) (TermLike variable)
+    -> TermLike variable
+
 pattern Equals_
     :: Sort
     -> Sort
@@ -2005,6 +2010,9 @@ pattern Builtin_ builtin <- (Recursive.project -> _ :< BuiltinF builtin)
 
 pattern BuiltinList_ internalList
     <- (Recursive.project -> _ :< BuiltinF (Domain.BuiltinList internalList))
+
+pattern BuiltinMap_ internalMap
+    <- (Recursive.project -> _ :< BuiltinF (Domain.BuiltinMap internalMap))
 
 pattern Equals_ equalsOperandSort equalsResultSort equalsFirst equalsSecond <-
     (Recursive.project ->

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -83,6 +83,7 @@ module Kore.Internal.TermLike
     , pattern App_
     , pattern Bottom_
     , pattern Builtin_
+    , pattern BuiltinList_
     , pattern Ceil_
     , pattern DV_
     , pattern Equals_
@@ -1886,6 +1887,10 @@ pattern Builtin_
     :: Domain.Builtin (TermLike Concrete) (TermLike variable)
     -> TermLike variable
 
+pattern BuiltinList_
+    :: Domain.InternalList (TermLike variable)
+    -> TermLike variable
+
 pattern Equals_
     :: Sort
     -> Sort
@@ -1997,6 +2002,9 @@ pattern DV_ domainValueSort domainValueChild <-
     )
 
 pattern Builtin_ builtin <- (Recursive.project -> _ :< BuiltinF builtin)
+
+pattern BuiltinList_ internalList
+    <- (Recursive.project -> _ :< BuiltinF (Domain.BuiltinList internalList))
 
 pattern Equals_ equalsOperandSort equalsResultSort equalsFirst equalsSecond <-
     (Recursive.project ->

--- a/kore/src/Kore/Proof/Value.hs
+++ b/kore/src/Kore/Proof/Value.hs
@@ -10,9 +10,9 @@ module Kore.Proof.Value
     ( ValueF (..)
     , Value
     , fromPattern
-    , Kore.Proof.Value.fromConcreteStepPattern
+    , fromTermLike
     , asPattern
-    , Kore.Proof.Value.asConcreteStepPattern
+    , asTermLike
     ) where
 
 import           Control.Comonad.Trans.Cofree
@@ -28,10 +28,7 @@ import           GHC.Generics
 
 import qualified Kore.Attribute.Pattern as Attribute
                  ( Pattern (..) )
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
 import           Kore.Internal.Symbol
 import           Kore.Internal.TermLike
                  ( TermLike, TermLikeF (..) )
@@ -93,10 +90,9 @@ eraseSortInjection original@(Recursive.project -> _ :< value) =
 
  -}
 fromPattern
-    :: SmtMetadataTools StepperAttributes
-    -> Base (TermLike Concrete) (Maybe Value)
+    :: Base (TermLike Concrete) (Maybe Value)
     -> Maybe Value
-fromPattern _ (attrs :< termLikeF) =
+fromPattern (attrs :< termLikeF) =
     fmap (Recursive.embed . (attrs :<))
     $ case termLikeF of
         ApplySymbolF applySymbolF
@@ -140,12 +136,8 @@ a sort injection applied only to normalized value.
 See also: 'fromPattern'
 
  -}
-fromConcreteStepPattern
-    :: SmtMetadataTools StepperAttributes
-    -> TermLike Concrete
-    -> Maybe Value
-fromConcreteStepPattern tools =
-    Recursive.fold (fromPattern tools)
+fromTermLike :: TermLike Concrete -> Maybe Value
+fromTermLike = Recursive.fold fromPattern
 
 {- | Project a 'Value' to a concrete 'Pattern' head.
  -}
@@ -161,5 +153,5 @@ asPattern (Recursive.project -> attrs :< value) =
 
 {- | View a normalized value as a 'ConcreteStepPattern'.
  -}
-asConcreteStepPattern :: Value -> TermLike Concrete
-asConcreteStepPattern = Recursive.unfold asPattern
+asTermLike :: Value -> TermLike Concrete
+asTermLike = Recursive.unfold asPattern

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -32,6 +32,7 @@ import           Kore.Internal.Pattern
 import qualified Kore.Internal.Pattern as Pattern
 import           Kore.Internal.Symbol
 import           Kore.Internal.TermLike
+import qualified Kore.Proof.Value as Value
 import           Kore.Step.Axiom.Matcher
                  ( unificationWithAppMatchOnTop )
 import qualified Kore.Step.Result as Result
@@ -48,7 +49,6 @@ import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
                  ( AttemptedAxiomResults (..) )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiom
                  ( AttemptedAxiom (..), hasRemainders, maybeNotApplicable )
-import qualified Kore.Step.Simplification.Data as Simplifier
 import           Kore.Step.Step
                  ( UnificationProcedure (UnificationProcedure) )
 import qualified Kore.Step.Step as Step
@@ -57,8 +57,6 @@ import           Kore.Unparser
                  ( Unparse, unparse )
 import           Kore.Variables.Fresh
                  ( FreshVariable )
-
-import qualified Kore.Proof.Value as Value
 
 {-|Describes whether simplifiers are allowed to return multiple results or not.
 -}
@@ -183,10 +181,7 @@ evaluateBuiltin
     axiomIdToSimplifier
     patt
   = do
-    tools <- Simplifier.askMetadataTools
-    let
-        isValue pat = isJust $
-            Value.fromConcreteStepPattern tools =<< asConcrete pat
+    let isValue pat = isJust $ Value.fromTermLike =<< asConcrete pat
     result <-
         builtinEvaluator
             substitutionSimplifier

--- a/kore/src/Kore/Step/Simplification/Builtin.hs
+++ b/kore/src/Kore/Step/Simplification/Builtin.hs
@@ -10,11 +10,9 @@ module Kore.Step.Simplification.Builtin
 import qualified Kore.Domain.Builtin as Domain
 import           Kore.Internal.Conditional
                  ( Conditional )
-import qualified Kore.Internal.Conditional as Conditional
 import           Kore.Internal.MultiOr as MultiOr
 import           Kore.Internal.OrPattern
                  ( OrPattern )
-import qualified Kore.Internal.Pattern as Pattern
 import           Kore.Internal.TermLike
 import           Kore.Unparser
 
@@ -59,23 +57,3 @@ simplifyBuiltin =
         Domain.BuiltinBool bool -> (return . pure) (Domain.BuiltinBool bool)
         Domain.BuiltinString string ->
             (return . pure) (Domain.BuiltinString string)
-
-simplifyInternalMap
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    =>  Domain.InternalMap (TermLike Concrete) (OrPattern variable)
-    ->  MultiOr
-            (Conditional variable
-                (Domain.InternalMap (TermLike Concrete) (TermLike variable))
-            )
-simplifyInternalMap internalMapOrPattern = do
-    internalMapConditional <- sequence internalMapOrPattern
-    let conditionalInternalMap = sequenceA internalMapConditional
-        normalizedInternalMap =
-            fromMaybe
-                (`Conditional.andPredicate` makeFalsePredicate)
-                (traverse normalizeInternalMap conditionalInternalMap)
-    return (Domain.BuiltinMap <$> normalizedInternalMap)

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -43,6 +43,7 @@ test_internalize =
     , internalizes  "concatList(unit, element)"
         (concatList unitList (elementList y))
         (mkList [y])
+    , notInternalizes "l:List" (mkVar (varS "l" listSort))
 
     , internalizes  "unitMap"
         unitMap
@@ -62,6 +63,7 @@ test_internalize =
     , internalizes  "concatMap(unit, element)"
         (concatMap unitMap (elementMap one y))
         (mkMap [(one, y)])
+    , notInternalizes "m:Map" (mkVar (varS "m" mapSort))
 
     , internalizes  "unitSet"
         unitSet
@@ -81,18 +83,22 @@ test_internalize =
     , internalizes  "concatSet(unit, element)"
         (concatSet unitSet (elementSet one))
         (mkSet [one])
+    , notInternalizes "s:Set" (mkVar (varS "s" setSort))
     ]
   where
+    listSort = Builtin.listSort
     unitList = Builtin.unitList
     elementList = Builtin.elementList
     concatList = Builtin.concatList
     mkList = List.asInternal
 
+    mapSort = Builtin.mapSort
     unitMap = Builtin.unitMap
     elementMap = Builtin.elementMap
     concatMap = Builtin.concatMap
     mkMap = Map.asInternal . Data.Map.fromList
 
+    setSort = Builtin.setSort
     unitSet = Builtin.unitSet
     elementSet = Builtin.elementSet
     concatSet = Builtin.concatSet
@@ -124,6 +130,14 @@ internalizes
     -> TestTree
 internalizes name origin expect =
     withInternalized (assertEqual "" expect) name origin
+
+notInternalizes
+    :: GHC.HasCallStack
+    => TestName
+    -> TermLike Variable
+    -> TestTree
+notInternalizes name origin =
+    withInternalized (assertEqual "" origin) name origin
 
 metadata :: SmtMetadataTools Attribute.Symbol
 metadata = Builtin.testMetadataTools

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -4,6 +4,10 @@ module Test.Kore.Builtin
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import qualified Data.Map
+import           Prelude hiding
+                 ( concatMap )
+
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Kore
 import           Kore.IndexedModule.MetadataTools
@@ -14,6 +18,7 @@ import qualified Test.Kore.Builtin.Builtin as Builtin
 import qualified Test.Kore.Builtin.Definition as Builtin
 import qualified Test.Kore.Builtin.Int as Int
 import qualified Test.Kore.Builtin.List as List
+import qualified Test.Kore.Builtin.Map as Map
 
 test_internalize :: [TestTree]
 test_internalize =
@@ -21,27 +26,56 @@ test_internalize =
         unitList
         (mkList [])
     , internalizes  "elementList"
-        (elementList (mkInt 0))
-        (mkList [mkInt 0])
+        (elementList zero)
+        (mkList [zero])
     , internalizes  "concatList(internal, internal)"
-        (concatList (mkList [mkInt 0]) (mkList [mkInt 1]))
-        (mkList [mkInt 0, mkInt 1])
+        (concatList (mkList [zero]) (mkList [one]))
+        (mkList [zero, one])
     , internalizes  "concatList(element, element)"
-        (concatList (elementList (mkInt 0)) (elementList (mkInt 1)))
-        (mkList [mkInt 0, mkInt 1])
+        (concatList (elementList zero) (elementList one))
+        (mkList [zero, one])
     , internalizes  "concatList(element, unit)"
-        (concatList (elementList (mkInt 0)) unitList)
-        (mkList [mkInt 0])
+        (concatList (elementList zero) unitList)
+        (mkList [zero])
     , internalizes  "concatList(unit, element)"
-        (concatList unitList (elementList (mkInt 1)))
-        (mkList [mkInt 1])
+        (concatList unitList (elementList one))
+        (mkList [one])
+
+    , internalizes  "unitMap"
+        unitMap
+        (mkMap [])
+    , internalizes  "elementMap"
+        (elementMap zero one)
+        (mkMap [(zero, one)])
+    , internalizes  "concatMap(internal, internal)"
+        (concatMap (mkMap [(zero, one)]) (mkMap [(one, two)]))
+        (mkMap [(zero, one), (one, two)])
+    , internalizes  "concatMap(element, element)"
+        (concatMap (elementMap zero one) (elementMap one two))
+        (mkMap [(zero, one), (one, two)])
+    , internalizes  "concatMap(element, unit)"
+        (concatMap (elementMap zero one) unitMap)
+        (mkMap [(zero, one)])
+    , internalizes  "concatMap(unit, element)"
+        (concatMap unitMap (elementMap one two))
+        (mkMap [(one, two)])
     ]
   where
     unitList = Builtin.unitList
     elementList = Builtin.elementList
     concatList = Builtin.concatList
     mkList = List.asInternal
+    unitMap = Builtin.unitMap
+    elementMap = Builtin.elementMap
+    concatMap = Builtin.concatMap
+    mkMap = Map.asInternal . Data.Map.fromList
+
+    mkInt :: Ord variable => Integer -> TermLike variable
     mkInt = Int.asInternal
+    zero, one, two :: Ord variable => TermLike variable
+    zero = mkInt 0
+    one = mkInt 1
+    two = mkInt 2
 
 withInternalized
     :: (TermLike Variable -> Assertion)

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -1,0 +1,63 @@
+module Test.Kore.Builtin
+    ( test_internalize ) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Kore.Attribute.Symbol as Attribute
+import qualified Kore.Builtin as Kore
+import           Kore.IndexedModule.MetadataTools
+                 ( SmtMetadataTools )
+import           Kore.Internal.TermLike
+
+import qualified Test.Kore.Builtin.Builtin as Builtin
+import qualified Test.Kore.Builtin.Definition as Builtin
+import qualified Test.Kore.Builtin.Int as Int
+import qualified Test.Kore.Builtin.List as List
+
+test_internalize :: [TestTree]
+test_internalize =
+    [ internalizes  "unitList"
+        unitList
+        (mkList [])
+    , internalizes  "elementList"
+        (elementList (mkInt 0))
+        (mkList [mkInt 0])
+    , internalizes  "concatList(internal, internal)"
+        (concatList (mkList [mkInt 0]) (mkList [mkInt 1]))
+        (mkList [mkInt 0, mkInt 1])
+    , internalizes  "concatList(element, element)"
+        (concatList (elementList (mkInt 0)) (elementList (mkInt 1)))
+        (mkList [mkInt 0, mkInt 1])
+    , internalizes  "concatList(element, unit)"
+        (concatList (elementList (mkInt 0)) unitList)
+        (mkList [mkInt 0])
+    , internalizes  "concatList(unit, element)"
+        (concatList unitList (elementList (mkInt 1)))
+        (mkList [mkInt 1])
+    ]
+  where
+    unitList = Builtin.unitList
+    elementList = Builtin.elementList
+    concatList = Builtin.concatList
+    mkList = List.asInternal
+    mkInt = Int.asInternal
+
+withInternalized
+    :: (TermLike Variable -> Assertion)
+    -> TestName
+    -> TermLike Variable
+    -> TestTree
+withInternalized check name origin =
+    testCase name (check $ Kore.internalize metadata origin)
+
+internalizes
+    :: TestName
+    -> TermLike Variable
+    -> TermLike Variable
+    -> TestTree
+internalizes name origin expect =
+    withInternalized (assertEqual "" expect) name origin
+
+metadata :: SmtMetadataTools Attribute.Symbol
+metadata = Builtin.testMetadataTools

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import qualified Data.Map
+import qualified GHC.Stack as GHC
 import           Prelude hiding
                  ( concatMap )
 
@@ -26,7 +27,7 @@ test_internalize =
         unitList
         (mkList [])
     , internalizes  "elementList"
-        (elementList zero)
+        (elementList x)
         (mkList [x])
     , internalizes  "concatList(internal, internal)"
         (concatList (mkList [x]) (mkList [y]))
@@ -80,7 +81,8 @@ test_internalize =
     y = mkVar (varS "y" intSort)
 
 withInternalized
-    :: (TermLike Variable -> Assertion)
+    :: GHC.HasCallStack
+    => (TermLike Variable -> Assertion)
     -> TestName
     -> TermLike Variable
     -> TestTree
@@ -88,7 +90,8 @@ withInternalized check name origin =
     testCase name (check $ Kore.internalize metadata origin)
 
 internalizes
-    :: TestName
+    :: GHC.HasCallStack
+    => TestName
     -> TermLike Variable
     -> TermLike Variable
     -> TestTree

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import qualified Data.Map
+import qualified Data.Set
 import qualified GHC.Stack as GHC
 import           Prelude hiding
                  ( concatMap )
@@ -20,6 +21,7 @@ import qualified Test.Kore.Builtin.Definition as Builtin
 import qualified Test.Kore.Builtin.Int as Int
 import qualified Test.Kore.Builtin.List as List
 import qualified Test.Kore.Builtin.Map as Map
+import qualified Test.Kore.Builtin.Set as Set
 
 test_internalize :: [TestTree]
 test_internalize =
@@ -60,16 +62,41 @@ test_internalize =
     , internalizes  "concatMap(unit, element)"
         (concatMap unitMap (elementMap one y))
         (mkMap [(one, y)])
+
+    , internalizes  "unitSet"
+        unitSet
+        (mkSet [])
+    , internalizes  "elementSet"
+        (elementSet zero)
+        (mkSet [zero])
+    , internalizes  "concatSet(internal, internal)"
+        (concatSet (mkSet [zero]) (mkSet [one]))
+        (mkSet [zero, one])
+    , internalizes  "concatSet(element, element)"
+        (concatSet (elementSet zero) (elementSet one))
+        (mkSet [zero, one])
+    , internalizes  "concatSet(element, unit)"
+        (concatSet (elementSet zero) unitSet)
+        (mkSet [zero])
+    , internalizes  "concatSet(unit, element)"
+        (concatSet unitSet (elementSet one))
+        (mkSet [one])
     ]
   where
     unitList = Builtin.unitList
     elementList = Builtin.elementList
     concatList = Builtin.concatList
     mkList = List.asInternal
+
     unitMap = Builtin.unitMap
     elementMap = Builtin.elementMap
     concatMap = Builtin.concatMap
     mkMap = Map.asInternal . Data.Map.fromList
+
+    unitSet = Builtin.unitSet
+    elementSet = Builtin.elementSet
+    concatSet = Builtin.concatSet
+    mkSet = Set.asInternal . Data.Set.fromList
 
     mkInt :: Ord variable => Integer -> TermLike variable
     mkInt = Int.asInternal

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -27,38 +27,38 @@ test_internalize =
         (mkList [])
     , internalizes  "elementList"
         (elementList zero)
-        (mkList [zero])
+        (mkList [x])
     , internalizes  "concatList(internal, internal)"
-        (concatList (mkList [zero]) (mkList [one]))
-        (mkList [zero, one])
+        (concatList (mkList [x]) (mkList [y]))
+        (mkList [x, y])
     , internalizes  "concatList(element, element)"
-        (concatList (elementList zero) (elementList one))
-        (mkList [zero, one])
+        (concatList (elementList x) (elementList y))
+        (mkList [x, y])
     , internalizes  "concatList(element, unit)"
-        (concatList (elementList zero) unitList)
-        (mkList [zero])
+        (concatList (elementList x) unitList)
+        (mkList [x])
     , internalizes  "concatList(unit, element)"
-        (concatList unitList (elementList one))
-        (mkList [one])
+        (concatList unitList (elementList y))
+        (mkList [y])
 
     , internalizes  "unitMap"
         unitMap
         (mkMap [])
     , internalizes  "elementMap"
-        (elementMap zero one)
-        (mkMap [(zero, one)])
+        (elementMap zero x)
+        (mkMap [(zero, x)])
     , internalizes  "concatMap(internal, internal)"
-        (concatMap (mkMap [(zero, one)]) (mkMap [(one, two)]))
-        (mkMap [(zero, one), (one, two)])
+        (concatMap (mkMap [(zero, x)]) (mkMap [(one, y)]))
+        (mkMap [(zero, x), (one, y)])
     , internalizes  "concatMap(element, element)"
-        (concatMap (elementMap zero one) (elementMap one two))
-        (mkMap [(zero, one), (one, two)])
+        (concatMap (elementMap zero x) (elementMap one y))
+        (mkMap [(zero, x), (one, y)])
     , internalizes  "concatMap(element, unit)"
-        (concatMap (elementMap zero one) unitMap)
-        (mkMap [(zero, one)])
+        (concatMap (elementMap zero x) unitMap)
+        (mkMap [(zero, x)])
     , internalizes  "concatMap(unit, element)"
-        (concatMap unitMap (elementMap one two))
-        (mkMap [(one, two)])
+        (concatMap unitMap (elementMap one y))
+        (mkMap [(one, y)])
     ]
   where
     unitList = Builtin.unitList
@@ -72,10 +72,12 @@ test_internalize =
 
     mkInt :: Ord variable => Integer -> TermLike variable
     mkInt = Int.asInternal
-    zero, one, two :: Ord variable => TermLike variable
+    intSort = Builtin.intSort
+    zero, one :: Ord variable => TermLike variable
     zero = mkInt 0
     one = mkInt 1
-    two = mkInt 2
+    x = mkVar (varS "x" intSort)
+    y = mkVar (varS "y" intSort)
 
 withInternalized
     :: (TermLike Variable -> Assertion)

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -66,6 +66,8 @@ test_internalize =
         (concatMap unitMap (elementMap one y))
         (mkMap [(one, y)])
     , notInternalizes "m:Map" m
+    , internalizes "concatMap(m:Map, unit)" (concatMap m unitMap) m
+    , internalizes "concatMap(unit, m:Map)" (concatMap unitMap m) m
 
     , internalizes  "unitSet"
         unitSet

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -43,7 +43,9 @@ test_internalize =
     , internalizes  "concatList(unit, element)"
         (concatList unitList (elementList y))
         (mkList [y])
-    , notInternalizes "l:List" (mkVar (varS "l" listSort))
+    , notInternalizes "l:List" l
+    , internalizes "concatList(l:List, unit)" (concatList l unitList) l
+    , internalizes "concatList(unit, l:List)" (concatList unitList l) l
 
     , internalizes  "unitMap"
         unitMap
@@ -63,7 +65,7 @@ test_internalize =
     , internalizes  "concatMap(unit, element)"
         (concatMap unitMap (elementMap one y))
         (mkMap [(one, y)])
-    , notInternalizes "m:Map" (mkVar (varS "m" mapSort))
+    , notInternalizes "m:Map" m
 
     , internalizes  "unitSet"
         unitSet
@@ -83,7 +85,7 @@ test_internalize =
     , internalizes  "concatSet(unit, element)"
         (concatSet unitSet (elementSet one))
         (mkSet [one])
-    , notInternalizes "s:Set" (mkVar (varS "s" setSort))
+    , notInternalizes "s:Set" s
     ]
   where
     listSort = Builtin.listSort
@@ -91,18 +93,21 @@ test_internalize =
     elementList = Builtin.elementList
     concatList = Builtin.concatList
     mkList = List.asInternal
+    l = mkVar (varS "l" listSort)
 
     mapSort = Builtin.mapSort
     unitMap = Builtin.unitMap
     elementMap = Builtin.elementMap
     concatMap = Builtin.concatMap
     mkMap = Map.asInternal . Data.Map.fromList
+    m = mkVar (varS "m" mapSort)
 
     setSort = Builtin.setSort
     unitSet = Builtin.unitSet
     elementSet = Builtin.elementSet
     concatSet = Builtin.concatSet
     mkSet = Set.asInternal . Data.Set.fromList
+    s = mkVar (varS "s" setSort)
 
     mkInt :: Ord variable => Integer -> TermLike variable
     mkInt = Int.asInternal

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -88,6 +88,8 @@ test_internalize =
         (concatSet unitSet (elementSet one))
         (mkSet [one])
     , notInternalizes "s:Set" s
+    , internalizes "concatSet(s:Set, unit)" (concatSet s unitSet) s
+    , internalizes "concatSet(unit, s:Set)" (concatSet unitSet s) s
     ]
   where
     listSort = Builtin.listSort

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -435,6 +435,9 @@ elementSetSymbol =
     builtinSymbol "elementSet" setSort [intSort]
     & hook "SET.element" & functional
 
+elementSet :: TermLike Variable -> TermLike Variable
+elementSet x = mkApplySymbol elementSetSymbol [x]
+
 concatSetSymbol :: Internal.Symbol
 concatSetSymbol =
     binarySymbol "concatSet" setSort & hook "SET.concat" & functional

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -311,6 +311,9 @@ unitList = mkApplySymbol unitListSymbol []
 elementList :: TermLike Variable -> TermLike Variable
 elementList x = mkApplySymbol elementListSymbol [x]
 
+concatList :: TermLike Variable -> TermLike Variable -> TermLike Variable
+concatList x y = mkApplySymbol concatListSymbol [x, y]
+
 sizeList :: TermLike Variable -> TermLike Variable
 sizeList l = mkApplySymbol sizeListSymbol [l]
 

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -308,6 +308,9 @@ sizeListSymbol = builtinSymbol "sizeList" intSort [listSort] & hook "LIST.size"
 unitList :: TermLike Variable
 unitList = mkApplySymbol unitListSymbol []
 
+elementList :: TermLike Variable -> TermLike Variable
+elementList x = mkApplySymbol elementListSymbol [x]
+
 sizeList :: TermLike Variable -> TermLike Variable
 sizeList l = mkApplySymbol sizeListSymbol [l]
 

--- a/kore/test/Test/Kore/Builtin/List.hs
+++ b/kore/test/Test/Kore/Builtin/List.hs
@@ -155,26 +155,17 @@ test_simplify =
 test_isBuiltin :: [TestTree]
 test_isBuiltin =
     [ testCase "isSymbolConcat" $ do
-        assertBool ""
-            (List.isSymbolConcat mockHookTools Mock.concatListSymbol)
-        assertBool ""
-            (not (List.isSymbolConcat mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (List.isSymbolConcat mockHookTools Mock.elementListSymbol))
+        assertBool "" (List.isSymbolConcat Mock.concatListSymbol)
+        assertBool "" (not (List.isSymbolConcat Mock.aSymbol))
+        assertBool "" (not (List.isSymbolConcat Mock.elementListSymbol))
     , testCase "isSymbolElement" $ do
-        assertBool ""
-            (List.isSymbolElement mockHookTools Mock.elementListSymbol)
-        assertBool ""
-            (not (List.isSymbolElement mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (List.isSymbolElement mockHookTools Mock.concatListSymbol))
+        assertBool "" (List.isSymbolElement Mock.elementListSymbol)
+        assertBool "" (not (List.isSymbolElement Mock.aSymbol))
+        assertBool "" (not (List.isSymbolElement Mock.concatListSymbol))
     , testCase "isSymbolUnit" $ do
-        assertBool ""
-            (List.isSymbolUnit mockHookTools Mock.unitListSymbol)
-        assertBool ""
-            (not (List.isSymbolUnit mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (List.isSymbolUnit mockHookTools Mock.concatListSymbol))
+        assertBool "" (List.isSymbolUnit Mock.unitListSymbol)
+        assertBool "" (not (List.isSymbolUnit Mock.aSymbol))
+        assertBool "" (not (List.isSymbolUnit Mock.concatListSymbol))
     ]
 
 mockHookTools :: SmtMetadataTools Hook

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -403,26 +403,17 @@ test_symbolic =
 test_isBuiltin :: [TestTree]
 test_isBuiltin =
     [ testCase "isSymbolConcat" $ do
-        assertBool ""
-            (Map.isSymbolConcat mockHookTools Mock.concatMapSymbol)
-        assertBool ""
-            (not (Map.isSymbolConcat mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Map.isSymbolConcat mockHookTools Mock.elementMapSymbol))
+        assertBool "" (Map.isSymbolConcat Mock.concatMapSymbol)
+        assertBool "" (not (Map.isSymbolConcat Mock.aSymbol))
+        assertBool "" (not (Map.isSymbolConcat Mock.elementMapSymbol))
     , testCase "isSymbolElement" $ do
-        assertBool ""
-            (Map.isSymbolElement mockHookTools Mock.elementMapSymbol)
-        assertBool ""
-            (not (Map.isSymbolElement mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Map.isSymbolElement mockHookTools Mock.concatMapSymbol))
+        assertBool "" (Map.isSymbolElement Mock.elementMapSymbol)
+        assertBool "" (not (Map.isSymbolElement Mock.aSymbol))
+        assertBool "" (not (Map.isSymbolElement Mock.concatMapSymbol))
     , testCase "isSymbolUnit" $ do
-        assertBool ""
-            (Map.isSymbolUnit mockHookTools Mock.unitMapSymbol)
-        assertBool ""
-            (not (Map.isSymbolUnit mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Map.isSymbolUnit mockHookTools Mock.concatMapSymbol))
+        assertBool "" (Map.isSymbolUnit Mock.unitMapSymbol)
+        assertBool "" (not (Map.isSymbolUnit Mock.aSymbol))
+        assertBool "" (not (Map.isSymbolUnit Mock.concatMapSymbol))
     ]
 
 mockHookTools :: SmtMetadataTools Hook

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -682,7 +682,7 @@ test_unifyConcatElemVarVsElemSet =
 
             concreteElem <- forAll genConcreteIntegerPattern
             let set = asInternal (Set.fromList [concreteElem])
-                elementSet = asInternalNormalized
+                elementSet' = asInternalNormalized
                     $ emptyNormalizedSet
                     `with` VariableElement (mkVar elementVar2)
                 patSet = addSelectElement elementVar2 set
@@ -696,7 +696,7 @@ test_unifyConcatElemVarVsElemSet =
                 expect = do  -- list monad
                     (elemUnifier, setUnifier) <-
                         [ (mkVar elementVar2, set)
-                        , (elemStepPattern, elementSet)
+                        , (elemStepPattern, elementSet')
                         ]
                     return Conditional
                         { term = expectedPatSet

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -1546,26 +1546,17 @@ test_concretizeKeysAxiom =
 test_isBuiltin :: [TestTree]
 test_isBuiltin =
     [ testCase "isSymbolConcat" $ do
-        assertBool ""
-            (Set.isSymbolConcat mockHookTools Mock.concatSetSymbol)
-        assertBool ""
-            (not (Set.isSymbolConcat mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Set.isSymbolConcat mockHookTools Mock.elementSetSymbol))
+        assertBool "" (Set.isSymbolConcat Mock.concatSetSymbol)
+        assertBool "" (not (Set.isSymbolConcat Mock.aSymbol))
+        assertBool "" (not (Set.isSymbolConcat Mock.elementSetSymbol))
     , testCase "isSymbolElement" $ do
-        assertBool ""
-            (Set.isSymbolElement mockHookTools Mock.elementSetSymbol)
-        assertBool ""
-            (not (Set.isSymbolElement mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Set.isSymbolElement mockHookTools Mock.concatSetSymbol))
+        assertBool "" (Set.isSymbolElement Mock.elementSetSymbol)
+        assertBool "" (not (Set.isSymbolElement Mock.aSymbol))
+        assertBool "" (not (Set.isSymbolElement Mock.concatSetSymbol))
     , testCase "isSymbolUnit" $ do
-        assertBool ""
-            (Set.isSymbolUnit mockHookTools Mock.unitSetSymbol)
-        assertBool ""
-            (not (Set.isSymbolUnit mockHookTools Mock.aSymbol))
-        assertBool ""
-            (not (Set.isSymbolUnit mockHookTools Mock.concatSetSymbol))
+        assertBool "" (Set.isSymbolUnit Mock.unitSetSymbol)
+        assertBool "" (not (Set.isSymbolUnit Mock.aSymbol))
+        assertBool "" (not (Set.isSymbolUnit Mock.concatSetSymbol))
     ]
 
 hprop_unparse :: Property

--- a/kore/test/Test/Kore/Proof/Value.hs
+++ b/kore/test/Test/Kore/Proof/Value.hs
@@ -228,8 +228,8 @@ assertValue termLike =
   where
     concrete = asConcrete termLike
     roundTrip patt = do
-        value <- Value.fromConcreteStepPattern tools patt
-        return (Value.asConcreteStepPattern value)
+        value <- Value.fromTermLike patt
+        return (Value.asTermLike value)
 
 testValue :: GHC.HasCallStack => TestName -> TermLike Variable -> TestTree
 testValue name = testCase name . assertValue
@@ -238,7 +238,7 @@ assertNotValue :: GHC.HasCallStack => TermLike Variable -> Assertion
 assertNotValue purePattern =
     assertEqual "Unexpected normalized pattern"
         Nothing
-        (concretePattern >>= Value.fromConcreteStepPattern tools)
+        (concretePattern >>= Value.fromTermLike)
   where
     concretePattern = asConcrete purePattern
 

--- a/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -448,7 +448,7 @@ test_builtinEvaluation =
     , testCase "Failed evaluation"
         (assertErrorIO
             (assertSubstring ""
-                "Expecting hook MAP.unit to reduce concrete pattern"
+                "Expecting hook 'MAP.unit' to reduce concrete pattern"
             )
             (evaluate
                 (builtinEvaluation failingEvaluator)


### PR DESCRIPTION
This pull request adds `Kore.Builtin.internalize` which converts external syntax to internal representations. This function is _not_ yet used by default during execution because of the need to re-normalized the builtin associative-commutative representations. I will deal with that in a subsequent pull request.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

