### PR TITLE
Cleanup: Uniform-ish representation of syntax nodes

### DIFF
--- a/kore/src/Kore/AST/AstWithLocation.hs
+++ b/kore/src/Kore/AST/AstWithLocation.hs
@@ -119,7 +119,7 @@ instance
             CharLiteralF _ -> AstLocationUnknown
             TopF Top { topSort } -> locationFromAst topSort
             VariableF variable -> locationFromAst variable
-            InhabitantF s -> locationFromAst s
+            InhabitantF Inhabitant { inhSort } -> locationFromAst inhSort
             SetVariableF (SetVariable variable) ->
                 locationFromAst variable
 

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -350,8 +350,7 @@ verifyPatternHead (_ :< patternF) =
         Syntax.RewritesF rewrites ->
             transCofreeF Internal.RewritesF <$> verifyRewrites rewrites
         Syntax.StringLiteralF str ->
-            transCofreeF (Internal.StringLiteralF . getConst)
-                <$> verifyStringLiteral str
+            transCofreeF Internal.StringLiteralF <$> verifyStringLiteral str
         Syntax.CharLiteralF char ->
             transCofreeF (Internal.CharLiteralF . getConst)
                 <$> verifyCharLiteral char
@@ -717,12 +716,12 @@ verifyDomainValue domain = do
     return (attrs :< verified)
 
 verifyStringLiteral
-    :: (base ~ Const StringLiteral, valid ~ Attribute.Pattern Variable)
-    => StringLiteral
-    -> PatternVerifier (CofreeF base valid Verified.Pattern)
+    :: valid ~ Attribute.Pattern Variable
+    => StringLiteral (PatternVerifier Verified.Pattern)
+    -> PatternVerifier (CofreeF StringLiteral valid Verified.Pattern)
 verifyStringLiteral str = do
-    let verified = Const str
-        attrs = synthetic (Internal.extractAttributes <$> verified)
+    verified <- sequence str
+    let attrs = synthetic (Internal.extractAttributes <$> verified)
     return (attrs :< verified)
 
 verifyCharLiteral

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -352,8 +352,7 @@ verifyPatternHead (_ :< patternF) =
         Syntax.StringLiteralF str ->
             transCofreeF Internal.StringLiteralF <$> verifyStringLiteral str
         Syntax.CharLiteralF char ->
-            transCofreeF (Internal.CharLiteralF . getConst)
-                <$> verifyCharLiteral char
+            transCofreeF Internal.CharLiteralF <$> verifyCharLiteral char
         Syntax.TopF top ->
             transCofreeF Internal.TopF <$> verifyTop top
         Syntax.VariableF var ->
@@ -725,12 +724,12 @@ verifyStringLiteral str = do
     return (attrs :< verified)
 
 verifyCharLiteral
-    :: (base ~ Const CharLiteral, valid ~ Attribute.Pattern Variable)
-    => CharLiteral
-    -> PatternVerifier (CofreeF base valid Verified.Pattern)
+    :: valid ~ Attribute.Pattern Variable
+    => CharLiteral (PatternVerifier Verified.Pattern)
+    -> PatternVerifier (CofreeF CharLiteral valid Verified.Pattern)
 verifyCharLiteral char = do
-    let verified = Const char
-        attrs = synthetic (Internal.extractAttributes <$> verified)
+    verified <- sequence char
+    let attrs = synthetic (Internal.extractAttributes <$> verified)
     return (attrs :< verified)
 
 verifyVariableDeclaration :: Variable -> PatternVerifier VerifySuccess

--- a/kore/src/Kore/Attribute/Parser.hs
+++ b/kore/src/Kore/Attribute/Parser.hs
@@ -258,7 +258,7 @@ getSymbolOrAlias kore =
 
 {- | Accept a string literal.
  -}
-getStringLiteral :: AttributePattern -> Parser StringLiteral
+getStringLiteral :: AttributePattern -> Parser (StringLiteral AttributePattern)
 getStringLiteral kore =
     case Recursive.project kore of
         _ :< StringLiteralF lit -> return lit
@@ -291,7 +291,7 @@ parseReadS aReadS (Text.unpack -> syntax) =
 
 {- | Parse an 'Integer' from a 'StringLiteral'.
  -}
-parseInteger :: StringLiteral -> Parser Integer
+parseInteger :: StringLiteral child -> Parser Integer
 parseInteger (StringLiteral literal) = parseReadS reads literal
 
 {- | Parse an 'SExpr' for the @smtlib@ attribute.

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -171,7 +171,7 @@ instance Synthetic (Top sort) Defined where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Defined'.
-instance Synthetic (Const StringLiteral) Defined where
+instance Synthetic StringLiteral Defined where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -176,7 +176,7 @@ instance Synthetic StringLiteral Defined where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Defined'.
-instance Synthetic (Const CharLiteral) Defined where
+instance Synthetic CharLiteral Defined where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -180,6 +180,11 @@ instance Synthetic CharLiteral Defined where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
+-- | An 'Inhabitant' pattern is always 'Defined'.
+instance Synthetic Inhabitant Defined where
+    synthetic = const (Defined True)
+    {-# INLINE synthetic #-}
+
 -- | A 'Variable' pattern is always 'Defined'.
 instance Synthetic (Const Variable) Defined where
     synthetic = const (Defined True)

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -139,7 +139,7 @@ instance Synthetic StringLiteral Function where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Function'.
-instance Synthetic (Const CharLiteral) Function where
+instance Synthetic CharLiteral Function where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -134,7 +134,7 @@ instance Synthetic (Top sort) Function where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Function'.
-instance Synthetic (Const StringLiteral) Function where
+instance Synthetic StringLiteral Function where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -143,6 +143,11 @@ instance Synthetic CharLiteral Function where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 
+-- | An 'Inhabitant' pattern is never 'Function'.
+instance Synthetic Inhabitant Function where
+    synthetic = const (Function False)
+    {-# INLINE synthetic #-}
+
 -- | A 'Variable' pattern is always 'Function'.
 instance Synthetic (Const Variable) Function where
     synthetic = const (Function True)

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -177,7 +177,7 @@ instance Synthetic StringLiteral Functional where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Functional'.
-instance Synthetic (Const CharLiteral) Functional where
+instance Synthetic CharLiteral Functional where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -172,7 +172,7 @@ instance Synthetic (Const Variable) Functional where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Functional'.
-instance Synthetic (Const StringLiteral) Functional where
+instance Synthetic StringLiteral Functional where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -181,6 +181,11 @@ instance Synthetic CharLiteral Functional where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 
+-- | An 'Inhabitant' pattern is never 'Functional'.
+instance Synthetic Inhabitant Functional where
+    synthetic = const (Functional False)
+    {-# INLINE synthetic #-}
+
 instance Synthetic (Const Sort) Functional where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -55,6 +55,8 @@ import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
+import Kore.Attribute.Pattern.FreeSetVariables
+import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Domain.Class
@@ -648,6 +650,17 @@ builtinSort builtin =
 
 instance Synthetic (Builtin key) Sort where
     synthetic = builtinSort
+    {-# INLINE synthetic #-}
+
+instance Ord variable => Synthetic (Builtin key) (FreeVariables variable) where
+    synthetic = Foldable.fold
+    {-# INLINE synthetic #-}
+
+instance
+    Ord variable
+    => Synthetic (Builtin key) (FreeSetVariables variable)
+  where
+    synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
 instance Domain (Builtin key) where

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -273,7 +273,7 @@ data TermLikeF variable child
     | NuF            !(Nu variable child)
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
-    | StringLiteralF !StringLiteral
+    | StringLiteralF !(StringLiteral child)
     | CharLiteralF   !CharLiteral
     | TopF           !(Top Sort child)
     | VariableF      !variable
@@ -331,7 +331,7 @@ instance
     synthetic (BuiltinF builtinF) = Foldable.fold builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF stringLiteral) = synthetic (Const stringLiteral)
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
     synthetic (InhabitantF _) = mempty
 
@@ -369,7 +369,7 @@ instance
     synthetic (BuiltinF builtinF) = Foldable.fold builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF stringLiteral) = synthetic (Const stringLiteral)
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
     synthetic (InhabitantF _) = mempty
 
@@ -404,7 +404,7 @@ instance SortedVariable variable => Synthetic (TermLikeF variable) Sort where
     synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF stringLiteral) = synthetic (Const stringLiteral)
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
     synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
 
@@ -440,7 +440,7 @@ instance Synthetic (TermLikeF variable) Pattern.Functional where
     synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF stringLiteral) = synthetic (Const stringLiteral)
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
     synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
 
@@ -475,7 +475,7 @@ instance Synthetic (TermLikeF variable) Pattern.Function where
     synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF _) = Pattern.Function True
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF _) = Pattern.Function True
     synthetic (InhabitantF _) = Pattern.Function False
 
@@ -510,7 +510,7 @@ instance Synthetic (TermLikeF variable) Pattern.Defined where
     synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
-    synthetic (StringLiteralF _) = Pattern.Defined True
+    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF _) = Pattern.Defined True
     synthetic (InhabitantF _) = Pattern.Defined True
 

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -330,7 +330,7 @@ instance
     synthetic (OrF orF) = synthetic orF
     synthetic (RewritesF rewritesF) = synthetic rewritesF
     synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = Foldable.fold builtinF
+    synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
@@ -368,7 +368,7 @@ instance
     synthetic (OrF orF) = synthetic orF
     synthetic (RewritesF rewritesF) = synthetic rewritesF
     synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = Foldable.fold builtinF
+    synthetic (BuiltinF builtinF) = synthetic builtinF
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -125,6 +125,7 @@ module Kore.Internal.TermLike
     , module Kore.Syntax.Iff
     , module Kore.Syntax.Implies
     , module Kore.Syntax.In
+    , module Kore.Syntax.Inhabitant
     , module Kore.Syntax.Mu
     , module Kore.Syntax.Next
     , module Kore.Syntax.Not
@@ -203,6 +204,7 @@ import           Kore.Syntax.Id
 import           Kore.Syntax.Iff
 import           Kore.Syntax.Implies
 import           Kore.Syntax.In
+import           Kore.Syntax.Inhabitant
 import           Kore.Syntax.Mu
 import           Kore.Syntax.Next
 import           Kore.Syntax.Not
@@ -277,7 +279,7 @@ data TermLikeF variable child
     | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
     | VariableF      !variable
-    | InhabitantF    !Sort
+    | InhabitantF    !(Inhabitant child)
     | SetVariableF   !(SetVariable variable)
     | BuiltinF       !(Builtin child)
     | EvaluatedF     !(Evaluated child)
@@ -333,7 +335,7 @@ instance
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF _) = mempty
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -371,7 +373,7 @@ instance
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF _) = mempty
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -406,7 +408,7 @@ instance SortedVariable variable => Synthetic (TermLikeF variable) Sort where
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -442,7 +444,7 @@ instance Synthetic (TermLikeF variable) Pattern.Functional where
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -477,7 +479,7 @@ instance Synthetic (TermLikeF variable) Pattern.Function where
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF _) = Pattern.Function False
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -512,7 +514,7 @@ instance Synthetic (TermLikeF variable) Pattern.Defined where
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
     synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF _) = Pattern.Defined True
+    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
 
     synthetic (MuF muF) = synthetic muF
     synthetic (NuF nuF) = synthetic nuF
@@ -1731,7 +1733,7 @@ mkInhabitant
     :: (Ord variable, SortedVariable variable)
     => Sort
     -> TermLike variable
-mkInhabitant = synthesize . InhabitantF
+mkInhabitant = synthesize . InhabitantF . Inhabitant
 
 mkEvaluated
     :: (Ord variable, SortedVariable variable)

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -274,7 +274,7 @@ data TermLikeF variable child
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
     | StringLiteralF !(StringLiteral child)
-    | CharLiteralF   !CharLiteral
+    | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
     | VariableF      !variable
     | InhabitantF    !Sort
@@ -332,7 +332,7 @@ instance
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF _) = mempty
 
     synthetic (MuF muF) = synthetic muF
@@ -370,7 +370,7 @@ instance
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF _) = mempty
 
     synthetic (MuF muF) = synthetic muF
@@ -405,7 +405,7 @@ instance SortedVariable variable => Synthetic (TermLikeF variable) Sort where
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
 
     synthetic (MuF muF) = synthetic muF
@@ -441,7 +441,7 @@ instance Synthetic (TermLikeF variable) Pattern.Functional where
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteral) = synthetic (Const charLiteral)
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF inhSort) = synthetic (Const inhSort)
 
     synthetic (MuF muF) = synthetic muF
@@ -476,7 +476,7 @@ instance Synthetic (TermLikeF variable) Pattern.Function where
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF _) = Pattern.Function True
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF _) = Pattern.Function False
 
     synthetic (MuF muF) = synthetic muF
@@ -511,7 +511,7 @@ instance Synthetic (TermLikeF variable) Pattern.Defined where
     synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
 
     synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF _) = Pattern.Defined True
+    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
     synthetic (InhabitantF _) = Pattern.Defined True
 
     synthetic (MuF muF) = synthetic muF

--- a/kore/src/Kore/Parser/Lexeme.hs
+++ b/kore/src/Kore/Parser/Lexeme.hs
@@ -108,7 +108,7 @@ idParser = do
 
 Always starts with @"@.
 -} {- " -}
-stringLiteralParser :: Parser StringLiteral
+stringLiteralParser :: Parser (StringLiteral child)
 stringLiteralParser = lexeme stringLiteralRawParser
 
 {-|'charLiteralParser' parses a C-style char literal, unescaping it.
@@ -245,7 +245,7 @@ setVarIdRawParser = do
 @stringLiteralRawParser@ does not consume whitespace.
 
  -}
-stringLiteralRawParser :: Parser StringLiteral
+stringLiteralRawParser :: Parser (StringLiteral child)
 stringLiteralRawParser = do
     skipChar '"'
     StringLiteral . Text.pack <$> Parser.manyTill charParser (skipChar '"')

--- a/kore/src/Kore/Parser/Lexeme.hs
+++ b/kore/src/Kore/Parser/Lexeme.hs
@@ -115,7 +115,7 @@ stringLiteralParser = lexeme stringLiteralRawParser
 
 Always starts with @'@.
 -}
-charLiteralParser :: Parser CharLiteral
+charLiteralParser :: Parser (CharLiteral child)
 charLiteralParser = lexeme charLiteralRawParser
 
 {-|'moduleNameParser' parses a module name.-}
@@ -255,7 +255,7 @@ stringLiteralRawParser = do
 @charLiteralRawParser@ does not consume whitespace.
 
  -}
-charLiteralRawParser :: Parser CharLiteral
+charLiteralRawParser :: Parser (CharLiteral child)
 charLiteralRawParser = do
     skipChar '\''
     c <- charParser

--- a/kore/src/Kore/Proof/Functional.hs
+++ b/kore/src/Kore/Proof/Functional.hs
@@ -48,7 +48,7 @@ data FunctionalProof variable
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
     | FunctionalStringLiteral (StringLiteral ())
     -- ^A string literal is the repeated application of functional constructors.
-    | FunctionalCharLiteral CharLiteral
+    | FunctionalCharLiteral (CharLiteral ())
     -- ^A char literal is a functional constructor without arguments.
   deriving Generic
 

--- a/kore/src/Kore/Proof/Functional.hs
+++ b/kore/src/Kore/Proof/Functional.hs
@@ -46,7 +46,7 @@ data FunctionalProof variable
     | FunctionalHead Symbol
     -- ^Head of a total function, conforming to Definition 5.21
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
-    | FunctionalStringLiteral StringLiteral
+    | FunctionalStringLiteral (StringLiteral ())
     -- ^A string literal is the repeated application of functional constructors.
     | FunctionalCharLiteral CharLiteral
     -- ^A char literal is a functional constructor without arguments.

--- a/kore/src/Kore/Proof/Value.hs
+++ b/kore/src/Kore/Proof/Value.hs
@@ -52,7 +52,7 @@ data ValueF child
     | DomainValue !(Syntax.DomainValue Sort child)
     | Builtin !(Domain.Builtin (TermLike Concrete) child)
     | StringLiteral !(StringLiteral child)
-    | CharLiteral !CharLiteral
+    | CharLiteral !(CharLiteral child)
     deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
 
 newtype Value =
@@ -125,7 +125,7 @@ fromPattern (attrs :< termLikeF) =
             -- representations only.
             Builtin <$> sequence builtinP
         StringLiteralF stringL -> StringLiteral <$> sequence stringL
-        CharLiteralF charL -> Just (CharLiteral charL)
+        CharLiteralF charL -> CharLiteral <$> sequence charL
         _ -> Nothing
 
 {- | View a 'ConcreteStepPattern' as a normalized value.

--- a/kore/src/Kore/Proof/Value.hs
+++ b/kore/src/Kore/Proof/Value.hs
@@ -51,7 +51,7 @@ data ValueF child
     | SortInjection !(Syntax.Application Symbol child)
     | DomainValue !(Syntax.DomainValue Sort child)
     | Builtin !(Domain.Builtin (TermLike Concrete) child)
-    | StringLiteral !StringLiteral
+    | StringLiteral !(StringLiteral child)
     | CharLiteral !CharLiteral
     deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
 
@@ -124,7 +124,7 @@ fromPattern (attrs :< termLikeF) =
             -- BuiltinPattern and always run the stepper with internal
             -- representations only.
             Builtin <$> sequence builtinP
-        StringLiteralF stringL -> Just (StringLiteral stringL)
+        StringLiteralF stringL -> StringLiteral <$> sequence stringL
         CharLiteralF charL -> Just (CharLiteral charL)
         _ -> Nothing
 

--- a/kore/src/Kore/Step/PatternAttributes.hs
+++ b/kore/src/Kore/Step/PatternAttributes.hs
@@ -87,9 +87,9 @@ isPreconstructedPattern err (_ :< pattern') =
         BuiltinF domain ->
             (Right . Descend) (FunctionalBuiltin $ () <$ domain)
         StringLiteralF str ->
-            Right (DoNotDescend (FunctionalStringLiteral $ () <$ str))
+            Right $ DoNotDescend $ FunctionalStringLiteral $ () <$ str
         CharLiteralF char ->
-            Right (DoNotDescend (FunctionalCharLiteral char))
+            Right $ DoNotDescend $ FunctionalCharLiteral $ () <$ char
         _ -> Left err
 
 {-|@isConstructorLikeTop@ checks whether the given 'Pattern' is topped in a

--- a/kore/src/Kore/Step/PatternAttributes.hs
+++ b/kore/src/Kore/Step/PatternAttributes.hs
@@ -87,7 +87,7 @@ isPreconstructedPattern err (_ :< pattern') =
         BuiltinF domain ->
             (Right . Descend) (FunctionalBuiltin $ () <$ domain)
         StringLiteralF str ->
-            Right (DoNotDescend (FunctionalStringLiteral str))
+            Right (DoNotDescend (FunctionalStringLiteral $ () <$ str))
         CharLiteralF char ->
             Right (DoNotDescend (FunctionalCharLiteral char))
         _ -> Left err

--- a/kore/src/Kore/Step/Simplification/CharLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/CharLiteral.hs
@@ -22,7 +22,7 @@ an or containing a term made of that literal.
 -}
 simplify
     :: (Ord variable, SortedVariable variable)
-    => CharLiteral
+    => CharLiteral (OrPattern variable)
     -> OrPattern variable
 simplify (CharLiteral char) =
     OrPattern.fromPattern $ Pattern.fromTermLike $ mkCharLiteral char

--- a/kore/src/Kore/Step/Simplification/Inhabitant.hs
+++ b/kore/src/Kore/Step/Simplification/Inhabitant.hs
@@ -17,6 +17,6 @@ an or containing a term made of that literal.
 -}
 simplify
     :: (Ord variable, SortedVariable variable)
-    => Sort
+    => Inhabitant (OrPattern variable)
     -> OrPattern variable
-simplify s = OrPattern.fromTermLike $ mkInhabitant s
+simplify Inhabitant { inhSort } = OrPattern.fromTermLike $ mkInhabitant inhSort

--- a/kore/src/Kore/Step/Simplification/StringLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/StringLiteral.hs
@@ -21,7 +21,7 @@ an or containing a term made of that literal.
 -}
 simplify
     :: (Ord variable, SortedVariable variable)
-    => StringLiteral
+    => StringLiteral (OrPattern variable)
     -> OrPattern variable
 simplify (StringLiteral str) =
     OrPattern.fromTermLike $ mkStringLiteral str

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -166,11 +166,11 @@ simplifyInternal = simplifyInternalWorker
                 Rewrites.simplify <$> simplifyChildren rewritesF
             StringLiteralF stringLiteralF ->
                 StringLiteral.simplify <$> simplifyChildren stringLiteralF
+            CharLiteralF charLiteralF ->
+                CharLiteral.simplify <$> simplifyChildren charLiteralF
             TopF topF -> Top.simplify <$> simplifyChildren topF
             --
             InhabitantF inhF -> return $ Inhabitant.simplify inhF
-            CharLiteralF charLiteralF ->
-                return $ CharLiteral.simplify charLiteralF
             VariableF variableF -> return $ Variable.simplify variableF
             SetVariableF setVariableF ->
                 return $ SetVariable.simplify setVariableF

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -157,6 +157,7 @@ simplifyInternal = simplifyInternalWorker
                 DomainValue.simplify <$> simplifyChildren domainValueF
             FloorF floorF -> Floor.simplify <$> simplifyChildren floorF
             ForallF forallF -> Forall.simplify <$> simplifyChildren forallF
+            InhabitantF inhF -> Inhabitant.simplify <$> simplifyChildren inhF
             MuF muF -> Mu.simplify <$> simplifyChildren muF
             NuF nuF -> Nu.simplify <$> simplifyChildren nuF
             -- TODO(virgil): Move next up through patterns.
@@ -170,7 +171,6 @@ simplifyInternal = simplifyInternalWorker
                 CharLiteral.simplify <$> simplifyChildren charLiteralF
             TopF topF -> Top.simplify <$> simplifyChildren topF
             --
-            InhabitantF inhF -> return $ Inhabitant.simplify inhF
             VariableF variableF -> return $ Variable.simplify variableF
             SetVariableF setVariableF ->
                 return $ SetVariable.simplify setVariableF

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -164,11 +164,11 @@ simplifyInternal = simplifyInternalWorker
             OrF orF -> Or.simplify <$> simplifyChildren orF
             RewritesF rewritesF ->
                 Rewrites.simplify <$> simplifyChildren rewritesF
+            StringLiteralF stringLiteralF ->
+                StringLiteral.simplify <$> simplifyChildren stringLiteralF
             TopF topF -> Top.simplify <$> simplifyChildren topF
             --
             InhabitantF inhF -> return $ Inhabitant.simplify inhF
-            StringLiteralF stringLiteralF ->
-                return $ StringLiteral.simplify stringLiteralF
             CharLiteralF charLiteralF ->
                 return $ CharLiteral.simplify charLiteralF
             VariableF variableF -> return $ Variable.simplify variableF

--- a/kore/src/Kore/Syntax.hs
+++ b/kore/src/Kore/Syntax.hs
@@ -19,6 +19,7 @@ module Kore.Syntax
     , module Kore.Syntax.Iff
     , module Kore.Syntax.Implies
     , module Kore.Syntax.In
+    , module Kore.Syntax.Inhabitant
     , module Kore.Syntax.Mu
     , module Kore.Syntax.Next
     , module Kore.Syntax.Not
@@ -48,6 +49,7 @@ import Kore.Syntax.Forall
 import Kore.Syntax.Iff
 import Kore.Syntax.Implies
 import Kore.Syntax.In
+import Kore.Syntax.Inhabitant
 import Kore.Syntax.Mu
 import Kore.Syntax.Next
 import Kore.Syntax.Not

--- a/kore/src/Kore/Syntax/CharLiteral.hs
+++ b/kore/src/Kore/Syntax/CharLiteral.hs
@@ -10,7 +10,6 @@ module Kore.Syntax.CharLiteral
 
 import           Control.DeepSeq
                  ( NFData (..) )
-import           Data.Functor.Const
 import           Data.Hashable
 import           Data.String
                  ( fromString )
@@ -30,37 +29,37 @@ import Kore.Unparser
 {-|'CharLiteral' corresponds to the @char@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype CharLiteral = CharLiteral { getCharLiteral :: Char }
-    deriving (Show, Eq, Ord, GHC.Generic)
+newtype CharLiteral child = CharLiteral { getCharLiteral :: Char }
+    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-instance Hashable CharLiteral
+instance Hashable (CharLiteral child)
 
-instance NFData CharLiteral
+instance NFData (CharLiteral child)
 
-instance SOP.Generic CharLiteral
+instance SOP.Generic (CharLiteral child)
 
-instance SOP.HasDatatypeInfo CharLiteral
+instance SOP.HasDatatypeInfo (CharLiteral child)
 
-instance Debug CharLiteral
+instance Debug (CharLiteral child)
 
-instance Unparse CharLiteral where
+instance Unparse (CharLiteral child) where
     unparse = Pretty.squotes . fromString . escapeChar . getCharLiteral
     unparse2 = unparse
 
 instance
     Ord variable =>
-    Synthetic (Const CharLiteral) (FreeVariables variable)
+    Synthetic CharLiteral (FreeVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
 instance
     Ord variable =>
-    Synthetic (Const CharLiteral) (FreeSetVariables variable)
+    Synthetic CharLiteral (FreeSetVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Const CharLiteral) Sort where
+instance Synthetic CharLiteral Sort where
     synthetic = const charMetaSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Inhabitant.hs
+++ b/kore/src/Kore/Syntax/Inhabitant.hs
@@ -1,0 +1,60 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+
+module Kore.Syntax.Inhabitant
+    ( Inhabitant (..)
+    ) where
+
+import           Control.DeepSeq
+                 ( NFData (..) )
+import           Data.Hashable
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Attribute.Pattern.FreeSetVariables
+       ( FreeSetVariables )
+import Kore.Attribute.Pattern.FreeVariables
+       ( FreeVariables )
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Sort
+import Kore.Unparser
+
+-- | 'Inhabitant' symbolizes the inhabitants of a sort.
+data Inhabitant child = Inhabitant { inhSort :: !Sort }
+    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+
+instance Hashable (Inhabitant child)
+
+instance NFData (Inhabitant child)
+
+instance SOP.Generic (Inhabitant child)
+
+instance SOP.HasDatatypeInfo (Inhabitant child)
+
+instance Debug (Inhabitant child)
+
+instance Unparse (Inhabitant child) where
+    unparse = unparse . inhSort
+    unparse2 = unparse2 . inhSort
+
+instance
+    Ord variable =>
+    Synthetic Inhabitant (FreeVariables variable)
+  where
+    synthetic = const mempty
+    {-# INLINE synthetic #-}
+
+instance
+    Ord variable =>
+    Synthetic Inhabitant (FreeSetVariables variable)
+  where
+    synthetic = const mempty
+    {-# INLINE synthetic #-}
+
+instance Synthetic Inhabitant Sort where
+    synthetic = inhSort
+    {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -73,7 +73,7 @@ data PatternF variable child
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
     | StringLiteralF !(StringLiteral child)
-    | CharLiteralF   !CharLiteral
+    | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
     | VariableF      !variable
     | InhabitantF    !Sort

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -72,7 +72,7 @@ data PatternF variable child
     | NuF            !(Nu variable child)
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
-    | StringLiteralF !StringLiteral
+    | StringLiteralF !(StringLiteral child)
     | CharLiteralF   !CharLiteral
     | TopF           !(Top Sort child)
     | VariableF      !variable

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -38,6 +38,7 @@ import Kore.Syntax.Forall
 import Kore.Syntax.Iff
 import Kore.Syntax.Implies
 import Kore.Syntax.In
+import Kore.Syntax.Inhabitant
 import Kore.Syntax.Mu
 import Kore.Syntax.Next
 import Kore.Syntax.Not
@@ -76,7 +77,7 @@ data PatternF variable child
     | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
     | VariableF      !variable
-    | InhabitantF    !Sort
+    | InhabitantF    !(Inhabitant child)
     | SetVariableF   !(SetVariable variable)
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 

--- a/kore/src/Kore/Syntax/StringLiteral.hs
+++ b/kore/src/Kore/Syntax/StringLiteral.hs
@@ -10,7 +10,6 @@ module Kore.Syntax.StringLiteral
 
 import           Control.DeepSeq
                  ( NFData (..) )
-import           Data.Functor.Const
 import           Data.Hashable
 import           Data.Text
                  ( Text )
@@ -30,37 +29,37 @@ import Kore.Unparser
 {-|'StringLiteral' corresponds to the @string@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype StringLiteral = StringLiteral { getStringLiteral :: Text }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype StringLiteral child = StringLiteral { getStringLiteral :: Text }
+    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-instance Hashable StringLiteral
+instance Hashable (StringLiteral child)
 
-instance NFData StringLiteral
+instance NFData (StringLiteral child)
 
-instance SOP.Generic StringLiteral
+instance SOP.Generic (StringLiteral child)
 
-instance SOP.HasDatatypeInfo StringLiteral
+instance SOP.HasDatatypeInfo (StringLiteral child)
 
-instance Debug StringLiteral
+instance Debug (StringLiteral child)
 
-instance Unparse StringLiteral where
+instance Unparse (StringLiteral child) where
     unparse = Pretty.dquotes . Pretty.pretty . escapeStringT . getStringLiteral
     unparse2 = unparse
 
 instance
-    Ord variable =>
-    Synthetic (Const StringLiteral) (FreeVariables variable)
+    Ord variable
+    => Synthetic StringLiteral (FreeVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
 instance
-    Ord variable =>
-    Synthetic (Const StringLiteral) (FreeSetVariables variable)
+    Ord variable
+    => Synthetic StringLiteral (FreeSetVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Const StringLiteral) Sort where
+instance Synthetic StringLiteral Sort where
     synthetic = const stringMetaSort
     {-# INLINE synthetic #-}

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -120,7 +120,7 @@ stringLiteralGen :: MonadGen m => m (StringLiteral child)
 stringLiteralGen =
     StringLiteral <$> Gen.text (Range.linear 0 256) charGen
 
-charLiteralGen :: MonadGen m => m CharLiteral
+charLiteralGen :: MonadGen m => m (CharLiteral child)
 charLiteralGen = CharLiteral <$> charGen
 
 charGen :: MonadGen m => m Char

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -116,7 +116,7 @@ objectIdGen =
         (Gen.element idFirstChars)
         (Gen.element $ idFirstChars ++ idOtherChars)
 
-stringLiteralGen :: MonadGen m => m StringLiteral
+stringLiteralGen :: MonadGen m => m (StringLiteral child)
 stringLiteralGen =
     StringLiteral <$> Gen.text (Range.linear 0 256) charGen
 

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -788,10 +788,10 @@ instance EqualWithExplanation (StringLiteral child) where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 
-instance EqualWithExplanation CharLiteral
-  where
+instance EqualWithExplanation (CharLiteral child) where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
+
 instance
     (EqualWithExplanation child, Eq child, Show child)
     => EqualWithExplanation (Top Sort child)

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -816,6 +816,15 @@ instance
     compareWithExplanation = wrapperCompareWithExplanation
     printWithExplanation = show
 
+instance StructEqualWithExplanation (Inhabitant child) where
+    structFieldsWithNames expected@(Inhabitant _) actual =
+        [ Function.on (EqWrap "inhSort = ") inhSort expected actual ]
+    structConstructorName _ = "Inhabitant"
+
+instance EqualWithExplanation (Inhabitant child) where
+    compareWithExplanation = structCompareWithExplanation
+    printWithExplanation = show
+
 instance StructEqualWithExplanation Variable where
     structFieldsWithNames
         expected@(Variable _ _ _)

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -783,10 +783,11 @@ instance
   where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
-instance EqualWithExplanation StringLiteral
-  where
+
+instance EqualWithExplanation (StringLiteral child) where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
+
 instance EqualWithExplanation CharLiteral
   where
     compareWithExplanation = rawCompareWithExplanation

--- a/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
+++ b/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
@@ -26,5 +26,5 @@ test_charLiteralSimplification =
         )
     ]
 
-evaluate :: CharLiteral -> OrPattern Variable
+evaluate :: CharLiteral (OrPattern Variable) -> OrPattern Variable
 evaluate = simplify

--- a/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
+++ b/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
@@ -39,5 +39,5 @@ test_stringLiteralSimplification =
         )
     ]
 
-evaluate :: StringLiteral -> OrPattern Variable
+evaluate :: StringLiteral (OrPattern Variable) -> OrPattern Variable
 evaluate = simplify


### PR DESCRIPTION
This pull request makes (most) of the nodes in the syntax tree into functors to have a uniform representation. Previously, nodes which had no children were not functors, but this restriction is not necessary. When this is done, we can replace [all this](https://github.com/kframework/kore/blob/fab0cb0a96ded0f5a952f55b95931830806c10d7/kore/src/Kore/Internal/TermLike.hs#L305-L520) with some generically-derived code. Also, we can replace [these smart constructors](https://github.com/kframework/kore/blob/fab0cb0a96ded0f5a952f55b95931830806c10d7/kore/src/Kore/Internal/TermLike.hs#L1152-L2107) with generic ones that also work with the parser's pattern representation. (That's less important, but it will make it nicer to write parser/verifier tests and it will split up this giant module.)

@traiansf I left off doing the same thing for `Variable` and `SetVariable` because I know you're working on that now, and also because I'm not quite how it should look.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

