### PR TITLE
Derive Synthetic instances generically

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -266,6 +266,7 @@ language_extensions:
   - StandaloneDeriving
   - TypeApplications
   - TypeFamilies
+  - TypeOperators
   - TypeSynonymInstances
   - UndecidableInstances
   - ViewPatterns

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -103,6 +103,7 @@ default-extensions:
   - StandaloneDeriving
   - TypeApplications
   - TypeFamilies
+  - TypeOperators
   - TypeSynonymInstances
   - UndecidableInstances
   - ViewPatterns

--- a/kore/src/Generically.hs
+++ b/kore/src/Generically.hs
@@ -1,0 +1,21 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+
+module Generically
+    ( Generically1 (..)
+    ) where
+
+{- | @Generically1@ is a wrapper for deriving instances generically.
+
+For a constraint @C@ where we can write a generic instance in terms of
+'GHC.Generics.Generic1', we can write an instance of @Generically1@ by
+unwrapping ('unGenerically1'). Then, we can use @DerivingVia@ to derive any
+instance @via Generically1@.
+
+ -}
+newtype Generically1 (f :: * -> *) a =
+    Generically1 { unGenerically1 :: f a }
+    deriving Functor

--- a/kore/src/Kore/AST/AstWithLocation.hs
+++ b/kore/src/Kore/AST/AstWithLocation.hs
@@ -127,7 +127,7 @@ instance
             StringLiteralF _ -> AstLocationUnknown
             CharLiteralF _ -> AstLocationUnknown
             TopF Top { topSort } -> locationFromAst topSort
-            VariableF variable -> locationFromAst variable
+            VariableF (Const variable) -> locationFromAst variable
             InhabitantF Inhabitant { inhSort } -> locationFromAst inhSort
 
     updateAstLocation = undefined

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -748,8 +748,8 @@ verifySortHasDomainValues patternSort = do
 
 verifyStringLiteral
     :: valid ~ Attribute.Pattern Variable
-    => StringLiteral (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF StringLiteral valid Verified.Pattern)
+    => Const StringLiteral (PatternVerifier Verified.Pattern)
+    -> PatternVerifier (CofreeF (Const StringLiteral) valid Verified.Pattern)
 verifyStringLiteral str = do
     verified <- sequence str
     let attrs = synthetic (Internal.extractAttributes <$> verified)

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -383,7 +383,7 @@ verifyPatternSort patternSort = do
     return ()
 
 verifyOperands
-    :: (Traversable operator, Synthetic operator (Attribute.Pattern Variable))
+    :: (Traversable operator, Synthetic (Attribute.Pattern Variable) operator)
     => (forall a. operator a -> Sort)
     -> operator (PatternVerifier Verified.Pattern)
     ->  PatternVerifier
@@ -467,7 +467,7 @@ verifyRewrites = verifyOperands rewritesSort
 
 verifyPredicate
     ::  ( Traversable predicate
-        , Synthetic predicate (Attribute.Pattern Variable)
+        , Synthetic (Attribute.Pattern Variable) predicate
         , valid ~ Attribute.Pattern Variable
         )
     => (forall a. predicate a -> Sort)  -- ^ Operand sort
@@ -580,7 +580,7 @@ verifyApplySymbol getChildAttributes application =
     Application { applicationSymbolOrAlias = symbolOrAlias } = application
 
 verifyApplicationChildren
-    ::  Synthetic (Application head) (Attribute.Pattern Variable)
+    ::  Synthetic (Attribute.Pattern Variable) (Application head)
     =>  (child -> Attribute.Pattern Variable)
     ->  Application head (PatternVerifier child)
     ->  ApplicationSorts
@@ -618,7 +618,7 @@ verifyApplication getChildAttributes application = do
         <$> verifyApplySymbol getChildAttributes application
 
 verifyBinder
-    ::  ( Traversable binder, Synthetic binder (Attribute.Pattern Variable)
+    ::  ( Traversable binder, Synthetic (Attribute.Pattern Variable) binder
         , valid ~ Attribute.Pattern Variable
         )
     => (forall a. binder a -> Sort)

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -369,9 +369,8 @@ verifyPatternHead (_ :< patternF) =
             transCofreeF Internal.CharLiteralF <$> verifyCharLiteral char
         Syntax.TopF top ->
             transCofreeF Internal.TopF <$> verifyTop top
-        Syntax.VariableF var ->
-            transCofreeF (Internal.VariableF . getConst)
-                <$> verifyVariable var
+        Syntax.VariableF (Const variable) ->
+            transCofreeF Internal.VariableF <$> verifyVariable variable
         Syntax.InhabitantF _ ->
             koreFail "Unexpected pattern."
   where
@@ -882,10 +881,10 @@ patternNameForContext (RewritesF _) = "\\rewrites"
 patternNameForContext (StringLiteralF _) = "<string>"
 patternNameForContext (CharLiteralF _) = "<char>"
 patternNameForContext (TopF _) = "\\top"
-patternNameForContext (VariableF (ElemVar variable)) =
+patternNameForContext (VariableF (Const (ElemVar variable))) =
     "element variable '" <> variableNameForContext (getElementVariable variable) <> "'"
 patternNameForContext (InhabitantF _) = "\\inh"
-patternNameForContext (VariableF (SetVar variable)) =
+patternNameForContext (VariableF (Const (SetVar variable))) =
     "set variable '" <> variableNameForContext (getSetVariable variable) <> "'"
 
 variableNameForContext :: Variable -> Text

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -757,8 +757,8 @@ verifyStringLiteral str = do
 
 verifyCharLiteral
     :: valid ~ Attribute.Pattern Variable
-    => CharLiteral (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF CharLiteral valid Verified.Pattern)
+    => Const CharLiteral (PatternVerifier Verified.Pattern)
+    -> PatternVerifier (CofreeF (Const CharLiteral) valid Verified.Pattern)
 verifyCharLiteral char = do
     verified <- sequence char
     let attrs = synthetic (Internal.extractAttributes <$> verified)

--- a/kore/src/Kore/Attribute/Attributes.hs
+++ b/kore/src/Kore/Attribute/Attributes.hs
@@ -58,7 +58,7 @@ attributePattern_ applicationSymbolOrAlias =
 
 attributeString :: Text -> AttributePattern
 attributeString literal =
-    (asAttributePattern . StringLiteralF) (StringLiteral literal)
+    (asAttributePattern . StringLiteralF . Const) (StringLiteral literal)
 
 attributeInteger :: Integer -> AttributePattern
 attributeInteger = attributeString . Text.pack . show

--- a/kore/src/Kore/Attribute/Parser.hs
+++ b/kore/src/Kore/Attribute/Parser.hs
@@ -258,10 +258,10 @@ getSymbolOrAlias kore =
 
 {- | Accept a string literal.
  -}
-getStringLiteral :: AttributePattern -> Parser (StringLiteral AttributePattern)
+getStringLiteral :: AttributePattern -> Parser StringLiteral
 getStringLiteral kore =
     case Recursive.project kore of
-        _ :< StringLiteralF lit -> return lit
+        _ :< StringLiteralF (Const lit) -> return lit
         _ -> Kore.Error.koreFail "expected string literal pattern"
 
 {- | Parse a 'Text' through 'ReadS'.
@@ -291,7 +291,7 @@ parseReadS aReadS (Text.unpack -> syntax) =
 
 {- | Parse an 'Integer' from a 'StringLiteral'.
  -}
-parseInteger :: StringLiteral child -> Parser Integer
+parseInteger :: StringLiteral -> Parser Integer
 parseInteger (StringLiteral literal) = parseReadS reads literal
 
 {- | Parse an 'SExpr' for the @smtlib@ attribute.

--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -56,13 +56,13 @@ instance SOP.HasDatatypeInfo (Pattern variable)
 instance Debug variable => Debug (Pattern variable)
 
 instance
-    ( Synthetic base Sort
-    , Synthetic base (FreeVariables variable)
-    , Synthetic base Functional
-    , Synthetic base Function
-    , Synthetic base Defined
+    ( Synthetic Sort base
+    , Synthetic (FreeVariables variable) base
+    , Synthetic Functional base
+    , Synthetic Function base
+    , Synthetic Defined base
     ) =>
-    Synthetic base (Pattern variable)
+    Synthetic (Pattern variable) base
   where
     synthetic base =
         Pattern

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -42,17 +42,17 @@ instance NFData Defined
 
 instance Hashable Defined
 
-instance Synthetic (And sort) Defined where
+instance Synthetic Defined (And sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Bottom sort) Defined where
+instance Synthetic Defined (Bottom sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Defined' if the symbol is total and its
 -- arguments are 'Defined'.
-instance Synthetic (Application Internal.Symbol) Defined where
+instance Synthetic Defined (Application Internal.Symbol) where
     synthetic application =
         functionSymbol <> Foldable.fold children
       where
@@ -60,74 +60,74 @@ instance Synthetic (Application Internal.Symbol) Defined where
         children = applicationChildren application
         symbol = applicationSymbolOrAlias application
 
-instance Synthetic (Application Internal.Alias) Defined where
+instance Synthetic Defined (Application Internal.Alias) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Ceil sort) Defined where
+instance Synthetic Defined (Ceil sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' patterns is 'Defined' if its argument is 'Defined'.
-instance Synthetic (DomainValue sort) Defined where
+instance Synthetic Defined (DomainValue sort) where
     synthetic = domainValueChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Equals sort) Defined where
+instance Synthetic Defined (Equals sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Exists sort variable) Defined where
+instance Synthetic Defined (Exists sort variable) where
     synthetic = const (Defined False)
 
-instance Synthetic (Floor sort) Defined where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
-
-instance Synthetic (Forall sort variable) Defined where
+instance Synthetic Defined (Floor sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Iff sort) Defined where
+instance Synthetic Defined (Forall sort variable) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Implies sort) Defined where
+instance Synthetic Defined (Iff sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (In sort) Defined where
+instance Synthetic Defined (Implies sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Mu sort) Defined where
+instance Synthetic Defined (In sort) where
+    synthetic = const (Defined False)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Defined (Mu sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
 -- | A 'Next' pattern is 'Defined' if its argument is 'Defined'.
-instance Synthetic (Next sort) Defined where
+instance Synthetic Defined (Next sort) where
     synthetic = nextChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Not sort) Defined where
+instance Synthetic Defined (Not sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Nu sort) Defined where
+instance Synthetic Defined (Nu sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
 -- | An 'Or' pattern is 'Defined' if any of its subterms is 'Defined'.
-instance Synthetic (Or sort) Defined where
+instance Synthetic Defined (Or sort) where
     synthetic = Defined . getAny . Foldable.foldMap (Any . isDefined)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Rewrites sort) Defined where
+instance Synthetic Defined (Rewrites sort) where
     synthetic = const (Defined False)
     {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is defined if its subterms are 'Defined'.
-instance Synthetic (Builtin key) Defined where
+instance Synthetic Defined (Builtin key) where
     synthetic
         (BuiltinSet InternalAc
             {builtinAcChild = NormalizedSet builtinSetChild}
@@ -168,28 +168,28 @@ normalizedAcDefined ac@(NormalizedAc _ _ _) =
 
 
 -- | A 'Top' pattern is always 'Defined'.
-instance Synthetic (Top sort) Defined where
+instance Synthetic Defined (Top sort) where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Defined'.
-instance Synthetic (Const StringLiteral) Defined where
+instance Synthetic Defined (Const StringLiteral) where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Defined'.
-instance Synthetic (Const CharLiteral) Defined where
+instance Synthetic Defined (Const CharLiteral) where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is always 'Defined'.
-instance Synthetic Inhabitant Defined where
+instance Synthetic Defined Inhabitant where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
 -- | An element variable pattern is always 'Defined'.
 --   A set variable is not.
-instance Synthetic (Const (UnifiedVariable variable)) Defined where
+instance Synthetic Defined (Const (UnifiedVariable variable)) where
     synthetic (Const (ElemVar _))= Defined True
     synthetic (Const (SetVar _))= Defined False
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -178,7 +178,7 @@ instance Synthetic (Const StringLiteral) Defined where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Defined'.
-instance Synthetic CharLiteral Defined where
+instance Synthetic (Const CharLiteral) Defined where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -173,7 +173,7 @@ instance Synthetic (Top sort) Defined where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Defined'.
-instance Synthetic StringLiteral Defined where
+instance Synthetic (Const StringLiteral) Defined where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
@@ -52,7 +52,7 @@ instance Hashable variable => Hashable (FreeVariables variable) where
 
 instance
     Ord variable =>
-    Synthetic (Const (UnifiedVariable variable)) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Const (UnifiedVariable variable))
   where
     synthetic (Const var) = freeVariable var
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -141,7 +141,7 @@ instance Synthetic (Const StringLiteral) Function where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Function'.
-instance Synthetic CharLiteral Function where
+instance Synthetic (Const CharLiteral) Function where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -41,20 +41,20 @@ instance NFData Function
 
 instance Hashable Function
 
-instance Synthetic (And sort) Function where
+instance Synthetic Function (And sort) where
     -- TODO (thomas.tuegel):
     -- synthetic = getAny . Foldable.foldMap (Any . isFunction)
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
 -- | A 'Bottom' pattern is always 'Function'.
-instance Synthetic (Bottom sort) Function where
+instance Synthetic Function (Bottom sort) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Function' if its symbol is a function and its
 -- arguments are 'Function'.
-instance Synthetic (Application Internal.Symbol) Function where
+instance Synthetic Function (Application Internal.Symbol) where
     synthetic application =
         functionSymbol <> Foldable.fold children
       where
@@ -62,96 +62,96 @@ instance Synthetic (Application Internal.Symbol) Function where
         children = applicationChildren application
         symbol = applicationSymbolOrAlias application
 
-instance Synthetic (Application Internal.Alias) Function where
+instance Synthetic Function (Application Internal.Alias) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Ceil sort) Function where
+instance Synthetic Function (Ceil sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' pattern is 'Function' if its argument is 'Function'.
-instance Synthetic (DomainValue sort) Function where
+instance Synthetic Function (DomainValue sort) where
     synthetic = domainValueChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Equals sort) Function where
+instance Synthetic Function (Equals sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Exists sort variable) Function where
+instance Synthetic Function (Exists sort variable) where
     synthetic = const (Function False)
 
-instance Synthetic (Floor sort) Function where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
-
-instance Synthetic (Forall sort variable) Function where
+instance Synthetic Function (Floor sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Iff sort) Function where
+instance Synthetic Function (Forall sort variable) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Implies sort) Function where
+instance Synthetic Function (Iff sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (In sort) Function where
+instance Synthetic Function (Implies sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Mu sort) Function where
+instance Synthetic Function (In sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Next sort) Function where
+instance Synthetic Function (Mu sort) where
+    synthetic = const (Function False)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Function (Next sort) where
     synthetic = nextChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Not sort) Function where
+instance Synthetic Function (Not sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Nu sort) Function where
+instance Synthetic Function (Nu sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Or sort) Function where
+instance Synthetic Function (Or sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Rewrites sort) Function where
+instance Synthetic Function (Rewrites sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is 'Function' if its subterms are 'Function'.
-instance Synthetic (Builtin key) Function where
+instance Synthetic Function (Builtin key) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Top sort) Function where
+instance Synthetic Function (Top sort) where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Function'.
-instance Synthetic (Const StringLiteral) Function where
+instance Synthetic Function (Const StringLiteral) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Function'.
-instance Synthetic (Const CharLiteral) Function where
+instance Synthetic Function (Const CharLiteral) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is never 'Function'.
-instance Synthetic Inhabitant Function where
+instance Synthetic Function Inhabitant where
     synthetic = const (Function False)
     {-# INLINE synthetic #-}
 
 -- | A 'Variable' pattern is always 'Function'.
-instance Synthetic (Const (UnifiedVariable variable)) Function where
+instance Synthetic Function (Const (UnifiedVariable variable)) where
     synthetic (Const (ElemVar _)) = Function True
     synthetic (Const (SetVar _)) = Function False
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -136,7 +136,7 @@ instance Synthetic (Top sort) Function where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Function'.
-instance Synthetic StringLiteral Function where
+instance Synthetic (Const StringLiteral) Function where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -42,17 +42,17 @@ instance NFData Functional
 
 instance Hashable Functional
 
-instance Synthetic (And sort) Functional where
+instance Synthetic Functional (And sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Bottom sort) Functional where
+instance Synthetic Functional (Bottom sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Functional' if its symbol is functional and
 -- its arguments are 'Functional'.
-instance Synthetic (Application Internal.Symbol) Functional where
+instance Synthetic Functional (Application Internal.Symbol) where
     synthetic application =
         functionalSymbol <> Foldable.fold children
       where
@@ -60,72 +60,72 @@ instance Synthetic (Application Internal.Symbol) Functional where
         children = applicationChildren application
         symbol = applicationSymbolOrAlias application
 
-instance Synthetic (Application Internal.Alias) Functional where
+instance Synthetic Functional (Application Internal.Alias) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Ceil sort) Functional where
+instance Synthetic Functional (Ceil sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' pattern is 'Functional' if its argument is 'Functional'.
-instance Synthetic (DomainValue sort) Functional where
+instance Synthetic Functional (DomainValue sort) where
     synthetic = domainValueChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Equals sort) Functional where
+instance Synthetic Functional (Equals sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Exists sort variable) Functional where
+instance Synthetic Functional (Exists sort variable) where
     synthetic = const (Functional False)
 
-instance Synthetic (Floor sort) Functional where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
-
-instance Synthetic (Forall sort variable) Functional where
+instance Synthetic Functional (Floor sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Iff sort) Functional where
+instance Synthetic Functional (Forall sort variable) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Implies sort) Functional where
+instance Synthetic Functional (Iff sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (In sort) Functional where
+instance Synthetic Functional (Implies sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Mu sort) Functional where
+instance Synthetic Functional (In sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Next sort) Functional where
+instance Synthetic Functional (Mu sort) where
+    synthetic = const (Functional False)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Functional (Next sort) where
     synthetic = nextChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Not sort) Functional where
+instance Synthetic Functional (Not sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Nu sort) Functional where
+instance Synthetic Functional (Nu sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Or sort) Functional where
+instance Synthetic Functional (Or sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Rewrites sort) Functional where
+instance Synthetic Functional (Rewrites sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is 'Functional' if its subterms are 'Functional'.
-instance Synthetic (Builtin key) Functional where
+instance Synthetic Functional (Builtin key) where
     synthetic
         (BuiltinSet InternalAc
             {builtinAcChild = NormalizedSet builtinSetChild}
@@ -164,31 +164,31 @@ normalizedAcFunctional ac@(NormalizedAc _ _ _) =
   where
     sameAsChildren = Foldable.fold ac
 
-instance Synthetic (Top sort) Functional where
+instance Synthetic Functional (Top sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
 -- | A 'Variable' pattern is always 'Functional'.
-instance Synthetic (Const (UnifiedVariable variable)) Functional where
+instance Synthetic Functional (Const (UnifiedVariable variable)) where
     synthetic (Const (ElemVar _)) = Functional True
     synthetic (Const (SetVar _)) = Functional False
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Functional'.
-instance Synthetic (Const StringLiteral) Functional where
+instance Synthetic Functional (Const StringLiteral) where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Functional'.
-instance Synthetic (Const CharLiteral) Functional where
+instance Synthetic Functional (Const CharLiteral) where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is never 'Functional'.
-instance Synthetic Inhabitant Functional where
+instance Synthetic Functional Inhabitant where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}
 
-instance Synthetic (Const Sort) Functional where
+instance Synthetic Functional (Const Sort) where
     synthetic = const (Functional False)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -180,7 +180,7 @@ instance Synthetic (Const StringLiteral) Functional where
     {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Functional'.
-instance Synthetic CharLiteral Functional where
+instance Synthetic (Const CharLiteral) Functional where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -175,7 +175,7 @@ instance Synthetic (Const (UnifiedVariable variable)) Functional where
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Functional'.
-instance Synthetic StringLiteral Functional where
+instance Synthetic (Const StringLiteral) Functional where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Synthetic.hs
+++ b/kore/src/Kore/Attribute/Synthetic.hs
@@ -20,6 +20,8 @@ import           Data.Functor.Foldable
 import qualified Data.Functor.Foldable as Recursive
 import           GHC.Generics
 
+import Generically
+
 {- | @Synthetic@ is the class of synthetic attribute types @syn@.
 
 @Synthetic base syn@ allows synthesizing @syn@ given a @'Cofree' base@ tree;
@@ -32,6 +34,13 @@ class Functor base => Synthetic syn base where
 
 instance Synthetic a (Const a) where
     synthetic (Const a) = a
+    {-# INLINE synthetic #-}
+
+instance
+    (Functor base, Generic1 base, Synthetic syn (Rep1 base))
+    => Synthetic syn (Generically1 base)
+  where
+    synthetic = synthetic . from1 . unGenerically1
     {-# INLINE synthetic #-}
 
 instance (Functor base, Synthetic syn base) => Synthetic syn (M1 i c base) where

--- a/kore/src/Kore/Attribute/Synthetic.hs
+++ b/kore/src/Kore/Attribute/Synthetic.hs
@@ -18,6 +18,7 @@ import           Data.Functor.Const
 import           Data.Functor.Foldable
                  ( Base, Corecursive, Recursive )
 import qualified Data.Functor.Foldable as Recursive
+import           GHC.Generics
 
 {- | @Synthetic@ is the class of synthetic attribute types @syn@.
 
@@ -31,6 +32,24 @@ class Functor base => Synthetic syn base where
 
 instance Synthetic a (Const a) where
     synthetic (Const a) = a
+    {-# INLINE synthetic #-}
+
+instance (Functor base, Synthetic syn base) => Synthetic syn (M1 i c base) where
+    synthetic = synthetic . unM1
+    {-# INLINE synthetic #-}
+
+instance
+    (Functor l, Synthetic syn l, Functor r, Synthetic syn r)
+    => Synthetic syn (l :+: r)
+  where
+    synthetic =
+        \case
+            L1 lsyn -> synthetic lsyn
+            R1 rsyn -> synthetic rsyn
+    {-# INLINE synthetic #-}
+
+instance (Functor base, Synthetic syn base) => Synthetic syn (Rec1 base) where
+    synthetic = synthetic . unRec1
     {-# INLINE synthetic #-}
 
 {- | @/synthesize/@ attribute @b@ bottom-up along a tree @s@.

--- a/kore/src/Kore/Attribute/Synthetic.hs
+++ b/kore/src/Kore/Attribute/Synthetic.hs
@@ -25,11 +25,11 @@ import qualified Data.Functor.Foldable as Recursive
 that is, a 'Cofree' tree with branching described by a @'Functor' base@.
 
  -}
-class Functor base => Synthetic base syn where
+class Functor base => Synthetic syn base where
     -- | @synthetic@ is the @base@-algebra for synthesizing the attribute @syn@.
     synthetic :: base syn -> syn
 
-instance Synthetic (Const a) a where
+instance Synthetic a (Const a) where
     synthetic (Const a) = a
     {-# INLINE synthetic #-}
 
@@ -50,7 +50,7 @@ resynthesize
         , Recursive t
         , Base s ~ CofreeF base inh
         , Base t ~ CofreeF base syn
-        , Synthetic base syn
+        , Synthetic syn base
         )
     => s  -- ^ Original tree with attributes @a@
     -> t
@@ -87,7 +87,7 @@ resynthesizeAux synth =
 {- | @/synthesize/@ an attribute @a@ from one level of a tree @s@.
  -}
 synthesize
-    ::  ( Functor f, Synthetic f a
+    ::  ( Functor f, Synthetic a f
         , Corecursive s, Recursive s, Base s ~ CofreeF f a
         )
     => f s

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -647,11 +647,11 @@ builtinSort builtin =
         BuiltinList InternalList { builtinListSort } -> builtinListSort
         BuiltinSet InternalAc { builtinAcSort } -> builtinAcSort
 
-instance Synthetic (Builtin key) Sort where
+instance Synthetic Sort (Builtin key) where
     synthetic = builtinSort
     {-# INLINE synthetic #-}
 
-instance Ord variable => Synthetic (Builtin key) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Builtin key) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Internal/Alias.hs
+++ b/kore/src/Kore/Internal/Alias.hs
@@ -68,13 +68,13 @@ instance Unparse Alias where
 
 instance
     Ord variable =>
-    Synthetic (Application Alias) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Application Alias)
   where
     -- TODO (thomas.tuegel): Consider that there could be bound variables here.
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Application Alias) Sort where
+instance Synthetic Sort (Application Alias) where
     synthetic application =
         resultSort Function.& deepseq (matchSorts operandSorts children)
       where

--- a/kore/src/Kore/Internal/Symbol.hs
+++ b/kore/src/Kore/Internal/Symbol.hs
@@ -90,13 +90,13 @@ instance Unparse Symbol where
         unparse2 symbolConstructor
 
 instance
-    Ord variable =>
-    Synthetic (Application Symbol) (FreeVariables variable)
+    Ord variable
+    => Synthetic (FreeVariables variable) (Application Symbol)
   where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Application Symbol) Sort where
+instance Synthetic Sort (Application Symbol) where
     synthetic application =
         resultSort Function.& deepseq (matchSorts operandSorts children)
       where

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -190,6 +190,7 @@ import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 import qualified GHC.Stack as GHC
 
+import           Generically
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Pattern.Defined as Pattern
 import           Kore.Attribute.Pattern.FreeVariables
@@ -302,6 +303,11 @@ data TermLikeF variable child
     deriving (Eq, Ord, Show)
     deriving (Functor, Foldable, Traversable)
     deriving (GHC.Generic, GHC.Generic1)
+    deriving
+        ( Synthetic (FreeVariables variable), Synthetic Sort
+        , Synthetic Pattern.Functional, Synthetic Pattern.Function
+        , Synthetic Pattern.Defined
+        ) via (Generically1 (TermLikeF variable))
 
 instance SOP.Generic (TermLikeF variable child)
 
@@ -321,179 +327,6 @@ instance
   where
     unparse = Unparser.unparseGeneric
     unparse2 = Unparser.unparse2Generic
-
-instance
-    Ord variable
-    => Synthetic (FreeVariables variable) (TermLikeF variable)
-  where
-    -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
-    -- Functors.
-    synthetic (ForallF forallF) = synthetic forallF
-    synthetic (ExistsF existsF) = synthetic existsF
-    synthetic (VariableF variable) = synthetic variable
-
-    synthetic (AndF andF) = synthetic andF
-    synthetic (ApplySymbolF applySymbolF) = synthetic applySymbolF
-    synthetic (ApplyAliasF applyAliasF) = synthetic applyAliasF
-    synthetic (BottomF bottomF) = synthetic bottomF
-    synthetic (CeilF ceilF) = synthetic ceilF
-    synthetic (DomainValueF domainValueF) = synthetic domainValueF
-    synthetic (EqualsF equalsF) = synthetic equalsF
-    synthetic (FloorF floorF) = synthetic floorF
-    synthetic (IffF iffF) = synthetic iffF
-    synthetic (ImpliesF impliesF) = synthetic impliesF
-    synthetic (InF inF) = synthetic inF
-    synthetic (NextF nextF) = synthetic nextF
-    synthetic (NotF notF) = synthetic notF
-    synthetic (OrF orF) = synthetic orF
-    synthetic (RewritesF rewritesF) = synthetic rewritesF
-    synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = synthetic builtinF
-    synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
-
-    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
-
-    synthetic (MuF muF) = synthetic muF
-    synthetic (NuF nuF) = synthetic nuF
-    {-# INLINE synthetic #-}
-
-instance SortedVariable variable => Synthetic Sort (TermLikeF variable) where
-    -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
-    -- Functors.
-    synthetic (ForallF forallF) = synthetic forallF
-    synthetic (ExistsF existsF) = synthetic existsF
-    synthetic (VariableF variable) = synthetic variable
-
-    synthetic (AndF andF) = synthetic andF
-    synthetic (ApplySymbolF applySymbolF) = synthetic applySymbolF
-    synthetic (ApplyAliasF applyAliasF) = synthetic applyAliasF
-    synthetic (BottomF bottomF) = synthetic bottomF
-    synthetic (CeilF ceilF) = synthetic ceilF
-    synthetic (DomainValueF domainValueF) = synthetic domainValueF
-    synthetic (EqualsF equalsF) = synthetic equalsF
-    synthetic (FloorF floorF) = synthetic floorF
-    synthetic (IffF iffF) = synthetic iffF
-    synthetic (ImpliesF impliesF) = synthetic impliesF
-    synthetic (InF inF) = synthetic inF
-    synthetic (NextF nextF) = synthetic nextF
-    synthetic (NotF notF) = synthetic notF
-    synthetic (OrF orF) = synthetic orF
-    synthetic (RewritesF rewritesF) = synthetic rewritesF
-    synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = synthetic builtinF
-    synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
-
-    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
-
-    synthetic (MuF muF) = synthetic muF
-    synthetic (NuF nuF) = synthetic nuF
-    {-# INLINE synthetic #-}
-
-instance Synthetic Pattern.Functional (TermLikeF variable) where
-    -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
-    -- Functors.
-    synthetic (ForallF forallF) = synthetic forallF
-    synthetic (ExistsF existsF) = synthetic existsF
-    synthetic (VariableF variable) = synthetic variable
-
-    synthetic (AndF andF) = synthetic andF
-    synthetic (ApplySymbolF applySymbolF) = synthetic applySymbolF
-    synthetic (ApplyAliasF applyAliasF) = synthetic applyAliasF
-    synthetic (BottomF bottomF) = synthetic bottomF
-    synthetic (CeilF ceilF) = synthetic ceilF
-    synthetic (DomainValueF domainValueF) = synthetic domainValueF
-    synthetic (EqualsF equalsF) = synthetic equalsF
-    synthetic (FloorF floorF) = synthetic floorF
-    synthetic (IffF iffF) = synthetic iffF
-    synthetic (ImpliesF impliesF) = synthetic impliesF
-    synthetic (InF inF) = synthetic inF
-    synthetic (NextF nextF) = synthetic nextF
-    synthetic (NotF notF) = synthetic notF
-    synthetic (OrF orF) = synthetic orF
-    synthetic (RewritesF rewritesF) = synthetic rewritesF
-    synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = synthetic builtinF
-    synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
-
-    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
-
-    synthetic (MuF muF) = synthetic muF
-    synthetic (NuF nuF) = synthetic nuF
-    {-# INLINE synthetic #-}
-
-instance Synthetic Pattern.Function (TermLikeF variable) where
-    -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
-    -- Functors.
-    synthetic (ForallF forallF) = synthetic forallF
-    synthetic (ExistsF existsF) = synthetic existsF
-    synthetic (VariableF variable) = synthetic variable
-
-    synthetic (AndF andF) = synthetic andF
-    synthetic (ApplySymbolF applySymbolF) = synthetic applySymbolF
-    synthetic (ApplyAliasF applyAliasF) = synthetic applyAliasF
-    synthetic (BottomF bottomF) = synthetic bottomF
-    synthetic (CeilF ceilF) = synthetic ceilF
-    synthetic (DomainValueF domainValueF) = synthetic domainValueF
-    synthetic (EqualsF equalsF) = synthetic equalsF
-    synthetic (FloorF floorF) = synthetic floorF
-    synthetic (IffF iffF) = synthetic iffF
-    synthetic (ImpliesF impliesF) = synthetic impliesF
-    synthetic (InF inF) = synthetic inF
-    synthetic (NextF nextF) = synthetic nextF
-    synthetic (NotF notF) = synthetic notF
-    synthetic (OrF orF) = synthetic orF
-    synthetic (RewritesF rewritesF) = synthetic rewritesF
-    synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = synthetic builtinF
-    synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
-
-    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
-
-    synthetic (MuF muF) = synthetic muF
-    synthetic (NuF nuF) = synthetic nuF
-    {-# INLINE synthetic #-}
-
-instance Synthetic Pattern.Defined (TermLikeF variable) where
-    -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
-    -- Functors.
-    synthetic (ForallF forallF) = synthetic forallF
-    synthetic (ExistsF existsF) = synthetic existsF
-    synthetic (VariableF variable) = synthetic variable
-
-    synthetic (AndF andF) = synthetic andF
-    synthetic (ApplySymbolF applySymbolF) = synthetic applySymbolF
-    synthetic (ApplyAliasF applyAliasF) = synthetic applyAliasF
-    synthetic (BottomF bottomF) = synthetic bottomF
-    synthetic (CeilF ceilF) = synthetic ceilF
-    synthetic (DomainValueF domainValueF) = synthetic domainValueF
-    synthetic (EqualsF equalsF) = synthetic equalsF
-    synthetic (FloorF floorF) = synthetic floorF
-    synthetic (IffF iffF) = synthetic iffF
-    synthetic (ImpliesF impliesF) = synthetic impliesF
-    synthetic (InF inF) = synthetic inF
-    synthetic (NextF nextF) = synthetic nextF
-    synthetic (NotF notF) = synthetic notF
-    synthetic (OrF orF) = synthetic orF
-    synthetic (RewritesF rewritesF) = synthetic rewritesF
-    synthetic (TopF topF) = synthetic topF
-    synthetic (BuiltinF builtinF) = synthetic builtinF
-    synthetic (EvaluatedF evaluatedF) = synthetic evaluatedF
-
-    synthetic (StringLiteralF stringLiteralF) = synthetic stringLiteralF
-    synthetic (CharLiteralF charLiteralF) = synthetic charLiteralF
-    synthetic (InhabitantF inhabitantF) = synthetic inhabitantF
-
-    synthetic (MuF muF) = synthetic muF
-    synthetic (NuF nuF) = synthetic nuF
-    {-# INLINE synthetic #-}
 
 {- | Use the provided mapping to replace all variables in a 'TermLikeF' head.
 

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -292,13 +292,13 @@ data TermLikeF variable child
     | NuF            !(Nu variable child)
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
-    | StringLiteralF !(StringLiteral child)
-    | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
-    | VariableF      !(UnifiedVariable variable)
     | InhabitantF    !(Inhabitant child)
     | BuiltinF       !(Builtin child)
     | EvaluatedF     !(Evaluated child)
+    | StringLiteralF !(Const StringLiteral child)
+    | CharLiteralF   !(CharLiteral child)
+    | VariableF      !(UnifiedVariable variable)
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (TermLikeF variable child)
@@ -1788,7 +1788,7 @@ mkStringLiteral
     :: (Ord variable, SortedVariable variable)
     => Text
     -> TermLike variable
-mkStringLiteral = synthesize . StringLiteralF . StringLiteral
+mkStringLiteral = synthesize . StringLiteralF . Const . StringLiteral
 
 {- | Construct a 'CharLiteral' pattern.
  -}
@@ -2242,7 +2242,7 @@ pattern ElemVar_ elemVariable <-
     (Recursive.project -> _ :< VariableF (ElemVar elemVariable))
 
 pattern StringLiteral_ str <-
-    (Recursive.project -> _ :< StringLiteralF (StringLiteral str))
+    (Recursive.project -> _ :< StringLiteralF (Const (StringLiteral str)))
 
 pattern CharLiteral_ char <-
     (Recursive.project -> _ :< CharLiteralF (CharLiteral char))

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -262,7 +262,7 @@ instance Unparse child => Unparse (Evaluated child) where
     unparse2 evaluated =
         Pretty.vsep ["/* evaluated: */", Unparser.unparse2Generic evaluated]
 
-instance Synthetic Evaluated syn where
+instance Synthetic syn Evaluated where
     synthetic = getEvaluated
     {-# INLINE synthetic #-}
 
@@ -321,8 +321,8 @@ instance
     unparse2 = Unparser.unparse2Generic
 
 instance
-    Ord variable =>
-    Synthetic (TermLikeF variable) (FreeVariables variable)
+    Ord variable
+    => Synthetic (FreeVariables variable) (TermLikeF variable)
   where
     -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
     -- Functors.
@@ -357,7 +357,7 @@ instance
     synthetic (NuF nuF) = synthetic nuF
     {-# INLINE synthetic #-}
 
-instance SortedVariable variable => Synthetic (TermLikeF variable) Sort where
+instance SortedVariable variable => Synthetic Sort (TermLikeF variable) where
     -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
     -- Functors.
     synthetic (ForallF forallF) = synthetic forallF
@@ -391,7 +391,7 @@ instance SortedVariable variable => Synthetic (TermLikeF variable) Sort where
     synthetic (NuF nuF) = synthetic nuF
     {-# INLINE synthetic #-}
 
-instance Synthetic (TermLikeF variable) Pattern.Functional where
+instance Synthetic Pattern.Functional (TermLikeF variable) where
     -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
     -- Functors.
     synthetic (ForallF forallF) = synthetic forallF
@@ -425,7 +425,7 @@ instance Synthetic (TermLikeF variable) Pattern.Functional where
     synthetic (NuF nuF) = synthetic nuF
     {-# INLINE synthetic #-}
 
-instance Synthetic (TermLikeF variable) Pattern.Function where
+instance Synthetic Pattern.Function (TermLikeF variable) where
     -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
     -- Functors.
     synthetic (ForallF forallF) = synthetic forallF
@@ -459,7 +459,7 @@ instance Synthetic (TermLikeF variable) Pattern.Function where
     synthetic (NuF nuF) = synthetic nuF
     {-# INLINE synthetic #-}
 
-instance Synthetic (TermLikeF variable) Pattern.Defined where
+instance Synthetic Pattern.Defined (TermLikeF variable) where
     -- TODO (thomas.tuegel): Use SOP.Generic here, after making the children
     -- Functors.
     synthetic (ForallF forallF) = synthetic forallF

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -299,7 +299,9 @@ data TermLikeF variable child
     | StringLiteralF !(Const StringLiteral child)
     | CharLiteralF   !(Const CharLiteral child)
     | VariableF      !(Const (UnifiedVariable variable) child)
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+    deriving (Eq, Ord, Show)
+    deriving (Functor, Foldable, Traversable)
+    deriving (GHC.Generic, GHC.Generic1)
 
 instance SOP.Generic (TermLikeF variable child)
 

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -297,7 +297,7 @@ data TermLikeF variable child
     | BuiltinF       !(Builtin child)
     | EvaluatedF     !(Evaluated child)
     | StringLiteralF !(Const StringLiteral child)
-    | CharLiteralF   !(CharLiteral child)
+    | CharLiteralF   !(Const CharLiteral child)
     | VariableF      !(UnifiedVariable variable)
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
@@ -1796,7 +1796,7 @@ mkCharLiteral
     :: (Ord variable, SortedVariable variable)
     => Char
     -> TermLike variable
-mkCharLiteral = synthesize . CharLiteralF . CharLiteral
+mkCharLiteral = synthesize . CharLiteralF . Const . CharLiteral
 
 mkInhabitant
     :: (Ord variable, SortedVariable variable)
@@ -2245,7 +2245,7 @@ pattern StringLiteral_ str <-
     (Recursive.project -> _ :< StringLiteralF (Const (StringLiteral str)))
 
 pattern CharLiteral_ char <-
-    (Recursive.project -> _ :< CharLiteralF (CharLiteral char))
+    (Recursive.project -> _ :< CharLiteralF (Const (CharLiteral char)))
 
 pattern Evaluated_ child <-
     (Recursive.project -> _ :< EvaluatedF (Evaluated child))

--- a/kore/src/Kore/Parser/Lexeme.hs
+++ b/kore/src/Kore/Parser/Lexeme.hs
@@ -115,7 +115,7 @@ stringLiteralParser = lexeme stringLiteralRawParser
 
 Always starts with @'@.
 -}
-charLiteralParser :: Parser (CharLiteral child)
+charLiteralParser :: Parser CharLiteral
 charLiteralParser = lexeme charLiteralRawParser
 
 {-|'moduleNameParser' parses a module name.-}
@@ -255,7 +255,7 @@ stringLiteralRawParser = do
 @charLiteralRawParser@ does not consume whitespace.
 
  -}
-charLiteralRawParser :: Parser (CharLiteral child)
+charLiteralRawParser :: Parser CharLiteral
 charLiteralRawParser = do
     skipChar '\''
     c <- charParser

--- a/kore/src/Kore/Parser/Lexeme.hs
+++ b/kore/src/Kore/Parser/Lexeme.hs
@@ -108,7 +108,7 @@ idParser = do
 
 Always starts with @"@.
 -} {- " -}
-stringLiteralParser :: Parser (StringLiteral child)
+stringLiteralParser :: Parser StringLiteral
 stringLiteralParser = lexeme stringLiteralRawParser
 
 {-|'charLiteralParser' parses a C-style char literal, unescaping it.
@@ -245,7 +245,7 @@ setVarIdRawParser = do
 @stringLiteralRawParser@ does not consume whitespace.
 
  -}
-stringLiteralRawParser :: Parser (StringLiteral child)
+stringLiteralRawParser :: Parser StringLiteral
 stringLiteralRawParser = do
     skipChar '"'
     StringLiteral . Text.pack <$> Parser.manyTill charParser (skipChar '"')

--- a/kore/src/Kore/Parser/Parser.hs
+++ b/kore/src/Kore/Parser/Parser.hs
@@ -432,8 +432,8 @@ variableOrTermPatternParser childParser isSetVariable = do
         then do
             var <- variableRemainderParser identifier
             if isSetVariable
-                then return $ VariableF (SetVar (SetVariable var))
-                else return $ VariableF (ElemVar (ElementVariable var))
+                then return $ VariableF $ Const $ SetVar  $ SetVariable     var
+                else return $ VariableF $ Const $ ElemVar $ ElementVariable var
         else symbolOrAliasPatternRemainderParser childParser identifier
 
 

--- a/kore/src/Kore/Parser/Parser.hs
+++ b/kore/src/Kore/Parser/Parser.hs
@@ -692,7 +692,7 @@ korePatternParser = do
     case c of
         '\\' -> koreMLConstructorParser
         '"'  -> asParsedPattern . StringLiteralF . Const <$> stringLiteralParser
-        '\'' -> asParsedPattern . CharLiteralF <$> charLiteralParser
+        '\'' -> asParsedPattern . CharLiteralF . Const <$> charLiteralParser
         _    -> koreVariableOrTermPatternParser
 
 {-|'inSquareBracketsListParser' parses a @list@ of items delimited by
@@ -989,7 +989,7 @@ leveledPatternParser patternParser domainValueParser' = do
     case c of
         '\\' -> leveledMLConstructorParser patternParser domainValueParser'
         '"'  -> StringLiteralF . Const <$> stringLiteralParser
-        '\'' -> CharLiteralF <$> charLiteralParser
+        '\'' -> CharLiteralF . Const <$> charLiteralParser
         _ -> variableOrTermPatternParser patternParser (c == '@')
 
 purePatternParser :: Parser ParsedPattern

--- a/kore/src/Kore/Parser/Parser.hs
+++ b/kore/src/Kore/Parser/Parser.hs
@@ -638,7 +638,8 @@ domainValueParser =
         <$> inCurlyBracesRemainderParser objectSortParser
         <*> inParenthesesParser childParser
   where
-    childParser = asParsedPattern . StringLiteralF <$> stringLiteralParser
+    childParser =
+        asParsedPattern . StringLiteralF . Const <$> stringLiteralParser
 
 {-|'korePatternParser' parses an unifiedPattern
 
@@ -690,7 +691,7 @@ korePatternParser = do
     c <- ParserUtils.peekChar'
     case c of
         '\\' -> koreMLConstructorParser
-        '"'  -> asParsedPattern . StringLiteralF <$> stringLiteralParser
+        '"'  -> asParsedPattern . StringLiteralF . Const <$> stringLiteralParser
         '\'' -> asParsedPattern . CharLiteralF <$> charLiteralParser
         _    -> koreVariableOrTermPatternParser
 
@@ -987,7 +988,7 @@ leveledPatternParser patternParser domainValueParser' = do
     c <- ParserUtils.peekChar'
     case c of
         '\\' -> leveledMLConstructorParser patternParser domainValueParser'
-        '"'  -> StringLiteralF <$> stringLiteralParser
+        '"'  -> StringLiteralF . Const <$> stringLiteralParser
         '\'' -> CharLiteralF <$> charLiteralParser
         _ -> variableOrTermPatternParser patternParser (c == '@')
 

--- a/kore/src/Kore/Proof/Functional.hs
+++ b/kore/src/Kore/Proof/Functional.hs
@@ -48,7 +48,7 @@ data FunctionalProof variable
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
     | FunctionalStringLiteral StringLiteral
     -- ^A string literal is the repeated application of functional constructors.
-    | FunctionalCharLiteral (CharLiteral ())
+    | FunctionalCharLiteral CharLiteral
     -- ^A char literal is a functional constructor without arguments.
   deriving Generic
 

--- a/kore/src/Kore/Proof/Functional.hs
+++ b/kore/src/Kore/Proof/Functional.hs
@@ -46,7 +46,7 @@ data FunctionalProof variable
     | FunctionalHead Symbol
     -- ^Head of a total function, conforming to Definition 5.21
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
-    | FunctionalStringLiteral (StringLiteral ())
+    | FunctionalStringLiteral StringLiteral
     -- ^A string literal is the repeated application of functional constructors.
     | FunctionalCharLiteral (CharLiteral ())
     -- ^A char literal is a functional constructor without arguments.

--- a/kore/src/Kore/Proof/Value.hs
+++ b/kore/src/Kore/Proof/Value.hs
@@ -19,6 +19,7 @@ import           Control.Comonad.Trans.Cofree
                  ( Cofree, CofreeF (..) )
 import qualified Control.Comonad.Trans.Cofree as Cofree
 import           Data.Functor.Compose
+import           Data.Functor.Const
 import           Data.Functor.Foldable
                  ( Base, Corecursive, Recursive )
 import qualified Data.Functor.Foldable as Recursive
@@ -51,7 +52,7 @@ data ValueF child
     | SortInjection !(Syntax.Application Symbol child)
     | DomainValue !(Syntax.DomainValue Sort child)
     | Builtin !(Domain.Builtin (TermLike Concrete) child)
-    | StringLiteral !(StringLiteral child)
+    | StringLiteral !StringLiteral
     | CharLiteral !(CharLiteral child)
     deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
 
@@ -124,7 +125,7 @@ fromPattern (attrs :< termLikeF) =
             -- BuiltinPattern and always run the stepper with internal
             -- representations only.
             Builtin <$> sequence builtinP
-        StringLiteralF stringL -> StringLiteral <$> sequence stringL
+        StringLiteralF (Const stringL) -> pure (StringLiteral stringL)
         CharLiteralF charL -> CharLiteral <$> sequence charL
         _ -> Nothing
 
@@ -148,7 +149,7 @@ asPattern (Recursive.project -> attrs :< value) =
         SortInjection appP    -> attrs :< ApplySymbolF   appP
         DomainValue dvP       -> attrs :< DomainValueF   dvP
         Builtin builtinP      -> attrs :< BuiltinF       builtinP
-        StringLiteral stringP -> attrs :< StringLiteralF stringP
+        StringLiteral stringP -> attrs :< StringLiteralF (Const stringP)
         CharLiteral charP     -> attrs :< CharLiteralF   charP
 
 {- | View a normalized value as a 'ConcreteStepPattern'.

--- a/kore/src/Kore/Proof/Value.hs
+++ b/kore/src/Kore/Proof/Value.hs
@@ -53,7 +53,7 @@ data ValueF child
     | DomainValue !(Syntax.DomainValue Sort child)
     | Builtin !(Domain.Builtin (TermLike Concrete) child)
     | StringLiteral !StringLiteral
-    | CharLiteral !(CharLiteral child)
+    | CharLiteral !CharLiteral
     deriving (Eq, Foldable, Functor, Generic, Ord, Show, Traversable)
 
 newtype Value =
@@ -126,7 +126,7 @@ fromPattern (attrs :< termLikeF) =
             -- representations only.
             Builtin <$> sequence builtinP
         StringLiteralF (Const stringL) -> pure (StringLiteral stringL)
-        CharLiteralF charL -> CharLiteral <$> sequence charL
+        CharLiteralF (Const charL) -> pure (CharLiteral charL)
         _ -> Nothing
 
 {- | View a 'ConcreteStepPattern' as a normalized value.
@@ -150,7 +150,7 @@ asPattern (Recursive.project -> attrs :< value) =
         DomainValue dvP       -> attrs :< DomainValueF   dvP
         Builtin builtinP      -> attrs :< BuiltinF       builtinP
         StringLiteral stringP -> attrs :< StringLiteralF (Const stringP)
-        CharLiteral charP     -> attrs :< CharLiteralF   charP
+        CharLiteral charP     -> attrs :< CharLiteralF   (Const charP)
 
 {- | View a normalized value as a 'ConcreteStepPattern'.
  -}

--- a/kore/src/Kore/Step/PatternAttributes.hs
+++ b/kore/src/Kore/Step/PatternAttributes.hs
@@ -89,8 +89,8 @@ isPreconstructedPattern err (_ :< pattern') =
             (Right . Descend) (FunctionalBuiltin $ () <$ domain)
         StringLiteralF (Const str) ->
             Right $ DoNotDescend $ FunctionalStringLiteral str
-        CharLiteralF char ->
-            Right $ DoNotDescend $ FunctionalCharLiteral $ () <$ char
+        CharLiteralF (Const char) ->
+            Right $ DoNotDescend $ FunctionalCharLiteral char
         _ -> Left err
 
 {-|@isConstructorLikeTop@ checks whether the given 'Pattern' is topped in a

--- a/kore/src/Kore/Step/PatternAttributes.hs
+++ b/kore/src/Kore/Step/PatternAttributes.hs
@@ -16,6 +16,7 @@ module Kore.Step.PatternAttributes
 
 import           Data.Either
                  ( isRight )
+import           Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
 import           Data.Reflection
                  ( give )
@@ -86,8 +87,8 @@ isPreconstructedPattern err (_ :< pattern') =
             (Right . Descend) (FunctionalDomainValue $ () <$ domain)
         BuiltinF domain ->
             (Right . Descend) (FunctionalBuiltin $ () <$ domain)
-        StringLiteralF str ->
-            Right $ DoNotDescend $ FunctionalStringLiteral $ () <$ str
+        StringLiteralF (Const str) ->
+            Right $ DoNotDescend $ FunctionalStringLiteral str
         CharLiteralF char ->
             Right $ DoNotDescend $ FunctionalCharLiteral $ () <$ char
         _ -> Left err

--- a/kore/src/Kore/Step/Simplification/CharLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/CharLiteral.hs
@@ -22,7 +22,7 @@ an or containing a term made of that literal.
 -}
 simplify
     :: (Ord variable, SortedVariable variable)
-    => CharLiteral (OrPattern variable)
+    => CharLiteral
     -> OrPattern variable
 simplify (CharLiteral char) =
     OrPattern.fromPattern $ Pattern.fromTermLike $ mkCharLiteral char

--- a/kore/src/Kore/Step/Simplification/StringLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/StringLiteral.hs
@@ -21,7 +21,7 @@ an or containing a term made of that literal.
 -}
 simplify
     :: (Ord variable, SortedVariable variable)
-    => StringLiteral (OrPattern variable)
+    => StringLiteral
     -> OrPattern variable
 simplify (StringLiteral str) =
     OrPattern.fromTermLike $ mkStringLiteral str

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -167,7 +167,7 @@ simplifyInternal = simplifyInternalWorker
             StringLiteralF stringLiteralF ->
                 return $ StringLiteral.simplify (getConst stringLiteralF)
             CharLiteralF charLiteralF ->
-                CharLiteral.simplify <$> simplifyChildren charLiteralF
+                return $ CharLiteral.simplify (getConst charLiteralF)
             TopF topF -> Top.simplify <$> simplifyChildren topF
             --
             VariableF variableF -> return $ Variable.simplify variableF

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -164,10 +164,11 @@ simplifyInternal = simplifyInternalWorker
             OrF orF -> Or.simplify <$> simplifyChildren orF
             RewritesF rewritesF ->
                 Rewrites.simplify <$> simplifyChildren rewritesF
+            TopF topF -> Top.simplify <$> simplifyChildren topF
+            --
             StringLiteralF stringLiteralF ->
                 return $ StringLiteral.simplify (getConst stringLiteralF)
             CharLiteralF charLiteralF ->
                 return $ CharLiteral.simplify (getConst charLiteralF)
-            TopF topF -> Top.simplify <$> simplifyChildren topF
-            --
-            VariableF variableF -> return $ Variable.simplify variableF
+            VariableF variableF ->
+                return $ Variable.simplify (getConst variableF)

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -9,6 +9,7 @@ module Kore.Step.Simplification.TermLike
     , simplifyInternal
     ) where
 
+import           Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
 
 import           Kore.Internal.OrPattern
@@ -164,7 +165,7 @@ simplifyInternal = simplifyInternalWorker
             RewritesF rewritesF ->
                 Rewrites.simplify <$> simplifyChildren rewritesF
             StringLiteralF stringLiteralF ->
-                StringLiteral.simplify <$> simplifyChildren stringLiteralF
+                return $ StringLiteral.simplify (getConst stringLiteralF)
             CharLiteralF charLiteralF ->
                 CharLiteral.simplify <$> simplifyChildren charLiteralF
             TopF topF -> Top.simplify <$> simplifyChildren topF

--- a/kore/src/Kore/Substitute.hs
+++ b/kore/src/Kore/Substitute.hs
@@ -54,7 +54,7 @@ substitute
         , CofreeF patternBase attribute ~ Base patternType
         , Binding patternType
         , VariableType patternType ~ UnifiedVariable variable
-        , Synthetic patternBase attribute
+        , Synthetic attribute patternBase
         )
     => (patternType -> FreeVariables variable)
     -- ^ View into free variables of the pattern

--- a/kore/src/Kore/Syntax.hs
+++ b/kore/src/Kore/Syntax.hs
@@ -33,6 +33,7 @@ module Kore.Syntax
     , module Kore.Syntax.StringLiteral
     , module Kore.Syntax.Top
     , module Kore.Syntax.Variable
+    , Const (..)
     ) where
 
 import Kore.Sort
@@ -59,7 +60,7 @@ import Kore.Syntax.Nu
 import Kore.Syntax.Or
 import Kore.Syntax.Pattern
 import Kore.Syntax.PatternF
-       ( PatternF (..) )
+       ( Const (..), PatternF (..) )
 import Kore.Syntax.Rewrites
 import Kore.Syntax.SetVariable
 import Kore.Syntax.StringLiteral

--- a/kore/src/Kore/Syntax/And.hs
+++ b/kore/src/Kore/Syntax/And.hs
@@ -61,11 +61,11 @@ instance Unparse child => Unparse (And Sort child) where
             , unparse2 andSecond
             ])
 
-instance Ord variable => Synthetic (And sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (And sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (And Sort) Sort where
+instance Synthetic Sort (And Sort) where
     synthetic And { andSort, andFirst, andSecond } =
         andSort
         & seq (matchSort andSort andFirst)

--- a/kore/src/Kore/Syntax/Bottom.hs
+++ b/kore/src/Kore/Syntax/Bottom.hs
@@ -44,10 +44,10 @@ instance Unparse (Bottom Sort child) where
         "\\bottom" <> parameters [bottomSort] <> noArguments
     unparse2 _ = "\\bottom"
 
-instance Ord variable => Synthetic (Bottom sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Bottom sort) where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Bottom Sort) Sort where
+instance Synthetic Sort (Bottom Sort) where
     synthetic = bottomSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Ceil.hs
+++ b/kore/src/Kore/Syntax/Ceil.hs
@@ -58,11 +58,11 @@ instance Unparse child => Unparse (Ceil Sort child) where
     unparse2 Ceil { ceilChild } =
         Pretty.parens (Pretty.fillSep ["\\ceil", unparse2 ceilChild])
 
-instance Ord variable => Synthetic (Ceil sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Ceil sort) where
     synthetic = ceilChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Ceil Sort) Sort where
+instance Synthetic Sort (Ceil Sort) where
     synthetic Ceil { ceilOperandSort, ceilResultSort, ceilChild } =
         ceilResultSort
         & seq (matchSort ceilOperandSort ceilChild)

--- a/kore/src/Kore/Syntax/CharLiteral.hs
+++ b/kore/src/Kore/Syntax/CharLiteral.hs
@@ -10,6 +10,7 @@ module Kore.Syntax.CharLiteral
 
 import           Control.DeepSeq
                  ( NFData (..) )
+import           Data.Functor.Const
 import           Data.Hashable
 import           Data.String
                  ( fromString )
@@ -27,30 +28,30 @@ import Kore.Unparser
 {-|'CharLiteral' corresponds to the @char@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype CharLiteral child = CharLiteral { getCharLiteral :: Char }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+newtype CharLiteral = CharLiteral { getCharLiteral :: Char }
+    deriving (Eq, GHC.Generic, Ord, Show)
 
-instance Hashable (CharLiteral child)
+instance Hashable CharLiteral
 
-instance NFData (CharLiteral child)
+instance NFData CharLiteral
 
-instance SOP.Generic (CharLiteral child)
+instance SOP.Generic CharLiteral
 
-instance SOP.HasDatatypeInfo (CharLiteral child)
+instance SOP.HasDatatypeInfo CharLiteral
 
-instance Debug (CharLiteral child)
+instance Debug CharLiteral
 
-instance Unparse (CharLiteral child) where
+instance Unparse CharLiteral where
     unparse = Pretty.squotes . fromString . escapeChar . getCharLiteral
     unparse2 = unparse
 
 instance
     Ord variable =>
-    Synthetic CharLiteral (FreeVariables variable)
+    Synthetic (Const CharLiteral) (FreeVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic CharLiteral Sort where
+instance Synthetic (Const CharLiteral) Sort where
     synthetic = const charMetaSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/CharLiteral.hs
+++ b/kore/src/Kore/Syntax/CharLiteral.hs
@@ -45,13 +45,11 @@ instance Unparse CharLiteral where
     unparse = Pretty.squotes . fromString . escapeChar . getCharLiteral
     unparse2 = unparse
 
-instance
-    Ord variable =>
-    Synthetic (Const CharLiteral) (FreeVariables variable)
+instance Ord variable => Synthetic (FreeVariables variable) (Const CharLiteral)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Const CharLiteral) Sort where
+instance Synthetic Sort (Const CharLiteral) where
     synthetic = const charMetaSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/DomainValue.hs
+++ b/kore/src/Kore/Syntax/DomainValue.hs
@@ -59,12 +59,12 @@ instance Unparse child => Unparse (DomainValue Sort child) where
 
 instance
     Ord variable =>
-    Synthetic (DomainValue sort) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (DomainValue sort)
   where
     synthetic = domainValueChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (DomainValue Sort) Sort where
+instance Synthetic Sort (DomainValue Sort) where
     synthetic DomainValue { domainValueSort, domainValueChild } =
         domainValueSort
         & seq (matchSort stringMetaSort domainValueChild)

--- a/kore/src/Kore/Syntax/Equals.hs
+++ b/kore/src/Kore/Syntax/Equals.hs
@@ -74,11 +74,11 @@ instance Unparse child => Unparse (Equals Sort child) where
             , unparse2 equalsSecond
             ])
 
-instance Ord variable => Synthetic (Equals sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Equals sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Equals Sort) Sort where
+instance Synthetic Sort (Equals Sort) where
     synthetic equals =
         equalsResultSort
         & seq (matchSort equalsOperandSort equalsFirst)

--- a/kore/src/Kore/Syntax/Exists.hs
+++ b/kore/src/Kore/Syntax/Exists.hs
@@ -72,13 +72,13 @@ instance
 
 instance
     Ord variable =>
-    Synthetic (Exists sort variable) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Exists sort variable)
   where
     synthetic Exists { existsVariable, existsChild } =
         bindVariable (ElemVar existsVariable) existsChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Exists Sort variable) Sort where
+instance Synthetic Sort (Exists Sort variable) where
     synthetic Exists { existsSort, existsChild } =
         existsSort `matchSort` existsChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Floor.hs
+++ b/kore/src/Kore/Syntax/Floor.hs
@@ -57,11 +57,11 @@ instance Unparse child => Unparse (Floor Sort child) where
     unparse2 Floor { floorChild } =
         Pretty.parens (Pretty.fillSep ["\\floor", unparse2 floorChild])
 
-instance Ord variable => Synthetic (Floor sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Floor sort) where
     synthetic = floorChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Floor Sort) Sort where
+instance Synthetic Sort (Floor Sort) where
     synthetic Floor { floorOperandSort, floorResultSort, floorChild } =
         floorResultSort
         & seq (matchSort floorOperandSort floorChild)

--- a/kore/src/Kore/Syntax/Forall.hs
+++ b/kore/src/Kore/Syntax/Forall.hs
@@ -72,13 +72,13 @@ instance
 
 instance
     Ord variable =>
-    Synthetic (Forall sort variable) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Forall sort variable)
   where
     synthetic Forall { forallVariable, forallChild } =
         bindVariable (ElemVar forallVariable) forallChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Forall Sort variable) Sort where
+instance Synthetic Sort (Forall Sort variable) where
     synthetic Forall { forallSort, forallChild } =
         forallSort `matchSort` forallChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Iff.hs
+++ b/kore/src/Kore/Syntax/Iff.hs
@@ -60,11 +60,11 @@ instance Unparse child => Unparse (Iff Sort child) where
             , unparse2 iffSecond
             ])
 
-instance Ord variable => Synthetic (Iff sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Iff sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Iff Sort) Sort where
+instance Synthetic Sort (Iff Sort) where
     synthetic Iff { iffSort, iffFirst, iffSecond } =
         iffSort
         & seq (matchSort iffSort iffFirst)

--- a/kore/src/Kore/Syntax/Implies.hs
+++ b/kore/src/Kore/Syntax/Implies.hs
@@ -60,11 +60,11 @@ instance Unparse child => Unparse (Implies Sort child) where
             , unparse2 impliesSecond
             ])
 
-instance Ord variable => Synthetic (Implies sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Implies sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Implies Sort) Sort where
+instance Synthetic Sort (Implies Sort) where
     synthetic Implies { impliesSort, impliesFirst, impliesSecond } =
         impliesSort
         & seq (matchSort impliesSort impliesFirst)

--- a/kore/src/Kore/Syntax/In.hs
+++ b/kore/src/Kore/Syntax/In.hs
@@ -74,11 +74,11 @@ instance Unparse child => Unparse (In Sort child) where
             , unparse2 inContainingChild
             ])
 
-instance Ord variable => Synthetic (In sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (In sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (In Sort) Sort where
+instance Synthetic Sort (In Sort) where
     synthetic in' =
         inResultSort
         & seq (matchSort inOperandSort inContainedChild)

--- a/kore/src/Kore/Syntax/Inhabitant.hs
+++ b/kore/src/Kore/Syntax/Inhabitant.hs
@@ -41,11 +41,11 @@ instance Unparse (Inhabitant child) where
 
 instance
     Ord variable =>
-    Synthetic Inhabitant (FreeVariables variable)
+    Synthetic (FreeVariables variable) Inhabitant
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic Inhabitant Sort where
+instance Synthetic Sort Inhabitant where
     synthetic = inhSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Mu.hs
+++ b/kore/src/Kore/Syntax/Mu.hs
@@ -65,13 +65,13 @@ instance
 
 instance
     Ord variable =>
-    Synthetic (Mu variable) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Mu variable)
   where
     synthetic Mu { muVariable, muChild } =
         bindVariable (SetVar muVariable) muChild
     {-# INLINE synthetic #-}
 
-instance SortedVariable variable => Synthetic (Mu variable) Sort where
+instance SortedVariable variable => Synthetic Sort (Mu variable) where
     synthetic Mu { muVariable, muChild } =
         muSort
         & seq (matchSort muSort muChild)

--- a/kore/src/Kore/Syntax/Next.hs
+++ b/kore/src/Kore/Syntax/Next.hs
@@ -52,11 +52,11 @@ instance Unparse child => Unparse (Next Sort child) where
     unparse2 Next { nextChild } =
         Pretty.parens (Pretty.fillSep ["\\next", unparse2 nextChild])
 
-instance Ord variable => Synthetic (Next sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Next sort) where
     synthetic = nextChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Next Sort) Sort where
+instance Synthetic Sort (Next Sort) where
     synthetic Next { nextSort, nextChild } =
         nextSort `matchSort` nextChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Not.hs
+++ b/kore/src/Kore/Syntax/Not.hs
@@ -58,11 +58,11 @@ instance TopBottom child => TopBottom (Not sort child) where
     isTop = isBottom . notChild
     isBottom = isTop . notChild
 
-instance Ord variable => Synthetic (Not child) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Not child) where
     synthetic = notChild
     {-# INLINE synthetic #-}
 
-instance Synthetic (Not Sort) Sort where
+instance Synthetic Sort (Not Sort) where
     synthetic Not { notSort, notChild } =
         notSort `matchSort` notChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Nu.hs
+++ b/kore/src/Kore/Syntax/Nu.hs
@@ -65,13 +65,13 @@ instance
 
 instance
     Ord variable =>
-    Synthetic (Nu variable) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Nu variable)
   where
     synthetic Nu { nuVariable, nuChild } =
         bindVariable (SetVar nuVariable) nuChild
     {-# INLINE synthetic #-}
 
-instance SortedVariable variable => Synthetic (Nu variable) Sort where
+instance SortedVariable variable => Synthetic Sort (Nu variable) where
     synthetic Nu { nuVariable, nuChild } =
         nuSort
         & seq (matchSort nuSort nuChild)

--- a/kore/src/Kore/Syntax/Or.hs
+++ b/kore/src/Kore/Syntax/Or.hs
@@ -60,11 +60,11 @@ instance Unparse child => Unparse (Or Sort child) where
             , unparse2 orSecond
             ])
 
-instance Ord variable => Synthetic (Or sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Or sort) where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Or Sort) Sort where
+instance Synthetic Sort (Or Sort) where
     synthetic Or { orSort, orFirst, orSecond } =
         orSort
         & seq (matchSort orSort orFirst)

--- a/kore/src/Kore/Syntax/Pattern.hs
+++ b/kore/src/Kore/Syntax/Pattern.hs
@@ -16,6 +16,7 @@ module Kore.Syntax.Pattern
     -- * Re-exports
     , Base, CofreeF (..)
     , PatternF (..)
+    , Const (..)
     , module Control.Comonad
     ) where
 
@@ -42,7 +43,7 @@ import qualified GHC.Generics as GHC
 import qualified Kore.Attribute.Null as Attribute
 import           Kore.Debug
 import           Kore.Syntax.PatternF
-                 ( PatternF (..) )
+                 ( Const (..), PatternF (..) )
 import qualified Kore.Syntax.PatternF as PatternF
 import           Kore.Syntax.Variable
 import           Kore.TopBottom

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -11,10 +11,13 @@ module Kore.Syntax.PatternF
     -- * Pure pattern heads
     , groundHead
     , constant
+    -- * Re-exports
+    , Const (..)
     ) where
 
 import           Control.DeepSeq
                  ( NFData (..) )
+import           Data.Functor.Const
 import           Data.Functor.Identity
                  ( Identity (..) )
 import           Data.Hashable
@@ -73,11 +76,11 @@ data PatternF variable child
     | NuF            !(Nu variable child)
     | OrF            !(Or Sort child)
     | RewritesF      !(Rewrites Sort child)
-    | StringLiteralF !(StringLiteral child)
-    | CharLiteralF   !(CharLiteral child)
     | TopF           !(Top Sort child)
-    | VariableF      !(UnifiedVariable variable)
     | InhabitantF    !(Inhabitant child)
+    | StringLiteralF !(Const StringLiteral child)
+    | CharLiteralF   !(CharLiteral child)
+    | VariableF      !(UnifiedVariable variable)
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (PatternF variable child)

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -79,7 +79,7 @@ data PatternF variable child
     | TopF           !(Top Sort child)
     | InhabitantF    !(Inhabitant child)
     | StringLiteralF !(Const StringLiteral child)
-    | CharLiteralF   !(CharLiteral child)
+    | CharLiteralF   !(Const CharLiteral child)
     | VariableF      !(UnifiedVariable variable)
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 

--- a/kore/src/Kore/Syntax/Rewrites.hs
+++ b/kore/src/Kore/Syntax/Rewrites.hs
@@ -60,14 +60,12 @@ instance Unparse child => Unparse (Rewrites Sort child) where
             , unparse2 rewritesSecond
             ])
 
-instance
-    Ord variable =>
-    Synthetic (Rewrites sort) (FreeVariables variable)
+instance Ord variable => Synthetic (FreeVariables variable) (Rewrites sort)
   where
     synthetic = Foldable.fold
     {-# INLINE synthetic #-}
 
-instance Synthetic (Rewrites Sort) Sort where
+instance Synthetic Sort (Rewrites Sort) where
     synthetic Rewrites { rewritesSort, rewritesFirst, rewritesSecond } =
         rewritesSort
         & seq (matchSort rewritesSort rewritesFirst)

--- a/kore/src/Kore/Syntax/StringLiteral.hs
+++ b/kore/src/Kore/Syntax/StringLiteral.hs
@@ -10,6 +10,7 @@ module Kore.Syntax.StringLiteral
 
 import           Control.DeepSeq
                  ( NFData (..) )
+import           Data.Functor.Const
 import           Data.Hashable
 import           Data.Text
                  ( Text )
@@ -27,30 +28,30 @@ import Kore.Unparser
 {-|'StringLiteral' corresponds to the @string@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype StringLiteral child = StringLiteral { getStringLiteral :: Text }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+newtype StringLiteral = StringLiteral { getStringLiteral :: Text }
+    deriving (Eq, GHC.Generic, Ord, Show)
 
-instance Hashable (StringLiteral child)
+instance Hashable StringLiteral
 
-instance NFData (StringLiteral child)
+instance NFData StringLiteral
 
-instance SOP.Generic (StringLiteral child)
+instance SOP.Generic StringLiteral
 
-instance SOP.HasDatatypeInfo (StringLiteral child)
+instance SOP.HasDatatypeInfo StringLiteral
 
-instance Debug (StringLiteral child)
+instance Debug StringLiteral
 
-instance Unparse (StringLiteral child) where
+instance Unparse StringLiteral where
     unparse = Pretty.dquotes . Pretty.pretty . escapeStringT . getStringLiteral
     unparse2 = unparse
 
 instance
     Ord variable =>
-    Synthetic StringLiteral (FreeVariables variable)
+    Synthetic (Const StringLiteral) (FreeVariables variable)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic StringLiteral Sort where
+instance Synthetic (Const StringLiteral) Sort where
     synthetic = const stringMetaSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/StringLiteral.hs
+++ b/kore/src/Kore/Syntax/StringLiteral.hs
@@ -47,11 +47,11 @@ instance Unparse StringLiteral where
 
 instance
     Ord variable =>
-    Synthetic (Const StringLiteral) (FreeVariables variable)
+    Synthetic (FreeVariables variable) (Const StringLiteral)
   where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Const StringLiteral) Sort where
+instance Synthetic Sort (Const StringLiteral) where
     synthetic = const stringMetaSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Top.hs
+++ b/kore/src/Kore/Syntax/Top.hs
@@ -45,10 +45,10 @@ instance Unparse (Top Sort child) where
 
     unparse2 _ = "\\top"
 
-instance Ord variable => Synthetic (Top sort) (FreeVariables variable) where
+instance Ord variable => Synthetic (FreeVariables variable) (Top sort) where
     synthetic = const mempty
     {-# INLINE synthetic #-}
 
-instance Synthetic (Top Sort) Sort where
+instance Synthetic Sort (Top Sort) where
     synthetic = topSort
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/kore/src/Kore/Unification/UnifierImpl.hs
@@ -89,15 +89,13 @@ simplifyAnds patterns = do
         else return result
 
 groupSubstitutionByVariable
-    :: Ord variable
+    :: (Ord variable, SortedVariable variable)
     => [(UnifiedVariable variable, TermLike variable)]
     -> [[(UnifiedVariable variable, TermLike variable)]]
 groupSubstitutionByVariable =
     groupBy ((==) `on` fst) . sortBy (compare `on` fst) . map sortRenaming
   where
-    sortRenaming (var, Recursive.project -> ann :< VariableF var')
-        | var' < var =
-            (var', Recursive.embed (ann :< VariableF var))
+    sortRenaming (var, Var_ var') | var' < var = (var', mkVar var)
     sortRenaming eq = eq
 
 -- simplifies x = t1 /\ x = t2 /\ ... /\ x = tn by transforming it into

--- a/kore/src/Kore/Variables/Free.hs
+++ b/kore/src/Kore/Variables/Free.hs
@@ -45,8 +45,8 @@ freePureVariables root =
 
     freePureVariables1 recursive =
         case Cofree.tailF (Recursive.project recursive) of
-            VariableF v ->
-                Monad.unlessM (isBound v) (recordFree v)
+            VariableF (Const variable) ->
+                Monad.unlessM (isBound variable) (recordFree variable)
             ExistsF Exists { existsVariable, existsChild } ->
                 Monad.RWS.local
                     -- record the bound variable
@@ -81,7 +81,7 @@ pureMergeVariables
     -> Set.Set (UnifiedVariable variable)
 pureMergeVariables base =
     case Cofree.tailF base of
-        VariableF v -> Set.singleton v
+        VariableF (Const variable) -> Set.singleton variable
         ExistsF Exists { existsVariable, existsChild } ->
             Set.insert (ElemVar existsVariable) existsChild
         ForallF Forall { forallVariable, forallChild } ->
@@ -100,4 +100,3 @@ pureAllVariables
     => Pattern variable annotation
     -> Set.Set (UnifiedVariable variable)
 pureAllVariables = Recursive.fold pureMergeVariables
-

--- a/kore/src/Kore/Variables/UnifiedVariable.hs
+++ b/kore/src/Kore/Variables/UnifiedVariable.hs
@@ -60,7 +60,7 @@ isSetVar _ = False
 
 instance
     SortedVariable variable =>
-    Synthetic (Const (UnifiedVariable variable)) Sort
+    Synthetic Sort (Const (UnifiedVariable variable))
   where
     synthetic (Const var) = foldMapVariable sortedVariableSort var
     {-# INLINE synthetic #-}

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -125,7 +125,7 @@ setVarIdGen = testId <$> fmap ("@" <>) objectIdGen
 stringLiteralGen :: MonadGen m => m StringLiteral
 stringLiteralGen = StringLiteral <$> Gen.text (Range.linear 0 256) charGen
 
-charLiteralGen :: MonadGen m => m (CharLiteral child)
+charLiteralGen :: MonadGen m => m CharLiteral
 charLiteralGen = CharLiteral <$> charGen
 
 charGen :: MonadGen m => m Char
@@ -421,7 +421,7 @@ korePatternChildGen patternSort' =
 
     korePatternGenCharLiteral :: Gen ParsedPattern
     korePatternGenCharLiteral =
-        asParsedPattern . Syntax.CharLiteralF <$> charLiteralGen
+        asParsedPattern . Syntax.CharLiteralF . Syntax.Const <$> charLiteralGen
 
     korePatternGenDomainValue :: Gen ParsedPattern
     korePatternGenDomainValue =

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -41,6 +41,7 @@ import qualified Hedgehog.Range as Range
 import           Control.Monad.Reader
                  ( ReaderT )
 import qualified Control.Monad.Reader as Reader
+import           Data.Functor.Const
 import           Data.Text
                  ( Text )
 import qualified Data.Text as Text
@@ -380,7 +381,7 @@ patternGen childGen patternSort =
         , (1, Syntax.NotF <$> notGen childGen patternSort)
         , (1, Syntax.OrF <$> orGen childGen patternSort)
         , (1, Syntax.TopF <$> topGen patternSort)
-        , (5, Syntax.VariableF <$> unifiedVariableGen patternSort)
+        , (5, Syntax.VariableF . Const <$> unifiedVariableGen patternSort)
         ]
 
 korePatternGen :: Hedgehog.Gen ParsedPattern
@@ -416,12 +417,12 @@ korePatternChildGen patternSort' =
 
     korePatternGenStringLiteral :: Gen ParsedPattern
     korePatternGenStringLiteral =
-        asParsedPattern . Syntax.StringLiteralF . Syntax.Const
+        asParsedPattern . Syntax.StringLiteralF . Const
         <$> stringLiteralGen
 
     korePatternGenCharLiteral :: Gen ParsedPattern
     korePatternGenCharLiteral =
-        asParsedPattern . Syntax.CharLiteralF . Syntax.Const <$> charLiteralGen
+        asParsedPattern . Syntax.CharLiteralF . Const <$> charLiteralGen
 
     korePatternGenDomainValue :: Gen ParsedPattern
     korePatternGenDomainValue =
@@ -440,7 +441,8 @@ korePatternChildGen patternSort' =
 
     korePatternGenVariable :: Gen ParsedPattern
     korePatternGenVariable =
-        asParsedPattern . Syntax.VariableF <$> unifiedVariableGen patternSort'
+        asParsedPattern . Syntax.VariableF . Const
+        <$> unifiedVariableGen patternSort'
 
 korePatternUnifiedGen :: Gen ParsedPattern
 korePatternUnifiedGen = korePatternChildGen =<< sortGen

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -58,7 +58,6 @@ import qualified Kore.Predicate.Predicate as Syntax
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import           Kore.Syntax.Definition
 import qualified Kore.Syntax.PatternF as Syntax
-                 ( PatternF (..) )
 import           Kore.Variables.UnifiedVariable
                  ( UnifiedVariable (..) )
 
@@ -123,9 +122,8 @@ objectIdGen =
 setVarIdGen :: MonadGen m => m Id
 setVarIdGen = testId <$> fmap ("@" <>) objectIdGen
 
-stringLiteralGen :: MonadGen m => m (StringLiteral child)
-stringLiteralGen =
-    StringLiteral <$> Gen.text (Range.linear 0 256) charGen
+stringLiteralGen :: MonadGen m => m StringLiteral
+stringLiteralGen = StringLiteral <$> Gen.text (Range.linear 0 256) charGen
 
 charLiteralGen :: MonadGen m => m (CharLiteral child)
 charLiteralGen = CharLiteral <$> charGen
@@ -418,7 +416,8 @@ korePatternChildGen patternSort' =
 
     korePatternGenStringLiteral :: Gen ParsedPattern
     korePatternGenStringLiteral =
-        asParsedPattern . Syntax.StringLiteralF <$> stringLiteralGen
+        asParsedPattern . Syntax.StringLiteralF . Syntax.Const
+        <$> stringLiteralGen
 
     korePatternGenCharLiteral :: Gen ParsedPattern
     korePatternGenCharLiteral =

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -636,7 +636,8 @@ setVariable (VariableName name) sort =
         }
 
 variablePattern :: VariableName -> Sort -> Syntax.PatternF Variable p
-variablePattern name sort = Syntax.VariableF (ElemVar $ variable name sort)
+variablePattern name sort =
+    Syntax.VariableF $ Const $ ElemVar $ variable name sort
 
 variableTermLike :: VariableName -> Sort -> TermLike Variable
 variableTermLike name sort = Internal.mkElemVar (variable name sort)

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -442,7 +442,7 @@ test_patternVerifier =
         ]
         NeedsInternalDefinitions
     , successTestsForObjectPattern "Object pattern - unquantified variable"
-        (VariableF (ElemVar objectVariable'))
+        (VariableF $ Const $ ElemVar objectVariable')
         (NamePrefix "dummy")
         (TestedPatternSort objectSort)
         (SortVariablesThatMustBeDeclared [])
@@ -450,7 +450,7 @@ test_patternVerifier =
         [ objectSortSentence, anotherSortSentence ]
         NeedsInternalDefinitions
     , successTestsForMetaPattern "Meta pattern - unquantified variable"
-        (VariableF (ElemVar metaVariable'))
+        (VariableF $ Const $ ElemVar metaVariable')
         (NamePrefix "#dummy")
         (TestedPatternSort metaSort1)
         (SortVariablesThatMustBeDeclared [])

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -472,7 +472,7 @@ test_patternVerifier =
         -- at least in some cases.
         NeedsInternalDefinitions
     , successTestsForMetaPattern "Simple char pattern"
-        (CharLiteralF (CharLiteral 'c'))
+        (CharLiteralF $ Const $ CharLiteral 'c')
         (NamePrefix "#dummy")
         (TestedPatternSort charMetaSort)
         (SortVariablesThatMustBeDeclared [])

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/PatternVerifier.hs
@@ -460,7 +460,7 @@ test_patternVerifier =
         []
         NeedsInternalDefinitions
     , successTestsForMetaPattern "Simple string pattern"
-        (StringLiteralF (StringLiteral "MetaString"))
+        (StringLiteralF (Const $ StringLiteral "MetaString"))
         (NamePrefix "#dummy")
         (TestedPatternSort stringMetaSort)
         (SortVariablesThatMustBeDeclared [])
@@ -489,7 +489,7 @@ test_patternVerifier =
         (ErrorStack
             [ "(<test data>, <implicitly defined entity>)" ]
         )
-        (StringLiteralF (StringLiteral "MetaString"))
+        (StringLiteralF (Const $ StringLiteral "MetaString"))
         (NamePrefix "#dummy")
         (TestedPatternSort (updateAstLocation charMetaSort AstLocationTest))
         (SortVariablesThatMustBeDeclared [])

--- a/kore/test/Test/Kore/Attribute/Assoc.hs
+++ b/kore/test/Test/Kore/Attribute/Assoc.hs
@@ -36,15 +36,7 @@ test_arguments =
         $ expectFailure
         $ parseAssoc $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = assocSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern assocSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Axiom/Unit.hs
+++ b/kore/test/Test/Kore/Attribute/Axiom/Unit.hs
@@ -36,15 +36,7 @@ test_arguments =
         $ expectFailure
         $ parseUnit $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = unitSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern unitSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Comm.hs
+++ b/kore/test/Test/Kore/Attribute/Comm.hs
@@ -36,15 +36,7 @@ test_arguments =
         $ expectFailure
         $ parseComm $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = commSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern commSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Constructor.hs
+++ b/kore/test/Test/Kore/Attribute/Constructor.hs
@@ -33,18 +33,11 @@ test_duplicate =
 test_arguments :: TestTree
 test_arguments =
     testCase "[constructor{}(\"illegal\")]"
-        $ expectFailure
-        $ parseConstructor $ Attributes [ illegalAttribute ]
+    $ expectFailure
+    $ parseConstructor $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = constructorSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern constructorSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Function.hs
+++ b/kore/test/Test/Kore/Attribute/Function.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseFunction $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = functionSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern functionSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Functional.hs
+++ b/kore/test/Test/Kore/Attribute/Functional.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseFunctional $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = functionalSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern functionalSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/HeatCool.hs
+++ b/kore/test/Test/Kore/Attribute/HeatCool.hs
@@ -36,15 +36,7 @@ test_heat_arguments =
         $ expectFailure
         $ parseHeatCool $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = heatSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern heatSymbol [attributeString "illegal"]
 
 test_heat_parameters :: TestTree
 test_heat_parameters =
@@ -89,15 +81,7 @@ test_cool_arguments =
         $ expectFailure
         $ parseHeatCool $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = coolSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern coolSymbol [attributeString "illegal"]
 
 test_cool_parameters :: TestTree
 test_cool_parameters =

--- a/kore/test/Test/Kore/Attribute/Hook.hs
+++ b/kore/test/Test/Kore/Attribute/Hook.hs
@@ -52,16 +52,8 @@ test_twoArguments =
         $ parseHook $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = hookSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    , (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern hookSymbol
+            [attributeString "illegal", attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =
@@ -70,16 +62,10 @@ test_parameters =
         $ parseHook $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias =
-                    SymbolOrAlias
-                        { symbolOrAliasConstructor = hookId
-                        , symbolOrAliasParams =
-                            [ SortVariableSort (SortVariable "illegal") ]
-                        }
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "BUILTIN.name")
-                    ]
+        attributePattern
+            SymbolOrAlias
+                { symbolOrAliasConstructor = hookId
+                , symbolOrAliasParams =
+                    [ SortVariableSort (SortVariable "illegal") ]
                 }
+            [attributeString "BUILTIN.name"]

--- a/kore/test/Test/Kore/Attribute/Idem.hs
+++ b/kore/test/Test/Kore/Attribute/Idem.hs
@@ -36,15 +36,7 @@ test_arguments =
         $ expectFailure
         $ parseIdem $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = idemSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern idemSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Injective.hs
+++ b/kore/test/Test/Kore/Attribute/Injective.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseInjective $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = injectiveSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern injectiveSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Label.hs
+++ b/kore/test/Test/Kore/Attribute/Label.hs
@@ -53,16 +53,10 @@ test_parameters =
     $ parseLabel $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias =
-                    SymbolOrAlias
-                        { symbolOrAliasConstructor = labelId
-                        , symbolOrAliasParams =
-                            [ SortVariableSort (SortVariable "illegal") ]
-                        }
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "text")
-                    ]
+        attributePattern
+            SymbolOrAlias
+                { symbolOrAliasConstructor = labelId
+                , symbolOrAliasParams =
+                    [ SortVariableSort (SortVariable "illegal") ]
                 }
+            [attributeString "text"]

--- a/kore/test/Test/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Defined.hs
@@ -102,7 +102,7 @@ test_instance_Synthetic =
     range = [defined, nonDefined]
 
     check
-        :: (GHC.HasCallStack, Synthetic term Defined)
+        :: (GHC.HasCallStack, Synthetic Defined term)
         => TestName
         -> (Defined -> Bool)
         -> term Defined
@@ -114,14 +114,14 @@ test_instance_Synthetic =
 
     is
         ::  ( GHC.HasCallStack
-            , Synthetic term Defined
+            , Synthetic Defined term
             )
         => term Defined -> TestTree
     is = check "Defined term" isDefined
 
     isn't
         ::  ( GHC.HasCallStack
-            , Synthetic term Defined
+            , Synthetic Defined term
             )
         => term Defined -> TestTree
     isn't = check "Non-defined pattern" (not . isDefined)

--- a/kore/test/Test/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Defined.hs
@@ -38,10 +38,10 @@ test_instance_Synthetic =
     , testGroup "TopF" [ is $ TopF (Top sort) ]
     , testGroup "ExistsF" $ map (isn't . ExistsF) (Exists sort Mock.x <$> range)
     , testGroup "ForallF" $ map (isn't . ForallF) (Forall sort Mock.x <$> range)
-    , testGroup "VariableF" [ is $ VariableF (ElemVar Mock.x) ]
+    , testGroup "VariableF" [ is $ VariableF $ Const (ElemVar Mock.x) ]
     , testGroup "MuF" $ map (isn't . MuF) (Mu (SetVariable Mock.x) <$> range)
     , testGroup "NuF" $ map (isn't . NuF) (Nu (SetVariable Mock.x) <$> range)
-    , testGroup "SetVariableF" [ isn't $ VariableF (SetVar Mock.setX) ]
+    , testGroup "SetVariableF" [ isn't $ VariableF $ Const (SetVar Mock.setX) ]
     -- Interesting cases
     , testGroup "ApplySymbolF"
         [ testGroup "functional" $ do

--- a/kore/test/Test/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/FreeVariables.hs
@@ -64,16 +64,16 @@ test_instance_Synthetic_TermLike =
     , RewritesF    (Rewrites sort x y)        `gives'` xy     $ "RewritesF"
     , TopF         (Top sort)                 `gives'` mempty $ "TopF"
     -- Binders and variables are the only interesting cases:
-    , ExistsF      (Exists sort Mock.x xy)    `gives'` y      $ "ExistsF - Bound"
-    , ExistsF      (Exists sort Mock.x y)     `gives'` y      $ "ExistsF - Free"
-    , ForallF      (Forall sort Mock.x xy)    `gives'` y      $ "ForallF - Bound"
-    , ForallF      (Forall sort Mock.x y)     `gives'` y      $ "ForallF - Free"
-    , VariableF    (ElemVar Mock.x)           `gives'` x      $ "Elem VariableF"
-    , MuF          (Mu Mock.setX sxy)         `gives'` sy     $ "MuF - Bound"
-    , MuF          (Mu Mock.setX sy)          `gives'` sy     $ "MuF - Free"
-    , NuF          (Nu Mock.setX sxy)         `gives'` sy     $ "NuF - Bound"
-    , NuF          (Nu Mock.setX sy)          `gives'` sy     $ "NuF - Free"
-    , VariableF    (SetVar Mock.setX)         `gives'` sx     $ "Set VariableF"
+    , ExistsF      (Exists sort Mock.x xy)    `gives'` y  $ "ExistsF - Bound"
+    , ExistsF      (Exists sort Mock.x y)     `gives'` y  $ "ExistsF - Free"
+    , ForallF      (Forall sort Mock.x xy)    `gives'` y  $ "ForallF - Bound"
+    , ForallF      (Forall sort Mock.x y)     `gives'` y  $ "ForallF - Free"
+    , (VariableF . Const) (ElemVar Mock.x)    `gives'` x  $ "Elem VariableF"
+    , MuF          (Mu Mock.setX sxy)         `gives'` sy $ "MuF - Bound"
+    , MuF          (Mu Mock.setX sy)          `gives'` sy $ "MuF - Free"
+    , NuF          (Nu Mock.setX sxy)         `gives'` sy $ "NuF - Bound"
+    , NuF          (Nu Mock.setX sy)          `gives'` sy $ "NuF - Free"
+    , (VariableF . Const) (SetVar Mock.setX)  `gives'` sx $ "Set VariableF"
     ]
   where
     gives' = gives @(TermLikeF Variable)

--- a/kore/test/Test/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/FreeVariables.hs
@@ -93,7 +93,7 @@ sy = FreeVariables.freeVariable (SetVar Mock.setY)
 sxy = sx <> sy
 
 gives
-    :: (Synthetic base (FreeVariables Variable), GHC.HasCallStack)
+    :: (Synthetic (FreeVariables Variable) base, GHC.HasCallStack)
     => base (FreeVariables Variable)
     -> FreeVariables Variable
     -> String

--- a/kore/test/Test/Kore/Attribute/Pattern/Function.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Function.hs
@@ -49,7 +49,7 @@ test_instance_Synthetic =
     , testGroup "TopF" [ isn't $ TopF (Top sort) ]
     , testGroup "ExistsF" $ map (isn't . ExistsF) (Exists sort Mock.x <$> range)
     , testGroup "ForallF" $ map (isn't . ForallF) (Forall sort Mock.x <$> range)
-    , testGroup "VariableF" [ is $ VariableF (ElemVar Mock.x) ]
+    , testGroup "VariableF" [ is $ VariableF $ Const (ElemVar Mock.x) ]
     , testGroup "MuF" $ map (isn't . MuF) (Mu Mock.setX <$> range)
     , testGroup "NuF" $ map (isn't . NuF) (Nu Mock.setX <$> range)
     ]

--- a/kore/test/Test/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Functional.hs
@@ -98,7 +98,7 @@ test_instance_Synthetic =
     range = [functional, nonFunctional]
 
     check
-        :: (GHC.HasCallStack, Synthetic term Functional)
+        :: (GHC.HasCallStack, Synthetic Functional term)
         => TestName
         -> (Functional -> Bool)
         -> term Functional
@@ -110,14 +110,14 @@ test_instance_Synthetic =
 
     is
         ::  ( GHC.HasCallStack
-            , Synthetic term Functional
+            , Synthetic Functional term
             )
         => term Functional -> TestTree
     is = check "Functional pattern" isFunctional
 
     isn't
         ::  ( GHC.HasCallStack
-            , Synthetic term Functional
+            , Synthetic Functional term
             )
         => term Functional -> TestTree
     isn't = check "Non-functional pattern" (not . isFunctional)

--- a/kore/test/Test/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Functional.hs
@@ -54,10 +54,10 @@ test_instance_Synthetic =
     , testGroup "TopF" [ isn't $ TopF (Top sort) ]
     , testGroup "ExistsF" $ map (isn't . ExistsF) (Exists sort Mock.x <$> range)
     , testGroup "ForallF" $ map (isn't . ForallF) (Forall sort Mock.x <$> range)
-    , testGroup "VariableF" [ is $ VariableF (ElemVar Mock.x) ]
+    , testGroup "VariableF" [ is $ VariableF $ Const (ElemVar Mock.x) ]
     , testGroup "MuF" $ map (isn't . MuF) (Mu Mock.setX <$> range)
     , testGroup "NuF" $ map (isn't . NuF) (Nu Mock.setX <$> range)
-    , testGroup "SetVariableF" [ isn't $ VariableF (SetVar Mock.setX) ]
+    , testGroup "SetVariableF" [ isn't $ VariableF $ Const (SetVar Mock.setX) ]
     , testGroup "BuiltinSet"
         [ is . asSetBuiltin
             $ emptyNormalizedSet

--- a/kore/test/Test/Kore/Attribute/Pattern/Sort.hs
+++ b/kore/test/Test/Kore/Attribute/Pattern/Sort.hs
@@ -92,7 +92,7 @@ test_instance_Synthetic =
         , failure $ ForallF (Forall sort Mock.x sort0)
         ]
     , testGroup "VariableF"
-        [ success $ VariableF (ElemVar Mock.x)
+        [ success $ VariableF (Const (ElemVar Mock.x))
         ]
     , testGroup "MuF"
         [ success $ MuF (Mu Mock.setX sort)

--- a/kore/test/Test/Kore/Attribute/ProductionID.hs
+++ b/kore/test/Test/Kore/Attribute/ProductionID.hs
@@ -53,16 +53,8 @@ test_twoArguments =
         $ parseProductionID $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = productionIDSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    , (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern productionIDSymbol
+            [attributeString "illegal", attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =
@@ -71,16 +63,10 @@ test_parameters =
         $ parseProductionID $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias =
-                    SymbolOrAlias
-                        { symbolOrAliasConstructor = productionIDId
-                        , symbolOrAliasParams =
-                            [ SortVariableSort (SortVariable "illegal") ]
-                        }
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "string")
-                    ]
+        attributePattern
+            SymbolOrAlias
+                { symbolOrAliasConstructor = productionIDId
+                , symbolOrAliasParams =
+                    [ SortVariableSort (SortVariable "illegal") ]
                 }
+            [attributeString "string"]

--- a/kore/test/Test/Kore/Attribute/Simplification.hs
+++ b/kore/test/Test/Kore/Attribute/Simplification.hs
@@ -38,14 +38,7 @@ test_arguments =
         $ parseSimplification $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = simplificationSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern simplificationSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Sort/HasDomainValues.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/HasDomainValues.hs
@@ -67,7 +67,7 @@ test_arguments =
             Application
                 { applicationSymbolOrAlias = hasDomainValuesSymbol
                 , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
+                    [ (asAttributePattern . StringLiteralF . Const)
                         (StringLiteral "illegal")
                     ]
                 }

--- a/kore/test/Test/Kore/Attribute/Sort/Unit.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/Unit.hs
@@ -65,15 +65,7 @@ test_arguments =
     $ expectFailure
     $ parseUnit $ Attributes [ illegalAttribute ]
   where
-    illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = unitSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+    illegalAttribute = attributePattern unitSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/SortInjection.hs
+++ b/kore/test/Test/Kore/Attribute/SortInjection.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseSortInjection $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = sortInjectionSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern sortInjectionSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Subsort.hs
+++ b/kore/test/Test/Kore/Attribute/Subsort.hs
@@ -62,11 +62,4 @@ test_arguments =
         $ parseSubsorts $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = subsortSymbol sub super
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern (subsortSymbol sub super) [attributeString "illegal"]

--- a/kore/test/Test/Kore/Attribute/Symbol/Anywhere.hs
+++ b/kore/test/Test/Kore/Attribute/Symbol/Anywhere.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseAnywhere $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = anywhereSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern anywhereSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Attribute/Trusted.hs
+++ b/kore/test/Test/Kore/Attribute/Trusted.hs
@@ -37,14 +37,7 @@ test_arguments =
         $ parseTrusted $ Attributes [ illegalAttribute ]
   where
     illegalAttribute =
-        (asAttributePattern . ApplicationF)
-            Application
-                { applicationSymbolOrAlias = trustedSymbol
-                , applicationChildren =
-                    [ (asAttributePattern . StringLiteralF)
-                        (StringLiteral "illegal")
-                    ]
-                }
+        attributePattern trustedSymbol [attributeString "illegal"]
 
 test_parameters :: TestTree
 test_parameters =

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -778,7 +778,7 @@ instance
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 
-instance EqualWithExplanation (StringLiteral child) where
+instance EqualWithExplanation StringLiteral where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -782,7 +782,7 @@ instance EqualWithExplanation StringLiteral where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 
-instance EqualWithExplanation (CharLiteral child) where
+instance EqualWithExplanation CharLiteral where
     compareWithExplanation = rawCompareWithExplanation
     printWithExplanation = show
 

--- a/kore/test/Test/Kore/Parser/Parser.hs
+++ b/kore/test/Test/Kore/Parser/Parser.hs
@@ -259,9 +259,9 @@ andPatternParserTests =
             ( asParsedPattern $ AndF And
                 { andSort = sortVariableSort "s" :: Sort
                 , andFirst =
-                    asParsedPattern $ StringLiteralF (StringLiteral "a")
+                    asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                 , andSecond =
-                    asParsedPattern $ StringLiteralF (StringLiteral "b")
+                    asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                 }
             )
         , FailureWithoutMessage
@@ -354,7 +354,7 @@ ceilPatternParserTests =
                     { ceilOperandSort = sortVariableSort "s1" :: Sort
                     , ceilResultSort = sortVariableSort "s2"
                     , ceilChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     }
             )
         , FailureWithoutMessage
@@ -389,9 +389,9 @@ equalsPatternParserTests =
                     { equalsOperandSort = sortVariableSort "s1" :: Sort
                     , equalsResultSort = sortVariableSort "s2"
                     , equalsFirst =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , equalsSecond =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -416,7 +416,7 @@ existsPatternParserTests =
                             , variableCounter = mempty
                             }
                     , existsChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -443,7 +443,7 @@ floorPatternParserTests =
                     { floorOperandSort = sortVariableSort "s1" :: Sort
                     , floorResultSort = sortVariableSort "s2"
                     , floorChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     }
             )
         , FailureWithoutMessage
@@ -467,7 +467,7 @@ forallPatternParserTests =
                             , variableCounter = mempty
                             }
                     , forallChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -492,9 +492,9 @@ iffPatternParserTests =
             ( asParsedPattern $ IffF Iff
                     { iffSort = sortVariableSort "s" :: Sort
                     , iffFirst =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , iffSecond =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -512,9 +512,9 @@ impliesPatternParserTests =
             ( asParsedPattern $ ImpliesF Implies
                     { impliesSort = sortVariableSort "s" :: Sort
                     , impliesFirst =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , impliesSecond =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -539,7 +539,7 @@ memPatternParserTests =
                             , variableCounter = mempty
                             }
                     , inContainingChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , success "\\in{s1,s2}(\"a\", \"b\")"
@@ -547,9 +547,9 @@ memPatternParserTests =
                     { inOperandSort = sortVariableSort "s1" :: Sort
                     , inResultSort = sortVariableSort "s2"
                     , inContainedChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , inContainingChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -606,7 +606,7 @@ notPatternParserTests =
             ( asParsedPattern $ NotF Not
                     { notSort = sortVariableSort "s" :: Sort
                     , notChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     }
             )
         , FailureWithoutMessage
@@ -626,7 +626,7 @@ nextPatternParserTests =
             ( asParsedPattern $ NextF Next
                     { nextSort = sortVariableSort "s"
                     , nextChild =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     }
             )
         , FailureWithoutMessage
@@ -678,9 +678,9 @@ orPatternParserTests =
             ( asParsedPattern $ OrF Or
                     { orSort = sortVariableSort "s" :: Sort
                     , orFirst =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , orSecond =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -698,9 +698,9 @@ rewritesPatternParserTests =
             ( asParsedPattern $ RewritesF Rewrites
                     { rewritesSort = sortVariableSort "s"
                     , rewritesFirst =
-                        asParsedPattern $ StringLiteralF (StringLiteral "a")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
                     , rewritesSecond =
-                        asParsedPattern $ StringLiteralF (StringLiteral "b")
+                        asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                     }
             )
         , FailureWithoutMessage
@@ -715,11 +715,11 @@ stringLiteralPatternParserTests :: [TestTree]
 stringLiteralPatternParserTests =
     parseTree korePatternParser
         [ success "\"hello\""
-            (asParsedPattern $ StringLiteralF (StringLiteral "hello"))
+            (asParsedPattern $ StringLiteralF $ Const (StringLiteral "hello"))
         , success "\"\""
-            (asParsedPattern $ StringLiteralF (StringLiteral ""))
+            (asParsedPattern $ StringLiteralF $ Const (StringLiteral ""))
         , success "\"\\\"\""
-            (asParsedPattern $ StringLiteralF (StringLiteral "\""))
+            (asParsedPattern $ StringLiteralF $ Const (StringLiteral "\""))
         , FailureWithoutMessage ["", "\""]
         ]
 topPatternParserTests :: [TestTree]
@@ -795,7 +795,7 @@ sentenceAliasParserTests =
                     , sentenceAliasAttributes =
                         Attributes
                             [asParsedPattern $
-                                StringLiteralF (StringLiteral "a")]
+                                StringLiteralF $ Const (StringLiteral "a")]
                     }
                 :: ParsedSentenceAlias)
             )
@@ -866,9 +866,9 @@ sentenceAliasParserTests =
                     , sentenceAliasAttributes =
                         Attributes
                             [ asParsedPattern $
-                                StringLiteralF (StringLiteral "a")
+                                StringLiteralF $ Const (StringLiteral "a")
                             , asParsedPattern $
-                                StringLiteralF (StringLiteral "b")
+                                StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAlias)
@@ -1042,11 +1042,11 @@ sentenceAxiomParserTests =
                         [SortVariable (testId "sv1")]
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1059,11 +1059,11 @@ sentenceAxiomParserTests =
                     { sentenceAxiomParameters = []
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1077,11 +1077,11 @@ sentenceAxiomParserTests =
                         ]
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1105,11 +1105,11 @@ sentenceClaimParserTests =
                     { sentenceAxiomParameters = [SortVariable (testId "sv1")]
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1122,11 +1122,11 @@ sentenceClaimParserTests =
                     { sentenceAxiomParameters = []
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1140,11 +1140,11 @@ sentenceClaimParserTests =
                         ]
                     , sentenceAxiomPattern =
                         asParsedPattern
-                        $ StringLiteralF (StringLiteral "a")
+                        $ StringLiteralF $ Const (StringLiteral "a")
                     , sentenceAxiomAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceAxiom)
@@ -1169,7 +1169,7 @@ sentenceImportParserTests =
                     , sentenceImportAttributes =
                         Attributes
                             [ asParsedPattern
-                              $ StringLiteralF (StringLiteral "b")
+                              $ StringLiteralF $ Const (StringLiteral "b")
                             ]
                     }
                 :: ParsedSentenceImport)
@@ -1193,7 +1193,7 @@ sentenceSortParserTests =
                     , sentenceSortAttributes =
                         Attributes
                             [ asParsedPattern
-                                $ StringLiteralF (StringLiteral "a")
+                                $ StringLiteralF $ Const (StringLiteral "a")
                             ]
                     }
                 :: ParsedSentenceSort)
@@ -1208,7 +1208,7 @@ sentenceSortParserTests =
                     , sentenceSortAttributes =
                         Attributes
                             [ asParsedPattern
-                                $ StringLiteralF (StringLiteral "a")
+                                $ StringLiteralF $ Const (StringLiteral "a")
                             ]
                     }
                 :: ParsedSentenceSort)
@@ -1239,7 +1239,7 @@ sentenceSymbolParserTests =
                     , sentenceSymbolAttributes =
                         Attributes
                             [asParsedPattern $
-                                StringLiteralF (StringLiteral "a")]
+                                StringLiteralF $ Const (StringLiteral "a")]
                     }
                 :: ParsedSentenceSymbol)
             )
@@ -1281,7 +1281,7 @@ sentenceHookedSortParserTests =
                         , sentenceSortAttributes =
                             Attributes
                                 [ asParsedPattern
-                                    $ StringLiteralF (StringLiteral "a")
+                                    $ StringLiteralF $ Const (StringLiteral "a")
                                 ]
                         }
 
@@ -1298,7 +1298,7 @@ sentenceHookedSortParserTests =
                         , sentenceSortAttributes =
                             Attributes
                                 [ asParsedPattern
-                                    $ StringLiteralF (StringLiteral "a")
+                                    $ StringLiteralF $ Const (StringLiteral "a")
                                 ]
                         }
                     :: ParsedSentenceHook
@@ -1331,7 +1331,7 @@ sentenceHookedSymbolParserTests =
                         , sentenceSymbolAttributes =
                             Attributes
                                 [asParsedPattern $
-                                    StringLiteralF (StringLiteral "a")]
+                                    StringLiteralF $ Const (StringLiteral "a")]
                         }
                     :: ParsedSentenceHook
                 )
@@ -1369,12 +1369,12 @@ attributesParserTests =
     parseTree attributesParser
         [ success "[\"a\"]"
             (Attributes
-                [asParsedPattern $ StringLiteralF (StringLiteral "a")])
+                [asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")])
         , success "[]" (Attributes [])
         , success "[\"a\", \"b\"]"
             (Attributes
-                [ asParsedPattern $ StringLiteralF (StringLiteral "a")
-                , asParsedPattern $ StringLiteralF (StringLiteral "b")
+                [ asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")
+                , asParsedPattern $ StringLiteralF $ Const (StringLiteral "b")
                 ])
         , FailureWithoutMessage ["", "a", "\"a\"", "[\"a\" \"a\"]"]
         ]
@@ -1397,7 +1397,7 @@ moduleParserTests =
                     ]
                 , moduleAttributes =
                     Attributes
-                        [asParsedPattern $ StringLiteralF (StringLiteral "a")]
+                        [asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")]
                 }
         , success "module MN sort c{}[] sort c{}[] endmodule [\"a\"]"
             Module
@@ -1418,7 +1418,7 @@ moduleParserTests =
                     ]
                 , moduleAttributes =
                     Attributes
-                        [asParsedPattern $ StringLiteralF (StringLiteral "a")]
+                        [asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")]
                 }
         , success "module MN endmodule []"
             Module
@@ -1442,7 +1442,7 @@ definitionParserTests =
             Definition
                 { definitionAttributes =
                     Attributes
-                        [asParsedPattern $ StringLiteralF (StringLiteral "a")]
+                        [asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")]
                 , definitionModules =
                     [ Module
                         { moduleName = ModuleName "M"
@@ -1458,7 +1458,7 @@ definitionParserTests =
                         , moduleAttributes =
                             Attributes
                                 [asParsedPattern $
-                                    StringLiteralF (StringLiteral "b")]
+                                    StringLiteralF $ Const (StringLiteral "b")]
                         }
                     ]
                 }
@@ -1470,7 +1470,7 @@ definitionParserTests =
             Definition
                 { definitionAttributes =
                     Attributes
-                        [asParsedPattern $ StringLiteralF (StringLiteral "a")]
+                        [asParsedPattern $ StringLiteralF $ Const (StringLiteral "a")]
                 , definitionModules =
                     [ Module
                         { moduleName = ModuleName "M"
@@ -1486,7 +1486,7 @@ definitionParserTests =
                         , moduleAttributes =
                             Attributes
                                 [asParsedPattern $
-                                    StringLiteralF (StringLiteral "b")]
+                                    StringLiteralF $ Const (StringLiteral "b")]
                         }
                     , Module
                         { moduleName = ModuleName "N"
@@ -1502,7 +1502,7 @@ definitionParserTests =
                         , moduleAttributes =
                             Attributes
                                 [asParsedPattern $
-                                    StringLiteralF (StringLiteral "e")]
+                                    StringLiteralF $ Const (StringLiteral "e")]
                         }
                     ]
                 }

--- a/kore/test/Test/Kore/Parser/Parser.hs
+++ b/kore/test/Test/Kore/Parser/Parser.hs
@@ -277,22 +277,24 @@ applicationPatternParserTests :: [TestTree]
 applicationPatternParserTests =
     parseTree korePatternParser
         [ success "@v:Char"
-            ( asParsedPattern . VariableF . SetVar . SetVariable $ Variable
-                { variableName = testId "@v"
-                , variableSort = sortVariableSort "Char"
-                , variableCounter = mempty
-                }
+            ( asParsedPattern . VariableF . Const . SetVar $ SetVariable
+                Variable
+                    { variableName = testId "@v"
+                    , variableSort = sortVariableSort "Char"
+                    , variableCounter = mempty
+                    }
             )
         , success "v:s1{s2}"
-            ( asParsedPattern $ VariableF . ElemVar . ElementVariable $ Variable
-                { variableName = testId "v" :: Id
-                , variableSort =
-                    SortActualSort SortActual
-                        { sortActualName = testId "s1"
-                        , sortActualSorts = [ sortVariableSort "s2" ]
-                        }
-                , variableCounter = mempty
-                }
+            ( asParsedPattern $ VariableF . Const . ElemVar $ ElementVariable
+                Variable
+                    { variableName = testId "v" :: Id
+                    , variableSort =
+                        SortActualSort SortActual
+                            { sortActualName = testId "s1"
+                            , sortActualSorts = [ sortVariableSort "s2" ]
+                            }
+                    , variableCounter = mempty
+                    }
             )
         , success "c{s1,s2}(v1:s1, v2:s2)"
             ( asParsedPattern $ ApplicationF Application
@@ -304,18 +306,18 @@ applicationPatternParserTests =
                             , sortVariableSort "s2" ]
                         }
                 , applicationChildren =
-                    [ asParsedPattern $ VariableF $ ElemVar $ ElementVariable
-                        Variable
-                        { variableName = testId "v1" :: Id
-                        , variableSort = sortVariableSort "s1"
-                        , variableCounter = mempty
-                        }
-                    , asParsedPattern $ VariableF $ ElemVar $ ElementVariable
-                        Variable
-                        { variableName = testId "v2" :: Id
-                        , variableSort = sortVariableSort "s2"
-                        , variableCounter = mempty
-                        }
+                    [ asParsedPattern $ VariableF $ Const $ ElemVar $
+                        ElementVariable Variable
+                            { variableName = testId "v1" :: Id
+                            , variableSort = sortVariableSort "s1"
+                            , variableCounter = mempty
+                            }
+                    , asParsedPattern $ VariableF $ Const $ ElemVar $
+                        ElementVariable Variable
+                            { variableName = testId "v2" :: Id
+                            , variableSort = sortVariableSort "s2"
+                            , variableCounter = mempty
+                            }
                     ]
                 }
             )
@@ -533,7 +535,7 @@ memPatternParserTests =
                     { inOperandSort = sortVariableSort "s1" :: Sort
                     , inResultSort = sortVariableSort "s2"
                     , inContainedChild = asParsedPattern $
-                        VariableF $ ElemVar $ ElementVariable Variable
+                        VariableF $ Const $ ElemVar $ ElementVariable Variable
                             { variableName = testId "v" :: Id
                             , variableSort = sortVariableSort "s3"
                             , variableCounter = mempty
@@ -736,21 +738,23 @@ variablePatternParserTests :: [TestTree]
 variablePatternParserTests =
     parseTree korePatternParser
         [ success "v:s"
-            ( asParsedPattern $ VariableF $ ElemVar $ ElementVariable Variable
-                { variableName = testId "v" :: Id
-                , variableSort = sortVariableSort "s"
-                , variableCounter = mempty
-                }
+            ( asParsedPattern $ VariableF $ Const $ ElemVar $
+                ElementVariable Variable
+                    { variableName = testId "v" :: Id
+                    , variableSort = sortVariableSort "s"
+                    , variableCounter = mempty
+                    }
             )
         , success "v:s1{s2}"
-            ( asParsedPattern $ VariableF $ ElemVar $ ElementVariable Variable
-                { variableName = testId "v" :: Id
-                , variableSort = SortActualSort SortActual
-                    { sortActualName=testId "s1"
-                    , sortActualSorts = [ sortVariableSort "s2" ]
+            ( asParsedPattern $ VariableF $ Const $ ElemVar $
+                ElementVariable Variable
+                    { variableName = testId "v" :: Id
+                    , variableSort = SortActualSort SortActual
+                        { sortActualName=testId "s1"
+                        , sortActualSorts = [ sortVariableSort "s2" ]
+                        }
+                    , variableCounter = mempty
                     }
-                , variableCounter = mempty
-                }
             )
             , FailureWithoutMessage ["", "var", "v:", ":s", "c(s)", "c{s}"]
         ]
@@ -849,13 +853,13 @@ sentenceAliasParserTests =
                                         ]
                                     }
                             , applicationChildren =
-                                [ asParsedPattern $ VariableF
-                                    $ElemVar $ ElementVariable Variable
+                                [ asParsedPattern $ VariableF $ Const
+                                    $ ElemVar $ ElementVariable Variable
                                     { variableName = testId "X" :: Id
                                     , variableSort = sortVariableSort "s3"
                                     , variableCounter = mempty
                                     }
-                                , asParsedPattern $ VariableF
+                                , asParsedPattern $ VariableF $ Const
                                     $ ElemVar $ ElementVariable Variable
                                     { variableName = testId "Y" :: Id
                                     , variableSort = sortVariableSort "s4"

--- a/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
+++ b/kore/test/Test/Kore/Step/Simplification/CharLiteral.hs
@@ -26,5 +26,5 @@ test_charLiteralSimplification =
         )
     ]
 
-evaluate :: CharLiteral (OrPattern Variable) -> OrPattern Variable
+evaluate :: CharLiteral -> OrPattern Variable
 evaluate = simplify

--- a/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
+++ b/kore/test/Test/Kore/Step/Simplification/StringLiteral.hs
@@ -39,5 +39,5 @@ test_stringLiteralSimplification =
         )
     ]
 
-evaluate :: StringLiteral (OrPattern Variable) -> OrPattern Variable
+evaluate :: StringLiteral -> OrPattern Variable
 evaluate = simplify

--- a/kore/test/Test/Kore/Unparser.hs
+++ b/kore/test/Test/Kore/Unparser.hs
@@ -155,14 +155,10 @@ test_unparse =
         , unparseTest
             (Attributes
                 { getAttributes =
-                    [ asParsedPattern
-                        (CharLiteralF CharLiteral
-                            { getCharLiteral = '\'' }
-                        )
-                    , asParsedPattern
-                        (CharLiteralF CharLiteral
-                            { getCharLiteral = '\'' }
-                        )
+                    [ asParsedPattern $ CharLiteralF $ Const
+                        CharLiteral { getCharLiteral = '\'' }
+                    , asParsedPattern $ CharLiteralF $ Const
+                        CharLiteral { getCharLiteral = '\'' }
                     ]
                 }::Attributes
             )

--- a/kore/test/Test/Kore/Unparser.hs
+++ b/kore/test/Test/Kore/Unparser.hs
@@ -60,8 +60,8 @@ test_unparse =
                             , sortActualSorts = []
                             }
                         , inContainedChild =
-                            asParsedPattern $ VariableF
-                                $ ElemVar $ ElementVariable Variable
+                            asParsedPattern $ VariableF $ Const $ ElemVar
+                            $ ElementVariable Variable
                                 { variableName = testId "T"
                                 , variableSort = SortVariableSort SortVariable
                                     { getSortVariable = testId "C" }

--- a/kore/test/Test/Kore/Unparser.hs
+++ b/kore/test/Test/Kore/Unparser.hs
@@ -67,8 +67,10 @@ test_unparse =
                                     { getSortVariable = testId "C" }
                                 , variableCounter = mempty
                                 }
-                        , inContainingChild = asParsedPattern (StringLiteralF
-                            StringLiteral { getStringLiteral = "" })
+                        , inContainingChild =
+                            asParsedPattern
+                            $ StringLiteralF $ Const
+                                StringLiteral { getStringLiteral = "" }
                         })
                     ]
                 }


### PR DESCRIPTION
This removes about 250 lines of boilerplate from `Kore.Internal.TermLike`. There is a little bit of code churn because I didn't think earlier about what would happen if we needed to partially apply the `Synthetic` class.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

