### PR TITLE
[kevm-integration] Skip OPAM setup

### DIFF
--- a/scripts/kevm-integration.sh
+++ b/scripts/kevm-integration.sh
@@ -4,7 +4,7 @@ set -exuo pipefail
 
 TOP=${TOP:-$(git rev-parse --show-toplevel)}
 EVM_SEMANTICS=$TOP/evm-semantics
-OPAM_SETUP_SKIP="${OPAM_SETUP_SKIP:-false}"
+OPAM_SETUP_SKIP="${OPAM_SETUP_SKIP:-true}"
 
 # Prefer to use Kore master
 PATH=$(stack path --local-install-root)/bin"${PATH:+:}$PATH"


### PR DESCRIPTION
I neglected to open this pull request before because the KEVM integration tests took 7 hours to run; what good would it do to save 5 to 10 minutes?

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

