### PR TITLE
Normalize inputs to SMT

### DIFF
--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -17,6 +17,7 @@ module Kore.Internal.Conditional
     , splitTerm
     , toPredicate
     , Kore.Internal.Conditional.mapVariables
+    , isNormalized
     ) where
 
 import           Control.DeepSeq
@@ -357,3 +358,14 @@ mapVariables
 
 splitTerm :: Conditional variable term -> (term, Conditional variable ())
 splitTerm patt@Conditional { term } = (term, withoutTerm patt)
+
+{- | Is the condition normalized?
+
+The 'Substitution' must be normalized and must have been substituted into the
+'Predicate'.
+
+ -}
+isNormalized :: Ord variable => Conditional variable term -> Bool
+isNormalized Conditional { predicate, substitution } =
+    Substitution.isNormalized substitution
+    && Predicate.isFreeOf predicate (Substitution.variables substitution)

--- a/kore/src/Kore/Predicate/Predicate.hs
+++ b/kore/src/Kore/Predicate/Predicate.hs
@@ -33,7 +33,8 @@ module Kore.Predicate.Predicate
     , makeOrPredicate
     , makeMultipleOrPredicate
     , makeTruePredicate
-    , Kore.Predicate.Predicate.freeVariables
+    , freeVariables
+    , isFreeOf
     , Kore.Predicate.Predicate.freeElementVariables
     , Kore.Predicate.Predicate.hasFreeVariable
     , Kore.Predicate.Predicate.mapVariables
@@ -56,6 +57,9 @@ import           Data.List
                  ( foldl', nub )
 import           Data.Map.Strict
                  ( Map )
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 import           GHC.Stack
@@ -65,7 +69,9 @@ import           Kore.Attribute.Pattern.FreeVariables
 import           Kore.Debug
 import           Kore.Error
                  ( Error, koreFail )
-import           Kore.Internal.TermLike as TermLike
+import           Kore.Internal.TermLike hiding
+                 ( freeVariables )
+import qualified Kore.Internal.TermLike as TermLike
 import           Kore.TopBottom
                  ( TopBottom (..) )
 import           Kore.Unification.Substitution
@@ -507,6 +513,14 @@ freeVariables
     => Predicate variable
     -> FreeVariables variable
 freeVariables = TermLike.freeVariables . unwrapPredicate
+
+isFreeOf
+    :: Ord variable
+    => Predicate variable
+    -> Set (UnifiedVariable variable)
+    -> Bool
+isFreeOf predicate =
+    Set.disjoint (getFreeVariables $ freeVariables predicate)
 
 freeElementVariables
     :: Ord variable

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -18,6 +18,7 @@ import           Control.Applicative
 import qualified Control.Applicative as Applicative
 import           Control.Error
                  ( MaybeT, runMaybeT )
+import qualified Control.Exception as Exception
 import qualified Control.Monad.State.Strict as State
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
@@ -37,7 +38,6 @@ import qualified Kore.Internal.Conditional as Conditional
 import           Kore.Internal.MultiOr
                  ( MultiOr )
 import qualified Kore.Internal.MultiOr as MultiOr
-import qualified Kore.Internal.Predicate as Predicate
 import           Kore.Logger
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
@@ -88,9 +88,9 @@ instance
     )
     => Evaluable (Conditional variable term)
   where
-    evaluate patt = evaluate (Predicate.toPredicate predicate)
-      where
-        (_term, predicate) = Conditional.splitTerm patt
+    evaluate conditional =
+        Exception.assert (Conditional.isNormalized conditional)
+        $ evaluate (Conditional.predicate conditional)
 
 {- | Removes from a MultiOr all items refuted by an external SMT solver. -}
 filterMultiOr

--- a/kore/src/Kore/Unification/Substitution.hs
+++ b/kore/src/Kore/Unification/Substitution.hs
@@ -225,10 +225,6 @@ null :: Substitution variable -> Bool
 null (Substitution denorm)         = List.null denorm
 null (NormalizedSubstitution norm) = Map.null norm
 
--- | Returns the list of variables in the 'Substitution'.
-variables :: Ord variable => Substitution variable -> [UnifiedVariable variable]
-variables = fmap fst . unwrap
-
 -- | Filter the variables of the 'Substitution'.
 filter
     :: Ord variable
@@ -361,3 +357,11 @@ freeVariables = Foldable.foldMap freeVariablesWorker . unwrap
   where
     freeVariablesWorker (x, t) =
         freeVariable x <> TermLike.freeVariables t
+
+-- | The left-hand side variables of the 'Substitution'.
+variables
+    :: Ord variable
+    => Substitution variable
+    -> Set (UnifiedVariable variable)
+variables (NormalizedSubstitution subst) = Map.keysSet subst
+variables (Substitution subst) = Foldable.foldMap (Set.singleton . fst) subst

--- a/kore/test/Test/Kore/Unification/Substitution.hs
+++ b/kore/test/Test/Kore/Unification/Substitution.hs
@@ -9,8 +9,9 @@ import Test.Tasty.HUnit
 import Test.Terse
        ( gives_ )
 
-import Prelude hiding
-       ( null )
+import qualified Data.Set as Set
+import           Prelude hiding
+                 ( null )
 
 import Kore.Internal.TermLike hiding
        ( mapVariables )
@@ -187,11 +188,11 @@ variablesTests =
             . variables $ wrap emptyRawSubst
     , testCase "singleton normalized subst has one variable"
         $ assertEqual ""
-           (fst <$> singletonSubst)
+           (Set.fromList $ fst <$> singletonSubst)
            . variables $ unsafeWrap singletonSubst
     , testCase "singleton subst has one variable"
         $ assertEqual ""
-           (fst <$> singletonSubst)
+           (Set.fromList $ fst <$> singletonSubst)
            . variables $ wrap singletonSubst
     ]
 


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

@vladciobanu We need to normalize the implication check which you added. However, this causes the concrete execution tests to fail and the unit tests to loop forever.