### PR TITLE
Fix eventlog tracing with ghc-events-analyze

### DIFF
--- a/kore/src/Kore/Profiler/Data.hs
+++ b/kore/src/Kore/Profiler/Data.hs
@@ -5,7 +5,7 @@ License     : NCSA
 module Kore.Profiler.Data
     ( MonadProfiler (..)
     , profileDurationEvent
-    , profileDurationStartEnd
+    , profileDurationStartStop
     , ProfileEvent (..)
     , Configuration (..)
     ) where
@@ -118,12 +118,12 @@ profileDurationEvent tags action = do
 
 {- Times an action in the format required by @ghc-events-analyze@.
 -}
-profileDurationStartEnd
+profileDurationStartStop
     :: MonadIO profiler => [String] -> profiler a -> profiler a
-profileDurationStartEnd event action = do
+profileDurationStartStop event action = do
     liftIO $ traceEventIO ("START " ++ show event)
     a <- action
-    liftIO $ traceEventIO ("END " ++ show event)
+    liftIO $ traceEventIO ("STOP " ++ show event)
     return a
 
 instance (MonadProfiler m) => MonadProfiler (ReaderT thing m )

--- a/kore/src/Kore/Profiler/Data.hs
+++ b/kore/src/Kore/Profiler/Data.hs
@@ -27,6 +27,7 @@ import           Control.Monad.Trans.Maybe
                  ( MaybeT )
 import           Data.Functor.Identity
                  ( Identity )
+import qualified Data.List as List
 import           Debug.Trace.String
                  ( traceEventIO )
 import           System.Clock
@@ -121,9 +122,9 @@ profileDurationEvent tags action = do
 profileDurationStartStop
     :: MonadIO profiler => [String] -> profiler a -> profiler a
 profileDurationStartStop event action = do
-    liftIO $ traceEventIO ("START " ++ show event)
+    liftIO $ traceEventIO ("START " ++ List.intercalate "/" event)
     a <- action
-    liftIO $ traceEventIO ("STOP " ++ show event)
+    liftIO $ traceEventIO ("STOP " ++ List.intercalate "/" event)
     return a
 
 instance (MonadProfiler m) => MonadProfiler (ReaderT thing m )


### PR DESCRIPTION
###### Reviewer checklist

- [x] Test coverage: `stack test --coverage`
- [x] Public API documentation: `stack haddock`
- [x] Style conformance: `stylish-haskell`

---

`ghc-events-analyze` was broken because we paired `START` with `END`, but it should be `START` and `STOP`.