### PR TITLE
Reformat the world with Ormolu

### DIFF
--- a/kore/src/Control/Monad/Counter.hs
+++ b/kore/src/Control/Monad/Counter.hs
@@ -11,45 +11,55 @@ concrete implementation of the class.
 
 -}
 module Control.Monad.Counter
-    ( -- * Class
-      MonadCounter (..)
-    , incrementState
-    , findState
-    , module Numeric.Natural
-      -- * Implementation
-    , CounterT (..)
-    , runCounterT, evalCounterT
-    , Counter
-    , runCounter, evalCounter
-    ) where
+  ( -- * Class
+    MonadCounter (..),
+    incrementState,
+    findState,
+    module Numeric.Natural,
+    -- * Implementation
+    CounterT (..),
+    runCounterT,
+    evalCounterT,
+    Counter,
+    runCounter,
+    evalCounter
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative )
-import           Control.Monad
-                 ( MonadPlus )
+import Control.Applicative
+  ( Alternative
+    )
+import Control.Monad
+  ( MonadPlus
+    )
 import qualified Control.Monad.Except as Monad.Except
+import Control.Monad.IO.Class
+  ( MonadIO (..)
+    )
 import qualified Control.Monad.Identity as Monad.Identity
-import           Control.Monad.IO.Class
-                 ( MonadIO (..) )
 import qualified Control.Monad.Morph as Morph
-import           Control.Monad.Reader
-                 ( MonadReader )
-import qualified Control.Monad.Reader as Monad.Reader
 import qualified Control.Monad.RWS.Lazy as Monad.RWS.Lazy
 import qualified Control.Monad.RWS.Strict as Monad.RWS.Strict
-import           Control.Monad.State
-                 ( MonadState )
+import Control.Monad.Reader
+  ( MonadReader
+    )
+import qualified Control.Monad.Reader as Monad.Reader
+import Control.Monad.State
+  ( MonadState
+    )
 import qualified Control.Monad.State.Class as Monad.State
 import qualified Control.Monad.State.Lazy as Monad.State.Lazy
 import qualified Control.Monad.State.Strict as Monad.State.Strict
-import           Control.Monad.Trans
-                 ( MonadTrans )
+import Control.Monad.Trans
+  ( MonadTrans
+    )
 import qualified Control.Monad.Trans as Monad.Trans
-import           Control.Monad.Trans.Maybe
-                 ( MaybeT )
+import Control.Monad.Trans.Maybe
+  ( MaybeT
+    )
 import qualified Control.Monad.Writer.Lazy as Monad.Writer.Lazy
 import qualified Control.Monad.Writer.Strict as Monad.Writer.Strict
-import           Numeric.Natural
+import Numeric.Natural
 
 {- | A computation using a monotonic counter.
  -}
@@ -57,30 +67,31 @@ type Counter = CounterT Monad.Identity.Identity
 
 {- | A computation using a monotonic counter.
  -}
-newtype CounterT m a =
-    CounterT { getCounterT :: Monad.State.Strict.StateT Natural m a }
-    deriving (Alternative, Applicative, Functor, Monad, MonadPlus, MonadTrans)
+newtype CounterT m a
+  = CounterT {getCounterT :: Monad.State.Strict.StateT Natural m a}
+  deriving (Alternative, Applicative, Functor, Monad, MonadPlus, MonadTrans)
 
 instance Monad m => MonadCounter (CounterT m) where
-    increment = CounterT incrementState
-    {-# INLINE increment #-}
+  increment = CounterT incrementState
+  {-# INLINE increment #-}
 
 deriving instance Monad m => MonadState Natural (CounterT m)
 
 instance MonadIO m => MonadIO (CounterT m) where
-    liftIO = CounterT . liftIO
-    {-# INLINE liftIO #-}
+  liftIO = CounterT . liftIO
+  {-# INLINE liftIO #-}
 
 instance MonadReader e m => MonadReader e (CounterT m) where
-    ask = Monad.Trans.lift Monad.Reader.ask
-    {-# INLINE ask #-}
 
-    local f =  CounterT . Monad.Reader.local f . getCounterT
-    {-# INLINE local #-}
+  ask = Monad.Trans.lift Monad.Reader.ask
+  {-# INLINE ask #-}
+
+  local f = CounterT . Monad.Reader.local f . getCounterT
+  {-# INLINE local #-}
 
 instance Morph.MFunctor CounterT where
-    hoist f = CounterT . Morph.hoist f . getCounterT
-    {-# INLINE hoist #-}
+  hoist f = CounterT . Morph.hoist f . getCounterT
+  {-# INLINE hoist #-}
 
 {- | Run a computation using a monotonic counter.
 
@@ -89,13 +100,13 @@ instance Morph.MFunctor CounterT where
 
  -}
 runCounterT
-    :: CounterT m a
-    -- ^ computation
-    -> Natural
-    -- ^ initial counter
-    -> m (a, Natural)
+  :: CounterT m a
+  -- ^ computation
+  -> Natural
+  -- ^ initial counter
+  -> m (a, Natural)
 runCounterT (CounterT counting) =
-    Monad.State.Strict.runStateT counting
+  Monad.State.Strict.runStateT counting
 
 {- | Return the final result of a computation using a monotonic counter.
 
@@ -104,8 +115,8 @@ runCounterT (CounterT counting) =
  -}
 evalCounterT :: Monad m => CounterT m a -> m a
 evalCounterT (CounterT counting) = do
-    (a, _) <- Monad.State.Strict.runStateT counting 0
-    return a
+  (a, _) <- Monad.State.Strict.runStateT counting 0
+  return a
 
 {- | Run a computation using a monotonic counter.
 
@@ -114,11 +125,11 @@ evalCounterT (CounterT counting) = do
 
  -}
 runCounter
-    :: Counter a
-    -- ^ computation
-    -> Natural
-    -- ^ initial counter
-    -> (a, Natural)
+  :: Counter a
+  -- ^ computation
+  -> Natural
+  -- ^ initial counter
+  -> (a, Natural)
 runCounter counter = Monad.Identity.runIdentity . runCounterT counter
 
 {- | Return the final result of a computation using a monotonic counter.
@@ -140,72 +151,72 @@ evalCounter counter = let (a, _) = runCounter counter 0 in a
 
  -}
 class Monad m => MonadCounter m where
-    {- | Increment the counter and return the prior value.
-
-      Using the @MonadCounter@ interface instead of the 'MonadState' instance
-      ensures that the counter cannot accidentally be reset, which could
-      generate duplicate fresh variables.
-     -}
-    increment :: m Natural
+  {- | Increment the counter and return the prior value.
+  
+    Using the @MonadCounter@ interface instead of the 'MonadState' instance
+    ensures that the counter cannot accidentally be reset, which could
+    generate duplicate fresh variables.
+   -}
+  increment :: m Natural
 
 -- | Generic implementation of 'increment' for any 'MonadState'.
 incrementState :: MonadState Natural m => m Natural
 incrementState = do
-    n <- Monad.State.get
-    Monad.State.modify' succ
-    return n
+  n <- Monad.State.get
+  Monad.State.modify' succ
+  return n
 
 instance MonadCounter m => MonadCounter (Monad.Except.ExceptT e m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance MonadCounter m => MonadCounter (Monad.Identity.IdentityT m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance MonadCounter m => MonadCounter (MaybeT m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance
-    (MonadCounter m, Monoid w) =>
-    MonadCounter (Monad.RWS.Lazy.RWST r w s m)
+  (MonadCounter m, Monoid w)
+  => MonadCounter (Monad.RWS.Lazy.RWST r w s m)
   where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance
-    (MonadCounter m, Monoid w) =>
-    MonadCounter (Monad.RWS.Strict.RWST r w s m)
+  (MonadCounter m, Monoid w)
+  => MonadCounter (Monad.RWS.Strict.RWST r w s m)
   where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance MonadCounter m => MonadCounter (Monad.Reader.ReaderT r m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance MonadCounter m => MonadCounter (Monad.State.Lazy.StateT s m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance MonadCounter m => MonadCounter (Monad.State.Strict.StateT s m) where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance
-    (MonadCounter m, Monoid w) =>
-    MonadCounter (Monad.Writer.Lazy.WriterT w m)
+  (MonadCounter m, Monoid w)
+  => MonadCounter (Monad.Writer.Lazy.WriterT w m)
   where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 instance
-    (MonadCounter m, Monoid w) =>
-    MonadCounter (Monad.Writer.Strict.WriterT w m)
+  (MonadCounter m, Monoid w)
+  => MonadCounter (Monad.Writer.Strict.WriterT w m)
   where
-    increment = Monad.Trans.lift increment
-    {-# INLINE increment #-}
+  increment = Monad.Trans.lift increment
+  {-# INLINE increment #-}
 
 {- | Execute a list of actions until one satisfies the given predicate.
 
@@ -213,21 +224,21 @@ instance
 
  -}
 findState
-    :: MonadState s m
-    => (a -> Bool)
-    -- ^ predicate
-    -> [m a]
-    -- ^ actions
-    -> m (Maybe a)
+  :: MonadState s m
+  => (a -> Bool)
+  -- ^ predicate
+  -> [m a]
+  -- ^ actions
+  -> m (Maybe a)
 findState predicate = findState0
   where
     findState0 [] = return Nothing
     findState0 (action : actions) =
-        do
-            s <- Monad.State.get
-            a <- action
-            if predicate a
-                then return (Just a)
-                else do
-                    Monad.State.put s
-                    findState0 actions
+      do
+        s <- Monad.State.get
+        a <- action
+        if predicate a
+          then return (Just a)
+          else do
+            Monad.State.put s
+            findState0 actions

--- a/kore/src/Data/Graph/TopologicalSort.hs
+++ b/kore/src/Data/Graph/TopologicalSort.hs
@@ -8,16 +8,19 @@ Stability   : experimental
 Portability : portable
 -}
 module Data.Graph.TopologicalSort
-    ( topologicalSort
-    , ToplogicalSortCycles(..)
-    ) where
+  ( topologicalSort,
+    ToplogicalSortCycles (..)
+    )
+where
 
-import           Data.Graph
-                 ( SCC (..), stronglyConnComp )
+import Data.Graph
+  ( SCC (..),
+    stronglyConnComp
+    )
 import qualified Data.Map as Map
 
 newtype ToplogicalSortCycles node = ToplogicalSortCycles [node]
-    deriving (Show, Eq)
+  deriving (Show, Eq)
 
 {-| 'topologicalSort' sorts a graph topologically, starting with nodes which
 have no 'next' nodes.
@@ -27,19 +30,19 @@ nodes.
 Returns an error for graphs that have cycles.
 -}
 topologicalSort
-    :: (Ord node, Show node)
-    => Map.Map node [node]
-    -> Either (ToplogicalSortCycles node) [node]
+  :: (Ord node, Show node)
+  => Map.Map node [node]
+  -> Either (ToplogicalSortCycles node) [node]
 topologicalSort edges =
-    mapM
-        extractSortedNode
-        (stronglyConnComp
-            (map
-                (\ (node, edges') -> (node, node, edges'))
-                (Map.toList edges)
-            )
-        )
+  mapM
+    extractSortedNode
+    ( stronglyConnComp
+        ( map
+            (\(node, edges') -> (node, node, edges'))
+            (Map.toList edges)
+          )
+      )
   where
     extractSortedNode :: SCC node -> Either (ToplogicalSortCycles node) node
-    extractSortedNode (AcyclicSCC n)    = Right n
+    extractSortedNode (AcyclicSCC n) = Right n
     extractSortedNode (CyclicSCC nodes) = Left (ToplogicalSortCycles nodes)

--- a/kore/src/Data/Limit.hs
+++ b/kore/src/Data/Limit.hs
@@ -12,51 +12,55 @@ import qualified Data.Limit as Limit
 @
 -}
 module Data.Limit
-    ( Limit (..)
-    , enumFromLimit
-    , replicate
-    , takeWithin
-    , withinLimit
-    ) where
+  ( Limit (..),
+    enumFromLimit,
+    replicate,
+    takeWithin,
+    withinLimit
+    )
+where
 
 import Prelude hiding
-       ( replicate )
+  ( replicate
+    )
 
 {- | An optionally-limited quantity.
  -}
 data Limit a
-    = Unlimited
+  = Unlimited
     -- ^ No limit
-    | Limit !a
+  | Limit !a
     -- ^ Limit @a@ by the given (inclusive) upper bound
-    deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show)
 
 instance Ord a => Ord (Limit a) where
-    compare =
+  compare =
+    \case
+      Unlimited ->
         \case
-            Unlimited ->
-                \case
-                    Unlimited -> EQ
-                    Limit _ -> GT
-            Limit a ->
-                \case
-                    Unlimited -> LT
-                    Limit b -> compare a b
+          Unlimited -> EQ
+          Limit _ -> GT
+      Limit a ->
+        \case
+          Unlimited -> LT
+          Limit b -> compare a b
 
 instance Ord a => Semigroup (Limit a) where
-    (<>) = min
+  (<>) = min
 
 instance Ord a => Monoid (Limit a) where
-    mempty = Unlimited
-    mappend = (<>)
+
+  mempty = Unlimited
+
+  mappend = (<>)
 
 {- | Is the given value within the (inclusive) upper bound?
  -}
 withinLimit :: Ord a => Limit a -> a -> Bool
 withinLimit =
-    \case
-        Unlimited -> const True
-        Limit u -> (<= u)
+  \case
+    Unlimited -> const True
+    Limit u -> (<= u)
 
 {- | Enumerate values beginning at @a@ and within the limit.
  -}

--- a/kore/src/Data/Sup.hs
+++ b/kore/src/Data/Sup.hs
@@ -6,23 +6,28 @@ License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
-
 module Data.Sup
-    ( Sup (..)
-    ) where
+  ( Sup (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Data
-                 ( Data )
-import           Data.Hashable
-                 ( Hashable )
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty (..) )
-import           Data.Typeable
-                 ( Typeable )
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Data
+  ( Data
+    )
+import Data.Hashable
+  ( Hashable
+    )
+import Data.Text.Prettyprint.Doc
+  ( Pretty (..)
+    )
+import Data.Typeable
+  ( Typeable
+    )
 import qualified GHC.Generics as GHC
+import qualified Generics.SOP as SOP
 
 {- | @Sup a@ is an extension of @a@ with a least upper bound.
 
@@ -30,17 +35,21 @@ If @a@ already has a least upper bound, 'Sup' is greater than that bound.
 
  -}
 data Sup a
-    = Element !a
-    | Sup  -- ^ least upper bound (supremum)
-    deriving (Data, Functor, GHC.Generic, Read, Show, Typeable)
+  = Element !a
+  | Sup -- ^ least upper bound (supremum)
+  deriving (Data, Functor, GHC.Generic, Read, Show, Typeable)
 
 instance Eq a => Eq (Sup a) where
-    (==) Sup         = \case { Sup       -> True  ; _ -> False }
-    (==) (Element a) = \case { Element b -> a == b; _ -> False }
+  (==) Sup = \case
+    Sup -> True; _ -> False
+  (==) (Element a) = \case
+    Element b -> a == b; _ -> False
 
 instance Ord a => Ord (Sup a) where
-    compare Sup         = \case { Sup       -> EQ         ; _   -> GT }
-    compare (Element a) = \case { Element b -> compare a b; Sup -> LT }
+  compare Sup = \case
+    Sup -> EQ; _ -> GT
+  compare (Element a) = \case
+    Element b -> compare a b; Sup -> LT
 
 instance Hashable a => Hashable (Sup a)
 
@@ -52,14 +61,17 @@ instance SOP.HasDatatypeInfo (Sup a)
 
 -- | 'Sup' is the annihilator of 'Element'.
 instance Ord a => Semigroup (Sup a) where
-    (<>) a b = max <$> a <*> b
+  (<>) a b = max <$> a <*> b
 
 -- | 'Sup' is the annihilator of 'Element'.
 instance Applicative Sup where
-    pure = Element
-    (<*>) Sup         = const Sup
-    (<*>) (Element f) = \case { Sup -> Sup; Element a -> Element (f a) }
+
+  pure = Element
+
+  (<*>) Sup = const Sup
+  (<*>) (Element f) = \case
+    Sup -> Sup; Element a -> Element (f a)
 
 instance Pretty a => Pretty (Sup a) where
-    pretty (Element a) = pretty a
-    pretty Sup = mempty
+  pretty (Element a) = pretty a
+  pretty Sup = mempty

--- a/kore/src/Generically.hs
+++ b/kore/src/Generically.hs
@@ -3,10 +3,10 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Generically
-    ( Generically1 (..)
-    ) where
+  ( Generically1 (..)
+    )
+where
 
 {- | @Generically1@ is a wrapper for deriving instances generically.
 
@@ -16,6 +16,6 @@ unwrapping ('unGenerically1'). Then, we can use @DerivingVia@ to derive any
 instance @via Generically1@.
 
  -}
-newtype Generically1 (f :: * -> *) a =
-    Generically1 { unGenerically1 :: f a }
-    deriving Functor
+newtype Generically1 (f :: * -> *) a
+  = Generically1 {unGenerically1 :: f a}
+  deriving (Functor)

--- a/kore/src/Kore/AST/ApplicativeKore.hs
+++ b/kore/src/Kore/AST/ApplicativeKore.hs
@@ -3,45 +3,52 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 module Kore.AST.ApplicativeKore
-    ( completeDefinition ) where
+  ( completeDefinition
+    )
+where
 
-import           Kore.Attribute.Pattern.FreeVariables
-import           Kore.Internal.TermLike as TermLike
-import           Kore.Syntax.Definition
-                 ( Definition (..), Module (..), Sentence (..),
-                 SentenceAxiom (..) )
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Internal.TermLike as TermLike
+import Kore.Syntax.Definition
+  ( Definition (..),
+    Module (..),
+    Sentence (..),
+    SentenceAxiom (..)
+    )
 import qualified Kore.Verified as Verified
 
 completeDefinition
-    :: Definition Verified.Sentence
-    -> Definition Verified.Sentence
-completeDefinition Definition { definitionAttributes, definitionModules } =
-    Definition
-    { definitionAttributes
-    , definitionModules = map completeModule definitionModules
-    }
+  :: Definition Verified.Sentence
+  -> Definition Verified.Sentence
+completeDefinition Definition {definitionAttributes, definitionModules} =
+  Definition
+    { definitionAttributes,
+      definitionModules = map completeModule definitionModules
+      }
 
 completeModule :: Module Verified.Sentence -> Module Verified.Sentence
-completeModule Module { moduleName, moduleSentences, moduleAttributes } =
-    Module
-    { moduleName
-    , moduleSentences = concatMap completeSentence moduleSentences
-    , moduleAttributes
-    }
+completeModule Module {moduleName, moduleSentences, moduleAttributes} =
+  Module
+    { moduleName,
+      moduleSentences = concatMap completeSentence moduleSentences,
+      moduleAttributes
+      }
 
 completeSentence :: Verified.Sentence -> [Verified.Sentence]
 completeSentence (SentenceAxiomSentence sentenceAxiom) =
-    [ SentenceAxiomSentence sentenceAxiom
-        { sentenceAxiomPattern = quantifiedAxiomPattern }
+  [ SentenceAxiomSentence
+      sentenceAxiom
+        { sentenceAxiomPattern = quantifiedAxiomPattern
+          }
     ]
- where
-   quantifiedAxiomPattern =
-       quantifyFreeVariables (sentenceAxiomPattern sentenceAxiom)
+  where
+    quantifiedAxiomPattern =
+      quantifyFreeVariables (sentenceAxiomPattern sentenceAxiom)
 completeSentence s = [s]
 
 quantifyFreeVariables :: TermLike Variable -> TermLike Variable
 quantifyFreeVariables termLike =
-    foldr mkForall termLike
+  foldr mkForall termLike
     . getFreeElementVariables
     . TermLike.freeVariables
     $ termLike

--- a/kore/src/Kore/AST/AstWithLocation.hs
+++ b/kore/src/Kore/AST/AstWithLocation.hs
@@ -8,126 +8,154 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.AST.AstWithLocation
-    ( AstWithLocation(..)
-    , prettyPrintLocationFromAst
-    ) where
+  ( AstWithLocation (..),
+    prettyPrintLocationFromAst
+    )
+where
 
 import Data.Text
-       ( Text )
-
+  ( Text
+    )
 import Kore.Syntax
 import Kore.Syntax.Definition
 import Kore.Syntax.PatternF
-       ( PatternF (..) )
+  ( PatternF (..)
+    )
 import Kore.Variables.UnifiedVariable
-       ( UnifiedVariable (..) )
+  ( UnifiedVariable (..)
+    )
 
 {-| 'AstWithLocation' should be implemented by all AST terms that have
 an 'AstLocation'.
 -}
 class AstWithLocation awl where
-    locationFromAst :: awl -> AstLocation
-    updateAstLocation :: awl -> AstLocation -> awl
+
+  locationFromAst :: awl -> AstLocation
+
+  updateAstLocation :: awl -> AstLocation -> awl
 
 prettyPrintLocationFromAst
-    :: AstWithLocation astWithLocation
-    => astWithLocation -> Text
+  :: AstWithLocation astWithLocation
+  => astWithLocation
+  -> Text
 prettyPrintLocationFromAst = prettyPrintAstLocation . locationFromAst
 
 instance AstWithLocation AstLocation where
-    locationFromAst = id
-    updateAstLocation _ loc = loc
+
+  locationFromAst = id
+
+  updateAstLocation _ loc = loc
 
 instance AstWithLocation Id where
-    locationFromAst = idLocation
-    updateAstLocation id' loc = id' { idLocation = loc }
+
+  locationFromAst = idLocation
+
+  updateAstLocation id' loc = id' {idLocation = loc}
 
 instance AstWithLocation SortVariable where
-    locationFromAst = locationFromAst . getSortVariable
-    updateAstLocation (SortVariable v) loc =
-        SortVariable (updateAstLocation v loc)
+
+  locationFromAst = locationFromAst . getSortVariable
+
+  updateAstLocation (SortVariable v) loc =
+    SortVariable (updateAstLocation v loc)
 
 instance AstWithLocation SortActual where
-    locationFromAst = locationFromAst . sortActualName
-    updateAstLocation sa loc =
-        sa { sortActualName = updateAstLocation (sortActualName sa) loc }
+
+  locationFromAst = locationFromAst . sortActualName
+
+  updateAstLocation sa loc =
+    sa {sortActualName = updateAstLocation (sortActualName sa) loc}
 
 instance AstWithLocation Sort where
-    locationFromAst (SortVariableSort sortVariable) =
-        locationFromAst sortVariable
-    locationFromAst (SortActualSort sortActual) =
-        locationFromAst sortActual
-    updateAstLocation (SortVariableSort sortVariable) loc =
-        SortVariableSort (updateAstLocation sortVariable loc)
-    updateAstLocation (SortActualSort sortActual) loc =
-        SortActualSort (updateAstLocation sortActual loc)
+
+  locationFromAst (SortVariableSort sortVariable) =
+    locationFromAst sortVariable
+  locationFromAst (SortActualSort sortActual) =
+    locationFromAst sortActual
+
+  updateAstLocation (SortVariableSort sortVariable) loc =
+    SortVariableSort (updateAstLocation sortVariable loc)
+  updateAstLocation (SortActualSort sortActual) loc =
+    SortActualSort (updateAstLocation sortActual loc)
 
 instance AstWithLocation Variable where
-    locationFromAst = locationFromAst . variableName
-    updateAstLocation var loc =
-        var {variableName = updateAstLocation (variableName var) loc}
+
+  locationFromAst = locationFromAst . variableName
+
+  updateAstLocation var loc =
+    var {variableName = updateAstLocation (variableName var) loc}
+
 instance
-    AstWithLocation variable =>
-    AstWithLocation (UnifiedVariable variable)
+  AstWithLocation variable
+  => AstWithLocation (UnifiedVariable variable)
   where
-    locationFromAst (ElemVar v) = locationFromAst . getElementVariable $ v
-    locationFromAst (SetVar v) = locationFromAst . getSetVariable $ v
-    updateAstLocation var loc = fmap (`updateAstLocation` loc) var
+
+  locationFromAst (ElemVar v) = locationFromAst . getElementVariable $ v
+  locationFromAst (SetVar v) = locationFromAst . getSetVariable $ v
+
+  updateAstLocation var loc = fmap (`updateAstLocation` loc) var
 
 instance AstWithLocation Alias where
-    locationFromAst = locationFromAst . aliasConstructor
-    updateAstLocation al loc =
-        al { aliasConstructor = updateAstLocation (aliasConstructor al) loc }
+
+  locationFromAst = locationFromAst . aliasConstructor
+
+  updateAstLocation al loc =
+    al {aliasConstructor = updateAstLocation (aliasConstructor al) loc}
 
 instance AstWithLocation SymbolOrAlias where
-    locationFromAst = locationFromAst . symbolOrAliasConstructor
-    updateAstLocation sal loc =
-        sal
-            { symbolOrAliasConstructor =
-                updateAstLocation (symbolOrAliasConstructor sal) loc
-            }
+
+  locationFromAst = locationFromAst . symbolOrAliasConstructor
+
+  updateAstLocation sal loc =
+    sal
+      { symbolOrAliasConstructor =
+          updateAstLocation (symbolOrAliasConstructor sal) loc
+        }
 
 instance AstWithLocation Symbol where
-    locationFromAst = locationFromAst . symbolConstructor
-    updateAstLocation s loc =
-        s { symbolConstructor = updateAstLocation (symbolConstructor s) loc }
+
+  locationFromAst = locationFromAst . symbolConstructor
+
+  updateAstLocation s loc =
+    s {symbolConstructor = updateAstLocation (symbolConstructor s) loc}
 
 instance
-    AstWithLocation variable =>
-    AstWithLocation (PatternF variable child)
+  AstWithLocation variable
+  => AstWithLocation (PatternF variable child)
   where
-    locationFromAst =
-        \case
-            AndF And { andSort } -> locationFromAst andSort
-            ApplicationF Application { applicationSymbolOrAlias } ->
-                locationFromAst applicationSymbolOrAlias
-            BottomF Bottom { bottomSort } -> locationFromAst bottomSort
-            CeilF Ceil { ceilResultSort } -> locationFromAst ceilResultSort
-            DomainValueF domain -> locationFromAst $ domainValueSort domain
-            EqualsF Equals { equalsResultSort } ->
-                locationFromAst equalsResultSort
-            ExistsF Exists { existsSort } -> locationFromAst existsSort
-            FloorF Floor { floorResultSort } ->
-                locationFromAst floorResultSort
-            ForallF Forall { forallSort } -> locationFromAst forallSort
-            IffF Iff { iffSort } -> locationFromAst iffSort
-            ImpliesF Implies { impliesSort } ->
-                locationFromAst impliesSort
-            InF In { inResultSort } ->
-                locationFromAst inResultSort
-            MuF Mu { muVariable = SetVariable variable } ->
-                locationFromAst variable
-            NextF Next { nextSort } -> locationFromAst nextSort
-            NotF Not { notSort } -> locationFromAst notSort
-            NuF Nu { nuVariable = SetVariable variable } ->
-                locationFromAst variable
-            OrF Or { orSort } -> locationFromAst orSort
-            RewritesF Rewrites { rewritesSort } ->
-                locationFromAst rewritesSort
-            StringLiteralF _ -> AstLocationUnknown
-            CharLiteralF _ -> AstLocationUnknown
-            TopF Top { topSort } -> locationFromAst topSort
-            VariableF (Const variable) -> locationFromAst variable
-            InhabitantF Inhabitant { inhSort } -> locationFromAst inhSort
 
-    updateAstLocation = undefined
+  locationFromAst =
+    \case
+      AndF And {andSort} -> locationFromAst andSort
+      ApplicationF Application {applicationSymbolOrAlias} ->
+        locationFromAst applicationSymbolOrAlias
+      BottomF Bottom {bottomSort} -> locationFromAst bottomSort
+      CeilF Ceil {ceilResultSort} -> locationFromAst ceilResultSort
+      DomainValueF domain -> locationFromAst $ domainValueSort domain
+      EqualsF Equals {equalsResultSort} ->
+        locationFromAst equalsResultSort
+      ExistsF Exists {existsSort} -> locationFromAst existsSort
+      FloorF Floor {floorResultSort} ->
+        locationFromAst floorResultSort
+      ForallF Forall {forallSort} -> locationFromAst forallSort
+      IffF Iff {iffSort} -> locationFromAst iffSort
+      ImpliesF Implies {impliesSort} ->
+        locationFromAst impliesSort
+      InF In {inResultSort} ->
+        locationFromAst inResultSort
+      MuF Mu {muVariable = SetVariable variable} ->
+        locationFromAst variable
+      NextF Next {nextSort} -> locationFromAst nextSort
+      NotF Not {notSort} -> locationFromAst notSort
+      NuF Nu {nuVariable = SetVariable variable} ->
+        locationFromAst variable
+      OrF Or {orSort} -> locationFromAst orSort
+      RewritesF Rewrites {rewritesSort} ->
+        locationFromAst rewritesSort
+      StringLiteralF _ -> AstLocationUnknown
+      CharLiteralF _ -> AstLocationUnknown
+      TopF Top {topSort} -> locationFromAst topSort
+      VariableF (Const variable) -> locationFromAst variable
+      InhabitantF Inhabitant {inhSort} -> locationFromAst inhSort
+
+  updateAstLocation = undefined

--- a/kore/src/Kore/AST/Common.hs
+++ b/kore/src/Kore/AST/Common.hs
@@ -13,85 +13,87 @@ an AST term in a single data type (e.g. 'UnifiedSort' that can be either
 Please refer to Section 9 (The Kore Language) of the
 <http://github.com/kframework/kore/blob/master/docs/semantics-of-k.pdf Semantics of K>.
 -}
-
 module Kore.AST.Common where
 
 import Data.Hashable
 import Data.String
-       ( fromString )
+  ( fromString
+    )
 import GHC.Generics
-       ( Generic )
-
+  ( Generic
+    )
 import Kore.Unparser
 
 {-|Enumeration of patterns starting with @\@
 -}
 data MLPatternType
-    = AndPatternType
-    | BottomPatternType
-    | CeilPatternType
-    | DomainValuePatternType
-    | EqualsPatternType
-    | ExistsPatternType
-    | FloorPatternType
-    | ForallPatternType
-    | IffPatternType
-    | ImpliesPatternType
-    | InPatternType
-    | MuPatternType
-    | NextPatternType
-    | NotPatternType
-    | NuPatternType
-    | OrPatternType
-    | RewritesPatternType
-    | TopPatternType
-    deriving (Show, Generic)
+  = AndPatternType
+  | BottomPatternType
+  | CeilPatternType
+  | DomainValuePatternType
+  | EqualsPatternType
+  | ExistsPatternType
+  | FloorPatternType
+  | ForallPatternType
+  | IffPatternType
+  | ImpliesPatternType
+  | InPatternType
+  | MuPatternType
+  | NextPatternType
+  | NotPatternType
+  | NuPatternType
+  | OrPatternType
+  | RewritesPatternType
+  | TopPatternType
+  deriving (Show, Generic)
 
 instance Hashable MLPatternType
 
 instance Unparse MLPatternType where
-    unparse = ("\\" <>) . fromString . patternString
-    unparse2 = ("\\" <>) . fromString . patternString
+
+  unparse = ("\\" <>) . fromString . patternString
+
+  unparse2 = ("\\" <>) . fromString . patternString
 
 allPatternTypes :: [MLPatternType]
 allPatternTypes =
-    [ AndPatternType
-    , BottomPatternType
-    , CeilPatternType
-    , DomainValuePatternType
-    , EqualsPatternType
-    , ExistsPatternType
-    , FloorPatternType
-    , ForallPatternType
-    , IffPatternType
-    , ImpliesPatternType
-    , InPatternType
-    , MuPatternType
-    , NextPatternType
-    , NotPatternType
-    , NuPatternType
-    , OrPatternType
-    , RewritesPatternType
-    , TopPatternType
+  [ AndPatternType,
+    BottomPatternType,
+    CeilPatternType,
+    DomainValuePatternType,
+    EqualsPatternType,
+    ExistsPatternType,
+    FloorPatternType,
+    ForallPatternType,
+    IffPatternType,
+    ImpliesPatternType,
+    InPatternType,
+    MuPatternType,
+    NextPatternType,
+    NotPatternType,
+    NuPatternType,
+    OrPatternType,
+    RewritesPatternType,
+    TopPatternType
     ]
 
 patternString :: MLPatternType -> String
 patternString pt = case pt of
-    AndPatternType         -> "and"
-    BottomPatternType      -> "bottom"
-    CeilPatternType        -> "ceil"
-    DomainValuePatternType -> "dv"
-    EqualsPatternType      -> "equals"
-    ExistsPatternType      -> "exists"
-    FloorPatternType       -> "floor"
-    ForallPatternType      -> "forall"
-    IffPatternType         -> "iff"
-    ImpliesPatternType     -> "implies"
-    InPatternType          -> "in"
-    MuPatternType          -> "mu"
-    NextPatternType        -> "next"
-    NotPatternType         -> "not"
-    NuPatternType          -> "nu"
-    OrPatternType          -> "or"
-    RewritesPatternType    -> "rewrites"
-    TopPatternType         -> "top"
+  AndPatternType -> "and"
+  BottomPatternType -> "bottom"
+  CeilPatternType -> "ceil"
+  DomainValuePatternType -> "dv"
+  EqualsPatternType -> "equals"
+  ExistsPatternType -> "exists"
+  FloorPatternType -> "floor"
+  ForallPatternType -> "forall"
+  IffPatternType -> "iff"
+  ImpliesPatternType -> "implies"
+  InPatternType -> "in"
+  MuPatternType -> "mu"
+  NextPatternType -> "next"
+  NotPatternType -> "not"
+  NuPatternType -> "nu"
+  OrPatternType -> "or"
+  RewritesPatternType -> "rewrites"
+  TopPatternType -> "top"

--- a/kore/src/Kore/AST/Error.hs
+++ b/kore/src/Kore/AST/Error.hs
@@ -8,24 +8,25 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.AST.Error
-    ( koreFailWithLocations
-    , koreFailWithLocationsWhen
-    , withLocationAndContext
-    , withLocationsContext
-    , withSentenceAliasContext
-    , withSentenceAxiomContext
-    , withSentenceClaimContext
-    , withSentenceHookContext
-    , withSentenceImportContext
-    , withSentenceSortContext
-    , withSentenceSymbolContext
-    , withSentenceContext
-    ) where
+  ( koreFailWithLocations,
+    koreFailWithLocationsWhen,
+    withLocationAndContext,
+    withLocationsContext,
+    withSentenceAliasContext,
+    withSentenceAxiomContext,
+    withSentenceClaimContext,
+    withSentenceHookContext,
+    withSentenceImportContext,
+    withSentenceSortContext,
+    withSentenceSymbolContext,
+    withSentenceContext
+    )
+where
 
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-
 import Kore.AST.AstWithLocation
 import Kore.Error
 import Kore.Syntax
@@ -34,149 +35,144 @@ import Kore.Syntax.Definition
 {-|'koreFailWithLocations' produces an error result with a context containing
 the provided locations. -}
 koreFailWithLocations
-    :: (AstWithLocation astWithLocation, MonadError (Error e) m)
-    => [astWithLocation]
-    -> Text
-    -> m a
+  :: (AstWithLocation astWithLocation, MonadError (Error e) m)
+  => [astWithLocation]
+  -> Text
+  -> m a
 koreFailWithLocations locations errorMessage =
-    withLocationsContext locations (koreFailText errorMessage)
+  withLocationsContext locations (koreFailText errorMessage)
 
 {-|'koreFailWithLocationsWhen' produces an error result with a context
 containing the provided locations whenever the provided flag is true.
 -}
 koreFailWithLocationsWhen
-    :: (AstWithLocation astWithLocation, MonadError (Error e) m)
-    => Bool
-    -> [astWithLocation]
-    -> Text
-    -> m ()
+  :: (AstWithLocation astWithLocation, MonadError (Error e) m)
+  => Bool
+  -> [astWithLocation]
+  -> Text
+  -> m ()
 koreFailWithLocationsWhen condition locations errorMessage =
-    withLocationsContext locations (koreFailWhenText condition errorMessage)
+  withLocationsContext locations (koreFailWhenText condition errorMessage)
 
 {-|'withLocationsContext' prepends the given location to the error context
 whenever the given action fails.
 -}
 withLocationsContext
-    :: (AstWithLocation astWithLocation, MonadError (Error e) m)
-    => [astWithLocation]
-    -> m result
-    -> m result
+  :: (AstWithLocation astWithLocation, MonadError (Error e) m)
+  => [astWithLocation]
+  -> m result
+  -> m result
 withLocationsContext locations =
-    withTextContext
-        (  "("
+  withTextContext
+    ( "("
         <> Text.intercalate ", " (map prettyPrintLocationFromAst locations)
         <> ")"
-        )
+      )
 
 {-|'withLocationsContext' prepends the given message, associated with the
 location, to the error context whenever the given action fails.
 -}
 withLocationAndContext
-    :: (AstWithLocation astWithLocation, MonadError (Error e) m)
-    => astWithLocation
-    -> Text
-    -> m result
-    -> m result
+  :: (AstWithLocation astWithLocation, MonadError (Error e) m)
+  => astWithLocation
+  -> Text
+  -> m result
+  -> m result
 withLocationAndContext location message =
-    withTextContext
-        (message <> " (" <> prettyPrintLocationFromAst location <> ")")
+  withTextContext
+    (message <> " (" <> prettyPrintLocationFromAst location <> ")")
 
 {- | Identify and locate the given symbol declaration in the error context.
  -}
 withSentenceSymbolContext
-    :: MonadError (Error e) m
-    => SentenceSymbol patternType
-    -> m a
-    -> m a
-withSentenceSymbolContext
-    SentenceSymbol { sentenceSymbolSymbol = Symbol { symbolConstructor } }
-  =
-    withLocationAndContext symbolConstructor
-        ("symbol '" <> getId symbolConstructor <> "' declaration")
+  :: MonadError (Error e) m
+  => SentenceSymbol patternType
+  -> m a
+  -> m a
+withSentenceSymbolContext SentenceSymbol {sentenceSymbolSymbol = Symbol {symbolConstructor}} =
+  withLocationAndContext symbolConstructor
+    ("symbol '" <> getId symbolConstructor <> "' declaration")
 
 {- | Identify and locate the given alias declaration in the error context.
  -}
 withSentenceAliasContext
-    :: SentenceAlias patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
-withSentenceAliasContext
-    SentenceAlias { sentenceAliasAlias = Alias { aliasConstructor } }
-  =
-    withLocationAndContext aliasConstructor
-        ("alias '" <> getId aliasConstructor <> "' declaration")
+  :: SentenceAlias patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
+withSentenceAliasContext SentenceAlias {sentenceAliasAlias = Alias {aliasConstructor}} =
+  withLocationAndContext aliasConstructor
+    ("alias '" <> getId aliasConstructor <> "' declaration")
 
 {- | Identify and locate the given axiom declaration in the error context.
  -}
 withSentenceAxiomContext
-    :: SentenceAxiom patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+  :: SentenceAxiom patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
 withSentenceAxiomContext _ = withContext "axiom declaration"
 
 {- | Identify and locate the given claim declaration in the error context.
  -}
 withSentenceClaimContext
-    :: SentenceClaim patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+  :: SentenceClaim patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
 withSentenceClaimContext _ = withContext "claim declaration"
 
 {- | Identify and locate the given sort declaration in the error context.
  -}
 withSentenceSortContext
-    :: SentenceSort patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
-withSentenceSortContext
-    SentenceSort { sentenceSortName }
-  =
-    withLocationAndContext sentenceSortName
-        ("sort '" <> getId sentenceSortName <> "' declaration")
+  :: SentenceSort patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
+withSentenceSortContext SentenceSort {sentenceSortName} =
+  withLocationAndContext sentenceSortName
+    ("sort '" <> getId sentenceSortName <> "' declaration")
 
 {- | Identify and locate the given hooked declaration in the error context.
  -}
 withSentenceHookContext
-    :: SentenceHook patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+  :: SentenceHook patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
 withSentenceHookContext =
-    \case
-        SentenceHookedSort SentenceSort { sentenceSortName } ->
-            withLocationAndContext sentenceSortName
-                (  "hooked-sort '"
-                <> getId sentenceSortName
-                <> "' declaration"
-                )
-
-        SentenceHookedSymbol SentenceSymbol
-            { sentenceSymbolSymbol = Symbol { symbolConstructor } } ->
-            withLocationAndContext symbolConstructor
-                (  "hooked-symbol '"
-                <> getId symbolConstructor
-                <> "' declaration"
-                )
+  \case
+    SentenceHookedSort SentenceSort {sentenceSortName} ->
+      withLocationAndContext sentenceSortName
+        ( "hooked-sort '"
+            <> getId sentenceSortName
+            <> "' declaration"
+          )
+    SentenceHookedSymbol
+      SentenceSymbol
+        { sentenceSymbolSymbol = Symbol {symbolConstructor}
+          } ->
+        withLocationAndContext symbolConstructor
+          ( "hooked-symbol '"
+              <> getId symbolConstructor
+              <> "' declaration"
+            )
 
 {- | Locate the given import declaration in the error context.
  -}
 withSentenceImportContext
-    :: SentenceImport patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+  :: SentenceImport patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
 withSentenceImportContext _ = id
 
 {- | Identify and  locate the given sentence in the error context.
  -}
 withSentenceContext
-    :: Sentence patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+  :: Sentence patternType
+  -> Either (Error e) a
+  -> Either (Error e) a
 withSentenceContext =
-    \case
-        SentenceAliasSentence s -> withSentenceAliasContext s
-        SentenceAxiomSentence s -> withSentenceAxiomContext s
-        SentenceClaimSentence s -> withSentenceClaimContext s
-        SentenceHookSentence s -> withSentenceHookContext s
-        SentenceImportSentence s -> withSentenceImportContext s
-        SentenceSortSentence s -> withSentenceSortContext s
-        SentenceSymbolSentence s -> withSentenceSymbolContext s
+  \case
+    SentenceAliasSentence s -> withSentenceAliasContext s
+    SentenceAxiomSentence s -> withSentenceAxiomContext s
+    SentenceClaimSentence s -> withSentenceClaimContext s
+    SentenceHookSentence s -> withSentenceHookContext s
+    SentenceImportSentence s -> withSentenceImportContext s
+    SentenceSortSentence s -> withSentenceSortContext s
+    SentenceSymbolSentence s -> withSentenceSymbolContext s

--- a/kore/src/Kore/ASTHelpers.hs
+++ b/kore/src/Kore/ASTHelpers.hs
@@ -12,79 +12,85 @@ more specific file. Also, one should consider extracting groups of functions in
 more specific files.
 -}
 module Kore.ASTHelpers
-    ( quantifyFreeVariables
-    ) where
+  ( quantifyFreeVariables
+    )
+where
 
-import           Control.Comonad.Trans.Cofree
-                 ( CofreeF (..) )
-import           Data.Foldable
-                 ( foldl' )
+import Control.Comonad.Trans.Cofree
+  ( CofreeF (..)
+    )
+import Data.Foldable
+  ( foldl'
+    )
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
-
+import Data.Text
+  ( Text
+    )
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Syntax hiding
-                 ( substituteSortVariables )
-import           Kore.Unparser
-import           Kore.Variables.Free
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..), foldMapVariable )
-
+import Kore.Syntax hiding
+  ( substituteSortVariables
+    )
+import Kore.Unparser
+import Kore.Variables.Free
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..),
+    foldMapVariable
+    )
 
 {-|'quantifyFreeVariables' quantifies all free variables in the given pattern.
 It assumes that the pattern has the provided sort.
 -}
 quantifyFreeVariables
-    :: Sort
-    -> Pattern Variable Attribute.Null
-    -> Pattern Variable Attribute.Null
+  :: Sort
+  -> Pattern Variable Attribute.Null
+  -> Pattern Variable Attribute.Null
 quantifyFreeVariables s p =
-    foldl'
-        (wrapAndQuantify s)
-        p
-        (checkUnique (freePureVariables p))
+  foldl'
+    (wrapAndQuantify s)
+    p
+    (checkUnique (freePureVariables p))
 
 wrapAndQuantify
-    :: Sort
-    -> Pattern Variable Attribute.Null
-    -> UnifiedVariable Variable
-    -> Pattern Variable Attribute.Null
+  :: Sort
+  -> Pattern Variable Attribute.Null
+  -> UnifiedVariable Variable
+  -> Pattern Variable Attribute.Null
 wrapAndQuantify s p (ElemVar var) =
-    asPattern
-        (mempty :< ForallF Forall
-            { forallSort = s
-            , forallVariable = var
-            , forallChild = p
-            }
-        )
+  asPattern
+    ( mempty
+        :< ForallF Forall
+             { forallSort = s,
+               forallVariable = var,
+               forallChild = p
+               }
+      )
 --TODO(traiansf): think about changing this to ElementVariable
 wrapAndQuantify _ _ (SetVar var) =
-    error ("Cannot quantify set variable " ++ unparseToString var)
+  error ("Cannot quantify set variable " ++ unparseToString var)
 
 checkUnique
-    :: Set.Set (UnifiedVariable Variable) -> Set.Set (UnifiedVariable Variable)
+  :: Set.Set (UnifiedVariable Variable) -> Set.Set (UnifiedVariable Variable)
 checkUnique variables =
-    case checkUniqueEither (Set.toList variables) Map.empty of
-        Right _  -> variables
-        Left err -> error err
+  case checkUniqueEither (Set.toList variables) Map.empty of
+    Right _ -> variables
+    Left err -> error err
 
 checkUniqueEither
-    :: [UnifiedVariable Variable]
-    -> Map.Map Text (UnifiedVariable Variable)
-    -> Either String ()
+  :: [UnifiedVariable Variable]
+  -> Map.Map Text (UnifiedVariable Variable)
+  -> Either String ()
 checkUniqueEither [] _ = Right ()
-checkUniqueEither (var:vars) indexed =
-    case Map.lookup name indexed of
-        Nothing -> checkUniqueEither vars (Map.insert name var indexed)
-        Just existingV ->
-            Left
-                (  "Conflicting variables: "
-                ++ show var
-                ++ " and "
-                ++ show existingV
-                ++ "."
-                )
+checkUniqueEither (var : vars) indexed =
+  case Map.lookup name indexed of
+    Nothing -> checkUniqueEither vars (Map.insert name var indexed)
+    Just existingV ->
+      Left
+        ( "Conflicting variables: "
+            ++ show var
+            ++ " and "
+            ++ show existingV
+            ++ "."
+          )
   where
     name = getId . foldMapVariable variableName $ var

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -8,35 +8,39 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.ASTVerifier.DefinitionVerifier
-    ( defaultAttributesVerification
-    , defaultNullAttributesVerification
-    , verifyDefinition
-    , verifyAndIndexDefinition
-    , verifyAndIndexDefinitionWithBase
-    , AttributesVerification (..)
-    ) where
+  ( defaultAttributesVerification,
+    defaultNullAttributesVerification,
+    verifyDefinition,
+    verifyAndIndexDefinition,
+    verifyAndIndexDefinitionWithBase,
+    AttributesVerification (..)
+    )
+where
 
-import           Control.Monad
-                 ( foldM )
+import Control.Monad
+  ( foldM
+    )
 import qualified Data.Map as Map
-import           Data.Maybe
-import           Data.Proxy
-                 ( Proxy (..) )
-import           Data.Text
-                 ( Text )
-
-import           Kore.ASTVerifier.AttributesVerifier
-import           Kore.ASTVerifier.Error
-import           Kore.ASTVerifier.ModuleVerifier
+import Data.Maybe
+import Data.Proxy
+  ( Proxy (..)
+    )
+import Data.Text
+  ( Text
+    )
+import Kore.ASTVerifier.AttributesVerifier
+import Kore.ASTVerifier.Error
+import Kore.ASTVerifier.ModuleVerifier
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Attribute.Parser
-                 ( ParseAttributes (..) )
+import Kore.Attribute.Parser
+  ( ParseAttributes (..)
+    )
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
-import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
-import           Kore.Syntax as Syntax
-import           Kore.Syntax.Definition
+import Kore.Error
+import Kore.IndexedModule.IndexedModule
+import Kore.Syntax as Syntax
+import Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
 
 {-|'verifyDefinition' verifies the welformedness of a Kore 'Definition'.
@@ -59,36 +63,38 @@ e.g.:
 
 -}
 verifyDefinition
-    :: ParseAttributes axiomAtts
-    => AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> ParsedDefinition
-    -> Either (Error VerifyError) VerifySuccess
+  :: ParseAttributes axiomAtts
+  => AttributesVerification Attribute.Symbol axiomAtts
+  -> Builtin.Verifiers
+  -> ParsedDefinition
+  -> Either (Error VerifyError) VerifySuccess
 verifyDefinition attributesVerification builtinVerifiers definition = do
-    _ <-
-        verifyAndIndexDefinition
-            attributesVerification builtinVerifiers definition
-    verifySuccess
+  _ <-
+    verifyAndIndexDefinition
+      attributesVerification
+      builtinVerifiers
+      definition
+  verifySuccess
 
 {-|'verifyAndIndexDefinition' verifies a definition and returns an indexed
 collection of the definition's modules.
 -}
 verifyAndIndexDefinition
-    :: ParseAttributes axiomAtts
-    => AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> ParsedDefinition
-    -> Either
-        (Error VerifyError)
-        (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
+  :: ParseAttributes axiomAtts
+  => AttributesVerification Attribute.Symbol axiomAtts
+  -> Builtin.Verifiers
+  -> ParsedDefinition
+  -> Either
+       (Error VerifyError)
+       (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
 verifyAndIndexDefinition attributesVerification builtinVerifiers definition = do
-    (indexedModules, _defaultNames) <-
-        verifyAndIndexDefinitionWithBase
-            Nothing
-            attributesVerification
-            builtinVerifiers
-            definition
-    return indexedModules
+  (indexedModules, _defaultNames) <-
+    verifyAndIndexDefinitionWithBase
+      Nothing
+      attributesVerification
+      builtinVerifiers
+      definition
+  return indexedModules
 
 {-|Verifies a `ParsedDefinition` against a preverified definition, consisting of
 map of indexed modules and a map of defined names.
@@ -97,99 +103,90 @@ If verification is successfull, it returns the updated maps op indexed modules
 and defined names.
 -}
 verifyAndIndexDefinitionWithBase
-    :: forall axiomAtts
-    .  ParseAttributes axiomAtts
-    => Maybe
-        ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts)
-        , Map.Map Text AstLocation
-        )
-    -> AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> ParsedDefinition
-    -> Either (Error VerifyError)
-        ( Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts)
-        , Map.Map Text AstLocation
-        )
+  :: forall axiomAtts. ParseAttributes axiomAtts
+  => Maybe
+       ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts),
+         Map.Map Text AstLocation
+         )
+  -> AttributesVerification Attribute.Symbol axiomAtts
+  -> Builtin.Verifiers
+  -> ParsedDefinition
+  -> Either (Error VerifyError)
+       ( Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts),
+         Map.Map Text AstLocation
+         )
 verifyAndIndexDefinitionWithBase
-    maybeBaseDefinition
-    attributesVerification
-    builtinVerifiers
-    definition
-  = do
-    let
-        (baseIndexedModules, baseNames) =
+  maybeBaseDefinition
+  attributesVerification
+  builtinVerifiers
+  definition =
+    do
+      let (baseIndexedModules, baseNames) =
             fromMaybe (implicitModules, implicitNames) maybeBaseDefinition
-
-    names <- foldM verifyUniqueNames baseNames (definitionModules definition)
-
-    let
-        defaultModule
+      names <- foldM verifyUniqueNames baseNames (definitionModules definition)
+      let defaultModule
             :: ImplicitIndexedModule ParsedPattern Attribute.Symbol axiomAtts
-        defaultModule = ImplicitIndexedModule implicitIndexedModule
-        indexModules
+          defaultModule = ImplicitIndexedModule implicitIndexedModule
+          indexModules
             :: [ParsedModule]
             -> Either
-                (Error VerifyError)
-                (Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts))
-        indexModules modules =
-            castError $ foldM
-                (indexModuleIfNeeded
-                    (Just defaultModule)
-                    (modulesByName modules)
-                )
-                baseIndexedModules
-                modules
-
-        verifyModule' = verifyModule attributesVerification builtinVerifiers
-        verifyModules = traverse verifyModule'
-
-    -- Index the unverified modules.
-    indexedModules <- indexModules (definitionModules definition)
-
-    -- Verify the contents of the definition.
-    verifiedModules <- verifyModules (Map.elems indexedModules)
-    verifyAttributes
+                 (Error VerifyError)
+                 (Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts))
+          indexModules modules =
+            castError
+              $ foldM
+                  ( indexModuleIfNeeded
+                      (Just defaultModule)
+                      (modulesByName modules)
+                    )
+                  baseIndexedModules
+                  modules
+          verifyModule' = verifyModule attributesVerification builtinVerifiers
+          verifyModules = traverse verifyModule'
+      -- Index the unverified modules.
+      indexedModules <- indexModules (definitionModules definition)
+      -- Verify the contents of the definition.
+      verifiedModules <- verifyModules (Map.elems indexedModules)
+      verifyAttributes
         (definitionAttributes definition)
         attributesVerification
-
-    let
-        verifiedDefaultModule
+      let verifiedDefaultModule
             :: ImplicitIndexedModule Verified.Pattern Attribute.Symbol axiomAtts
-        verifiedDefaultModule = ImplicitIndexedModule implicitIndexedModule
-        indexVerifiedModules
+          verifiedDefaultModule = ImplicitIndexedModule implicitIndexedModule
+          indexVerifiedModules
             :: [Module Verified.Sentence]
             -> Either
-                (Error VerifyError)
-                (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
-        indexVerifiedModules modules =
-            castError $ foldM
-                (indexModuleIfNeeded
-                    (Just verifiedDefaultModule)
-                    verifiedModulesByName
-                )
-                implicitModules
-                modules
-          where
-            verifiedModulesByName = modulesByName modules
-
-    -- Re-index the (now verified) modules.
-    reindexedModules <- indexVerifiedModules verifiedModules
-    return (reindexedModules, names)
-  where
-    modulesByName = Map.fromList . map (\m -> (moduleName m, m))
+                 (Error VerifyError)
+                 (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
+          indexVerifiedModules modules =
+            castError
+              $ foldM
+                  ( indexModuleIfNeeded
+                      (Just verifiedDefaultModule)
+                      verifiedModulesByName
+                    )
+                  implicitModules
+                  modules
+            where
+              verifiedModulesByName = modulesByName modules
+      -- Re-index the (now verified) modules.
+      reindexedModules <- indexVerifiedModules verifiedModules
+      return (reindexedModules, names)
+    where
+      modulesByName = Map.fromList . map (\m -> (moduleName m, m))
 
 defaultAttributesVerification
-    :: (ParseAttributes declAtts, ParseAttributes axiomAtts)
-    => Proxy declAtts
-    -> Proxy axiomAtts
-    -> AttributesVerification declAtts axiomAtts
+  :: (ParseAttributes declAtts, ParseAttributes axiomAtts)
+  => Proxy declAtts
+  -> Proxy axiomAtts
+  -> AttributesVerification declAtts axiomAtts
 defaultAttributesVerification = VerifyAttributes
 
 -- |default option for verifying attributes without parsing them
 defaultNullAttributesVerification
-    :: AttributesVerification Attribute.Null Attribute.Null
+  :: AttributesVerification Attribute.Null Attribute.Null
 defaultNullAttributesVerification =
-   defaultAttributesVerification proxy proxy
+  defaultAttributesVerification proxy proxy
   where
     proxy :: Proxy Attribute.Null
     proxy = Proxy

--- a/kore/src/Kore/ASTVerifier/Error.hs
+++ b/kore/src/Kore/ASTVerifier/Error.hs
@@ -10,21 +10,26 @@ Portability : POSIX
 module Kore.ASTVerifier.Error where
 
 import Data.Text
-       ( Text )
-
+  ( Text
+    )
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
-import           Kore.Error
-import           Kore.Sort
-                 ( Sort, getSortId )
-import           Kore.Syntax.Id
-                 ( Id (getId), getIdForError )
+import Kore.Error
+import Kore.Sort
+  ( Sort,
+    getSortId
+    )
+import Kore.Syntax.Id
+  ( Id (getId),
+    getIdForError
+    )
 
 {-| 'VerifyError' is a tag for verification errors. -}
 newtype VerifyError = VerifyError ()
-    deriving (Eq, Show)
+  deriving (Eq, Show)
+
 {-| 'VerifySuccess' is a tag for verification success. -}
 newtype VerifySuccess = VerifySuccess ()
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 {-| 'verifySuccess' helper for signaling verification success. -}
 verifySuccess :: MonadError (Error VerifyError) m => m VerifySuccess
@@ -32,12 +37,14 @@ verifySuccess = return (VerifySuccess ())
 
 noConstructorWithDomainValuesMessage :: Id -> Sort -> String
 noConstructorWithDomainValuesMessage symbol resultSort =
-    "Cannot define constructor '" ++ getIdForError symbol
-    ++ "' for sort with domain values '" ++ getIdForError (getSortId resultSort)
+  "Cannot define constructor '" ++ getIdForError symbol
+    ++ "' for sort with domain values '"
+    ++ getIdForError (getSortId resultSort)
     ++ "'."
 
 sortNeedsDomainValueAttributeMessage :: Text
 sortNeedsDomainValueAttributeMessage =
-    "Sorts used with domain value must have the '"
+  "Sorts used with domain value must have the '"
     <> getId Attribute.HasDomainValues.hasDomainValuesId
-    <> "' " <> "attribute."
+    <> "' "
+    <> "attribute."

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -8,67 +8,69 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.ASTVerifier.ModuleVerifier
-    ( verifyModule
-    , verifyUniqueNames
-    ) where
+  ( verifyModule,
+    verifyUniqueNames
+    )
+where
 
 import qualified Data.Map as Map
-import           Data.Text
-                 ( Text )
-
-import           Kore.ASTVerifier.AttributesVerifier
-import           Kore.ASTVerifier.Error
+import Data.Text
+  ( Text
+    )
+import Kore.ASTVerifier.AttributesVerifier
+import Kore.ASTVerifier.Error
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
-import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
-import           Kore.Syntax
-import           Kore.Syntax.Definition
-import           Kore.Unparser
+import Kore.Error
+import Kore.IndexedModule.IndexedModule
+import Kore.Syntax
+import Kore.Syntax.Definition
+import Kore.Unparser
 import qualified Kore.Verified as Verified
 
 {-|'verifyUniqueNames' verifies that names defined in a module are unique both
 within the module and outside, using the provided name set. -}
 verifyUniqueNames
-    :: Unparse pat
-    => Map.Map Text AstLocation
-    -- ^ Names that are already defined.
-    -> Module (Sentence pat)
-    -> Either (Error VerifyError) (Map.Map Text AstLocation)
-    -- ^ On success returns the names that were previously defined together with
-    -- the names defined in the given 'Module'.
+  :: Unparse pat
+  => Map.Map Text AstLocation
+  -- ^ Names that are already defined.
+  -> Module (Sentence pat)
+  -> Either (Error VerifyError) (Map.Map Text AstLocation)
+  -- ^ On success returns the names that were previously defined together with
+  -- the names defined in the given 'Module'.
 verifyUniqueNames existingNames koreModule =
-    withContext
-        ("module '" ++ getModuleNameForError (moduleName koreModule) ++ "'")
-        (SentenceVerifier.verifyUniqueNames
-            (moduleSentences koreModule)
-            existingNames)
+  withContext
+    ("module '" ++ getModuleNameForError (moduleName koreModule) ++ "'")
+    ( SentenceVerifier.verifyUniqueNames
+        (moduleSentences koreModule)
+        existingNames
+      )
 
 {-|'verifyModule' verifies the welformedness of a Kore 'Module'. -}
 verifyModule
-    :: AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
-    -> Either (Error VerifyError) (Module Verified.Sentence)
+  :: AttributesVerification Attribute.Symbol axiomAtts
+  -> Builtin.Verifiers
+  -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
+  -> Either (Error VerifyError) (Module Verified.Sentence)
 verifyModule attributesVerification builtinVerifiers indexedModule =
-    withContext
-        (  "module '"
+  withContext
+    ( "module '"
         ++ getModuleNameForError (indexedModuleName indexedModule)
         ++ "'"
-        )
-        (do
-            verifyAttributes
-                (snd (indexedModuleAttributes indexedModule))
-                attributesVerification
-            moduleSentences <-
-                SentenceVerifier.verifySentences
-                    indexedModule
-                    attributesVerification
-                    builtinVerifiers
-                    (indexedModuleRawSentences indexedModule)
-            return Module { moduleName, moduleSentences, moduleAttributes }
-        )
+      )
+    ( do
+        verifyAttributes
+          (snd (indexedModuleAttributes indexedModule))
+          attributesVerification
+        moduleSentences <-
+          SentenceVerifier.verifySentences
+            indexedModule
+            attributesVerification
+            builtinVerifiers
+            (indexedModuleRawSentences indexedModule)
+        return Module {moduleName, moduleSentences, moduleAttributes}
+      )
   where
     moduleName = indexedModuleName indexedModule
     (_, moduleAttributes) = indexedModuleAttributes indexedModule

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -2,174 +2,185 @@
 Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 -}
-
 module Kore.ASTVerifier.PatternVerifier
-    ( verifyPattern
-    , verifyStandalonePattern
-    , verifyNoPatterns
-    , verifyAliasLeftPattern
-    , verifyFreeVariables
-    , withDeclaredVariables
-    , PatternVerifier (..)
-    , runPatternVerifier
-    , Context (..)
-    , DeclaredVariables (..), emptyDeclaredVariables
-    , assertExpectedSort
-    , assertSameSort
-    ) where
+  ( verifyPattern,
+    verifyStandalonePattern,
+    verifyNoPatterns,
+    verifyAliasLeftPattern,
+    verifyFreeVariables,
+    withDeclaredVariables,
+    PatternVerifier (..),
+    runPatternVerifier,
+    Context (..),
+    DeclaredVariables (..),
+    emptyDeclaredVariables,
+    assertExpectedSort,
+    assertSameSort
+    )
+where
 
-import           Control.Applicative
+import Control.Applicative
 import qualified Control.Monad as Monad
-import           Control.Monad.Reader
-                 ( MonadReader, ReaderT, runReaderT )
+import Control.Monad.Reader
+  ( MonadReader,
+    ReaderT,
+    runReaderT
+    )
 import qualified Control.Monad.Reader as Reader
 import qualified Control.Monad.Trans.Class as Trans
-import           Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Maybe
 import qualified Data.Foldable as Foldable
-import           Data.Function
-                 ( (&) )
+import Data.Function
+  ( (&)
+    )
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map as Map
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( (<+>) )
+import Data.Text
+  ( Text
+    )
+import Data.Text.Prettyprint.Doc
+  ( (<+>)
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           Data.Text.Prettyprint.Doc.Render.Text
-                 ( renderStrict )
-
-import           Kore.AST.Error
-import           Kore.ASTVerifier.Error
-import           Kore.ASTVerifier.SortVerifier
+import Data.Text.Prettyprint.Doc.Render.Text
+  ( renderStrict
+    )
+import Kore.AST.Error
+import Kore.ASTVerifier.Error
+import Kore.ASTVerifier.SortVerifier
 import qualified Kore.Attribute.Null as Attribute
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Sort as Attribute.Sort
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Attribute.Synthetic
+import Kore.Attribute.Synthetic
 import qualified Kore.Builtin as Builtin
-import           Kore.Error
-import           Kore.IndexedModule.Error
-import           Kore.IndexedModule.IndexedModule
-import           Kore.IndexedModule.Resolvers
+import Kore.Error
+import Kore.IndexedModule.Error
+import Kore.IndexedModule.IndexedModule
+import Kore.IndexedModule.Resolvers
 import qualified Kore.Internal.Alias as Internal
-import           Kore.Internal.ApplicationSorts
+import Kore.Internal.ApplicationSorts
 import qualified Kore.Internal.Symbol as Internal
-import           Kore.Internal.TermLike
-                 ( TermLike )
+import Kore.Internal.TermLike
+  ( TermLike
+    )
 import qualified Kore.Internal.TermLike as Internal
-import           Kore.Parser
-                 ( ParsedPattern )
-import           Kore.Syntax as Syntax
-import           Kore.Syntax.Definition
-import           Kore.Unparser
+import Kore.Parser
+  ( ParsedPattern
+    )
+import Kore.Syntax as Syntax
+import Kore.Syntax.Definition
+import Kore.Unparser
 import qualified Kore.Variables.Free as Variables
-import           Kore.Variables.UnifiedVariable
+import Kore.Variables.UnifiedVariable
 import qualified Kore.Verified as Verified
 
-newtype DeclaredVariables =
-    DeclaredVariables
-        { getDeclaredVariables :: Map.Map Id (UnifiedVariable Variable) }
-    deriving (Monoid, Semigroup)
+newtype DeclaredVariables
+  = DeclaredVariables
+      {getDeclaredVariables :: Map.Map Id (UnifiedVariable Variable)}
+  deriving (Monoid, Semigroup)
 
 emptyDeclaredVariables :: DeclaredVariables
 emptyDeclaredVariables = mempty
 
-data Context =
-    Context
-        { declaredVariables :: !DeclaredVariables
-        , declaredSortVariables :: !(Set SortVariable)
+data Context
+  = Context
+      { declaredVariables :: !DeclaredVariables,
+        declaredSortVariables :: !(Set SortVariable),
         -- ^ The sort variables in scope.
-        , indexedModule :: !(IndexedModule () Attribute.Symbol Attribute.Null)
+        indexedModule :: !(IndexedModule () Attribute.Symbol Attribute.Null),
         -- ^ The indexed Kore module containing all definitions in scope.
-        , builtinDomainValueVerifiers
-            :: !(Builtin.DomainValueVerifiers Verified.Pattern)
+        builtinDomainValueVerifiers
+          :: !(Builtin.DomainValueVerifiers Verified.Pattern)
         }
 
-newtype PatternVerifier a =
-    PatternVerifier
-        { getPatternVerifier :: ReaderT Context (Either (Error VerifyError)) a }
-    deriving (Applicative, Functor, Monad)
+newtype PatternVerifier a
+  = PatternVerifier
+      {getPatternVerifier :: ReaderT Context (Either (Error VerifyError)) a}
+  deriving (Applicative, Functor, Monad)
 
 deriving instance MonadReader Context PatternVerifier
 
 deriving instance e ~ VerifyError => MonadError (Error e) PatternVerifier
 
 runPatternVerifier
-    :: Context
-    -> PatternVerifier a
-    -> Either (Error VerifyError) a
-runPatternVerifier context PatternVerifier { getPatternVerifier } =
-    runReaderT getPatternVerifier context
+  :: Context
+  -> PatternVerifier a
+  -> Either (Error VerifyError) a
+runPatternVerifier context PatternVerifier {getPatternVerifier} =
+  runReaderT getPatternVerifier context
 
 lookupSortDeclaration
-    :: Id
-    -> PatternVerifier (SentenceSort ())
+  :: Id
+  -> PatternVerifier (SentenceSort ())
 lookupSortDeclaration sortId = do
-    Context { indexedModule } <- Reader.ask
-    (_, sortDecl) <- resolveSort indexedModule sortId
-    return sortDecl
+  Context {indexedModule} <- Reader.ask
+  (_, sortDecl) <- resolveSort indexedModule sortId
+  return sortDecl
 
 lookupAlias
-    ::  SymbolOrAlias
-    ->  MaybeT PatternVerifier Internal.Alias
+  :: SymbolOrAlias
+  -> MaybeT PatternVerifier Internal.Alias
 lookupAlias symbolOrAlias = do
-    Context { indexedModule } <- Reader.ask
-    let resolveAlias' = resolveAlias indexedModule aliasConstructor
-    (_, decl) <- resolveAlias' `catchError` const empty
-    aliasSorts <-
-        Trans.lift
-        $ applicationSortsFromSymbolOrAliasSentence symbolOrAlias decl
-    return Internal.Alias
-        { aliasConstructor
-        , aliasParams
-        , aliasSorts
-        }
+  Context {indexedModule} <- Reader.ask
+  let resolveAlias' = resolveAlias indexedModule aliasConstructor
+  (_, decl) <- resolveAlias' `catchError` const empty
+  aliasSorts <-
+    Trans.lift
+      $ applicationSortsFromSymbolOrAliasSentence symbolOrAlias decl
+  return Internal.Alias
+    { aliasConstructor,
+      aliasParams,
+      aliasSorts
+      }
   where
     aliasConstructor = symbolOrAliasConstructor symbolOrAlias
     aliasParams = symbolOrAliasParams symbolOrAlias
 
 lookupSymbol
-    ::  SymbolOrAlias
-    ->  MaybeT PatternVerifier Internal.Symbol
+  :: SymbolOrAlias
+  -> MaybeT PatternVerifier Internal.Symbol
 lookupSymbol symbolOrAlias = do
-    Context { indexedModule } <- Reader.ask
-    let resolveSymbol' = resolveSymbol indexedModule symbolConstructor
-    (symbolAttributes, decl) <- resolveSymbol' `catchError` const empty
-    symbolSorts <-
-        Trans.lift
-        $ applicationSortsFromSymbolOrAliasSentence symbolOrAlias decl
-    let symbol =
-            Internal.Symbol
-                { symbolConstructor
-                , symbolParams
-                , symbolAttributes
-                , symbolSorts
-                }
-    return symbol
+  Context {indexedModule} <- Reader.ask
+  let resolveSymbol' = resolveSymbol indexedModule symbolConstructor
+  (symbolAttributes, decl) <- resolveSymbol' `catchError` const empty
+  symbolSorts <-
+    Trans.lift
+      $ applicationSortsFromSymbolOrAliasSentence symbolOrAlias decl
+  let symbol =
+        Internal.Symbol
+          { symbolConstructor,
+            symbolParams,
+            symbolAttributes,
+            symbolSorts
+            }
+  return symbol
   where
     symbolConstructor = symbolOrAliasConstructor symbolOrAlias
     symbolParams = symbolOrAliasParams symbolOrAlias
 
 lookupDeclaredVariable :: Id -> PatternVerifier (UnifiedVariable Variable)
 lookupDeclaredVariable varId = do
-    variables <- Reader.asks (getDeclaredVariables . declaredVariables)
-    maybe errorUnquantified return $ Map.lookup varId variables
+  variables <- Reader.asks (getDeclaredVariables . declaredVariables)
+  maybe errorUnquantified return $ Map.lookup varId variables
   where
     errorUnquantified :: PatternVerifier (UnifiedVariable Variable)
     errorUnquantified =
-        koreFailWithLocations [varId]
-            ("Unquantified variable: '" <> getId varId <> "'.")
+      koreFailWithLocations [varId]
+        ("Unquantified variable: '" <> getId varId <> "'.")
 
 addDeclaredVariable
-    :: UnifiedVariable Variable
-    -> DeclaredVariables
-    -> DeclaredVariables
+  :: UnifiedVariable Variable
+  -> DeclaredVariables
+  -> DeclaredVariables
 addDeclaredVariable variable (getDeclaredVariables -> variables) =
-    DeclaredVariables $ Map.insert
+  DeclaredVariables
+    $ Map.insert
         (foldMapVariable variableName variable)
         variable
         variables
@@ -180,24 +191,24 @@ The new variable must not already be declared.
 
  -}
 newDeclaredVariable
-    :: DeclaredVariables
-    -> UnifiedVariable Variable
-    -> PatternVerifier DeclaredVariables
+  :: DeclaredVariables
+  -> UnifiedVariable Variable
+  -> PatternVerifier DeclaredVariables
 newDeclaredVariable declared variable = do
-    let declaredVariables = getDeclaredVariables declared
-    case Map.lookup name declaredVariables of
-        Just variable' -> alreadyDeclared variable'
-        Nothing -> return (addDeclaredVariable variable declared)
+  let declaredVariables = getDeclaredVariables declared
+  case Map.lookup name declaredVariables of
+    Just variable' -> alreadyDeclared variable'
+    Nothing -> return (addDeclaredVariable variable declared)
   where
     name = foldMapVariable variableName variable
     alreadyDeclared
-        :: UnifiedVariable Variable -> PatternVerifier DeclaredVariables
+      :: UnifiedVariable Variable -> PatternVerifier DeclaredVariables
     alreadyDeclared variable' =
-        koreFailWithLocations [variable', variable]
-            (  "Variable '"
+      koreFailWithLocations [variable', variable]
+        ( "Variable '"
             <> getId name
             <> "' was already declared."
-            )
+          )
 
 {- | Collect 'DeclaredVariables'.
 
@@ -207,11 +218,11 @@ See also: 'newDeclaredVariable'
 
  -}
 uniqueDeclaredVariables
-    :: Foldable f
-    => f (UnifiedVariable Variable)
-    -> PatternVerifier DeclaredVariables
+  :: Foldable f
+  => f (UnifiedVariable Variable)
+  -> PatternVerifier DeclaredVariables
 uniqueDeclaredVariables =
-    Foldable.foldlM newDeclaredVariable emptyDeclaredVariables
+  Foldable.foldlM newDeclaredVariable emptyDeclaredVariables
 
 {- | Run a 'PatternVerifier' in a particular variable context.
 
@@ -219,11 +230,11 @@ See also: 'verifyStandalonePattern'
 
  -}
 withDeclaredVariables
-    :: DeclaredVariables
-    -> PatternVerifier a
-    -> PatternVerifier a
+  :: DeclaredVariables
+  -> PatternVerifier a
+  -> PatternVerifier a
 withDeclaredVariables declaredVariables' =
-    Reader.local (\ctx -> ctx { declaredVariables = declaredVariables' })
+  Reader.local (\ctx -> ctx {declaredVariables = declaredVariables'})
 
 {- | Verify the left-hand side of an alias definition.
 
@@ -238,33 +249,35 @@ See also: 'uniqueDeclaredVariables', 'withDeclaredVariables'
 
  -}
 verifyAliasLeftPattern
-    :: Application SymbolOrAlias (ElementVariable Variable)
-    -> PatternVerifier
-        ( DeclaredVariables
-        , Application SymbolOrAlias (ElementVariable Variable)
-        )
+  :: Application SymbolOrAlias (ElementVariable Variable)
+  -> PatternVerifier
+       ( DeclaredVariables,
+         Application SymbolOrAlias (ElementVariable Variable)
+         )
 verifyAliasLeftPattern leftPattern = do
-    _ :< verified <-
-        verifyApplyAlias snd (expectVariable . ElemVar  <$> leftPattern)
-        & runMaybeT
-        & (>>= maybe (error . noHead $ symbolOrAlias) return)
-    declaredVariables <- uniqueDeclaredVariables (fst <$> verified)
-    let verifiedLeftPattern = traverse extractElementVariable
-            leftPattern
-                { applicationChildren = fst <$> applicationChildren verified }
-    case verifiedLeftPattern of
-        Just result -> return (declaredVariables, result)
-        Nothing -> error "Impossible change from element var to set var"
+  _ :< verified <-
+    verifyApplyAlias snd (expectVariable . ElemVar <$> leftPattern)
+      & runMaybeT
+      & (>>= maybe (error . noHead $ symbolOrAlias) return)
+  declaredVariables <- uniqueDeclaredVariables (fst <$> verified)
+  let verifiedLeftPattern =
+        traverse extractElementVariable
+          leftPattern
+            { applicationChildren = fst <$> applicationChildren verified
+              }
+  case verifiedLeftPattern of
+    Just result -> return (declaredVariables, result)
+    Nothing -> error "Impossible change from element var to set var"
   where
     symbolOrAlias = applicationSymbolOrAlias leftPattern
     expectVariable
-        :: UnifiedVariable Variable
-        -> PatternVerifier
-            (UnifiedVariable Variable, Attribute.Pattern Variable)
+      :: UnifiedVariable Variable
+      -> PatternVerifier
+           (UnifiedVariable Variable, Attribute.Pattern Variable)
     expectVariable var = do
-        verifyVariableDeclaration var
-        let attrs = synthetic (Const var)
-        return (var, attrs)
+      verifyVariableDeclaration var
+      let attrs = synthetic (Const var)
+      return (var, attrs)
 
 {- | Verify that a Kore pattern is well-formed.
 
@@ -275,14 +288,14 @@ This includes verifying that:
 
  -}
 verifyPattern
-    :: Maybe Sort
-    -- ^ If present, represents the expected sort of the pattern.
-    -> ParsedPattern
-    -> PatternVerifier Verified.Pattern
+  :: Maybe Sort
+  -- ^ If present, represents the expected sort of the pattern.
+  -> ParsedPattern
+  -> PatternVerifier Verified.Pattern
 verifyPattern expectedSort korePattern = do
-    verified <- Recursive.fold verifyPatternWorker korePattern
-    assertExpectedSort expectedSort (Internal.extractAttributes verified)
-    return verified
+  verified <- Recursive.fold verifyPatternWorker korePattern
+  assertExpectedSort expectedSort (Internal.extractAttributes verified)
+  return verified
   where
     verifyPatternWorker base = Recursive.embed <$> verifyObjectPattern base
 
@@ -295,13 +308,13 @@ See also: 'verifyPattern', 'verifyFreeVariables', 'withDeclaredVariables'
 
  -}
 verifyStandalonePattern
-    :: Maybe Sort
-    -> ParsedPattern
-    -> PatternVerifier Verified.Pattern
+  :: Maybe Sort
+  -> ParsedPattern
+  -> PatternVerifier Verified.Pattern
 verifyStandalonePattern expectedSort korePattern = do
-    declaredVariables <- verifyFreeVariables korePattern
-    withDeclaredVariables declaredVariables
-        (verifyPattern expectedSort korePattern)
+  declaredVariables <- verifyFreeVariables korePattern
+  withDeclaredVariables declaredVariables
+    (verifyPattern expectedSort korePattern)
 
 {- | Fail if a Kore pattern is found.
 
@@ -310,563 +323,564 @@ type variables.
 
  -}
 verifyNoPatterns
-    :: MonadError (Error VerifyError) m
-    => ParsedPattern
-    -> m Verified.Pattern
+  :: MonadError (Error VerifyError) m
+  => ParsedPattern
+  -> m Verified.Pattern
 verifyNoPatterns _ = koreFail "Unexpected pattern."
 
 verifyObjectPattern
-    :: Base ParsedPattern (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (Base (TermLike Variable) Verified.Pattern)
+  :: Base ParsedPattern (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (Base (TermLike Variable) Verified.Pattern)
 verifyObjectPattern base@(_ :< patternF) =
-    withLocationAndContext patternF patternName $ verifyPatternHead base
+  withLocationAndContext patternF patternName $ verifyPatternHead base
   where
     patternName = patternNameForContext patternF
 
 verifyPatternHead
-    :: Base ParsedPattern (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (Base (TermLike Variable) Verified.Pattern)
+  :: Base ParsedPattern (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (Base (TermLike Variable) Verified.Pattern)
 verifyPatternHead (_ :< patternF) =
-    case patternF of
-        Syntax.AndF and' ->
-            transCofreeF Internal.AndF <$> verifyAnd and'
-        Syntax.ApplicationF app ->
-            verifyApplication Internal.extractAttributes app
-        Syntax.BottomF bottom ->
-            transCofreeF Internal.BottomF <$> verifyBottom bottom
-        Syntax.CeilF ceil' ->
-            transCofreeF Internal.CeilF <$> verifyCeil ceil'
-        Syntax.DomainValueF dv -> verifyDomainValue dv
-        Syntax.EqualsF equals' ->
-            transCofreeF Internal.EqualsF <$> verifyEquals equals'
-        Syntax.ExistsF exists ->
-            transCofreeF Internal.ExistsF <$> verifyExists exists
-        Syntax.FloorF floor' ->
-            transCofreeF Internal.FloorF <$> verifyFloor floor'
-        Syntax.ForallF forall' ->
-            transCofreeF Internal.ForallF <$> verifyForall forall'
-        Syntax.IffF iff ->
-            transCofreeF Internal.IffF <$> verifyIff iff
-        Syntax.ImpliesF implies ->
-            transCofreeF Internal.ImpliesF <$> verifyImplies implies
-        Syntax.InF in' ->
-            transCofreeF Internal.InF <$> verifyIn in'
-        Syntax.MuF mu ->
-            transCofreeF Internal.MuF <$> verifyMu mu
-        Syntax.NextF next ->
-            transCofreeF Internal.NextF <$> verifyNext next
-        Syntax.NotF not' ->
-            transCofreeF Internal.NotF <$> verifyNot not'
-        Syntax.NuF nu ->
-            transCofreeF Internal.NuF <$> verifyNu nu
-        Syntax.OrF or' ->
-            transCofreeF Internal.OrF <$> verifyOr or'
-        Syntax.RewritesF rewrites ->
-            transCofreeF Internal.RewritesF <$> verifyRewrites rewrites
-        Syntax.StringLiteralF str ->
-            transCofreeF Internal.StringLiteralF <$> verifyStringLiteral str
-        Syntax.CharLiteralF char ->
-            transCofreeF Internal.CharLiteralF <$> verifyCharLiteral char
-        Syntax.TopF top ->
-            transCofreeF Internal.TopF <$> verifyTop top
-        Syntax.VariableF (Const variable) ->
-            transCofreeF Internal.VariableF <$> verifyVariable variable
-        Syntax.InhabitantF _ ->
-            koreFail "Unexpected pattern."
+  case patternF of
+    Syntax.AndF and' ->
+      transCofreeF Internal.AndF <$> verifyAnd and'
+    Syntax.ApplicationF app ->
+      verifyApplication Internal.extractAttributes app
+    Syntax.BottomF bottom ->
+      transCofreeF Internal.BottomF <$> verifyBottom bottom
+    Syntax.CeilF ceil' ->
+      transCofreeF Internal.CeilF <$> verifyCeil ceil'
+    Syntax.DomainValueF dv -> verifyDomainValue dv
+    Syntax.EqualsF equals' ->
+      transCofreeF Internal.EqualsF <$> verifyEquals equals'
+    Syntax.ExistsF exists ->
+      transCofreeF Internal.ExistsF <$> verifyExists exists
+    Syntax.FloorF floor' ->
+      transCofreeF Internal.FloorF <$> verifyFloor floor'
+    Syntax.ForallF forall' ->
+      transCofreeF Internal.ForallF <$> verifyForall forall'
+    Syntax.IffF iff ->
+      transCofreeF Internal.IffF <$> verifyIff iff
+    Syntax.ImpliesF implies ->
+      transCofreeF Internal.ImpliesF <$> verifyImplies implies
+    Syntax.InF in' ->
+      transCofreeF Internal.InF <$> verifyIn in'
+    Syntax.MuF mu ->
+      transCofreeF Internal.MuF <$> verifyMu mu
+    Syntax.NextF next ->
+      transCofreeF Internal.NextF <$> verifyNext next
+    Syntax.NotF not' ->
+      transCofreeF Internal.NotF <$> verifyNot not'
+    Syntax.NuF nu ->
+      transCofreeF Internal.NuF <$> verifyNu nu
+    Syntax.OrF or' ->
+      transCofreeF Internal.OrF <$> verifyOr or'
+    Syntax.RewritesF rewrites ->
+      transCofreeF Internal.RewritesF <$> verifyRewrites rewrites
+    Syntax.StringLiteralF str ->
+      transCofreeF Internal.StringLiteralF <$> verifyStringLiteral str
+    Syntax.CharLiteralF char ->
+      transCofreeF Internal.CharLiteralF <$> verifyCharLiteral char
+    Syntax.TopF top ->
+      transCofreeF Internal.TopF <$> verifyTop top
+    Syntax.VariableF (Const variable) ->
+      transCofreeF Internal.VariableF <$> verifyVariable variable
+    Syntax.InhabitantF _ ->
+      koreFail "Unexpected pattern."
   where
     transCofreeF fg (a :< fb) = a :< fg fb
 
 verifyPatternSort :: Sort -> PatternVerifier ()
 verifyPatternSort patternSort = do
-    Context { declaredSortVariables } <- Reader.ask
-    _ <- verifySort lookupSortDeclaration declaredSortVariables patternSort
-    return ()
+  Context {declaredSortVariables} <- Reader.ask
+  _ <- verifySort lookupSortDeclaration declaredSortVariables patternSort
+  return ()
 
 verifyOperands
-    :: (Traversable operator, Synthetic (Attribute.Pattern Variable) operator)
-    => (forall a. operator a -> Sort)
-    -> operator (PatternVerifier Verified.Pattern)
-    ->  PatternVerifier
-            (CofreeF operator (Attribute.Pattern Variable) Verified.Pattern)
+  :: (Traversable operator, Synthetic (Attribute.Pattern Variable) operator)
+  => (forall a. operator a -> Sort)
+  -> operator (PatternVerifier Verified.Pattern)
+  -> PatternVerifier
+       (CofreeF operator (Attribute.Pattern Variable) Verified.Pattern)
 verifyOperands operandSort = \operator -> do
-    let patternSort = operandSort operator
-        expectedSort = Just patternSort
-    verifyPatternSort patternSort
-    let verifyChildWithSort verify = do
-            child <- verify
-            assertExpectedSort expectedSort (Internal.extractAttributes child)
-            return child
-    verified <- traverse verifyChildWithSort operator
-    let attrs = synthetic (Internal.extractAttributes <$> verified)
-    return (attrs :< verified)
+  let patternSort = operandSort operator
+      expectedSort = Just patternSort
+  verifyPatternSort patternSort
+  let verifyChildWithSort verify = do
+        child <- verify
+        assertExpectedSort expectedSort (Internal.extractAttributes child)
+        return child
+  verified <- traverse verifyChildWithSort operator
+  let attrs = synthetic (Internal.extractAttributes <$> verified)
+  return (attrs :< verified)
 {-# INLINE verifyOperands #-}
 
 verifyAnd
-    ::  ( logical ~ And Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ And Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyAnd = verifyOperands andSort
 
 verifyOr
-    ::  ( logical ~ Or Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Or Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyOr = verifyOperands orSort
 
 verifyIff
-    ::  ( logical ~ Iff Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Iff Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyIff = verifyOperands iffSort
 
 verifyImplies
-    ::  ( logical ~ Implies Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Implies Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyImplies = verifyOperands impliesSort
 
 verifyBottom
-    ::  ( logical ~ Bottom Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Bottom Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyBottom = verifyOperands bottomSort
 
 verifyTop
-    ::  ( logical ~ Top Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Top Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyTop = verifyOperands topSort
 
 verifyNot
-    ::  ( logical ~ Not Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Not Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyNot = verifyOperands notSort
 
 verifyRewrites
-    ::  ( logical ~ Rewrites Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => logical (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF logical valid Verified.Pattern)
+  :: ( logical ~ Rewrites Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => logical (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF logical valid Verified.Pattern)
 verifyRewrites = verifyOperands rewritesSort
 
 verifyPredicate
-    ::  ( Traversable predicate
-        , Synthetic (Attribute.Pattern Variable) predicate
-        , valid ~ Attribute.Pattern Variable
-        )
-    => (forall a. predicate a -> Sort)  -- ^ Operand sort
-    -> (forall a. predicate a -> Sort)  -- ^ Result sort
-    -> predicate (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
+  :: ( Traversable predicate,
+       Synthetic (Attribute.Pattern Variable) predicate,
+       valid ~ Attribute.Pattern Variable
+       )
+  => (forall a. predicate a -> Sort) -- ^ Operand sort
+  -> (forall a. predicate a -> Sort) -- ^ Result sort
+  -> predicate (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
 verifyPredicate operandSort resultSort = \predicate -> do
-    let patternSort = resultSort predicate
-    verifyPatternSort patternSort
-    verifyOperands operandSort predicate
+  let patternSort = resultSort predicate
+  verifyPatternSort patternSort
+  verifyOperands operandSort predicate
 {-# INLINE verifyPredicate #-}
 
 verifyCeil
-    ::  ( predicate ~ Ceil Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => predicate (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
+  :: ( predicate ~ Ceil Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => predicate (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
 verifyCeil = verifyPredicate ceilOperandSort ceilResultSort
 
 verifyFloor
-    ::  ( predicate ~ Floor Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => predicate (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
+  :: ( predicate ~ Floor Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => predicate (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
 verifyFloor = verifyPredicate floorOperandSort floorResultSort
 
 verifyEquals
-    ::  ( predicate ~ Equals Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => predicate (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
+  :: ( predicate ~ Equals Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => predicate (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
 verifyEquals = verifyPredicate equalsOperandSort equalsResultSort
 
 verifyIn
-    ::  ( predicate ~ In Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => predicate (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
+  :: ( predicate ~ In Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => predicate (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF predicate valid Verified.Pattern)
 verifyIn = verifyPredicate inOperandSort inResultSort
 
 verifyNext
-    ::  ( operator ~ Next Sort
-        , valid ~ Attribute.Pattern Variable
-        )
-    => operator (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF operator valid Verified.Pattern)
+  :: ( operator ~ Next Sort,
+       valid ~ Attribute.Pattern Variable
+       )
+  => operator (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF operator valid Verified.Pattern)
 verifyNext = verifyOperands nextSort
 
 verifyPatternsWithSorts
-    :: (child -> Attribute.Pattern Variable)
-    -> [Sort]
-    -> [PatternVerifier child]
-    -> PatternVerifier [child]
+  :: (child -> Attribute.Pattern Variable)
+  -> [Sort]
+  -> [PatternVerifier child]
+  -> PatternVerifier [child]
 verifyPatternsWithSorts getChildAttributes sorts operands = do
-    koreFailWhen (declaredOperandCount /= actualOperandCount)
-        (  "Expected "
+  koreFailWhen (declaredOperandCount /= actualOperandCount)
+    ( "Expected "
         ++ show declaredOperandCount
         ++ " operands, but got "
         ++ show actualOperandCount
         ++ "."
-        )
-    Monad.zipWithM
-        (\sort verify -> do
-            verified <- verify
-            assertExpectedSort (Just sort) (getChildAttributes verified)
-            return verified
-        )
-        sorts
-        operands
+      )
+  Monad.zipWithM
+    ( \sort verify -> do
+        verified <- verify
+        assertExpectedSort (Just sort) (getChildAttributes verified)
+        return verified
+      )
+    sorts
+    operands
   where
     declaredOperandCount = length sorts
     actualOperandCount = length operands
 
 verifyApplyAlias
-    ::  (child -> Attribute.Pattern Variable)
-    ->  Application SymbolOrAlias (PatternVerifier child)
-    ->  MaybeT PatternVerifier
-            (CofreeF
-                (Application Internal.Alias)
-                (Attribute.Pattern Variable)
-                child
-            )
+  :: (child -> Attribute.Pattern Variable)
+  -> Application SymbolOrAlias (PatternVerifier child)
+  -> MaybeT PatternVerifier
+       ( CofreeF
+           (Application Internal.Alias)
+           (Attribute.Pattern Variable)
+           child
+         )
 verifyApplyAlias getChildAttributes application =
-    lookupAlias symbolOrAlias >>= \alias -> Trans.lift $ do
-    let verified = application { applicationSymbolOrAlias = alias }
+  lookupAlias symbolOrAlias >>= \alias -> Trans.lift $ do
+    let verified = application {applicationSymbolOrAlias = alias}
         sorts = Internal.aliasSorts alias
     verifyApplicationChildren getChildAttributes verified sorts
   where
-    Application { applicationSymbolOrAlias = symbolOrAlias } = application
+    Application {applicationSymbolOrAlias = symbolOrAlias} = application
 
 verifyApplySymbol
-    ::  (child -> Attribute.Pattern Variable)
-    ->  Application SymbolOrAlias (PatternVerifier child)
-    ->  MaybeT PatternVerifier
-            (CofreeF
-                (Application Internal.Symbol)
-                (Attribute.Pattern Variable)
-                child
-            )
+  :: (child -> Attribute.Pattern Variable)
+  -> Application SymbolOrAlias (PatternVerifier child)
+  -> MaybeT PatternVerifier
+       ( CofreeF
+           (Application Internal.Symbol)
+           (Attribute.Pattern Variable)
+           child
+         )
 verifyApplySymbol getChildAttributes application =
-    lookupSymbol symbolOrAlias >>= \symbol -> Trans.lift $ do
-    let verified = application { applicationSymbolOrAlias = symbol }
+  lookupSymbol symbolOrAlias >>= \symbol -> Trans.lift $ do
+    let verified = application {applicationSymbolOrAlias = symbol}
         sorts = Internal.symbolSorts symbol
     verifyApplicationChildren getChildAttributes verified sorts
   where
-    Application { applicationSymbolOrAlias = symbolOrAlias } = application
+    Application {applicationSymbolOrAlias = symbolOrAlias} = application
 
 verifyApplicationChildren
-    ::  Synthetic (Attribute.Pattern Variable) (Application head)
-    =>  (child -> Attribute.Pattern Variable)
-    ->  Application head (PatternVerifier child)
-    ->  ApplicationSorts
-    ->  PatternVerifier
-            (CofreeF
-                (Application head)
-                (Attribute.Pattern Variable)
-                child
-            )
+  :: Synthetic (Attribute.Pattern Variable) (Application head)
+  => (child -> Attribute.Pattern Variable)
+  -> Application head (PatternVerifier child)
+  -> ApplicationSorts
+  -> PatternVerifier
+       ( CofreeF
+           (Application head)
+           (Attribute.Pattern Variable)
+           child
+         )
 verifyApplicationChildren getChildAttributes application sorts = do
-    let operandSorts = applicationSortsOperands sorts
-    verifiedChildren <- verifyChildren operandSorts children
-    let verified = application { applicationChildren = verifiedChildren }
-        attrs = synthetic (getChildAttributes <$> verified)
-    return (attrs :< verified)
+  let operandSorts = applicationSortsOperands sorts
+  verifiedChildren <- verifyChildren operandSorts children
+  let verified = application {applicationChildren = verifiedChildren}
+      attrs = synthetic (getChildAttributes <$> verified)
+  return (attrs :< verified)
   where
     verifyChildren = verifyPatternsWithSorts getChildAttributes
-    Application { applicationChildren = children } = application
+    Application {applicationChildren = children} = application
 
 verifyApplication
-    ::  (Verified.Pattern -> Attribute.Pattern Variable)
-    ->  Application SymbolOrAlias (PatternVerifier Verified.Pattern)
-    ->  PatternVerifier (Base (TermLike Variable) Verified.Pattern)
+  :: (Verified.Pattern -> Attribute.Pattern Variable)
+  -> Application SymbolOrAlias (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (Base (TermLike Variable) Verified.Pattern)
 verifyApplication getChildAttributes application = do
-    result <- verifyApplyAlias' <|> verifyApplySymbol' & runMaybeT
-    maybe (koreFail . noHead $ symbolOrAlias) return result
+  result <- verifyApplyAlias' <|> verifyApplySymbol' & runMaybeT
+  maybe (koreFail . noHead $ symbolOrAlias) return result
   where
     symbolOrAlias = applicationSymbolOrAlias application
     transCofreeF fg (a :< fb) = a :< fg fb
     verifyApplyAlias' =
-        transCofreeF Internal.ApplyAliasF
+      transCofreeF Internal.ApplyAliasF
         <$> verifyApplyAlias getChildAttributes application
     verifyApplySymbol' =
-        transCofreeF Internal.ApplySymbolF
+      transCofreeF Internal.ApplySymbolF
         <$> verifyApplySymbol getChildAttributes application
 
 verifyBinder
-    ::  ( Traversable binder, Synthetic (Attribute.Pattern Variable) binder
-        , valid ~ Attribute.Pattern Variable
-        )
-    => (forall a. binder a -> Sort)
-    -> (forall a. binder a -> (UnifiedVariable Variable))
-    -> binder (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF binder valid Verified.Pattern)
+  :: ( Traversable binder,
+       Synthetic (Attribute.Pattern Variable) binder,
+       valid ~ Attribute.Pattern Variable
+       )
+  => (forall a. binder a -> Sort)
+  -> (forall a. binder a -> (UnifiedVariable Variable))
+  -> binder (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF binder valid Verified.Pattern)
 verifyBinder binderSort binderVariable = \binder -> do
-    let variable = binderVariable binder
-        patternSort = binderSort binder
-    verifyVariableDeclaration variable
-    verifyPatternSort patternSort
-    let withQuantifiedVariable ctx@Context { declaredVariables } =
-            ctx
-                { declaredVariables =
-                    addDeclaredVariable
-                        variable
-                        declaredVariables
-                }
-    valid :< binder' <-
-        Reader.local
-            withQuantifiedVariable
-            (verifyOperands binderSort binder)
-    let valid' = Attribute.deleteFreeVariable variable valid
-    return (valid' :< binder')
+  let variable = binderVariable binder
+      patternSort = binderSort binder
+  verifyVariableDeclaration variable
+  verifyPatternSort patternSort
+  let withQuantifiedVariable ctx@Context {declaredVariables} =
+        ctx
+          { declaredVariables =
+              addDeclaredVariable
+                variable
+                declaredVariables
+            }
+  valid :< binder' <-
+    Reader.local
+      withQuantifiedVariable
+      (verifyOperands binderSort binder)
+  let valid' = Attribute.deleteFreeVariable variable valid
+  return (valid' :< binder')
 {-# INLINE verifyBinder #-}
 
 verifyExists
-    ::  ( binder ~ Exists Sort Variable
-        , valid ~ Attribute.Pattern Variable
-        )
-    => binder (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF binder valid Verified.Pattern)
+  :: ( binder ~ Exists Sort Variable,
+       valid ~ Attribute.Pattern Variable
+       )
+  => binder (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF binder valid Verified.Pattern)
 verifyExists = verifyBinder existsSort (ElemVar . existsVariable)
 
 verifyForall
-    ::  ( binder ~ Forall Sort Variable
-        , valid ~ Attribute.Pattern Variable
-        )
-    => binder (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF binder valid Verified.Pattern)
+  :: ( binder ~ Forall Sort Variable,
+       valid ~ Attribute.Pattern Variable
+       )
+  => binder (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF binder valid Verified.Pattern)
 verifyForall = verifyBinder forallSort (ElemVar . forallVariable)
 
 verifyMu
-    ::  ( binder ~ Mu Variable
-        , valid ~ Attribute.Pattern Variable
-        )
-    => binder (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF binder valid Verified.Pattern)
+  :: ( binder ~ Mu Variable,
+       valid ~ Attribute.Pattern Variable
+       )
+  => binder (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF binder valid Verified.Pattern)
 verifyMu = verifyBinder muSort (SetVar . muVariable)
   where
     muSort = variableSort . getSetVariable . muVariable
 
 verifyNu
-    ::  ( binder ~ Nu Variable
-        , valid ~ Attribute.Pattern Variable
-        )
-    => binder (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF binder valid Verified.Pattern)
+  :: ( binder ~ Nu Variable,
+       valid ~ Attribute.Pattern Variable
+       )
+  => binder (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF binder valid Verified.Pattern)
 verifyNu = verifyBinder nuSort (SetVar . nuVariable)
   where
     nuSort = variableSort . getSetVariable . nuVariable
 
 verifyVariable
-    ::  ( base ~ Const (UnifiedVariable Variable)
-        , valid ~ Attribute.Pattern Variable
-        )
-    => UnifiedVariable Variable
-    -> PatternVerifier (CofreeF base valid Verified.Pattern)
+  :: ( base ~ Const (UnifiedVariable Variable),
+       valid ~ Attribute.Pattern Variable
+       )
+  => UnifiedVariable Variable
+  -> PatternVerifier (CofreeF base valid Verified.Pattern)
 verifyVariable var = do
-    declaredVariable <- lookupDeclaredVariable varName
-    let declaredSort = foldMapVariable variableSort declaredVariable
-    koreFailWithLocationsWhen
-        (varSort /= declaredSort)
-        [ var, declaredVariable ]
-        "The declared sort is different."
-    let verified = Const var
-        attrs = synthetic (Internal.extractAttributes <$> verified)
-    return (attrs :< verified)
+  declaredVariable <- lookupDeclaredVariable varName
+  let declaredSort = foldMapVariable variableSort declaredVariable
+  koreFailWithLocationsWhen
+    (varSort /= declaredSort)
+    [var, declaredVariable]
+    "The declared sort is different."
+  let verified = Const var
+      attrs = synthetic (Internal.extractAttributes <$> verified)
+  return (attrs :< verified)
   where
     varName = foldMapVariable variableName var
     varSort = foldMapVariable variableSort var
 
 verifyDomainValue
-    :: DomainValue Sort (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (Base Verified.Pattern Verified.Pattern)
+  :: DomainValue Sort (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (Base Verified.Pattern Verified.Pattern)
 verifyDomainValue domain = do
-    let DomainValue { domainValueSort = patternSort } = domain
-    Context { builtinDomainValueVerifiers, indexedModule } <- Reader.ask
-    verifyPatternSort patternSort
-    let
-        lookupSortDeclaration' sortId = do
-            (_, sortDecl) <- resolveSort indexedModule sortId
-            return sortDecl
-    verifySortHasDomainValues patternSort
-    domain' <- sequence domain
-    verified <-
-        PatternVerifier
-        $ Reader.lift
-        $ Builtin.verifyDomainValue
-            builtinDomainValueVerifiers
-            lookupSortDeclaration'
-            domain'
-    let attrs = synthetic (Internal.extractAttributes <$> verified)
-        Attribute.Pattern { freeVariables } = attrs
-    Monad.unless (null freeVariables)
-        (koreFail "Domain value must not contain free variables.")
-    return (attrs :< verified)
+  let DomainValue {domainValueSort = patternSort} = domain
+  Context {builtinDomainValueVerifiers, indexedModule} <- Reader.ask
+  verifyPatternSort patternSort
+  let lookupSortDeclaration' sortId = do
+        (_, sortDecl) <- resolveSort indexedModule sortId
+        return sortDecl
+  verifySortHasDomainValues patternSort
+  domain' <- sequence domain
+  verified <-
+    PatternVerifier
+      $ Reader.lift
+      $ Builtin.verifyDomainValue
+          builtinDomainValueVerifiers
+          lookupSortDeclaration'
+          domain'
+  let attrs = synthetic (Internal.extractAttributes <$> verified)
+      Attribute.Pattern {freeVariables} = attrs
+  Monad.unless (null freeVariables)
+    (koreFail "Domain value must not contain free variables.")
+  return (attrs :< verified)
 
 verifySortHasDomainValues :: Sort -> PatternVerifier ()
 verifySortHasDomainValues patternSort = do
-    Context { indexedModule } <- Reader.ask
-    (sortAttrs, _) <- resolveSort indexedModule dvSortId
-    koreFailWithLocationsWhen
-        (not
-            (Attribute.HasDomainValues.getHasDomainValues
-                (Attribute.Sort.hasDomainValues sortAttrs)
-            )
-        )
-        [patternSort]
-        sortNeedsDomainValueAttributeMessage
+  Context {indexedModule} <- Reader.ask
+  (sortAttrs, _) <- resolveSort indexedModule dvSortId
+  koreFailWithLocationsWhen
+    ( not
+        ( Attribute.HasDomainValues.getHasDomainValues
+            (Attribute.Sort.hasDomainValues sortAttrs)
+          )
+      )
+    [patternSort]
+    sortNeedsDomainValueAttributeMessage
   where
     dvSortId = case patternSort of
-        SortVariableSort _ ->
-            error "Unimplemented: domain values with variable sorts"
-        SortActualSort SortActual {sortActualName} -> sortActualName
+      SortVariableSort _ ->
+        error "Unimplemented: domain values with variable sorts"
+      SortActualSort SortActual {sortActualName} -> sortActualName
 
 verifyStringLiteral
-    :: valid ~ Attribute.Pattern Variable
-    => Const StringLiteral (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF (Const StringLiteral) valid Verified.Pattern)
+  :: valid ~ Attribute.Pattern Variable
+  => Const StringLiteral (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF (Const StringLiteral) valid Verified.Pattern)
 verifyStringLiteral str = do
-    verified <- sequence str
-    let attrs = synthetic (Internal.extractAttributes <$> verified)
-    return (attrs :< verified)
+  verified <- sequence str
+  let attrs = synthetic (Internal.extractAttributes <$> verified)
+  return (attrs :< verified)
 
 verifyCharLiteral
-    :: valid ~ Attribute.Pattern Variable
-    => Const CharLiteral (PatternVerifier Verified.Pattern)
-    -> PatternVerifier (CofreeF (Const CharLiteral) valid Verified.Pattern)
+  :: valid ~ Attribute.Pattern Variable
+  => Const CharLiteral (PatternVerifier Verified.Pattern)
+  -> PatternVerifier (CofreeF (Const CharLiteral) valid Verified.Pattern)
 verifyCharLiteral char = do
-    verified <- sequence char
-    let attrs = synthetic (Internal.extractAttributes <$> verified)
-    return (attrs :< verified)
+  verified <- sequence char
+  let attrs = synthetic (Internal.extractAttributes <$> verified)
+  return (attrs :< verified)
 
 verifyVariableDeclaration
-    :: UnifiedVariable Variable -> PatternVerifier VerifySuccess
+  :: UnifiedVariable Variable -> PatternVerifier VerifySuccess
 verifyVariableDeclaration variable = do
-    Context { declaredSortVariables } <- Reader.ask
-    verifySort
-        lookupSortDeclaration
-        declaredSortVariables
-        varSort
+  Context {declaredSortVariables} <- Reader.ask
+  verifySort
+    lookupSortDeclaration
+    declaredSortVariables
+    varSort
   where
     varSort = foldMapVariable variableSort variable
 
 applicationSortsFromSymbolOrAliasSentence
-    :: SentenceSymbolOrAlias sentence
-    => SymbolOrAlias
-    -> sentence pat
-    -> PatternVerifier ApplicationSorts
+  :: SentenceSymbolOrAlias sentence
+  => SymbolOrAlias
+  -> sentence pat
+  -> PatternVerifier ApplicationSorts
 applicationSortsFromSymbolOrAliasSentence symbolOrAlias sentence = do
-    Context { declaredSortVariables } <- Reader.ask
-    mapM_
-        ( verifySort
-            lookupSortDeclaration
-            declaredSortVariables
-        )
-        (symbolOrAliasParams symbolOrAlias)
-    symbolOrAliasSorts (symbolOrAliasParams symbolOrAlias) sentence
+  Context {declaredSortVariables} <- Reader.ask
+  mapM_
+    ( verifySort
+        lookupSortDeclaration
+        declaredSortVariables
+      )
+    (symbolOrAliasParams symbolOrAlias)
+  symbolOrAliasSorts (symbolOrAliasParams symbolOrAlias) sentence
 
 assertSameSort
-    :: Sort
-    -> Sort
-    -> PatternVerifier ()
+  :: Sort
+  -> Sort
+  -> PatternVerifier ()
 assertSameSort expectedSort actualSort =
-    koreFailWithLocationsWhen
-        (expectedSort /= actualSort)
-        [expectedSort, actualSort]
-        ((renderStrict . Pretty.layoutCompact)
-         ("Expecting sort"
-          <+> Pretty.squotes (unparse expectedSort)
-          <+> "but got"
-          <+> Pretty.squotes (unparse actualSort)
-          <> Pretty.dot)
-        )
+  koreFailWithLocationsWhen
+    (expectedSort /= actualSort)
+    [expectedSort, actualSort]
+    ( (renderStrict . Pretty.layoutCompact)
+        ( "Expecting sort"
+            <+> Pretty.squotes (unparse expectedSort)
+            <+> "but got"
+            <+> Pretty.squotes (unparse actualSort)
+            <> Pretty.dot
+          )
+      )
 
 assertExpectedSort
-    :: Maybe Sort
-    -> Attribute.Pattern variable
-    -> PatternVerifier ()
+  :: Maybe Sort
+  -> Attribute.Pattern variable
+  -> PatternVerifier ()
 assertExpectedSort Nothing _ = return ()
-assertExpectedSort (Just expected) Attribute.Pattern { patternSort } =
-    assertSameSort expected patternSort
+assertExpectedSort (Just expected) Attribute.Pattern {patternSort} =
+  assertSameSort expected patternSort
 
 verifyFreeVariables
-    :: ParsedPattern
-    -> PatternVerifier DeclaredVariables
+  :: ParsedPattern
+  -> PatternVerifier DeclaredVariables
 verifyFreeVariables unifiedPattern =
-    Monad.foldM
-        addFreeVariable
-        emptyDeclaredVariables
-        $
-        Set.toList (Variables.freePureVariables unifiedPattern)
+  Monad.foldM
+    addFreeVariable
+    emptyDeclaredVariables
+    $ Set.toList (Variables.freePureVariables unifiedPattern)
 
 addFreeVariable
-    :: DeclaredVariables
-    -> UnifiedVariable Variable
-    -> PatternVerifier DeclaredVariables
+  :: DeclaredVariables
+  -> UnifiedVariable Variable
+  -> PatternVerifier DeclaredVariables
 addFreeVariable (getDeclaredVariables -> vars) var = do
-    checkVariable var vars
-    return . DeclaredVariables $
-        Map.insert (foldMapVariable variableName var) var vars
+  checkVariable var vars
+  return . DeclaredVariables
+    $ Map.insert (foldMapVariable variableName var) var vars
 
 checkVariable
-    :: UnifiedVariable Variable
-    -> Map.Map Id (UnifiedVariable Variable)
-    -> PatternVerifier VerifySuccess
+  :: UnifiedVariable Variable
+  -> Map.Map Id (UnifiedVariable Variable)
+  -> PatternVerifier VerifySuccess
 checkVariable var vars =
-    maybe verifySuccess inconsistent
+  maybe verifySuccess inconsistent
     $ Map.lookup (foldMapVariable variableName var) vars
   where
     inconsistent v =
-        koreFailWithLocations [v, var]
-        $ renderStrict $ Pretty.layoutCompact
+      koreFailWithLocations [v, var]
+        $ renderStrict
+        $ Pretty.layoutCompact
         $ "Inconsistent free variable usage:"
-            <+> unparse v
-            <+> "and"
-            <+> unparse var
-            <> Pretty.dot
+        <+> unparse v
+        <+> "and"
+        <+> unparse var
+        <> Pretty.dot
 
 patternNameForContext :: PatternF Variable p -> Text
 patternNameForContext (AndF _) = "\\and"
 patternNameForContext (ApplicationF application) =
-    "symbol or alias '"
+  "symbol or alias '"
     <> getId
-        (symbolOrAliasConstructor (applicationSymbolOrAlias application))
+         (symbolOrAliasConstructor (applicationSymbolOrAlias application))
     <> "'"
 patternNameForContext (BottomF _) = "\\bottom"
 patternNameForContext (CeilF _) = "\\ceil"
 patternNameForContext (DomainValueF _) = "\\dv"
 patternNameForContext (EqualsF _) = "\\equals"
 patternNameForContext (ExistsF exists) =
-    "\\exists '"
+  "\\exists '"
     <> variableNameForContext (getElementVariable $ existsVariable exists)
     <> "'"
 patternNameForContext (FloorF _) = "\\floor"
 patternNameForContext (ForallF forall) =
-    "\\forall '"
+  "\\forall '"
     <> variableNameForContext (getElementVariable $ forallVariable forall)
     <> "'"
 patternNameForContext (IffF _) = "\\iff"
@@ -882,10 +896,10 @@ patternNameForContext (StringLiteralF _) = "<string>"
 patternNameForContext (CharLiteralF _) = "<char>"
 patternNameForContext (TopF _) = "\\top"
 patternNameForContext (VariableF (Const (ElemVar variable))) =
-    "element variable '" <> variableNameForContext (getElementVariable variable) <> "'"
+  "element variable '" <> variableNameForContext (getElementVariable variable) <> "'"
 patternNameForContext (InhabitantF _) = "\\inh"
 patternNameForContext (VariableF (Const (SetVar variable))) =
-    "set variable '" <> variableNameForContext (getSetVariable variable) <> "'"
+  "set variable '" <> variableNameForContext (getSetVariable variable) <> "'"
 
 variableNameForContext :: Variable -> Text
 variableNameForContext variable = getId (variableName variable)

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -8,390 +8,392 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.ASTVerifier.SentenceVerifier
-    ( verifyUniqueNames
-    , verifySentences
-    , noConstructorWithDomainValuesMessage
-    ) where
+  ( verifyUniqueNames,
+    verifySentences,
+    noConstructorWithDomainValuesMessage
+    )
+where
 
-import           Control.Monad
-                 ( foldM )
-import           Data.Function
+import Control.Monad
+  ( foldM
+    )
+import Data.Function
 import qualified Data.Map as Map
-import           Data.Maybe
-                 ( isJust )
+import Data.Maybe
+  ( isJust
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
-
-import           Kore.AST.Error
-import           Kore.ASTVerifier.AttributesVerifier
-import           Kore.ASTVerifier.Error
-import           Kore.ASTVerifier.PatternVerifier as PatternVerifier
-import           Kore.ASTVerifier.SortVerifier
+import Data.Text
+  ( Text
+    )
+import Kore.AST.Error
+import Kore.ASTVerifier.AttributesVerifier
+import Kore.ASTVerifier.Error
+import Kore.ASTVerifier.PatternVerifier as PatternVerifier
+import Kore.ASTVerifier.SortVerifier
 import qualified Kore.Attribute.Constructor as Attribute
 import qualified Kore.Attribute.Hook as Attribute
 import qualified Kore.Attribute.Parser as Attribute.Parser
 import qualified Kore.Attribute.Sort as Attribute.Sort
 import qualified Kore.Attribute.Sort as Attribute
-                 ( Sort )
+  ( Sort
+    )
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
-import           Kore.Error
-import           Kore.IndexedModule.IndexedModule as IndexedModule
-import           Kore.IndexedModule.Resolvers
-import           Kore.Sort
-import           Kore.Syntax.Definition
+import Kore.Error
+import Kore.IndexedModule.IndexedModule as IndexedModule
+import Kore.IndexedModule.Resolvers
+import Kore.Sort
+import Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
 
 {-|'verifyUniqueNames' verifies that names defined in a list of sentences are
 unique both within the list and outside, using the provided name set.
 -}
 verifyUniqueNames
-    :: [Sentence pat]
-    -> Map.Map Text AstLocation
-    -- ^ Names that are already defined.
-    -> Either (Error VerifyError) (Map.Map Text AstLocation)
-    -- ^ On success returns the names that were previously defined together with
-    -- the names defined in the given 'Module'.
+  :: [Sentence pat]
+  -> Map.Map Text AstLocation
+  -- ^ Names that are already defined.
+  -> Either (Error VerifyError) (Map.Map Text AstLocation)
+  -- ^ On success returns the names that were previously defined together with
+  -- the names defined in the given 'Module'.
 verifyUniqueNames sentences existingNames =
-    foldM verifyUniqueId existingNames definedNames
+  foldM verifyUniqueId existingNames definedNames
   where
     definedNames =
-        concatMap definedNamesForSentence sentences
+      concatMap definedNamesForSentence sentences
 
-data UnparameterizedId = UnparameterizedId
-    { unparameterizedIdName     :: Text
-    , unparameterizedIdLocation :: AstLocation
-    }
-    deriving (Show)
+data UnparameterizedId
+  = UnparameterizedId
+      { unparameterizedIdName :: Text,
+        unparameterizedIdLocation :: AstLocation
+        }
+  deriving (Show)
 
 toUnparameterizedId :: Id -> UnparameterizedId
 toUnparameterizedId Id {getId = name, idLocation = location} =
-    UnparameterizedId
-        { unparameterizedIdName = name
-        , unparameterizedIdLocation = location
-        }
+  UnparameterizedId
+    { unparameterizedIdName = name,
+      unparameterizedIdLocation = location
+      }
 
 verifyUniqueId
-    :: Map.Map Text AstLocation
-    -> UnparameterizedId
-    -> Either (Error VerifyError) (Map.Map Text AstLocation)
+  :: Map.Map Text AstLocation
+  -> UnparameterizedId
+  -> Either (Error VerifyError) (Map.Map Text AstLocation)
 verifyUniqueId existing (UnparameterizedId name location) =
-    case Map.lookup name existing of
-        Just location' ->
-            koreFailWithLocations [location, location']
-                ("Duplicated name: '" <> name <> "'.")
-        _ -> Right (Map.insert name location existing)
+  case Map.lookup name existing of
+    Just location' ->
+      koreFailWithLocations [location, location']
+        ("Duplicated name: '" <> name <> "'.")
+    _ -> Right (Map.insert name location existing)
 
 definedNamesForSentence :: Sentence pat -> [UnparameterizedId]
 definedNamesForSentence (SentenceAliasSentence sentenceAlias) =
-    [ toUnparameterizedId (getSentenceSymbolOrAliasConstructor sentenceAlias) ]
+  [toUnparameterizedId (getSentenceSymbolOrAliasConstructor sentenceAlias)]
 definedNamesForSentence (SentenceSymbolSentence sentenceSymbol) =
-    [ toUnparameterizedId (getSentenceSymbolOrAliasConstructor sentenceSymbol) ]
+  [toUnparameterizedId (getSentenceSymbolOrAliasConstructor sentenceSymbol)]
 definedNamesForSentence (SentenceImportSentence _) = []
-definedNamesForSentence (SentenceAxiomSentence _)  = []
-definedNamesForSentence (SentenceClaimSentence _)  = []
+definedNamesForSentence (SentenceAxiomSentence _) = []
+definedNamesForSentence (SentenceClaimSentence _) = []
 definedNamesForSentence (SentenceSortSentence sentenceSort) =
-    [ toUnparameterizedId (sentenceSortName sentenceSort) ]
+  [toUnparameterizedId (sentenceSortName sentenceSort)]
 definedNamesForSentence (SentenceHookSentence (SentenceHookedSort sentence)) =
-    definedNamesForSentence (SentenceSortSentence sentence)
+  definedNamesForSentence (SentenceSortSentence sentence)
 definedNamesForSentence (SentenceHookSentence (SentenceHookedSymbol sentence)) =
-    definedNamesForSentence (SentenceSymbolSentence sentence)
+  definedNamesForSentence (SentenceSymbolSentence sentence)
 
 {-|'verifySentences' verifies the welformedness of a list of Kore 'Sentence's.
 -}
 verifySentences
-    :: KoreIndexedModule Attribute.Symbol axiomAtts
-    -- ^ The module containing all definitions which are visible in this
-    -- pattern.
-    -> AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> [ParsedSentence]
-    -> Either (Error VerifyError) [Verified.Sentence]
+  :: KoreIndexedModule Attribute.Symbol axiomAtts
+  -- ^ The module containing all definitions which are visible in this
+  -- pattern.
+  -> AttributesVerification Attribute.Symbol axiomAtts
+  -> Builtin.Verifiers
+  -> [ParsedSentence]
+  -> Either (Error VerifyError) [Verified.Sentence]
 verifySentences indexedModule attributesVerification builtinVerifiers =
-    traverse
-        (verifySentence
-            builtinVerifiers
-            indexedModule
-            attributesVerification
-        )
+  traverse
+    ( verifySentence
+        builtinVerifiers
+        indexedModule
+        attributesVerification
+      )
 
 verifySentence
-    :: Builtin.Verifiers
-    -> KoreIndexedModule Attribute.Symbol axiomAtts
-    -> AttributesVerification Attribute.Symbol axiomAtts
-    -> ParsedSentence
-    -> Either (Error VerifyError) Verified.Sentence
+  :: Builtin.Verifiers
+  -> KoreIndexedModule Attribute.Symbol axiomAtts
+  -> AttributesVerification Attribute.Symbol axiomAtts
+  -> ParsedSentence
+  -> Either (Error VerifyError) Verified.Sentence
 verifySentence builtinVerifiers indexedModule attributesVerification sentence =
-    withSentenceContext sentence verifySentenceWorker
+  withSentenceContext sentence verifySentenceWorker
   where
     verifySentenceWorker :: Either (Error VerifyError) Verified.Sentence
     verifySentenceWorker = do
-        verified <-
-            case sentence of
-                SentenceSymbolSentence symbolSentence ->
-                    (<$>)
-                        SentenceSymbolSentence
-                        (verifySymbolSentence
-                            indexedModule
-                            symbolSentence
-                        )
-                SentenceAliasSentence aliasSentence ->
-                    (<$>)
-                        SentenceAliasSentence
-                        (verifyAliasSentence
-                            builtinVerifiers
-                            indexedModule
-                            aliasSentence
-                        )
-                SentenceAxiomSentence axiomSentence ->
-                    (<$>)
-                        SentenceAxiomSentence
-                        (verifyAxiomSentence
-                            axiomSentence
-                            builtinVerifiers
-                            indexedModule
-                        )
-                SentenceClaimSentence claimSentence ->
-                    (<$>)
-                        (SentenceClaimSentence . SentenceClaim)
-                        (verifyAxiomSentence
-                            (getSentenceClaim claimSentence)
-                            builtinVerifiers
-                            indexedModule
-                        )
-                SentenceImportSentence importSentence ->
-                    -- Since we have an IndexedModule, we assume that imports
-                    -- were already resolved, so there is nothing left to verify
-                    -- here.
-                    (<$>)
-                        SentenceImportSentence
-                        (traverse verifyNoPatterns importSentence)
-                SentenceSortSentence sortSentence ->
-                    (<$>)
-                        SentenceSortSentence
-                        (verifySortSentence sortSentence)
-                SentenceHookSentence hookSentence ->
-                    (<$>)
-                        SentenceHookSentence
-                        (verifyHookSentence
-                            builtinVerifiers
-                            indexedModule
-                            attributesVerification
-                            hookSentence
-                        )
-        verifySentenceAttributes
-            attributesVerification
-            sentence
-        return verified
+      verified <-
+        case sentence of
+          SentenceSymbolSentence symbolSentence ->
+            (<$>)
+              SentenceSymbolSentence
+              ( verifySymbolSentence
+                  indexedModule
+                  symbolSentence
+                )
+          SentenceAliasSentence aliasSentence ->
+            (<$>)
+              SentenceAliasSentence
+              ( verifyAliasSentence
+                  builtinVerifiers
+                  indexedModule
+                  aliasSentence
+                )
+          SentenceAxiomSentence axiomSentence ->
+            (<$>)
+              SentenceAxiomSentence
+              ( verifyAxiomSentence
+                  axiomSentence
+                  builtinVerifiers
+                  indexedModule
+                )
+          SentenceClaimSentence claimSentence ->
+            (<$>)
+              (SentenceClaimSentence . SentenceClaim)
+              ( verifyAxiomSentence
+                  (getSentenceClaim claimSentence)
+                  builtinVerifiers
+                  indexedModule
+                )
+          SentenceImportSentence importSentence ->
+            -- Since we have an IndexedModule, we assume that imports
+            -- were already resolved, so there is nothing left to verify
+            -- here.
+            (<$>)
+              SentenceImportSentence
+              (traverse verifyNoPatterns importSentence)
+          SentenceSortSentence sortSentence ->
+            (<$>)
+              SentenceSortSentence
+              (verifySortSentence sortSentence)
+          SentenceHookSentence hookSentence ->
+            (<$>)
+              SentenceHookSentence
+              ( verifyHookSentence
+                  builtinVerifiers
+                  indexedModule
+                  attributesVerification
+                  hookSentence
+                )
+      verifySentenceAttributes
+        attributesVerification
+        sentence
+      return verified
 
 verifySentenceAttributes
-    :: AttributesVerification declAtts axiomAtts
-    -> ParsedSentence
-    -> Either (Error VerifyError) VerifySuccess
+  :: AttributesVerification declAtts axiomAtts
+  -> ParsedSentence
+  -> Either (Error VerifyError) VerifySuccess
 verifySentenceAttributes attributesVerification sentence =
-    do
-        let attributes = sentenceAttributes sentence
-        verifyAttributes attributes attributesVerification
-        case sentence of
-            SentenceHookSentence _ -> return ()
-            _ -> verifyNoHookAttribute attributesVerification attributes
-        verifySuccess
+  do
+    let attributes = sentenceAttributes sentence
+    verifyAttributes attributes attributesVerification
+    case sentence of
+      SentenceHookSentence _ -> return ()
+      _ -> verifyNoHookAttribute attributesVerification attributes
+    verifySuccess
 
 verifyHookSentence
-    :: Builtin.Verifiers
-    -> KoreIndexedModule declAtts axiomAtts
-    -> AttributesVerification declAtts axiomAtts
-    -> ParsedSentenceHook
-    -> Either (Error VerifyError) Verified.SentenceHook
+  :: Builtin.Verifiers
+  -> KoreIndexedModule declAtts axiomAtts
+  -> AttributesVerification declAtts axiomAtts
+  -> ParsedSentenceHook
+  -> Either (Error VerifyError) Verified.SentenceHook
 verifyHookSentence
-    builtinVerifiers
-    indexedModule
-    attributesVerification
-  =
+  builtinVerifiers
+  indexedModule
+  attributesVerification =
     \case
-        SentenceHookedSort s -> SentenceHookedSort <$> verifyHookedSort s
-        SentenceHookedSymbol s -> SentenceHookedSymbol <$> verifyHookedSymbol s
-  where
-    verifyHookedSort
-        sentence@SentenceSort { sentenceSortAttributes }
-      = do
-        verified <- verifySortSentence sentence
-        hook <-
+      SentenceHookedSort s -> SentenceHookedSort <$> verifyHookedSort s
+      SentenceHookedSymbol s -> SentenceHookedSymbol <$> verifyHookedSymbol s
+    where
+      verifyHookedSort sentence@SentenceSort {sentenceSortAttributes} =
+        do
+          verified <- verifySortSentence sentence
+          hook <-
             verifySortHookAttribute
-                indexedModule
-                attributesVerification
-                sentenceSortAttributes
-        attrs <-
+              indexedModule
+              attributesVerification
+              sentenceSortAttributes
+          attrs <-
             Attribute.Parser.liftParser
-            $ Attribute.Parser.parseAttributes sentenceSortAttributes
-        Builtin.sortDeclVerifier
+              $ Attribute.Parser.parseAttributes sentenceSortAttributes
+          Builtin.sortDeclVerifier
             builtinVerifiers
             hook
             (IndexedModule.eraseAttributes indexedModule)
             sentence
             attrs
-        return verified
-
-    verifyHookedSymbol
-        sentence@SentenceSymbol { sentenceSymbolAttributes }
-      = do
-        verified <- verifySymbolSentence indexedModule sentence
-        hook <-
+          return verified
+      verifyHookedSymbol sentence@SentenceSymbol {sentenceSymbolAttributes} =
+        do
+          verified <- verifySymbolSentence indexedModule sentence
+          hook <-
             verifySymbolHookAttribute
-                attributesVerification
-                sentenceSymbolAttributes
-        Builtin.runSymbolVerifier
-            (Builtin.symbolVerifier builtinVerifiers hook) findSort sentence
-        return verified
-
-    findSort = findIndexedSort indexedModule
+              attributesVerification
+              sentenceSymbolAttributes
+          Builtin.runSymbolVerifier
+            (Builtin.symbolVerifier builtinVerifiers hook)
+            findSort
+            sentence
+          return verified
+      findSort = findIndexedSort indexedModule
 
 verifySymbolSentence
-    :: KoreIndexedModule declAtts axiomAtts
-    -> ParsedSentenceSymbol
-    -> Either (Error VerifyError) Verified.SentenceSymbol
+  :: KoreIndexedModule declAtts axiomAtts
+  -> ParsedSentenceSymbol
+  -> Either (Error VerifyError) Verified.SentenceSymbol
 verifySymbolSentence indexedModule sentence =
-    do
-        variables <- buildDeclaredSortVariables sortParams
-        mapM_
-            (verifySort findSort variables)
-            (sentenceSymbolSorts sentence)
-        verifyConstructorNotInHookedOrDvSort
-        verifySort
-            findSort
-            variables
-            (sentenceSymbolResultSort sentence)
-        traverse verifyNoPatterns sentence
+  do
+    variables <- buildDeclaredSortVariables sortParams
+    mapM_
+      (verifySort findSort variables)
+      (sentenceSymbolSorts sentence)
+    verifyConstructorNotInHookedOrDvSort
+    verifySort
+      findSort
+      variables
+      (sentenceSymbolResultSort sentence)
+    traverse verifyNoPatterns sentence
   where
     findSort = findIndexedSort indexedModule
     sortParams = (symbolParams . sentenceSymbolSymbol) sentence
-
     verifyConstructorNotInHookedOrDvSort :: Either (Error VerifyError) ()
     verifyConstructorNotInHookedOrDvSort =
-        let
-            symbol = symbolConstructor $ sentenceSymbolSymbol sentence
-            attributes = sentenceSymbolAttributes sentence
-            resultSort = sentenceSymbolResultSort sentence
-            resultSortId = getSortId resultSort
-
-            -- TODO(vladimir.ciobanu): Lookup this attribute in the symbol
-            -- attribute record when it becomes available.
-            isCtor =
-                Attribute.constructorAttribute  `elem` getAttributes attributes
-            sortData = do
-                (sortDescription, _) <-
-                    Map.lookup resultSortId
-                        $ indexedModuleSortDescriptions indexedModule
-                return
-                    (maybeHook sortDescription, hasDomainValues sortDescription)
-        in case sortData of
+      let symbol = symbolConstructor $ sentenceSymbolSymbol sentence
+          attributes = sentenceSymbolAttributes sentence
+          resultSort = sentenceSymbolResultSort sentence
+          resultSortId = getSortId resultSort
+          -- TODO(vladimir.ciobanu): Lookup this attribute in the symbol
+          -- attribute record when it becomes available.
+          isCtor =
+            Attribute.constructorAttribute `elem` getAttributes attributes
+          sortData = do
+            (sortDescription, _) <-
+              Map.lookup resultSortId
+                $ indexedModuleSortDescriptions indexedModule
+            return
+              (maybeHook sortDescription, hasDomainValues sortDescription)
+       in case sortData of
             Nothing -> return ()
             Just (resultSortHook, resultHasDomainValues) -> do
-                koreFailWhen
-                    (isCtor && isJust resultSortHook)
-                    ( "Cannot define constructor '"
+              koreFailWhen
+                (isCtor && isJust resultSortHook)
+                ( "Cannot define constructor '"
                     ++ getIdForError symbol
                     ++ "' for hooked sort '"
                     ++ getIdForError resultSortId
                     ++ "'."
-                    )
-                koreFailWhen
-                    (isCtor && resultHasDomainValues)
-                    (noConstructorWithDomainValuesMessage symbol resultSort)
+                  )
+              koreFailWhen
+                (isCtor && resultHasDomainValues)
+                (noConstructorWithDomainValuesMessage symbol resultSort)
 
 maybeHook :: Attribute.Sort -> Maybe Text
 maybeHook = Attribute.getHook . Attribute.Sort.hook
 
 hasDomainValues :: Attribute.Sort -> Bool
 hasDomainValues =
-    Attribute.HasDomainValues.getHasDomainValues
+  Attribute.HasDomainValues.getHasDomainValues
     . Attribute.Sort.hasDomainValues
 
 verifyAliasSentence
-    :: Builtin.Verifiers
-    -> KoreIndexedModule Attribute.Symbol axiomAtts
-    -> ParsedSentenceAlias
-    -> Either (Error VerifyError) Verified.SentenceAlias
+  :: Builtin.Verifiers
+  -> KoreIndexedModule Attribute.Symbol axiomAtts
+  -> ParsedSentenceAlias
+  -> Either (Error VerifyError) Verified.SentenceAlias
 verifyAliasSentence builtinVerifiers indexedModule sentence =
-    do
-        variables <- buildDeclaredSortVariables sortParams
-        mapM_ (verifySort findSort variables) sentenceAliasSorts
-        verifySort findSort variables sentenceAliasResultSort
-        let context =
-                PatternVerifier.Context
-                    { builtinDomainValueVerifiers =
-                        Builtin.domainValueVerifiers builtinVerifiers
-                    , indexedModule =
-                        IndexedModule.eraseAxiomAttributes
-                        $ IndexedModule.erasePatterns indexedModule
-                    , declaredSortVariables = variables
-                    , declaredVariables = emptyDeclaredVariables
-                    }
-        runPatternVerifier context $ do
-            (declaredVariables, verifiedLeftPattern) <-
-                verifyAliasLeftPattern leftPattern
-            verifiedRightPattern <-
-                withDeclaredVariables declaredVariables
-                $ verifyPattern (Just expectedSort) rightPattern
-            return sentence
-                { sentenceAliasLeftPattern = verifiedLeftPattern
-                , sentenceAliasRightPattern = verifiedRightPattern
-                }
+  do
+    variables <- buildDeclaredSortVariables sortParams
+    mapM_ (verifySort findSort variables) sentenceAliasSorts
+    verifySort findSort variables sentenceAliasResultSort
+    let context =
+          PatternVerifier.Context
+            { builtinDomainValueVerifiers =
+                Builtin.domainValueVerifiers builtinVerifiers,
+              indexedModule =
+                IndexedModule.eraseAxiomAttributes
+                  $ IndexedModule.erasePatterns indexedModule,
+              declaredSortVariables = variables,
+              declaredVariables = emptyDeclaredVariables
+              }
+    runPatternVerifier context $ do
+      (declaredVariables, verifiedLeftPattern) <-
+        verifyAliasLeftPattern leftPattern
+      verifiedRightPattern <-
+        withDeclaredVariables declaredVariables
+          $ verifyPattern (Just expectedSort) rightPattern
+      return
+        sentence
+          { sentenceAliasLeftPattern = verifiedLeftPattern,
+            sentenceAliasRightPattern = verifiedRightPattern
+            }
   where
-    SentenceAlias { sentenceAliasLeftPattern = leftPattern } = sentence
-    SentenceAlias { sentenceAliasRightPattern = rightPattern } = sentence
-    SentenceAlias { sentenceAliasSorts } = sentence
-    SentenceAlias { sentenceAliasResultSort } = sentence
-    findSort     = findIndexedSort indexedModule
-    sortParams   = (aliasParams . sentenceAliasAlias) sentence
+    SentenceAlias {sentenceAliasLeftPattern = leftPattern} = sentence
+    SentenceAlias {sentenceAliasRightPattern = rightPattern} = sentence
+    SentenceAlias {sentenceAliasSorts} = sentence
+    SentenceAlias {sentenceAliasResultSort} = sentence
+    findSort = findIndexedSort indexedModule
+    sortParams = (aliasParams . sentenceAliasAlias) sentence
     expectedSort = sentenceAliasResultSort
 
 verifyAxiomSentence
-    :: ParsedSentenceAxiom
-    -> Builtin.Verifiers
-    -> KoreIndexedModule Attribute.Symbol axiomAtts
-    -> Either (Error VerifyError) Verified.SentenceAxiom
+  :: ParsedSentenceAxiom
+  -> Builtin.Verifiers
+  -> KoreIndexedModule Attribute.Symbol axiomAtts
+  -> Either (Error VerifyError) Verified.SentenceAxiom
 verifyAxiomSentence axiom builtinVerifiers indexedModule =
-    do
-        variables <- buildDeclaredSortVariables $ sentenceAxiomParameters axiom
-        let context =
-                PatternVerifier.Context
-                    { builtinDomainValueVerifiers =
-                        Builtin.domainValueVerifiers builtinVerifiers
-                    , indexedModule =
-                        indexedModule
-                        & IndexedModule.erasePatterns
-                        & IndexedModule.eraseAxiomAttributes
-                    , declaredSortVariables = variables
-                    , declaredVariables = emptyDeclaredVariables
-                    }
-        verifiedAxiomPattern <- runPatternVerifier context $
-            verifyStandalonePattern Nothing sentenceAxiomPattern
-        return axiom { sentenceAxiomPattern = verifiedAxiomPattern }
+  do
+    variables <- buildDeclaredSortVariables $ sentenceAxiomParameters axiom
+    let context =
+          PatternVerifier.Context
+            { builtinDomainValueVerifiers =
+                Builtin.domainValueVerifiers builtinVerifiers,
+              indexedModule =
+                indexedModule
+                  & IndexedModule.erasePatterns
+                  & IndexedModule.eraseAxiomAttributes,
+              declaredSortVariables = variables,
+              declaredVariables = emptyDeclaredVariables
+              }
+    verifiedAxiomPattern <-
+      runPatternVerifier context
+        $ verifyStandalonePattern Nothing sentenceAxiomPattern
+    return axiom {sentenceAxiomPattern = verifiedAxiomPattern}
   where
-    SentenceAxiom { sentenceAxiomPattern } = axiom
+    SentenceAxiom {sentenceAxiomPattern} = axiom
 
 verifySortSentence
-    :: ParsedSentenceSort
-    -> Either (Error VerifyError) Verified.SentenceSort
+  :: ParsedSentenceSort
+  -> Either (Error VerifyError) Verified.SentenceSort
 verifySortSentence sentenceSort = do
-    _ <- buildDeclaredSortVariables (sentenceSortParameters sentenceSort)
-    traverse verifyNoPatterns sentenceSort
+  _ <- buildDeclaredSortVariables (sentenceSortParameters sentenceSort)
+  traverse verifyNoPatterns sentenceSort
 
 buildDeclaredSortVariables
-    :: [SortVariable]
-    -> Either (Error VerifyError) (Set.Set SortVariable)
+  :: [SortVariable]
+  -> Either (Error VerifyError) (Set.Set SortVariable)
 buildDeclaredSortVariables [] = Right Set.empty
 buildDeclaredSortVariables (unifiedVariable : list) = do
-    variables <- buildDeclaredSortVariables list
-    koreFailWithLocationsWhen
-        (unifiedVariable `Set.member` variables)
-        [unifiedVariable]
-        (  "Duplicated sort variable: '"
+  variables <- buildDeclaredSortVariables list
+  koreFailWithLocationsWhen
+    (unifiedVariable `Set.member` variables)
+    [unifiedVariable]
+    ( "Duplicated sort variable: '"
         <> extractVariableName unifiedVariable
-        <> "'.")
-    return (Set.insert unifiedVariable variables)
+        <> "'."
+      )
+  return (Set.insert unifiedVariable variables)
   where
     extractVariableName variable = getId (getSortVariable variable)

--- a/kore/src/Kore/ASTVerifier/SortVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SortVerifier.hs
@@ -7,10 +7,12 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX
 -}
-module Kore.ASTVerifier.SortVerifier (verifySort) where
+module Kore.ASTVerifier.SortVerifier
+  ( verifySort
+    )
+where
 
 import qualified Data.Set as Set
-
 import Kore.AST.Error
 import Kore.ASTVerifier.Error
 import Kore.Error
@@ -19,67 +21,67 @@ import Kore.Syntax.Definition
 
 {-|'verifySort' verifies the welformedness of a Kore 'Sort'. -}
 verifySort
-    :: MonadError (Error VerifyError) m
-    => (Id -> m (SentenceSort patternType))
-    -- ^ Provides a sortMetaSorts description.
-    -> Set.Set SortVariable
-    -- ^ Sort variables visible here.
-    -> Sort
-    -> m VerifySuccess
-verifySort _ declaredSortVariables (SortVariableSort variable)
-  = do
+  :: MonadError (Error VerifyError) m
+  => (Id -> m (SentenceSort patternType))
+  -- ^ Provides a sortMetaSorts description.
+  -> Set.Set SortVariable
+  -- ^ Sort variables visible here.
+  -> Sort
+  -> m VerifySuccess
+verifySort _ declaredSortVariables (SortVariableSort variable) =
+  do
     koreFailWithLocationsWhen
-        (Set.notMember variable declaredSortVariables)
-        [variableId]
-        ("Sort variable '" <> getId variableId <> "' not declared.")
+      (Set.notMember variable declaredSortVariables)
+      [variableId]
+      ("Sort variable '" <> getId variableId <> "' not declared.")
     verifySuccess
   where
     variableId = getSortVariable variable
-verifySort findSortDescription declaredSortVariables (SortActualSort sort)
-  = do
+verifySort findSortDescription declaredSortVariables (SortActualSort sort) =
+  do
     withLocationAndContext
-        sortName
-        ("sort '" <> getId (sortActualName sort) <> "'")
-        ( do
-            sortDescription <- findSortDescription sortName
-            verifySortMatchesDeclaration
-                findSortDescription
-                declaredSortVariables
-                sort
-                sortDescription )
+      sortName
+      ("sort '" <> getId (sortActualName sort) <> "'")
+      ( do
+          sortDescription <- findSortDescription sortName
+          verifySortMatchesDeclaration
+            findSortDescription
+            declaredSortVariables
+            sort
+            sortDescription
+        )
     koreFailWithLocationsWhen
-        (sortIsMeta && sortActualSorts sort /= [])
-        [sortName]
-        (  "Malformed meta sort '"
-        <> sortId
-        <> "' with non-empty Parameter sorts."
+      (sortIsMeta && sortActualSorts sort /= [])
+      [sortName]
+      ( "Malformed meta sort '"
+          <> sortId
+          <> "' with non-empty Parameter sorts."
         )
     verifySuccess
   where
     sortIsMeta = False
-    sortName   = sortActualName sort
-    sortId     = getId sortName
+    sortName = sortActualName sort
+    sortId = getId sortName
 
 verifySortMatchesDeclaration
-    :: MonadError (Error VerifyError) m
-    => (Id -> m (SentenceSort patternType))
-    -> Set.Set SortVariable
-    -> SortActual
-    -> SentenceSort patternType'
-    -> m VerifySuccess
-verifySortMatchesDeclaration
-    findSortDescription declaredSortVariables sort sortDescription
-  = do
+  :: MonadError (Error VerifyError) m
+  => (Id -> m (SentenceSort patternType))
+  -> Set.Set SortVariable
+  -> SortActual
+  -> SentenceSort patternType'
+  -> m VerifySuccess
+verifySortMatchesDeclaration findSortDescription declaredSortVariables sort sortDescription =
+  do
     koreFailWhen (actualSortCount /= declaredSortCount)
-        (  "Expected "
-        ++ show declaredSortCount
-        ++ " sort arguments, but got "
-        ++ show actualSortCount
-        ++ "."
+      ( "Expected "
+          ++ show declaredSortCount
+          ++ " sort arguments, but got "
+          ++ show actualSortCount
+          ++ "."
         )
     mapM_
-        (verifySort findSortDescription declaredSortVariables)
-        (sortActualSorts sort)
+      (verifySort findSortDescription declaredSortVariables)
+      (sortActualSorts sort)
     verifySuccess
   where
     actualSortCount = length (sortActualSorts sort)

--- a/kore/src/Kore/Attribute/Assoc.hs
+++ b/kore/src/Kore/Attribute/Assoc.hs
@@ -7,21 +7,23 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Assoc
-    ( Assoc (..)
-    , assocId, assocSymbol, assocAttribute
-    ) where
+  ( Assoc (..),
+    assocId,
+    assocSymbol,
+    assocAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Assoc@ represents the @assoc@ attribute for axioms.
  -}
-newtype Assoc = Assoc { isAssoc :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Assoc = Assoc {isAssoc :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Assoc
 
@@ -32,7 +34,7 @@ instance Debug Assoc
 instance NFData Assoc
 
 instance Default Assoc where
-    def = Assoc False
+  def = Assoc False
 
 -- | Kore identifier representing the @assoc@ attribute symbol.
 assocId :: Id
@@ -41,24 +43,25 @@ assocId = "assoc"
 -- | Kore symbol representing the @assoc@ attribute.
 assocSymbol :: SymbolOrAlias
 assocSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = assocId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = assocId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @assoc@ attribute.
 assocAttribute :: AttributePattern
 assocAttribute = attributePattern_ assocSymbol
 
 instance ParseAttributes Assoc where
-    parseAttribute =
-        withApplication' $ \params args Assoc { isAssoc } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isAssoc failDuplicate'
-            return Assoc { isAssoc = True }
-      where
-        withApplication' = Parser.withApplication assocId
-        failDuplicate' = Parser.failDuplicate assocId
 
-    toAttributes Assoc { isAssoc } = Attributes [assocAttribute | isAssoc]
+  parseAttribute =
+    withApplication' $ \params args Assoc {isAssoc} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isAssoc failDuplicate'
+      return Assoc {isAssoc = True}
+    where
+      withApplication' = Parser.withApplication assocId
+      failDuplicate' = Parser.failDuplicate assocId
+
+  toAttributes Assoc {isAssoc} = Attributes [assocAttribute | isAssoc]

--- a/kore/src/Kore/Attribute/Attributes.hs
+++ b/kore/src/Kore/Attribute/Attributes.hs
@@ -4,33 +4,38 @@ License     : NCSA
 
  -}
 module Kore.Attribute.Attributes
-    ( Attributes (..)
-    , ParsedPattern
-    , AttributePattern
-    , asAttributePattern
-    , attributePattern
-    , attributePattern_
-    , attributeString
-    , attributeInteger
-    ) where
+  ( Attributes (..),
+    ParsedPattern,
+    AttributePattern,
+    asAttributePattern,
+    attributePattern,
+    attributePattern_,
+    attributeString,
+    attributeInteger
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Default
-                 ( Default (..) )
-import           Data.Hashable
-                 ( Hashable )
-import           Data.Text
-                 ( Text )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Default
+  ( Default (..)
+    )
+import Data.Hashable
+  ( Hashable
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import qualified Kore.Attribute.Null as Attribute
-                 ( Null )
-import           Kore.Debug
-import           Kore.Syntax
-import           Kore.Unparser
+  ( Null
+    )
+import Kore.Debug
+import Kore.Syntax
+import Kore.Unparser
 
 -- | A pure pattern which has only been parsed.
 type ParsedPattern = Pattern Variable Attribute.Null
@@ -42,23 +47,22 @@ asAttributePattern = asPattern . (mempty :<)
 
 -- | An 'AttributePattern' of the attribute symbol applied to its arguments.
 attributePattern
-    :: SymbolOrAlias  -- ^ symbol
-    -> [AttributePattern]  -- ^ arguments
-    -> AttributePattern
+  :: SymbolOrAlias -- ^ symbol
+  -> [AttributePattern] -- ^ arguments
+  -> AttributePattern
 attributePattern applicationSymbolOrAlias applicationChildren =
-    (asAttributePattern . ApplicationF)
-        Application { applicationSymbolOrAlias, applicationChildren }
+  (asAttributePattern . ApplicationF) Application {applicationSymbolOrAlias, applicationChildren}
 
 -- | An 'AttributePattern' of the attribute symbol applied to no arguments.
 attributePattern_
-    :: SymbolOrAlias  -- ^ symbol
-    -> AttributePattern
+  :: SymbolOrAlias -- ^ symbol
+  -> AttributePattern
 attributePattern_ applicationSymbolOrAlias =
-    attributePattern applicationSymbolOrAlias []
+  attributePattern applicationSymbolOrAlias []
 
 attributeString :: Text -> AttributePattern
 attributeString literal =
-    (asAttributePattern . StringLiteralF . Const) (StringLiteral literal)
+  (asAttributePattern . StringLiteralF . Const) (StringLiteral literal)
 
 attributeInteger :: Integer -> AttributePattern
 attributeInteger = attributeString . Text.pack . show
@@ -66,10 +70,9 @@ attributeInteger = attributeString . Text.pack . show
 {-|'Attributes' corresponds to the @attributes@ Kore syntactic declaration.
 It is parameterized by the types of Patterns, @pat@.
 -}
-
-newtype Attributes =
-    Attributes { getAttributes :: [AttributePattern] }
-    deriving (Eq, Ord, GHC.Generic, Show)
+newtype Attributes
+  = Attributes {getAttributes :: [AttributePattern]}
+  deriving (Eq, Ord, GHC.Generic, Show)
 
 instance Hashable Attributes
 
@@ -86,8 +89,10 @@ deriving instance Semigroup Attributes
 deriving instance Monoid Attributes
 
 instance Unparse Attributes where
-    unparse = attributes . getAttributes
-    unparse2 = attributes . getAttributes
+
+  unparse = attributes . getAttributes
+
+  unparse2 = attributes . getAttributes
 
 instance Default Attributes where
-    def = Attributes []
+  def = Attributes []

--- a/kore/src/Kore/Attribute/Axiom.hs
+++ b/kore/src/Kore/Attribute/Axiom.hs
@@ -6,35 +6,36 @@ License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
-
 module Kore.Attribute.Axiom
-    ( Axiom (..)
-    , HeatCool (..)
-    , ProductionID (..)
-    , Assoc (..)
-    , Comm (..)
-    , Unit (..)
-    , Idem (..)
-    , Trusted (..)
-    , Concrete (..)
-    , Simplification (..)
-    , Overload (..)
-    , SmtLemma (..)
-    , Label (..)
-    , SourceLocation (..)
-    , Constructor (..)
-    , RuleIndex (..)
-    ) where
+  ( Axiom (..),
+    HeatCool (..),
+    ProductionID (..),
+    Assoc (..),
+    Comm (..),
+    Unit (..),
+    Idem (..),
+    Trusted (..),
+    Concrete (..),
+    Simplification (..),
+    Overload (..),
+    SmtLemma (..),
+    Label (..),
+    SourceLocation (..),
+    Constructor (..),
+    RuleIndex (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Monad as Monad
-import           Data.Default
-                 ( Default (..) )
-import           Data.Generics.Product
-import qualified Generics.SOP as SOP
+import Data.Default
+  ( Default (..)
+    )
+import Data.Generics.Product
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Assoc
 import Kore.Attribute.Axiom.Concrete
 import Kore.Attribute.Axiom.Constructor
@@ -45,7 +46,8 @@ import Kore.Attribute.Idem
 import Kore.Attribute.Label
 import Kore.Attribute.Overload
 import Kore.Attribute.Parser
-       ( ParseAttributes (..) )
+  ( ParseAttributes (..)
+    )
 import Kore.Attribute.ProductionID
 import Kore.Attribute.RuleIndex
 import Kore.Attribute.Simplification
@@ -56,41 +58,41 @@ import Kore.Debug
 
 {- | Attributes specific to Kore axiom sentences.
  -}
-data Axiom =
-    Axiom
-    { heatCool :: !HeatCool
-    -- ^ An axiom may be denoted as a heating or cooling rule.
-    , productionID :: !ProductionID
-    -- ^ The identifier from the front-end identifying a rule or group of rules.
-    , assoc :: !Assoc
-    -- ^ The axiom is an associativity axiom.
-    , comm :: !Comm
-    -- ^ The axiom is a commutativity axiom.
-    , unit :: !Unit
-    -- ^ The axiom is a left- or right-unit axiom.
-    , idem :: !Idem
-    -- ^ The axiom is an idempotency axiom.
-    , trusted :: !Trusted
-    -- ^ The claim is trusted
-    , concrete :: !Concrete
-    , simplification :: !Simplification
-    -- ^ This is an axiom used for simplification
-    -- (as opposed to, e.g., function evaluation).
-    , overload :: !Overload
-    -- ^ The axiom is an overloaded-production axiom.
-    , smtLemma :: !SmtLemma
-    -- ^ The axiom should be sent to SMT as a lemma.
-    , label :: !Label
-    -- ^ The user-defined label associated with the axiom.
-    , sourceLocation :: !SourceLocation
-    -- ^ Source and location in the original file.
-    , constructor :: !Constructor
-    -- ^ Shows that this is one of the constructor axioms
-    -- (e.g. no confusion, no junk)
-    , identifier :: !RuleIndex
-    -- ^ Used to identify an axiom in the repl.
-    }
-    deriving (Eq, GHC.Generic, Ord, Show)
+data Axiom
+  = Axiom
+      { heatCool :: !HeatCool,
+        -- ^ An axiom may be denoted as a heating or cooling rule.
+        productionID :: !ProductionID,
+        -- ^ The identifier from the front-end identifying a rule or group of rules.
+        assoc :: !Assoc,
+        -- ^ The axiom is an associativity axiom.
+        comm :: !Comm,
+        -- ^ The axiom is a commutativity axiom.
+        unit :: !Unit,
+        -- ^ The axiom is a left- or right-unit axiom.
+        idem :: !Idem,
+        -- ^ The axiom is an idempotency axiom.
+        trusted :: !Trusted,
+        -- ^ The claim is trusted
+        concrete :: !Concrete,
+        simplification :: !Simplification,
+        -- ^ This is an axiom used for simplification
+        -- (as opposed to, e.g., function evaluation).
+        overload :: !Overload,
+        -- ^ The axiom is an overloaded-production axiom.
+        smtLemma :: !SmtLemma,
+        -- ^ The axiom should be sent to SMT as a lemma.
+        label :: !Label,
+        -- ^ The user-defined label associated with the axiom.
+        sourceLocation :: !SourceLocation,
+        -- ^ Source and location in the original file.
+        constructor :: !Constructor,
+        -- ^ Shows that this is one of the constructor axioms
+        -- (e.g. no confusion, no junk)
+        identifier :: !RuleIndex
+        -- ^ Used to identify an axiom in the repl.
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Axiom
 
@@ -101,56 +103,58 @@ instance Debug Axiom
 instance NFData Axiom
 
 instance Default Axiom where
-    def =
-        Axiom
-            { heatCool = def
-            , productionID = def
-            , assoc = def
-            , comm = def
-            , unit = def
-            , idem = def
-            , trusted = def
-            , concrete = def
-            , simplification = def
-            , overload = def
-            , smtLemma = def
-            , label = def
-            , sourceLocation = def
-            , constructor = def
-            , identifier = def
-            }
+  def =
+    Axiom
+      { heatCool = def,
+        productionID = def,
+        assoc = def,
+        comm = def,
+        unit = def,
+        idem = def,
+        trusted = def,
+        concrete = def,
+        simplification = def,
+        overload = def,
+        smtLemma = def,
+        label = def,
+        sourceLocation = def,
+        constructor = def,
+        identifier = def
+        }
 
 instance ParseAttributes Axiom where
-    parseAttribute attr =
-        typed @HeatCool (parseAttribute attr)
-        Monad.>=> typed @ProductionID (parseAttribute attr)
-        Monad.>=> typed @Assoc (parseAttribute attr)
-        Monad.>=> typed @Comm (parseAttribute attr)
-        Monad.>=> typed @Unit (parseAttribute attr)
-        Monad.>=> typed @Idem (parseAttribute attr)
-        Monad.>=> typed @Trusted (parseAttribute attr)
-        Monad.>=> typed @Concrete (parseAttribute attr)
-        Monad.>=> typed @Simplification (parseAttribute attr)
-        Monad.>=> typed @Overload (parseAttribute attr)
-        Monad.>=> typed @SmtLemma (parseAttribute attr)
-        Monad.>=> typed @Label (parseAttribute attr)
-        Monad.>=> typed @SourceLocation (parseAttribute attr)
-        Monad.>=> typed @Constructor (parseAttribute attr)
 
-    toAttributes =
-        mconcat . sequence
-            [ toAttributes . heatCool
-            , toAttributes . productionID
-            , toAttributes . assoc
-            , toAttributes . comm
-            , toAttributes . unit
-            , toAttributes . idem
-            , toAttributes . trusted
-            , toAttributes . concrete
-            , toAttributes . simplification
-            , toAttributes . overload
-            , toAttributes . smtLemma
-            , toAttributes . label
-            , toAttributes . sourceLocation
-            , toAttributes . constructor
+  parseAttribute attr =
+    typed @HeatCool (parseAttribute attr)
+      Monad.>=> typed @ProductionID (parseAttribute attr)
+      Monad.>=> typed @Assoc (parseAttribute attr)
+      Monad.>=> typed @Comm (parseAttribute attr)
+      Monad.>=> typed @Unit (parseAttribute attr)
+      Monad.>=> typed @Idem (parseAttribute attr)
+      Monad.>=> typed @Trusted (parseAttribute attr)
+      Monad.>=> typed @Concrete (parseAttribute attr)
+      Monad.>=> typed @Simplification (parseAttribute attr)
+      Monad.>=> typed @Overload (parseAttribute attr)
+      Monad.>=> typed @SmtLemma (parseAttribute attr)
+      Monad.>=> typed @Label (parseAttribute attr)
+      Monad.>=> typed @SourceLocation (parseAttribute attr)
+      Monad.>=> typed @Constructor (parseAttribute attr)
+
+  toAttributes =
+    mconcat
+      . sequence
+          [ toAttributes . heatCool,
+            toAttributes . productionID,
+            toAttributes . assoc,
+            toAttributes . comm,
+            toAttributes . unit,
+            toAttributes . idem,
+            toAttributes . trusted,
+            toAttributes . concrete,
+            toAttributes . simplification,
+            toAttributes . overload,
+            toAttributes . smtLemma,
+            toAttributes . label,
+            toAttributes . sourceLocation,
+            toAttributes . constructor
             ]

--- a/kore/src/Kore/Attribute/Axiom/Concrete.hs
+++ b/kore/src/Kore/Attribute/Axiom/Concrete.hs
@@ -7,21 +7,23 @@ Maintainer  : phillip.harris@runtimeverification.com
 
 -}
 module Kore.Attribute.Axiom.Concrete
-    ( Concrete (..)
-    , concreteId, concreteSymbol, concreteAttribute
-    ) where
+  ( Concrete (..),
+    concreteId,
+    concreteSymbol,
+    concreteAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Concrete@ represents the @concrete@ attribute for axioms.
  -}
-newtype Concrete = Concrete { isConcrete :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Concrete = Concrete {isConcrete :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Concrete
 
@@ -32,7 +34,7 @@ instance Debug Concrete
 instance NFData Concrete
 
 instance Default Concrete where
-    def = Concrete False
+  def = Concrete False
 
 -- | Kore identifier representing the @concrete@ attribute symbol.
 concreteId :: Id
@@ -41,25 +43,26 @@ concreteId = "concrete"
 -- | Kore symbol representing the @concrete@ attribute.
 concreteSymbol :: SymbolOrAlias
 concreteSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = concreteId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = concreteId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @concrete@ attribute.
 concreteAttribute :: AttributePattern
 concreteAttribute = attributePattern_ concreteSymbol
 
 instance ParseAttributes Concrete where
-    parseAttribute =
-        withApplication' $ \params args Concrete { isConcrete } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isConcrete failDuplicate'
-            return Concrete { isConcrete = True }
-      where
-        withApplication' = Parser.withApplication concreteId
-        failDuplicate' = Parser.failDuplicate concreteId
 
-    toAttributes Concrete { isConcrete } =
-        Attributes [concreteAttribute | isConcrete]
+  parseAttribute =
+    withApplication' $ \params args Concrete {isConcrete} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isConcrete failDuplicate'
+      return Concrete {isConcrete = True}
+    where
+      withApplication' = Parser.withApplication concreteId
+      failDuplicate' = Parser.failDuplicate concreteId
+
+  toAttributes Concrete {isConcrete} =
+    Attributes [concreteAttribute | isConcrete]

--- a/kore/src/Kore/Attribute/Axiom/Constructor.hs
+++ b/kore/src/Kore/Attribute/Axiom/Constructor.hs
@@ -7,21 +7,23 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 
 -}
 module Kore.Attribute.Axiom.Constructor
-    ( Constructor (..)
-    , constructorId, constructorSymbol, constructorAttribute
-    ) where
+  ( Constructor (..),
+    constructorId,
+    constructorSymbol,
+    constructorAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Constructor@ represents the @constructor@ attribute for axioms.
  -}
-newtype Constructor = Constructor { isConstructor :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Constructor = Constructor {isConstructor :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Constructor
 
@@ -32,7 +34,7 @@ instance Debug Constructor
 instance NFData Constructor
 
 instance Default Constructor where
-    def = Constructor False
+  def = Constructor False
 
 -- | Kore identifier representing the @constructor@ attribute symbol.
 constructorId :: Id
@@ -41,25 +43,26 @@ constructorId = "constructor"
 -- | Kore symbol representing the @constructor@ attribute.
 constructorSymbol :: SymbolOrAlias
 constructorSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = constructorId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = constructorId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @constructor@ attribute.
 constructorAttribute :: AttributePattern
 constructorAttribute = attributePattern_ constructorSymbol
 
 instance ParseAttributes Constructor where
-    parseAttribute =
-        withApplication' $ \params args Constructor { isConstructor } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isConstructor failDuplicate'
-            return Constructor { isConstructor = True }
-      where
-        withApplication' = Parser.withApplication constructorId
-        failDuplicate' = Parser.failDuplicate constructorId
 
-    toAttributes Constructor { isConstructor } =
-        Attributes [constructorAttribute | isConstructor]
+  parseAttribute =
+    withApplication' $ \params args Constructor {isConstructor} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isConstructor failDuplicate'
+      return Constructor {isConstructor = True}
+    where
+      withApplication' = Parser.withApplication constructorId
+      failDuplicate' = Parser.failDuplicate constructorId
+
+  toAttributes Constructor {isConstructor} =
+    Attributes [constructorAttribute | isConstructor]

--- a/kore/src/Kore/Attribute/Axiom/Unit.hs
+++ b/kore/src/Kore/Attribute/Axiom/Unit.hs
@@ -7,21 +7,23 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Axiom.Unit
-    ( Unit (..)
-    , unitId, unitSymbol, unitAttribute
-    ) where
+  ( Unit (..),
+    unitId,
+    unitSymbol,
+    unitAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Unit@ represents the @unit@ attribute for axioms.
  -}
-newtype Unit = Unit { isUnit :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Unit = Unit {isUnit :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Unit
 
@@ -32,7 +34,7 @@ instance Debug Unit
 instance NFData Unit
 
 instance Default Unit where
-    def = Unit False
+  def = Unit False
 
 -- | Kore identifier representing the @unit@ attribute symbol.
 unitId :: Id
@@ -41,24 +43,25 @@ unitId = "unit"
 -- | Kore symbol representing the @unit@ attribute.
 unitSymbol :: SymbolOrAlias
 unitSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = unitId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = unitId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @unit@ attribute.
 unitAttribute :: AttributePattern
 unitAttribute = attributePattern_ unitSymbol
 
 instance ParseAttributes Unit where
-    parseAttribute =
-        withApplication' $ \params args Unit { isUnit } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isUnit failDuplicate'
-            return Unit { isUnit = True }
-      where
-        withApplication' = Parser.withApplication unitId
-        failDuplicate' = Parser.failDuplicate unitId
 
-    toAttributes Unit { isUnit } = Attributes [unitAttribute | isUnit]
+  parseAttribute =
+    withApplication' $ \params args Unit {isUnit} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isUnit failDuplicate'
+      return Unit {isUnit = True}
+    where
+      withApplication' = Parser.withApplication unitId
+      failDuplicate' = Parser.failDuplicate unitId
+
+  toAttributes Unit {isUnit} = Attributes [unitAttribute | isUnit]

--- a/kore/src/Kore/Attribute/Comm.hs
+++ b/kore/src/Kore/Attribute/Comm.hs
@@ -7,24 +7,27 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Comm
-    ( Comm (..)
-    , commId, commSymbol, commAttribute
-    ) where
+  ( Comm (..),
+    commId,
+    commSymbol,
+    commAttribute
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Monad as Monad
-import           Data.Default
-import qualified Generics.SOP as SOP
+import Data.Default
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Comm@ represents the @comm@ attribute for axioms.
  -}
-newtype Comm = Comm { isComm :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Comm = Comm {isComm :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Comm
 
@@ -35,7 +38,7 @@ instance Debug Comm
 instance NFData Comm
 
 instance Default Comm where
-    def = Comm False
+  def = Comm False
 
 -- | Kore identifier representing the @comm@ attribute symbol.
 commId :: Id
@@ -44,24 +47,25 @@ commId = "comm"
 -- | Kore symbol representing the @comm@ attribute.
 commSymbol :: SymbolOrAlias
 commSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = commId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = commId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @comm@ attribute.
 commAttribute :: AttributePattern
 commAttribute = attributePattern_ commSymbol
 
 instance ParseAttributes Comm where
-    parseAttribute =
-        withApplication' $ \params args Comm { isComm } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isComm failDuplicate'
-            return Comm { isComm = True }
-      where
-        withApplication' = Parser.withApplication commId
-        failDuplicate' = Parser.failDuplicate commId
 
-    toAttributes Comm { isComm } = Attributes [commAttribute | isComm]
+  parseAttribute =
+    withApplication' $ \params args Comm {isComm} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isComm failDuplicate'
+      return Comm {isComm = True}
+    where
+      withApplication' = Parser.withApplication commId
+      failDuplicate' = Parser.failDuplicate commId
+
+  toAttributes Comm {isComm} = Attributes [commAttribute | isComm]

--- a/kore/src/Kore/Attribute/Constructor.hs
+++ b/kore/src/Kore/Attribute/Constructor.hs
@@ -7,29 +7,31 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Constructor
-    ( Constructor (..)
-    , constructorId, constructorSymbol, constructorAttribute
-    ) where
+  ( Constructor (..),
+    constructorId,
+    constructorSymbol,
+    constructorAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @Constructor@ represents the @constructor@ attribute for symbols.
-newtype Constructor = Constructor { isConstructor :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Constructor = Constructor {isConstructor :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup Constructor where
-    (<>) (Constructor a) (Constructor b) = Constructor (a || b)
+  (<>) (Constructor a) (Constructor b) = Constructor (a || b)
 
 instance Monoid Constructor where
-    mempty = Constructor False
+  mempty = Constructor False
 
 instance Default Constructor where
-    def = mempty
+  def = mempty
 
 instance NFData Constructor
 
@@ -46,25 +48,26 @@ constructorId = "constructor"
 -- | Kore symbol representing the @constructor@ attribute.
 constructorSymbol :: SymbolOrAlias
 constructorSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = constructorId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = constructorId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @constructor@ attribute.
 constructorAttribute :: AttributePattern
 constructorAttribute = attributePattern_ constructorSymbol
 
 instance ParseAttributes Constructor where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Constructor { isConstructor } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isConstructor failDuplicate'
-            return Constructor { isConstructor = True }
-        withApplication' = Parser.withApplication constructorId
-        failDuplicate' = Parser.failDuplicate constructorId
 
-    toAttributes Constructor { isConstructor } =
-        Attributes [constructorAttribute | isConstructor]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Constructor {isConstructor} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isConstructor failDuplicate'
+        return Constructor {isConstructor = True}
+      withApplication' = Parser.withApplication constructorId
+      failDuplicate' = Parser.failDuplicate constructorId
+
+  toAttributes Constructor {isConstructor} =
+    Attributes [constructorAttribute | isConstructor]

--- a/kore/src/Kore/Attribute/Function.hs
+++ b/kore/src/Kore/Attribute/Function.hs
@@ -7,29 +7,31 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Function
-    ( Function (..)
-    , functionId, functionSymbol, functionAttribute
-    ) where
+  ( Function (..),
+    functionId,
+    functionSymbol,
+    functionAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @Function@ represents the @function@ attribute for symbols.
-newtype Function = Function { isDeclaredFunction :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Function = Function {isDeclaredFunction :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup Function where
-    (<>) (Function a) (Function b) = Function (a || b)
+  (<>) (Function a) (Function b) = Function (a || b)
 
 instance Monoid Function where
-    mempty = Function False
+  mempty = Function False
 
 instance Default Function where
-    def = mempty
+  def = mempty
 
 instance NFData Function
 
@@ -46,25 +48,26 @@ functionId = "function"
 -- | Kore symbol representing the @function@ attribute.
 functionSymbol :: SymbolOrAlias
 functionSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = functionId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = functionId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @function@ attribute.
 functionAttribute :: AttributePattern
 functionAttribute = attributePattern_ functionSymbol
 
 instance ParseAttributes Function where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Function { isDeclaredFunction } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isDeclaredFunction failDuplicate'
-            return Function { isDeclaredFunction = True }
-        withApplication' = Parser.withApplication functionId
-        failDuplicate' = Parser.failDuplicate functionId
 
-    toAttributes Function { isDeclaredFunction } =
-        Attributes [functionAttribute | isDeclaredFunction]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Function {isDeclaredFunction} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isDeclaredFunction failDuplicate'
+        return Function {isDeclaredFunction = True}
+      withApplication' = Parser.withApplication functionId
+      failDuplicate' = Parser.failDuplicate functionId
+
+  toAttributes Function {isDeclaredFunction} =
+    Attributes [functionAttribute | isDeclaredFunction]

--- a/kore/src/Kore/Attribute/Functional.hs
+++ b/kore/src/Kore/Attribute/Functional.hs
@@ -7,30 +7,32 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Functional
-    ( Functional (..)
-    , functionalId, functionalSymbol, functionalAttribute
-    ) where
+  ( Functional (..),
+    functionalId,
+    functionalSymbol,
+    functionalAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Functional@ represents the @functional@ attribute for symbols.
  -}
-newtype Functional = Functional { isDeclaredFunctional :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Functional = Functional {isDeclaredFunctional :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup Functional where
-    (<>) (Functional a) (Functional b) = Functional (a || b)
+  (<>) (Functional a) (Functional b) = Functional (a || b)
 
 instance Monoid Functional where
-    mempty = Functional False
+  mempty = Functional False
 
 instance Default Functional where
-    def = mempty
+  def = mempty
 
 instance NFData Functional
 
@@ -47,25 +49,26 @@ functionalId = "functional"
 -- | Kore symbol representing the @functional@ attribute.
 functionalSymbol :: SymbolOrAlias
 functionalSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = functionalId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = functionalId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @functional@ attribute.
 functionalAttribute :: AttributePattern
 functionalAttribute = attributePattern_ functionalSymbol
 
 instance ParseAttributes Functional where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Functional { isDeclaredFunctional } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isDeclaredFunctional failDuplicate'
-            return Functional { isDeclaredFunctional = True }
-        withApplication' = Parser.withApplication functionalId
-        failDuplicate' = Parser.failDuplicate functionalId
 
-    toAttributes Functional { isDeclaredFunctional } =
-        Attributes [functionalAttribute | isDeclaredFunctional]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Functional {isDeclaredFunctional} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isDeclaredFunctional failDuplicate'
+        return Functional {isDeclaredFunctional = True}
+      withApplication' = Parser.withApplication functionalId
+      failDuplicate' = Parser.failDuplicate functionalId
+
+  toAttributes Functional {isDeclaredFunctional} =
+    Attributes [functionalAttribute | isDeclaredFunctional]

--- a/kore/src/Kore/Attribute/HeatCool.hs
+++ b/kore/src/Kore/Attribute/HeatCool.hs
@@ -7,19 +7,25 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.HeatCool
-    ( HeatCool (..)
-    , heatId, heatSymbol, heatAttribute
-    , coolId, coolSymbol, coolAttribute
-    ) where
+  ( HeatCool (..),
+    heatId,
+    heatSymbol,
+    heatAttribute,
+    coolId,
+    coolSymbol,
+    coolAttribute
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Control.Monad
-                 ( (>=>) )
-import           Data.Default
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData
+    )
+import Control.Monad
+  ( (>=>)
+    )
+import Data.Default
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
@@ -27,7 +33,7 @@ import Kore.Debug
 
  -}
 data HeatCool = Heat | Normal | Cool
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic HeatCool
 
@@ -38,7 +44,7 @@ instance Debug HeatCool
 instance NFData HeatCool
 
 instance Default HeatCool where
-    def = Normal
+  def = Normal
 
 -- | Kore identifier representing the @heat@ attribute symbol.
 heatId :: Id
@@ -47,10 +53,10 @@ heatId = "heat"
 -- | Kore symbol representing the @heat@ attribute.
 heatSymbol :: SymbolOrAlias
 heatSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = heatId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = heatId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @heat@ attribute.
 heatAttribute :: AttributePattern
@@ -63,44 +69,45 @@ coolId = "cool"
 -- | Kore symbol representing the @cool@ attribute.
 coolSymbol :: SymbolOrAlias
 coolSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = coolId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = coolId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @cool@ attribute.
 coolAttribute :: AttributePattern
 coolAttribute = attributePattern_ coolSymbol
 
 instance ParseAttributes HeatCool where
-    parseAttribute attr =
-        parseHeat attr >=> parseCool attr
-      where
-        parseHeat =
-            withApplication' $ \params args heatCool -> do
-                Parser.getZeroParams params
-                Parser.getZeroArguments args
-                case heatCool of
-                    Normal -> return Heat
-                    Heat -> failDuplicate'
-                    Cool -> failConflicting'
-          where
-            withApplication' = Parser.withApplication heatId
-            failDuplicate' = Parser.failDuplicate heatId
-            failConflicting' = Parser.failConflicting [coolId, heatId]
-        parseCool =
-            withApplication' $ \params args heatCool -> do
-                Parser.getZeroParams params
-                Parser.getZeroArguments args
-                case heatCool of
-                    Normal -> return Cool
-                    Cool -> failDuplicate'
-                    Heat -> failConflicting'
-          where
-            withApplication' = Parser.withApplication coolId
-            failDuplicate' = Parser.failDuplicate coolId
-            failConflicting' = Parser.failConflicting [heatId, coolId]
 
-    toAttributes Heat = Attributes [heatAttribute]
-    toAttributes Cool = Attributes [coolAttribute]
-    toAttributes Normal = def
+  parseAttribute attr =
+    parseHeat attr >=> parseCool attr
+    where
+      parseHeat =
+        withApplication' $ \params args heatCool -> do
+          Parser.getZeroParams params
+          Parser.getZeroArguments args
+          case heatCool of
+            Normal -> return Heat
+            Heat -> failDuplicate'
+            Cool -> failConflicting'
+        where
+          withApplication' = Parser.withApplication heatId
+          failDuplicate' = Parser.failDuplicate heatId
+          failConflicting' = Parser.failConflicting [coolId, heatId]
+      parseCool =
+        withApplication' $ \params args heatCool -> do
+          Parser.getZeroParams params
+          Parser.getZeroArguments args
+          case heatCool of
+            Normal -> return Cool
+            Cool -> failDuplicate'
+            Heat -> failConflicting'
+        where
+          withApplication' = Parser.withApplication coolId
+          failDuplicate' = Parser.failDuplicate coolId
+          failConflicting' = Parser.failConflicting [heatId, coolId]
+
+  toAttributes Heat = Attributes [heatAttribute]
+  toAttributes Cool = Attributes [coolAttribute]
+  toAttributes Normal = def

--- a/kore/src/Kore/Attribute/Hook.hs
+++ b/kore/src/Kore/Attribute/Hook.hs
@@ -6,30 +6,34 @@ License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 -}
 module Kore.Attribute.Hook
-    ( Hook (..)
-    , emptyHook
-    , hookId, hookSymbol, hookAttribute
-    , getHookAttribute
-    ) where
+  ( Hook (..),
+    emptyHook,
+    hookId,
+    hookSymbol,
+    hookAttribute,
+    getHookAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import           Data.Hashable
-                 ( Hashable )
+import Data.Hashable
+  ( Hashable
+    )
 import qualified Data.Maybe as Maybe
-import           Data.Text
-                 ( Text )
-import qualified Generics.SOP as SOP
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 import Kore.Error
 
-newtype Hook = Hook { getHook :: Maybe Text }
+newtype Hook = Hook {getHook :: Maybe Text}
   deriving (Eq, GHC.Generic, Ord, Read, Show)
 
 instance Default Hook where
-    def = emptyHook
+  def = emptyHook
 
 instance Hashable Hook
 
@@ -50,19 +54,20 @@ instance Debug Hook
 
  -}
 instance ParseAttributes Hook where
-    parseAttribute =
-        withApplication' $ \params args (Hook hook) -> do
-            getZeroParams params
-            arg <- getOneArgument args
-            StringLiteral name <- getStringLiteral arg
-            Monad.unless (Maybe.isNothing hook) failDuplicate'
-            return Hook { getHook = Just name }
-      where
-        withApplication' = withApplication hookId
-        failDuplicate' = failDuplicate hookId
 
-    toAttributes Hook { getHook } =
-        Attributes $ maybe [] ((: []) . hookAttribute) getHook
+  parseAttribute =
+    withApplication' $ \params args (Hook hook) -> do
+      getZeroParams params
+      arg <- getOneArgument args
+      StringLiteral name <- getStringLiteral arg
+      Monad.unless (Maybe.isNothing hook) failDuplicate'
+      return Hook {getHook = Just name}
+    where
+      withApplication' = withApplication hookId
+      failDuplicate' = failDuplicate hookId
+
+  toAttributes Hook {getHook} =
+    Attributes $ maybe [] ((: []) . hookAttribute) getHook
 
 {- | The missing @hook@ attribute.
 
@@ -82,10 +87,10 @@ Kore syntax: @hook{}@
  -}
 hookSymbol :: SymbolOrAlias
 hookSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = hookId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = hookId,
+      symbolOrAliasParams = []
+      }
 
 {- | Kore pattern representing a @hook@ attribute
 
@@ -94,8 +99,9 @@ Kore syntax: @hook{}("HOOKED.function")@
 function.
 
  -}
-hookAttribute :: Text  -- ^ hooked function name
-              -> AttributePattern
+hookAttribute
+  :: Text -- ^ hooked function name
+  -> AttributePattern
 hookAttribute builtin = attributePattern hookSymbol [attributeString builtin]
 
 {- | Look up a required @hook{}()@ attribute from the given attributes.
@@ -104,10 +110,10 @@ hookAttribute builtin = attributePattern hookSymbol [attributeString builtin]
 
  -}
 getHookAttribute
-    :: MonadError (Error e) m
-    => Attributes
-    -> m Text
+  :: MonadError (Error e) m
+  => Attributes
+  -> m Text
 getHookAttribute attributes = do
-    let parser = Parser.parseAttributes attributes
-    hook <- Parser.liftParser parser
-    maybe (koreFail "missing hook attribute") return (getHook hook)
+  let parser = Parser.parseAttributes attributes
+  hook <- Parser.liftParser parser
+  maybe (koreFail "missing hook attribute") return (getHook hook)

--- a/kore/src/Kore/Attribute/Idem.hs
+++ b/kore/src/Kore/Attribute/Idem.hs
@@ -7,21 +7,23 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Idem
-    ( Idem (..)
-    , idemId, idemSymbol, idemAttribute
-    ) where
+  ( Idem (..),
+    idemId,
+    idemSymbol,
+    idemAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Idem@ represents the @idem@ attribute for axioms.
  -}
-newtype Idem = Idem { isIdem :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Idem = Idem {isIdem :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Idem
 
@@ -32,7 +34,7 @@ instance Debug Idem
 instance NFData Idem
 
 instance Default Idem where
-    def = Idem False
+  def = Idem False
 
 -- | Kore identifier representing the @idem@ attribute symbol.
 idemId :: Id
@@ -41,24 +43,25 @@ idemId = "idem"
 -- | Kore symbol representing the @idem@ attribute.
 idemSymbol :: SymbolOrAlias
 idemSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = idemId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = idemId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @idem@ attribute.
 idemAttribute :: AttributePattern
 idemAttribute = attributePattern_ idemSymbol
 
 instance ParseAttributes Idem where
-    parseAttribute =
-        withApplication' $ \params args Idem { isIdem } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isIdem failDuplicate'
-            return Idem { isIdem = True }
-      where
-        withApplication' = Parser.withApplication idemId
-        failDuplicate' = Parser.failDuplicate idemId
 
-    toAttributes Idem { isIdem } = Attributes [idemAttribute | isIdem]
+  parseAttribute =
+    withApplication' $ \params args Idem {isIdem} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isIdem failDuplicate'
+      return Idem {isIdem = True}
+    where
+      withApplication' = Parser.withApplication idemId
+      failDuplicate' = Parser.failDuplicate idemId
+
+  toAttributes Idem {isIdem} = Attributes [idemAttribute | isIdem]

--- a/kore/src/Kore/Attribute/Injective.hs
+++ b/kore/src/Kore/Attribute/Injective.hs
@@ -7,30 +7,32 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Injective
-    ( Injective (..)
-    , injectiveId, injectiveSymbol, injectiveAttribute
-    ) where
+  ( Injective (..),
+    injectiveId,
+    injectiveSymbol,
+    injectiveAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Injective@ represents the @injective@ attribute for symbols.
  -}
-newtype Injective = Injective { isDeclaredInjective :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Injective = Injective {isDeclaredInjective :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup Injective where
-    (<>) (Injective a) (Injective b) = Injective (a || b)
+  (<>) (Injective a) (Injective b) = Injective (a || b)
 
 instance Monoid Injective where
-    mempty = Injective False
+  mempty = Injective False
 
 instance Default Injective where
-    def = mempty
+  def = mempty
 
 instance NFData Injective
 
@@ -47,25 +49,26 @@ injectiveId = "injective"
 -- | Kore symbol representing the @injective@ attribute.
 injectiveSymbol :: SymbolOrAlias
 injectiveSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = injectiveId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = injectiveId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @injective@ attribute.
 injectiveAttribute :: AttributePattern
 injectiveAttribute = attributePattern_ injectiveSymbol
 
 instance ParseAttributes Injective where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Injective { isDeclaredInjective } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isDeclaredInjective failDuplicate'
-            return Injective { isDeclaredInjective = True }
-        withApplication' = Parser.withApplication injectiveId
-        failDuplicate' = Parser.failDuplicate injectiveId
 
-    toAttributes Injective { isDeclaredInjective } =
-        Attributes [injectiveAttribute | isDeclaredInjective]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Injective {isDeclaredInjective} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isDeclaredInjective failDuplicate'
+        return Injective {isDeclaredInjective = True}
+      withApplication' = Parser.withApplication injectiveId
+      failDuplicate' = Parser.failDuplicate injectiveId
+
+  toAttributes Injective {isDeclaredInjective} =
+    Attributes [injectiveAttribute | isDeclaredInjective]

--- a/kore/src/Kore/Attribute/Location.hs
+++ b/kore/src/Kore/Attribute/Location.hs
@@ -7,28 +7,33 @@ Maintainer  : vladimir.ciobanu@runtimeverification.com
 
 -}
 module Kore.Attribute.Location
-    ( Location (..)
-    , LineColumn (..)
-    ) where
+  ( Location (..),
+    LineColumn (..)
+    )
+where
 
-import           Data.Maybe
+import Data.Maybe
 import qualified Data.Text as Text
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-import           Text.Megaparsec
-                 ( Parsec, parseMaybe )
-import           Text.Megaparsec.Char
-import           Text.Megaparsec.Char.Lexer
-                 ( decimal )
-
-import           Kore.Attribute.Parser as AttributeParser
-import           Kore.Debug
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Parser as AttributeParser
+import Kore.Debug
 import qualified Kore.Error
+import Text.Megaparsec
+  ( Parsec,
+    parseMaybe
+    )
+import Text.Megaparsec.Char
+import Text.Megaparsec.Char.Lexer
+  ( decimal
+    )
 
-data LineColumn = LineColumn
-    { line   :: !Int
-    , column :: !Int
-    } deriving (Eq, GHC.Generic, Ord, Show)
+data LineColumn
+  = LineColumn
+      { line :: !Int,
+        column :: !Int
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic LineColumn
 
@@ -38,10 +43,12 @@ instance Debug LineColumn
 
 instance NFData LineColumn
 
-data Location = Location
-    { start :: Maybe LineColumn
-    , end   :: Maybe LineColumn
-    } deriving (Eq, GHC.Generic, Ord, Show)
+data Location
+  = Location
+      { start :: Maybe LineColumn,
+        end :: Maybe LineColumn
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Location
 
@@ -52,39 +59,40 @@ instance Debug Location
 instance NFData Location
 
 instance Default Location where
-    def = Location Nothing Nothing
+  def = Location Nothing Nothing
 
 -- | Kore identifier representing the @location@ attribute symbol.
 locationId :: Id
 locationId = "org'Stop'kframework'Stop'attributes'Stop'Location"
 
 instance ParseAttributes Location where
-    parseAttribute = AttributeParser.withApplication locationId parseApplication
-      where
-        parseApplication
-            :: [Sort]
-            -> [AttributePattern]
-            -> Location
-            -> AttributeParser.Parser Location
-        parseApplication params args l@(Location Nothing Nothing) = do
-            AttributeParser.getZeroParams params
-            case args of
-                [] -> pure l
-                [_] -> do
-                    arg <- AttributeParser.getOneArgument args
-                    StringLiteral str <- AttributeParser.getStringLiteral arg
-                    pure
-                        . fromMaybe def
-                        . parseMaybe locationParser
-                        $ Text.unpack str
-                _ ->
-                    Kore.Error.koreFail
-                        ("expected one argument, found " ++ show (length args))
-        parseApplication _ _ _ =
-            AttributeParser.failDuplicate locationId
 
-    -- TODO (thomas.tuegel): Implement
-    toAttributes = def
+  parseAttribute = AttributeParser.withApplication locationId parseApplication
+    where
+      parseApplication
+        :: [Sort]
+        -> [AttributePattern]
+        -> Location
+        -> AttributeParser.Parser Location
+      parseApplication params args l@(Location Nothing Nothing) = do
+        AttributeParser.getZeroParams params
+        case args of
+          [] -> pure l
+          [_] -> do
+            arg <- AttributeParser.getOneArgument args
+            StringLiteral str <- AttributeParser.getStringLiteral arg
+            pure
+              . fromMaybe def
+              . parseMaybe locationParser
+              $ Text.unpack str
+          _ ->
+            Kore.Error.koreFail
+              ("expected one argument, found " ++ show (length args))
+      parseApplication _ _ _ =
+        AttributeParser.failDuplicate locationId
+
+  -- TODO (thomas.tuegel): Implement
+  toAttributes = def
 
 -- | This parser is used to parse the inner representation of the attribute.
 -- The expected format is "Location(sl,sc,el,ec)" where sc, sc, el, and ec are
@@ -93,18 +101,17 @@ type StringParser = Parsec String String
 
 locationParser :: StringParser Location
 locationParser =
-    Location
-        <$> (Just <$> parseStart)
-        <*> (Just <$> parseEnd)
+  Location
+    <$> (Just <$> parseStart)
+    <*> (Just <$> parseEnd)
   where
     parseStart :: StringParser LineColumn
     parseStart =
-        LineColumn
-            <$> (string "Location(" *> decimal)
-            <*> (string "," *> decimal)
-
+      LineColumn
+        <$> (string "Location(" *> decimal)
+        <*> (string "," *> decimal)
     parseEnd :: StringParser LineColumn
     parseEnd =
-        LineColumn
-            <$> (string "," *> decimal)
-            <*> (string "," *> decimal <* ")")
+      LineColumn
+        <$> (string "," *> decimal)
+        <*> (string "," *> decimal <* ")")

--- a/kore/src/Kore/Attribute/Null.hs
+++ b/kore/src/Kore/Attribute/Null.hs
@@ -16,19 +16,20 @@ import qualified Kore.Attribute.Null as Attribute
 
 -}
 module Kore.Attribute.Null
-    ( Null (..)
-    ) where
+  ( Null (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Default
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Default
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 
 data Null = Null
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance NFData Null
 
@@ -39,10 +40,10 @@ instance SOP.HasDatatypeInfo Null
 instance Debug Null
 
 instance Default Null where
-    def = Null
+  def = Null
 
 instance Semigroup Null where
-    (<>) _ _ = Null
+  (<>) _ _ = Null
 
 instance Monoid Null where
-    mempty = Null
+  mempty = Null

--- a/kore/src/Kore/Attribute/Overload.hs
+++ b/kore/src/Kore/Attribute/Overload.hs
@@ -7,21 +7,23 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Overload
-    ( Overload (..)
-    , overloadId, overloadSymbol, overloadAttribute
-    ) where
+  ( Overload (..),
+    overloadId,
+    overloadSymbol,
+    overloadAttribute
+    )
+where
 
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @Overload@ represents the @overload@ attribute for symbols.
-newtype Overload =
-    Overload
-        { getOverload :: Maybe (SymbolOrAlias, SymbolOrAlias) }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Overload
+  = Overload
+      {getOverload :: Maybe (SymbolOrAlias, SymbolOrAlias)}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Overload
 
@@ -30,14 +32,14 @@ instance SOP.HasDatatypeInfo Overload
 instance Debug Overload
 
 instance Semigroup Overload where
-    (<>) a@(Overload (Just _)) _ = a
-    (<>) _                     b = b
+  (<>) a@(Overload (Just _)) _ = a
+  (<>) _ b = b
 
 instance Monoid Overload where
-    mempty = Overload { getOverload = Nothing }
+  mempty = Overload {getOverload = Nothing}
 
 instance Default Overload where
-    def = mempty
+  def = mempty
 
 instance NFData Overload
 
@@ -48,38 +50,40 @@ overloadId = "overload"
 -- | Kore symbol representing the @overload@ attribute.
 overloadSymbol :: SymbolOrAlias
 overloadSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = overloadId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = overloadId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @overload@ attribute.
 overloadAttribute
-    :: SymbolOrAlias
-    -> SymbolOrAlias
-    -> AttributePattern
+  :: SymbolOrAlias
+  -> SymbolOrAlias
+  -> AttributePattern
 overloadAttribute symbol1 symbol2 =
-    attributePattern overloadSymbol
-        [ attributePattern_ symbol1
-        , attributePattern_ symbol2
-        ]
+  attributePattern overloadSymbol
+    [ attributePattern_ symbol1,
+      attributePattern_ symbol2
+      ]
 
 instance ParseAttributes Overload where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Overload { getOverload }
-          | Just _ <- getOverload = failDuplicate'
-          | otherwise = do
+
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Overload {getOverload}
+        | Just _ <- getOverload = failDuplicate'
+        | otherwise =
+          do
             Parser.getZeroParams params
             (arg1, arg2) <- Parser.getTwoArguments args
             symbol1 <- Parser.getSymbolOrAlias arg1
             symbol2 <- Parser.getSymbolOrAlias arg2
-            return Overload { getOverload = Just (symbol1, symbol2) }
-        withApplication' = Parser.withApplication overloadId
-        failDuplicate' = Parser.failDuplicate overloadId
+            return Overload {getOverload = Just (symbol1, symbol2)}
+      withApplication' = Parser.withApplication overloadId
+      failDuplicate' = Parser.failDuplicate overloadId
 
-    toAttributes =
-        maybe def toAttribute . getOverload
-      where
-        toAttribute (symbol1, symbol2) =
-            Attributes [overloadAttribute symbol1 symbol2]
+  toAttributes =
+    maybe def toAttribute . getOverload
+    where
+      toAttribute (symbol1, symbol2) =
+        Attributes [overloadAttribute symbol1 symbol2]

--- a/kore/src/Kore/Attribute/Parser.hs
+++ b/kore/src/Kore/Attribute/Parser.hs
@@ -19,250 +19,268 @@ This module is intended to be imported qualified or explicitly:
 
 -}
 module Kore.Attribute.Parser
-    ( -- * Parsing attributes
-      ParseAttributes (..)
-    , Attributes (..)
-    , Parser
-    , ParseError
-    , parseAttributes
-    , parseAttributesWith
-    , liftParser
-      -- * Parsers
-    , failDuplicate
-    , failConflicting
-    , withApplication
-    , getZeroParams
-    , getTwoParams
-    , getZeroArguments
-    , getOneArgument
-    , getTwoArguments
-    , getSymbolOrAlias
-    , Kore.Attribute.Parser.getStringLiteral
-    , parseSExpr
-    , parseReadS
-    , parseInteger
-      -- * Re-exports
-    , AttributePattern
-    , asAttributePattern
-    , attributePattern
-    , attributePattern_
-    , attributeString
-    , attributeInteger
-    , Default (..)
-    , StringLiteral (StringLiteral)
-    , Generic
-    , NFData
-    , module Kore.AST.Common
-    , module Kore.Sort
-    , module Kore.Syntax.Application
-    ) where
+  ( -- * Parsing attributes
+    ParseAttributes (..),
+    Attributes (..),
+    Parser,
+    ParseError,
+    parseAttributes,
+    parseAttributesWith,
+    liftParser,
+    -- * Parsers
+    failDuplicate,
+    failConflicting,
+    withApplication,
+    getZeroParams,
+    getTwoParams,
+    getZeroArguments,
+    getOneArgument,
+    getTwoArguments,
+    getSymbolOrAlias,
+    Kore.Attribute.Parser.getStringLiteral,
+    parseSExpr,
+    parseReadS,
+    parseInteger,
+    -- * Re-exports
+    AttributePattern,
+    asAttributePattern,
+    attributePattern,
+    attributePattern_,
+    attributeString,
+    attributeInteger,
+    Default (..),
+    StringLiteral (StringLiteral),
+    Generic,
+    NFData,
+    module Kore.AST.Common,
+    module Kore.Sort,
+    module Kore.Syntax.Application
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Monad as Monad
-import           Control.Monad.Except
-                 ( MonadError )
+import Control.Monad.Except
+  ( MonadError
+    )
 import qualified Control.Monad.Except as Monad.Except
-import           Data.Default
-                 ( Default (..) )
+import Data.Default
+  ( Default (..)
+    )
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           GHC.Generics
-                 ( Generic )
-
-import           Kore.AST.Common
+import GHC.Generics
+  ( Generic
+    )
+import Kore.AST.Common
 import qualified Kore.AST.Error as Kore.Error
-import           Kore.Attribute.Attributes
+import Kore.Attribute.Attributes
 import qualified Kore.Attribute.Null as Attribute
-                 ( Null )
+  ( Null
+    )
 import qualified Kore.Attribute.Smtlib.Smtlib as Attribute
-import           Kore.Error
-                 ( Error, castError )
+import Kore.Error
+  ( Error,
+    castError
+    )
 import qualified Kore.Error
-import           Kore.Sort
-import           Kore.Syntax.Application
-import           Kore.Syntax.Pattern
-import           Kore.Syntax.StringLiteral
-                 ( StringLiteral (StringLiteral) )
-import           SMT.SimpleSMT
-                 ( SExpr, readSExprs, showSExpr )
+import Kore.Sort
+import Kore.Syntax.Application
+import Kore.Syntax.Pattern
+import Kore.Syntax.StringLiteral
+  ( StringLiteral (StringLiteral)
+    )
+import SMT.SimpleSMT
+  ( SExpr,
+    readSExprs,
+    showSExpr
+    )
 
 data ParseError
 
 type Parser = Either (Error ParseError)
 
 class Default attrs => ParseAttributes attrs where
-    {- | Parse a 'AttributePattern' from 'Attributes' to produce @attrs@.
 
-    Attributes are parsed individually and the list of attributes is parsed by
-    folding over the list; @parseAttributes@ takes a second argument which is
-    the partial result obtained by folding over the preceeding attributes of the
-    list.
+  {- | Parse a 'AttributePattern' from 'Attributes' to produce @attrs@.
+  
+  Attributes are parsed individually and the list of attributes is parsed by
+  folding over the list; @parseAttributes@ takes a second argument which is
+  the partial result obtained by folding over the preceeding attributes of the
+  list.
+  
+  Ignore unrecognized attributes by 'return'-ing the partial result. Signal
+  errors with 'Control.Monad.Except.throwError' to abort parsing.
+  
+  See also: 'parseAttributes', 'withApplication', 'runParser'
+  
+   -}
+  parseAttribute
+    :: AttributePattern -- ^ attribute
+    -> attrs -- ^ partial parsing result
+    -> Parser attrs
 
-    Ignore unrecognized attributes by 'return'-ing the partial result. Signal
-    errors with 'Control.Monad.Except.throwError' to abort parsing.
-
-    See also: 'parseAttributes', 'withApplication', 'runParser'
-
-     -}
-    parseAttribute
-        :: AttributePattern  -- ^ attribute
-        -> attrs  -- ^ partial parsing result
-        -> Parser attrs
-
-    toAttributes :: attrs -> Attributes
+  toAttributes :: attrs -> Attributes
 
 instance ParseAttributes Attributes where
-    parseAttribute attr (Attributes attrs) =
-        return (Attributes $ attr : attrs)
-    toAttributes = id
+
+  parseAttribute attr (Attributes attrs) =
+    return (Attributes $ attr : attrs)
+
+  toAttributes = id
 
 instance ParseAttributes Attribute.Null where
-    parseAttribute _ _ = return mempty
-    toAttributes _ = Attributes []
+
+  parseAttribute _ _ = return mempty
+
+  toAttributes _ = Attributes []
 
 parseAttributesWith
-    :: ParseAttributes attrs
-    => Attributes
-    -> attrs
-    -> Parser attrs
+  :: ParseAttributes attrs
+  => Attributes
+  -> attrs
+  -> Parser attrs
 parseAttributesWith (Attributes attrs) def' =
-    Foldable.foldlM (flip parseAttribute) def' attrs
+  Foldable.foldlM (flip parseAttribute) def' attrs
 
 parseAttributes :: ParseAttributes attrs => Attributes -> Parser attrs
 parseAttributes attrs = parseAttributesWith attrs Default.def
 
 -- | Run an attribute parser in any 'MonadError' with the given initial state.
 liftParser
-    :: MonadError (Error e) m
-    => Parser a  -- ^ parser
-    -> m a
+  :: MonadError (Error e) m
+  => Parser a -- ^ parser
+  -> m a
 liftParser = Monad.Except.liftEither . Kore.Error.castError
 
 -- | Fail due to a duplicate attribute.
 failDuplicate :: Id -> Parser a
 failDuplicate ident =
-    Kore.Error.koreFail ("duplicate attribute: " ++ getIdForError ident)
+  Kore.Error.koreFail ("duplicate attribute: " ++ getIdForError ident)
 
 -- | Fail due to conflicting attributes.
 failConflicting :: [Id] -> Parser a
 failConflicting idents =
-    Kore.Error.koreFail
-        ("conflicting attributes: "
-            ++ List.intercalate ", " (getIdForError <$> idents))
+  Kore.Error.koreFail
+    ( "conflicting attributes: "
+        ++ List.intercalate ", " (getIdForError <$> idents)
+      )
 
 withApplication
-    :: Id
-    -> ([Sort] -> [AttributePattern] -> attrs -> Parser attrs)
-    -> AttributePattern
-    -> attrs
-    -> Parser attrs
+  :: Id
+  -> ([Sort] -> [AttributePattern] -> attrs -> Parser attrs)
+  -> AttributePattern
+  -> attrs
+  -> Parser attrs
 withApplication ident go kore =
-    case Recursive.project kore of
-        _ :< ApplicationF app
-          | symbolOrAliasConstructor == ident ->
-            Kore.Error.withLocationAndContext symbol context
-            . go symbolOrAliasParams applicationChildren
-          where
-            context = "attribute '" <> Text.pack (show symbol) <> "'"
-            Application { applicationSymbolOrAlias = symbol } = app
-            Application { applicationChildren } = app
-            SymbolOrAlias { symbolOrAliasConstructor } = symbol
-            SymbolOrAlias { symbolOrAliasParams } = symbol
-        _ -> return
+  case Recursive.project kore of
+    _ :< ApplicationF app
+      | symbolOrAliasConstructor == ident ->
+        Kore.Error.withLocationAndContext symbol context
+          . go symbolOrAliasParams applicationChildren
+      where
+        context = "attribute '" <> Text.pack (show symbol) <> "'"
+        Application {applicationSymbolOrAlias = symbol} = app
+        Application {applicationChildren} = app
+        SymbolOrAlias {symbolOrAliasConstructor} = symbol
+        SymbolOrAlias {symbolOrAliasParams} = symbol
+    _ -> return
 
 getZeroParams :: [Sort] -> Parser ()
 getZeroParams =
-    \case
-        [] -> return ()
-        params ->
-            Kore.Error.koreFailWithLocations params
-                ("expected zero parameters, found " <> Text.pack (show arity))
-          where
-            arity = length params
+  \case
+    [] -> return ()
+    params ->
+      Kore.Error.koreFailWithLocations params
+        ("expected zero parameters, found " <> Text.pack (show arity))
+      where
+        arity = length params
 
 getTwoParams :: [Sort] -> Parser (Sort, Sort)
 getTwoParams =
-    \case
-        [param1, param2] -> return (param1, param2)
-        params ->
-            Kore.Error.koreFailWithLocations params
-                ("expected two parameters, found " <> Text.pack (show arity))
-          where
-            arity = length params
+  \case
+    [param1, param2] -> return (param1, param2)
+    params ->
+      Kore.Error.koreFailWithLocations params
+        ("expected two parameters, found " <> Text.pack (show arity))
+      where
+        arity = length params
 
 {- | Accept exactly zero arguments.
  -}
 getZeroArguments
-    :: [AttributePattern]
-    -> Parser ()
+  :: [AttributePattern]
+  -> Parser ()
 getZeroArguments =
-    \case
-        [] -> return ()
-        args ->
-            Kore.Error.koreFail
-                ("expected zero arguments, found " ++ show arity)
-          where
-            arity = length args
+  \case
+    [] -> return ()
+    args ->
+      Kore.Error.koreFail
+        ("expected zero arguments, found " ++ show arity)
+      where
+        arity = length args
 
 {- | Accept exactly one argument.
  -}
 getOneArgument
-    :: [AttributePattern]
-    -> Parser AttributePattern
+  :: [AttributePattern]
+  -> Parser AttributePattern
 getOneArgument =
-    \case
-        [arg] -> return arg
-        args ->
-            Kore.Error.koreFail
-                ("expected one argument, found " ++ show arity)
-          where
-            arity = length args
+  \case
+    [arg] -> return arg
+    args ->
+      Kore.Error.koreFail
+        ("expected one argument, found " ++ show arity)
+      where
+        arity = length args
 
 {- | Accept exactly two arguments.
  -}
 getTwoArguments
-    :: [AttributePattern]
-    -> Parser (AttributePattern, AttributePattern)
+  :: [AttributePattern]
+  -> Parser (AttributePattern, AttributePattern)
 getTwoArguments =
-    \case
-        [arg1, arg2] -> return (arg1, arg2)
-        args ->
-            Kore.Error.koreFail
-                ("expected two arguments, found " ++ show arity)
-          where
-            arity = length args
+  \case
+    [arg1, arg2] -> return (arg1, arg2)
+    args ->
+      Kore.Error.koreFail
+        ("expected two arguments, found " ++ show arity)
+      where
+        arity = length args
 
 {- | Accept a symbol or alias applied to no arguments.
  -}
 getSymbolOrAlias :: AttributePattern -> Parser SymbolOrAlias
 getSymbolOrAlias kore =
-    case Recursive.project kore of
-        _ :< ApplicationF app
-          | [] <- applicationChildren -> return symbol
-          | otherwise ->
-            Kore.Error.withLocationAndContext
-                symbol
-                ("symbol '" <> Text.pack (show symbol) <> "'")
-                (Kore.Error.koreFail "expected zero arguments")
-          where
-            Application { applicationSymbolOrAlias = symbol } = app
-            Application { applicationChildren } = app
-        _ -> Kore.Error.koreFail "expected symbol or alias application"
+  case Recursive.project kore of
+    _ :< ApplicationF app
+      | [] <- applicationChildren -> return symbol
+      | otherwise ->
+        Kore.Error.withLocationAndContext
+          symbol
+          ("symbol '" <> Text.pack (show symbol) <> "'")
+          (Kore.Error.koreFail "expected zero arguments")
+      where
+        Application {applicationSymbolOrAlias = symbol} = app
+        Application {applicationChildren} = app
+    _ -> Kore.Error.koreFail "expected symbol or alias application"
 
 {- | Accept a string literal.
  -}
 getStringLiteral :: AttributePattern -> Parser StringLiteral
 getStringLiteral kore =
-    case Recursive.project kore of
-        _ :< StringLiteralF (Const lit) -> return lit
-        _ -> Kore.Error.koreFail "expected string literal pattern"
+  case Recursive.project kore of
+    _ :< StringLiteralF (Const lit) -> return lit
+    _ -> Kore.Error.koreFail "expected string literal pattern"
 
 {- | Parse a 'Text' through 'ReadS'.
 
@@ -271,23 +289,28 @@ See also: 'parseInteger'
  -}
 parseReadS :: ReadS a -> Text -> Parser a
 parseReadS aReadS (Text.unpack -> syntax) =
-    case aReadS syntax of
-        [ ] -> noParse
-        r : rs ->
-            case rs of
-                _ : _ -> ambiguousParse
-                _ | null unparsed -> return a
-                  | otherwise     -> incompleteParse unparsed
-          where
-            (a, unparsed) = r
+  case aReadS syntax of
+    [] -> noParse
+    r : rs ->
+      case rs of
+        _ : _ -> ambiguousParse
+        _
+          | null unparsed -> return a
+          | otherwise -> incompleteParse unparsed
+      where
+        (a, unparsed) = r
   where
     noParse = Kore.Error.koreFail ("failed to parse \"" ++ syntax ++ "\"")
     ambiguousParse =
-        Kore.Error.koreFail
-        $ "parsing \"" ++ syntax ++ "\" was ambiguous"
+      Kore.Error.koreFail
+        $ "parsing \""
+        ++ syntax
+        ++ "\" was ambiguous"
     incompleteParse unparsed =
-        Kore.Error.koreFail
-        $ "incomplete parse: failed to parse \"" ++ unparsed ++ "\""
+      Kore.Error.koreFail
+        $ "incomplete parse: failed to parse \""
+        ++ unparsed
+        ++ "\""
 
 {- | Parse an 'Integer' from a 'StringLiteral'.
  -}
@@ -301,33 +324,34 @@ entire argument is not consumed by the parser.
 
  -}
 parseSExpr
-    :: Text  -- ^ text representing an 'SExpr'
-    -> Parser SExpr
+  :: Text -- ^ text representing an 'SExpr'
+  -> Parser SExpr
 parseSExpr syntax =
-    case readSExprs syntax of
-        [] -> noParse
-        sExpr : rest ->
-            case rest of
-                [] -> return sExpr
-                _ -> incompleteParse
+  case readSExprs syntax of
+    [] -> noParse
+    sExpr : rest ->
+      case rest of
+        [] -> return sExpr
+        _ -> incompleteParse
   where
     noParse = Kore.Error.koreFail "failed to parse S-expression"
     incompleteParse = Kore.Error.koreFail "failed to parse entire argument"
 
 instance ParseAttributes Attribute.Smtlib where
-    parseAttribute =
-        withApplication' $ \params args Attribute.Smtlib { getSmtlib } -> do
-            getZeroParams params
-            arg <- getOneArgument args
-            StringLiteral syntax <- getStringLiteral arg
-            sExpr <- parseSExpr syntax
-            Monad.unless (Maybe.isNothing getSmtlib) failDuplicate'
-            return Attribute.Smtlib { getSmtlib = Just sExpr }
-      where
-        withApplication' = withApplication Attribute.smtlibId
-        failDuplicate' = failDuplicate Attribute.smtlibId
 
-    toAttributes =
-        Attributes
-        . maybe [] ((: []) . Attribute.smtlibAttribute . Text.pack . showSExpr)
-        . Attribute.getSmtlib
+  parseAttribute =
+    withApplication' $ \params args Attribute.Smtlib {getSmtlib} -> do
+      getZeroParams params
+      arg <- getOneArgument args
+      StringLiteral syntax <- getStringLiteral arg
+      sExpr <- parseSExpr syntax
+      Monad.unless (Maybe.isNothing getSmtlib) failDuplicate'
+      return Attribute.Smtlib {getSmtlib = Just sExpr}
+    where
+      withApplication' = withApplication Attribute.smtlibId
+      failDuplicate' = failDuplicate Attribute.smtlibId
+
+  toAttributes =
+    Attributes
+      . maybe [] ((: []) . Attribute.smtlibAttribute . Text.pack . showSExpr)
+      . Attribute.getSmtlib

--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -3,23 +3,24 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Pattern
-    ( Pattern (..)
-    , mapVariables
-    , traverseVariables
-    , deleteFreeVariable
-    ) where
+  ( Pattern (..),
+    mapVariables,
+    traverseVariables,
+    deleteFreeVariable
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Lens as Lens
-import           Data.Generics.Product
-import           Data.Hashable
-                 ( Hashable (..) )
-import qualified Generics.SOP as SOP
+import Data.Generics.Product
+import Data.Hashable
+  ( Hashable (..)
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.Defined
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Pattern.Function
@@ -27,23 +28,25 @@ import Kore.Attribute.Pattern.Functional
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
-       ( Sort )
+  ( Sort
+    )
 import Kore.Variables.UnifiedVariable
-       ( UnifiedVariable (..) )
+  ( UnifiedVariable (..)
+    )
 
 {- | @Pattern@ are the attributes of a pattern collected during verification.
  -}
-data Pattern variable =
-    Pattern
-        { patternSort :: !Sort
+data Pattern variable
+  = Pattern
+      { patternSort :: !Sort,
         -- ^ The sort determined by the verifier.
-        , freeVariables :: !(FreeVariables variable)
+        freeVariables :: !(FreeVariables variable),
         -- ^ The free variables of the pattern.
-        , functional :: !Functional
-        , function :: !Function
-        , defined :: !Defined
+        functional :: !Functional,
+        function :: !Function,
+        defined :: !Defined
         }
-    deriving (Eq, GHC.Generic, Show)
+  deriving (Eq, GHC.Generic, Show)
 
 instance NFData variable => NFData (Pattern variable)
 
@@ -56,22 +59,22 @@ instance SOP.HasDatatypeInfo (Pattern variable)
 instance Debug variable => Debug (Pattern variable)
 
 instance
-    ( Synthetic Sort base
-    , Synthetic (FreeVariables variable) base
-    , Synthetic Functional base
-    , Synthetic Function base
-    , Synthetic Defined base
-    ) =>
-    Synthetic (Pattern variable) base
+  ( Synthetic Sort base,
+    Synthetic (FreeVariables variable) base,
+    Synthetic Functional base,
+    Synthetic Function base,
+    Synthetic Defined base
+    )
+  => Synthetic (Pattern variable) base
   where
-    synthetic base =
-        Pattern
-            { patternSort = synthetic (patternSort <$> base)
-            , freeVariables = synthetic (freeVariables <$> base)
-            , functional = synthetic (functional <$> base)
-            , function = synthetic (function <$> base)
-            , defined = synthetic (defined <$> base)
-            }
+  synthetic base =
+    Pattern
+      { patternSort = synthetic (patternSort <$> base),
+        freeVariables = synthetic (freeVariables <$> base),
+        functional = synthetic (functional <$> base),
+        function = synthetic (function <$> base),
+        defined = synthetic (defined <$> base)
+        }
 
 {- | Use the provided mapping to replace all variables in a 'Pattern'.
 
@@ -79,11 +82,12 @@ See also: 'traverseVariables'
 
  -}
 mapVariables
-    :: Ord variable2
-    => (variable1 -> variable2)
-    -> Pattern variable1 -> Pattern variable2
+  :: Ord variable2
+  => (variable1 -> variable2)
+  -> Pattern variable1
+  -> Pattern variable2
 mapVariables mapping =
-    Lens.over (field @"freeVariables") (mapFreeVariables mapping)
+  Lens.over (field @"freeVariables") (mapFreeVariables mapping)
 
 {- | Use the provided traversal to replace the free variables in a 'Pattern'.
 
@@ -91,20 +95,19 @@ See also: 'mapVariables'
 
  -}
 traverseVariables
-    ::  forall m variable1 variable2.
-        (Monad m, Ord variable2)
-    => (variable1 -> m variable2)
-    -> Pattern variable1
-    -> m (Pattern variable2)
+  :: forall m variable1 variable2. (Monad m, Ord variable2)
+  => (variable1 -> m variable2)
+  -> Pattern variable1
+  -> m (Pattern variable2)
 traverseVariables traversing =
-    field @"freeVariables" (traverseFreeVariables traversing)
+  field @"freeVariables" (traverseFreeVariables traversing)
 
 {- | Delete the given variable from the set of free variables.
  -}
 deleteFreeVariable
-    :: Ord variable
-    => UnifiedVariable variable
-    -> Pattern variable
-    -> Pattern variable
+  :: Ord variable
+  => UnifiedVariable variable
+  -> Pattern variable
+  -> Pattern variable
 deleteFreeVariable variable =
-    Lens.over (field @"freeVariables") (bindVariable variable)
+  Lens.over (field @"freeVariables") (bindVariable variable)

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -3,34 +3,34 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Pattern.Defined
-    ( Defined (..)
-    ) where
+  ( Defined (..)
+    )
+where
 
-import           Control.DeepSeq
+import Control.DeepSeq
 import qualified Data.Foldable as Foldable
-import           Data.Functor.Const
-import           Data.Hashable
+import Data.Functor.Const
+import Data.Hashable
 import qualified Data.Map as Map
-import           Data.Monoid
-import qualified Generics.SOP as SOP
+import Data.Monoid
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
-import           Kore.Domain.Builtin
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Domain.Builtin
 import qualified Kore.Internal.Alias as Internal
 import qualified Kore.Internal.Symbol as Internal
-import           Kore.Syntax
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Syntax
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 {- | A pattern is 'Defined' if it matches at least one element.
  -}
-newtype Defined = Defined { isDefined :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
-    deriving (Semigroup, Monoid) via All
+newtype Defined = Defined {isDefined :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Semigroup, Monoid) via All
 
 instance SOP.Generic Defined
 
@@ -43,153 +43,157 @@ instance NFData Defined
 instance Hashable Defined
 
 instance Synthetic Defined (And sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Bottom sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Defined' if the symbol is total and its
 -- arguments are 'Defined'.
 instance Synthetic Defined (Application Internal.Symbol) where
-    synthetic application =
-        functionSymbol <> Foldable.fold children
-      where
-        functionSymbol = Defined (Internal.isTotal symbol)
-        children = applicationChildren application
-        symbol = applicationSymbolOrAlias application
+  synthetic application =
+    functionSymbol <> Foldable.fold children
+    where
+      functionSymbol = Defined (Internal.isTotal symbol)
+      children = applicationChildren application
+      symbol = applicationSymbolOrAlias application
 
 instance Synthetic Defined (Application Internal.Alias) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Ceil sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' patterns is 'Defined' if its argument is 'Defined'.
 instance Synthetic Defined (DomainValue sort) where
-    synthetic = domainValueChild
-    {-# INLINE synthetic #-}
+  synthetic = domainValueChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Equals sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Exists sort variable) where
-    synthetic = const (Defined False)
+  synthetic = const (Defined False)
 
 instance Synthetic Defined (Floor sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Forall sort variable) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Iff sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Implies sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (In sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Mu sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Next' pattern is 'Defined' if its argument is 'Defined'.
 instance Synthetic Defined (Next sort) where
-    synthetic = nextChild
-    {-# INLINE synthetic #-}
+  synthetic = nextChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Not sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Nu sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 -- | An 'Or' pattern is 'Defined' if any of its subterms is 'Defined'.
 instance Synthetic Defined (Or sort) where
-    synthetic = Defined . getAny . Foldable.foldMap (Any . isDefined)
-    {-# INLINE synthetic #-}
+  synthetic = Defined . getAny . Foldable.foldMap (Any . isDefined)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Defined (Rewrites sort) where
-    synthetic = const (Defined False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is defined if its subterms are 'Defined'.
 instance Synthetic Defined (Builtin key) where
-    synthetic
-        (BuiltinSet InternalAc
-            {builtinAcChild = NormalizedSet builtinSetChild}
-        )
-      = normalizedAcDefined builtinSetChild
-    synthetic
-        (BuiltinMap InternalAc
-            {builtinAcChild = NormalizedMap builtinMapChild}
-        )
-      = normalizedAcDefined builtinMapChild
-    synthetic builtin = Foldable.fold builtin
-    {-# INLINE synthetic #-}
+  synthetic
+    ( BuiltinSet
+        InternalAc
+          { builtinAcChild = NormalizedSet builtinSetChild
+            }
+      ) =
+      normalizedAcDefined builtinSetChild
+  synthetic
+    ( BuiltinMap
+        InternalAc
+          { builtinAcChild = NormalizedMap builtinMapChild
+            }
+      ) =
+      normalizedAcDefined builtinMapChild
+  synthetic builtin = Foldable.fold builtin
+  {-# INLINE synthetic #-}
 
 normalizedAcDefined
-    :: (Foldable (Element collection), Foldable (Value collection))
-    => NormalizedAc collection key Defined -> Defined
+  :: (Foldable (Element collection), Foldable (Value collection))
+  => NormalizedAc collection key Defined
+  -> Defined
 normalizedAcDefined ac@(NormalizedAc _ _ _) =
-    case ac of
-        NormalizedAc
-            { elementsWithVariables = []
-            , opaque = []
-            } -> sameAsChildren
-        NormalizedAc
-            { elementsWithVariables = [_]
-            , concreteElements
-            , opaque = []
-            }
-          | Map.null concreteElements -> sameAsChildren
-        NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements
-            , opaque = [_]
-            }
-          | Map.null concreteElements -> sameAsChildren
-        _ -> Defined False
+  case ac of
+    NormalizedAc
+      { elementsWithVariables = [],
+        opaque = []
+        } -> sameAsChildren
+    NormalizedAc
+      { elementsWithVariables = [_],
+        concreteElements,
+        opaque = []
+        }
+        | Map.null concreteElements -> sameAsChildren
+    NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements,
+        opaque = [_]
+        }
+        | Map.null concreteElements -> sameAsChildren
+    _ -> Defined False
   where
     sameAsChildren = Foldable.fold ac
 
-
 -- | A 'Top' pattern is always 'Defined'.
 instance Synthetic Defined (Top sort) where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined True)
+  {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Defined'.
 instance Synthetic Defined (Const StringLiteral) where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined True)
+  {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Defined'.
 instance Synthetic Defined (Const CharLiteral) where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined True)
+  {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is always 'Defined'.
 instance Synthetic Defined Inhabitant where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Defined True)
+  {-# INLINE synthetic #-}
 
 -- | An element variable pattern is always 'Defined'.
 --   A set variable is not.
 instance Synthetic Defined (Const (UnifiedVariable variable)) where
-    synthetic (Const (ElemVar _))= Defined True
-    synthetic (Const (SetVar _))= Defined False
-    {-# INLINE synthetic #-}
+  synthetic (Const (ElemVar _)) = Defined True
+  synthetic (Const (SetVar _)) = Defined False
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
@@ -3,40 +3,41 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Pattern.FreeVariables
-    ( FreeVariables (..)
-    , freeVariable
-    , isFreeVariable
-    , bindVariable
-    , mapFreeVariables
-    , traverseFreeVariables
-    , getFreeElementVariables
-    ) where
+  ( FreeVariables (..),
+    freeVariable,
+    isFreeVariable,
+    bindVariable,
+    mapFreeVariables,
+    traverseFreeVariables,
+    getFreeElementVariables
+    )
+where
 
-import           Control.DeepSeq
-import           Data.Functor.Const
-import           Data.Hashable
-import           Data.Maybe
-                 ( mapMaybe )
-import           Data.Set
-                 ( Set )
+import Control.DeepSeq
+import Data.Functor.Const
+import Data.Hashable
+import Data.Maybe
+  ( mapMaybe
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
 import qualified Data.Traversable as Traversable
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Syntax.ElementVariable
 import Kore.Variables.UnifiedVariable
 
-newtype FreeVariables variable =
-    FreeVariables { getFreeVariables :: Set (UnifiedVariable variable) }
-    deriving GHC.Generic
-    deriving (Eq, Show)
-    deriving Foldable
-    deriving (Semigroup, Monoid)
+newtype FreeVariables variable
+  = FreeVariables {getFreeVariables :: Set (UnifiedVariable variable)}
+  deriving (GHC.Generic)
+  deriving (Eq, Show)
+  deriving (Foldable)
+  deriving (Semigroup, Monoid)
 
 instance SOP.Generic (FreeVariables variable)
 
@@ -47,52 +48,57 @@ instance Debug variable => Debug (FreeVariables variable)
 instance NFData variable => NFData (FreeVariables variable)
 
 instance Hashable variable => Hashable (FreeVariables variable) where
-    hashWithSalt salt (FreeVariables freeVariables) =
-        hashWithSalt salt (Set.toList freeVariables)
+  hashWithSalt salt (FreeVariables freeVariables) =
+    hashWithSalt salt (Set.toList freeVariables)
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Const (UnifiedVariable variable))
+  Ord variable
+  => Synthetic (FreeVariables variable) (Const (UnifiedVariable variable))
   where
-    synthetic (Const var) = freeVariable var
-    {-# INLINE synthetic #-}
+  synthetic (Const var) = freeVariable var
+  {-# INLINE synthetic #-}
 
 bindVariable
-    :: Ord variable
-    => UnifiedVariable variable
-    -> FreeVariables variable
-    -> FreeVariables variable
+  :: Ord variable
+  => UnifiedVariable variable
+  -> FreeVariables variable
+  -> FreeVariables variable
 bindVariable variable (FreeVariables freeVariables) =
-    FreeVariables (Set.delete variable freeVariables)
+  FreeVariables (Set.delete variable freeVariables)
 {-# INLINE bindVariable #-}
 
 isFreeVariable
-    :: Ord variable
-    => UnifiedVariable variable -> FreeVariables variable -> Bool
+  :: Ord variable
+  => UnifiedVariable variable
+  -> FreeVariables variable
+  -> Bool
 isFreeVariable variable (FreeVariables freeVariables) =
-    Set.member variable freeVariables
+  Set.member variable freeVariables
 {-# INLINE isFreeVariable #-}
 
 freeVariable
-    :: Ord variable
-    => UnifiedVariable variable -> FreeVariables variable
+  :: Ord variable
+  => UnifiedVariable variable
+  -> FreeVariables variable
 freeVariable variable = FreeVariables (Set.singleton variable)
 {-# INLINE freeVariable #-}
 
 mapFreeVariables
-    :: Ord variable2
-    => (variable1 -> variable2)
-    -> FreeVariables variable1 -> FreeVariables variable2
+  :: Ord variable2
+  => (variable1 -> variable2)
+  -> FreeVariables variable1
+  -> FreeVariables variable2
 mapFreeVariables mapping (FreeVariables freeVariables) =
-    FreeVariables (Set.map (fmap mapping) freeVariables)
+  FreeVariables (Set.map (fmap mapping) freeVariables)
 {-# INLINE mapFreeVariables #-}
 
 traverseFreeVariables
-    :: (Applicative f, Ord variable2)
-    => (variable1 -> f variable2)
-    -> FreeVariables variable1 -> f (FreeVariables variable2)
+  :: (Applicative f, Ord variable2)
+  => (variable1 -> f variable2)
+  -> FreeVariables variable1
+  -> f (FreeVariables variable2)
 traverseFreeVariables traversing (FreeVariables freeVariables) =
-    FreeVariables . Set.fromList
+  FreeVariables . Set.fromList
     <$> Traversable.traverse (traverse traversing) (Set.toList freeVariables)
 {-# INLINE traverseFreeVariables #-}
 
@@ -100,4 +106,4 @@ traverseFreeVariables traversing (FreeVariables freeVariables) =
 -}
 getFreeElementVariables :: FreeVariables variable -> [ElementVariable variable]
 getFreeElementVariables =
-    mapMaybe extractElementVariable . Set.toList . getFreeVariables
+  mapMaybe extractElementVariable . Set.toList . getFreeVariables

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -3,33 +3,33 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Pattern.Function
-    ( Function (..)
-    ) where
+  ( Function (..)
+    )
+where
 
-import           Control.DeepSeq
+import Control.DeepSeq
 import qualified Data.Foldable as Foldable
-import           Data.Functor.Const
-import           Data.Hashable
-import           Data.Monoid
-import qualified Generics.SOP as SOP
+import Data.Functor.Const
+import Data.Hashable
+import Data.Monoid
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
-import           Kore.Domain.Builtin
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Domain.Builtin
 import qualified Kore.Internal.Alias as Internal
 import qualified Kore.Internal.Symbol as Internal
-import           Kore.Syntax
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Syntax
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 {- | A pattern is 'Function' if it matches zero or one elements.
  -}
-newtype Function = Function { isFunction :: Bool }
-    deriving (Eq, GHC.Generic, Show)
-    deriving (Semigroup, Monoid) via All
+newtype Function = Function {isFunction :: Bool}
+  deriving (Eq, GHC.Generic, Show)
+  deriving (Semigroup, Monoid) via All
 
 instance SOP.Generic Function
 
@@ -42,116 +42,116 @@ instance NFData Function
 instance Hashable Function
 
 instance Synthetic Function (And sort) where
-    -- TODO (thomas.tuegel):
-    -- synthetic = getAny . Foldable.foldMap (Any . isFunction)
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  -- TODO (thomas.tuegel):
+  -- synthetic = getAny . Foldable.foldMap (Any . isFunction)
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Bottom' pattern is always 'Function'.
 instance Synthetic Function (Bottom sort) where
-    synthetic = const (Function True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function True)
+  {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Function' if its symbol is a function and its
 -- arguments are 'Function'.
 instance Synthetic Function (Application Internal.Symbol) where
-    synthetic application =
-        functionSymbol <> Foldable.fold children
-      where
-        functionSymbol = Function (Internal.isFunction symbol)
-        children = applicationChildren application
-        symbol = applicationSymbolOrAlias application
+  synthetic application =
+    functionSymbol <> Foldable.fold children
+    where
+      functionSymbol = Function (Internal.isFunction symbol)
+      children = applicationChildren application
+      symbol = applicationSymbolOrAlias application
 
 instance Synthetic Function (Application Internal.Alias) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Ceil sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' pattern is 'Function' if its argument is 'Function'.
 instance Synthetic Function (DomainValue sort) where
-    synthetic = domainValueChild
-    {-# INLINE synthetic #-}
+  synthetic = domainValueChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Equals sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Exists sort variable) where
-    synthetic = const (Function False)
+  synthetic = const (Function False)
 
 instance Synthetic Function (Floor sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Forall sort variable) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Iff sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Implies sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (In sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Mu sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Next sort) where
-    synthetic = nextChild
-    {-# INLINE synthetic #-}
+  synthetic = nextChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Not sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Nu sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Or sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Rewrites sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is 'Function' if its subterms are 'Function'.
 instance Synthetic Function (Builtin key) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Function (Top sort) where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Function'.
 instance Synthetic Function (Const StringLiteral) where
-    synthetic = const (Function True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function True)
+  {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Function'.
 instance Synthetic Function (Const CharLiteral) where
-    synthetic = const (Function True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function True)
+  {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is never 'Function'.
 instance Synthetic Function Inhabitant where
-    synthetic = const (Function False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Function False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Variable' pattern is always 'Function'.
 instance Synthetic Function (Const (UnifiedVariable variable)) where
-    synthetic (Const (ElemVar _)) = Function True
-    synthetic (Const (SetVar _)) = Function False
-    {-# INLINE synthetic #-}
+  synthetic (Const (ElemVar _)) = Function True
+  synthetic (Const (SetVar _)) = Function False
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -3,34 +3,34 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Pattern.Functional
-    ( Functional (..)
-    ) where
+  ( Functional (..)
+    )
+where
 
-import           Control.DeepSeq
+import Control.DeepSeq
 import qualified Data.Foldable as Foldable
-import           Data.Functor.Const
-import           Data.Hashable
+import Data.Functor.Const
+import Data.Hashable
 import qualified Data.Map as Map
-import           Data.Monoid
-import qualified Generics.SOP as SOP
+import Data.Monoid
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
-import           Kore.Domain.Builtin
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Domain.Builtin
 import qualified Kore.Internal.Alias as Internal
 import qualified Kore.Internal.Symbol as Internal
-import           Kore.Syntax
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Syntax
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 {- | A pattern is 'Functional' if it matches exactly one element.
  -}
-newtype Functional = Functional { isFunctional :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
-    deriving (Semigroup, Monoid) via All
+newtype Functional = Functional {isFunctional :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Semigroup, Monoid) via All
 
 instance SOP.Generic Functional
 
@@ -43,152 +43,157 @@ instance NFData Functional
 instance Hashable Functional
 
 instance Synthetic Functional (And sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Bottom sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 -- | An 'Application' pattern is 'Functional' if its symbol is functional and
 -- its arguments are 'Functional'.
 instance Synthetic Functional (Application Internal.Symbol) where
-    synthetic application =
-        functionalSymbol <> Foldable.fold children
-      where
-        functionalSymbol = Functional (Internal.isFunctional symbol)
-        children = applicationChildren application
-        symbol = applicationSymbolOrAlias application
+  synthetic application =
+    functionalSymbol <> Foldable.fold children
+    where
+      functionalSymbol = Functional (Internal.isFunctional symbol)
+      children = applicationChildren application
+      symbol = applicationSymbolOrAlias application
 
 instance Synthetic Functional (Application Internal.Alias) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Ceil sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 -- | A 'DomainValue' pattern is 'Functional' if its argument is 'Functional'.
 instance Synthetic Functional (DomainValue sort) where
-    synthetic = domainValueChild
-    {-# INLINE synthetic #-}
+  synthetic = domainValueChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Equals sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Exists sort variable) where
-    synthetic = const (Functional False)
+  synthetic = const (Functional False)
 
 instance Synthetic Functional (Floor sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Forall sort variable) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Iff sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Implies sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (In sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Mu sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Next sort) where
-    synthetic = nextChild
-    {-# INLINE synthetic #-}
+  synthetic = nextChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Not sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Nu sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Or sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Rewrites sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Builtin' pattern is 'Functional' if its subterms are 'Functional'.
 instance Synthetic Functional (Builtin key) where
-    synthetic
-        (BuiltinSet InternalAc
-            {builtinAcChild = NormalizedSet builtinSetChild}
-        )
-      = normalizedAcFunctional builtinSetChild
-    synthetic
-        (BuiltinMap InternalAc
-            {builtinAcChild = NormalizedMap builtinMapChild}
-        )
-      = normalizedAcFunctional builtinMapChild
-    synthetic builtin = Foldable.fold builtin
-    {-# INLINE synthetic #-}
+  synthetic
+    ( BuiltinSet
+        InternalAc
+          { builtinAcChild = NormalizedSet builtinSetChild
+            }
+      ) =
+      normalizedAcFunctional builtinSetChild
+  synthetic
+    ( BuiltinMap
+        InternalAc
+          { builtinAcChild = NormalizedMap builtinMapChild
+            }
+      ) =
+      normalizedAcFunctional builtinMapChild
+  synthetic builtin = Foldable.fold builtin
+  {-# INLINE synthetic #-}
 
 normalizedAcFunctional
-    :: (Foldable (Element collection), Foldable (Value collection))
-    => NormalizedAc collection key Functional -> Functional
+  :: (Foldable (Element collection), Foldable (Value collection))
+  => NormalizedAc collection key Functional
+  -> Functional
 normalizedAcFunctional ac@(NormalizedAc _ _ _) =
-    case ac of
-        NormalizedAc
-            { elementsWithVariables = []
-            , opaque = []
-            } -> sameAsChildren
-        NormalizedAc
-            { elementsWithVariables = [_]
-            , concreteElements
-            , opaque = []
-            }
-          | Map.null concreteElements -> sameAsChildren
-        NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements
-            , opaque = [_]
-            }
-          | Map.null concreteElements -> sameAsChildren
-        _ -> Functional False
+  case ac of
+    NormalizedAc
+      { elementsWithVariables = [],
+        opaque = []
+        } -> sameAsChildren
+    NormalizedAc
+      { elementsWithVariables = [_],
+        concreteElements,
+        opaque = []
+        }
+        | Map.null concreteElements -> sameAsChildren
+    NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements,
+        opaque = [_]
+        }
+        | Map.null concreteElements -> sameAsChildren
+    _ -> Functional False
   where
     sameAsChildren = Foldable.fold ac
 
 instance Synthetic Functional (Top sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 -- | A 'Variable' pattern is always 'Functional'.
 instance Synthetic Functional (Const (UnifiedVariable variable)) where
-    synthetic (Const (ElemVar _)) = Functional True
-    synthetic (Const (SetVar _)) = Functional False
-    {-# INLINE synthetic #-}
+  synthetic (Const (ElemVar _)) = Functional True
+  synthetic (Const (SetVar _)) = Functional False
+  {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Functional'.
 instance Synthetic Functional (Const StringLiteral) where
-    synthetic = const (Functional True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional True)
+  {-# INLINE synthetic #-}
 
 -- | A 'CharLiteral' pattern is always 'Functional'.
 instance Synthetic Functional (Const CharLiteral) where
-    synthetic = const (Functional True)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional True)
+  {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is never 'Functional'.
 instance Synthetic Functional Inhabitant where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}
 
 instance Synthetic Functional (Const Sort) where
-    synthetic = const (Functional False)
-    {-# INLINE synthetic #-}
+  synthetic = const (Functional False)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Attribute/ProductionID.hs
+++ b/kore/src/Kore/Attribute/ProductionID.hs
@@ -7,24 +7,27 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.ProductionID
-    ( ProductionID (..)
-    , productionIDId, productionIDSymbol, productionIDAttribute
-    ) where
+  ( ProductionID (..),
+    productionIDId,
+    productionIDSymbol,
+    productionIDAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
 import qualified Data.Maybe as Maybe
-import           Data.Text
-                 ( Text )
-import qualified Generics.SOP as SOP
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @ProductionID@ represents the @productionID@ attribute.
  -}
-newtype ProductionID = ProductionID { getProductionID :: Maybe Text }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype ProductionID = ProductionID {getProductionID :: Maybe Text}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic ProductionID
 
@@ -35,7 +38,7 @@ instance Debug ProductionID
 instance NFData ProductionID
 
 instance Default ProductionID where
-    def = ProductionID Nothing
+  def = ProductionID Nothing
 
 -- | Kore identifier representing the @productionID@ attribute symbol.
 productionIDId :: Id
@@ -44,29 +47,30 @@ productionIDId = "productionID"
 -- | Kore symbol representing the @productionID@ attribute.
 productionIDSymbol :: SymbolOrAlias
 productionIDSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = productionIDId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = productionIDId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing a @productionID@ attribute.
 productionIDAttribute :: Text -> AttributePattern
 productionIDAttribute name =
-    attributePattern productionIDSymbol [attributeString name]
+  attributePattern productionIDSymbol [attributeString name]
 
 instance ParseAttributes ProductionID where
-    parseAttribute =
-        withApplication' $ \params args (ProductionID productionID) -> do
-            Parser.getZeroParams params
-            arg <- Parser.getOneArgument args
-            StringLiteral name <- Parser.getStringLiteral arg
-            Monad.unless (Maybe.isNothing productionID) failDuplicate'
-            return ProductionID { getProductionID = Just name }
-      where
-        withApplication' = Parser.withApplication productionIDId
-        failDuplicate' = Parser.failDuplicate productionIDId
 
-    toAttributes =
-        maybe def toAttribute . getProductionID
-      where
-        toAttribute = Attributes . (: []) . productionIDAttribute
+  parseAttribute =
+    withApplication' $ \params args (ProductionID productionID) -> do
+      Parser.getZeroParams params
+      arg <- Parser.getOneArgument args
+      StringLiteral name <- Parser.getStringLiteral arg
+      Monad.unless (Maybe.isNothing productionID) failDuplicate'
+      return ProductionID {getProductionID = Just name}
+    where
+      withApplication' = Parser.withApplication productionIDId
+      failDuplicate' = Parser.failDuplicate productionIDId
+
+  toAttributes =
+    maybe def toAttribute . getProductionID
+    where
+      toAttribute = Attributes . (: []) . productionIDAttribute

--- a/kore/src/Kore/Attribute/RuleIndex.hs
+++ b/kore/src/Kore/Attribute/RuleIndex.hs
@@ -5,22 +5,23 @@ License     : NCSA
 
 -}
 module Kore.Attribute.RuleIndex
-    ( RuleIndex (..)
-    ) where
+  ( RuleIndex (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Default
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Default
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 
 {- | This attribute is used in the REPL for tagging
     and uniquely identifiying axioms and claims.
  -}
-newtype RuleIndex = RuleIndex { getRuleIndex :: Maybe Int }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype RuleIndex = RuleIndex {getRuleIndex :: Maybe Int}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic RuleIndex
 
@@ -31,4 +32,4 @@ instance Debug RuleIndex
 instance NFData RuleIndex
 
 instance Default RuleIndex where
-    def = RuleIndex Nothing
+  def = RuleIndex Nothing

--- a/kore/src/Kore/Attribute/Simplification.hs
+++ b/kore/src/Kore/Attribute/Simplification.hs
@@ -17,21 +17,23 @@ Informal example of an axiom that would use the simplification attribute:
     if concrete(x) and concrete(z) and not concrete(y)
 -}
 module Kore.Attribute.Simplification
-    ( Simplification (..)
-    , simplificationId, simplificationSymbol, simplificationAttribute
-    ) where
+  ( Simplification (..),
+    simplificationId,
+    simplificationSymbol,
+    simplificationAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Simplification@ represents the @simplification@ attribute for axioms.
  -}
-newtype Simplification = Simplification { isSimplification :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Simplification = Simplification {isSimplification :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Simplification
 
@@ -42,7 +44,7 @@ instance Debug Simplification
 instance NFData Simplification
 
 instance Default Simplification where
-    def = Simplification False
+  def = Simplification False
 
 -- | Kore identifier representing the @simplification@ attribute symbol.
 simplificationId :: Id
@@ -51,25 +53,26 @@ simplificationId = "simplification"
 -- | Kore symbol representing the @simplification@ attribute.
 simplificationSymbol :: SymbolOrAlias
 simplificationSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = simplificationId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = simplificationId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @simplification@ attribute.
 simplificationAttribute :: AttributePattern
 simplificationAttribute = attributePattern_ simplificationSymbol
 
 instance ParseAttributes Simplification where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Simplification { isSimplification } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isSimplification failDuplicate'
-            return Simplification { isSimplification = True }
-        withApplication' = Parser.withApplication simplificationId
-        failDuplicate' = Parser.failDuplicate simplificationId
 
-    toAttributes Simplification { isSimplification } =
-        Attributes [simplificationAttribute | isSimplification]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Simplification {isSimplification} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isSimplification failDuplicate'
+        return Simplification {isSimplification = True}
+      withApplication' = Parser.withApplication simplificationId
+      failDuplicate' = Parser.failDuplicate simplificationId
+
+  toAttributes Simplification {isSimplification} =
+    Attributes [simplificationAttribute | isSimplification]

--- a/kore/src/Kore/Attribute/SmtLemma.hs
+++ b/kore/src/Kore/Attribute/SmtLemma.hs
@@ -7,20 +7,22 @@ Maintainer  : phillip.harris@runtimeverification.com
 
 -}
 module Kore.Attribute.SmtLemma
-    ( SmtLemma (..)
-    , smtLemmaId, smtLemmaSymbol, smtLemmaAttribute
-    ) where
+  ( SmtLemma (..),
+    smtLemmaId,
+    smtLemmaSymbol,
+    smtLemmaAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @SmtLemma@ represents the @smt-lemma@ attribute for symbols.
-newtype SmtLemma = SmtLemma { isSmtLemma :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype SmtLemma = SmtLemma {isSmtLemma :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic SmtLemma
 
@@ -29,7 +31,7 @@ instance SOP.HasDatatypeInfo SmtLemma
 instance Debug SmtLemma
 
 instance Default SmtLemma where
-    def = SmtLemma False
+  def = SmtLemma False
 
 instance NFData SmtLemma
 
@@ -40,25 +42,26 @@ smtLemmaId = "smt-lemma"
 -- | Kore symbol representing the @smt-lemma@ attribute.
 smtLemmaSymbol :: SymbolOrAlias
 smtLemmaSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = smtLemmaId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = smtLemmaId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @smt-lemma@ attribute.
 smtLemmaAttribute :: AttributePattern
 smtLemmaAttribute = attributePattern_ smtLemmaSymbol
 
 instance ParseAttributes SmtLemma where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args SmtLemma { isSmtLemma } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isSmtLemma failDuplicate'
-            return SmtLemma { isSmtLemma = True }
-        withApplication' = Parser.withApplication smtLemmaId
-        failDuplicate' = Parser.failDuplicate smtLemmaId
 
-    toAttributes SmtLemma { isSmtLemma } =
-        Attributes [smtLemmaAttribute | isSmtLemma]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args SmtLemma {isSmtLemma} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isSmtLemma failDuplicate'
+        return SmtLemma {isSmtLemma = True}
+      withApplication' = Parser.withApplication smtLemmaId
+      failDuplicate' = Parser.failDuplicate smtLemmaId
+
+  toAttributes SmtLemma {isSmtLemma} =
+    Attributes [smtLemmaAttribute | isSmtLemma]

--- a/kore/src/Kore/Attribute/Smthook.hs
+++ b/kore/src/Kore/Attribute/Smthook.hs
@@ -7,7 +7,8 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Smthook
-    ( module Kore.Attribute.Smtlib.Smthook
-    ) where
+  ( module Kore.Attribute.Smtlib.Smthook
+    )
+where
 
 import Kore.Attribute.Smtlib.Smthook

--- a/kore/src/Kore/Attribute/Smtlib/Smthook.hs
+++ b/kore/src/Kore/Attribute/Smtlib/Smthook.hs
@@ -7,28 +7,37 @@ Maintainer  : traian.serbanuta@runtimeverification.com
 
 -}
 module Kore.Attribute.Smtlib.Smthook
-    ( Smthook (..), SExpr (..)
-    , smthookId, smthookSymbol, smthookAttribute
-    ) where
+  ( Smthook (..),
+    SExpr (..),
+    smthookId,
+    smthookSymbol,
+    smthookAttribute
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Monad as Monad
-import           Data.Default
-                 ( Default (..) )
+import Data.Default
+  ( Default (..)
+    )
 import qualified Data.Maybe as Maybe
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser
 import Kore.Debug
 import Kore.Syntax.Id
-       ( Id )
+  ( Id
+    )
 import SMT.SimpleSMT
-       ( SExpr (..), showSExpr )
+  ( SExpr (..),
+    showSExpr
+    )
 
 {- | The @smthook@ attribute for symbols.
 
@@ -41,11 +50,11 @@ used for encoding needs not be declared.
 See 'Kore.Attribute.Smtlib.Smtlib'
 
  -}
-newtype Smthook = Smthook { getSmthook :: Maybe SExpr }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Smthook = Smthook {getSmthook :: Maybe SExpr}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Default Smthook where
-    def = Smthook Nothing
+  def = Smthook Nothing
 
 instance NFData Smthook
 
@@ -62,30 +71,31 @@ smthookId = "smt-hook"
 -- | Kore symbol representing the @smthook@ attribute.
 smthookSymbol :: SymbolOrAlias
 smthookSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = smthookId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = smthookId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @smthook@ attribute.
 smthookAttribute :: Text -> AttributePattern
 smthookAttribute syntax =
-    attributePattern smthookSymbol [attributeString syntax]
+  attributePattern smthookSymbol [attributeString syntax]
 
 instance ParseAttributes Smthook where
-    parseAttribute =
-        withApplication' $ \params args Smthook { getSmthook } -> do
-            getZeroParams params
-            arg <- getOneArgument args
-            StringLiteral syntax <- getStringLiteral arg
-            sExpr <- parseSExpr syntax
-            Monad.unless (Maybe.isNothing getSmthook) failDuplicate'
-            return Smthook { getSmthook = Just sExpr }
-      where
-        withApplication' = withApplication smthookId
-        failDuplicate' = failDuplicate smthookId
 
-    toAttributes =
-        Attributes
-        . maybe [] ((: []) . smthookAttribute . Text.pack . showSExpr)
-        . getSmthook
+  parseAttribute =
+    withApplication' $ \params args Smthook {getSmthook} -> do
+      getZeroParams params
+      arg <- getOneArgument args
+      StringLiteral syntax <- getStringLiteral arg
+      sExpr <- parseSExpr syntax
+      Monad.unless (Maybe.isNothing getSmthook) failDuplicate'
+      return Smthook {getSmthook = Just sExpr}
+    where
+      withApplication' = withApplication smthookId
+      failDuplicate' = failDuplicate smthookId
+
+  toAttributes =
+    Attributes
+      . maybe [] ((: []) . smthookAttribute . Text.pack . showSExpr)
+      . getSmthook

--- a/kore/src/Kore/Attribute/Smtlib/Smtlib.hs
+++ b/kore/src/Kore/Attribute/Smtlib/Smtlib.hs
@@ -7,29 +7,35 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Smtlib.Smtlib
-    ( Smtlib (..)
-    , smtlibId
-    , smtlibSymbol
-    , smtlibAttribute
-    ) where
+  ( Smtlib (..),
+    smtlibId,
+    smtlibSymbol,
+    smtlibAttribute
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Default
-                 ( Default (..) )
-import           Data.Text
-                 ( Text )
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Default
+  ( Default (..)
+    )
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Attributes
 import Kore.Debug
 import Kore.Syntax.Application
-       ( SymbolOrAlias (..) )
+  ( SymbolOrAlias (..)
+    )
 import Kore.Syntax.Id
-       ( Id )
+  ( Id
+    )
 import SMT.SimpleSMT
-       ( SExpr )
+  ( SExpr
+    )
 
 {- | The @smtlib@ attribute for symbols.
 
@@ -47,11 +53,11 @@ meta-variable symbols are only valid in the @smtlib@ attribute; they are /not/
 valid SMT-LIB S-expressions.
 
  -}
-newtype Smtlib = Smtlib { getSmtlib :: Maybe SExpr }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Smtlib = Smtlib {getSmtlib :: Maybe SExpr}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Default Smtlib where
-    def = Smtlib Nothing
+  def = Smtlib Nothing
 
 instance NFData Smtlib
 
@@ -68,12 +74,12 @@ smtlibId = "smtlib"
 -- | Kore symbol representing the @smtlib@ attribute.
 smtlibSymbol :: SymbolOrAlias
 smtlibSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = smtlibId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = smtlibId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @smtlib@ attribute.
 smtlibAttribute :: Text -> AttributePattern
 smtlibAttribute syntax =
-    attributePattern smtlibSymbol [attributeString syntax]
+  attributePattern smtlibSymbol [attributeString syntax]

--- a/kore/src/Kore/Attribute/Sort.hs
+++ b/kore/src/Kore/Attribute/Sort.hs
@@ -6,75 +6,79 @@ License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
-
 module Kore.Attribute.Sort
-    ( Sort (..)
-    ) where
+  ( Sort (..)
+    )
+where
 
 import qualified Control.Monad as Monad
-import           Data.Generics.Product
-import           Prelude hiding
-                 ( concat )
-
+import Data.Generics.Product
 import Kore.Attribute.Hook
 import Kore.Attribute.Parser hiding
-       ( Sort )
+  ( Sort
+    )
 import Kore.Attribute.Smtlib.Smtlib
 import Kore.Attribute.Sort.Concat
 import Kore.Attribute.Sort.Element
 import Kore.Attribute.Sort.HasDomainValues
-       ( HasDomainValues )
+  ( HasDomainValues
+    )
 import Kore.Attribute.Sort.Unit
+import Prelude hiding
+  ( concat
+    )
 
-data Sort =
-    Sort
-        { hook            :: !Hook
+data Sort
+  = Sort
+      { hook :: !Hook,
         -- ^ The builtin sort hooked to the sort.
-        , smtlib          :: !Smtlib
+        smtlib :: !Smtlib,
         -- ^ The user-defined translation of the sort for SMT.
-        , unit            :: !Unit
+        unit :: !Unit,
         -- ^ The unit symbol associated with the sort.
-        , element         :: !Element
+        element :: !Element,
         -- ^ The element symbol associated with the sort.
-        , concat          :: !Concat
+        concat :: !Concat,
         -- ^ The concat symbol associated with the sort.
-        , hasDomainValues :: !HasDomainValues
+        hasDomainValues :: !HasDomainValues
         -- ^ whether the sort has domain values
         }
-    deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Ord, Show)
 
 instance NFData Sort
 
 defaultSortAttributes :: Sort
 defaultSortAttributes =
-    Sort
-        { hook            = def
-        , smtlib          = def
-        , unit            = def
-        , element         = def
-        , concat          = def
-        , hasDomainValues = def
-        }
+  Sort
+    { hook = def,
+      smtlib = def,
+      unit = def,
+      element = def,
+      concat = def,
+      hasDomainValues = def
+      }
 
 -- | See also: 'defaultSortAttributes'
 instance Default Sort where
-    def = defaultSortAttributes
+  def = defaultSortAttributes
 
 instance ParseAttributes Sort where
-    parseAttribute attr =
-        typed @Hook (parseAttribute attr)
-        Monad.>=> typed @Smtlib (parseAttribute attr)
-        Monad.>=> typed @Unit (parseAttribute attr)
-        Monad.>=> typed @Element (parseAttribute attr)
-        Monad.>=> typed @Concat (parseAttribute attr)
-        Monad.>=> typed @HasDomainValues (parseAttribute attr)
 
-    toAttributes =
-        mconcat . sequence
-            [ toAttributes . hook
-            , toAttributes . smtlib
-            , toAttributes . unit
-            , toAttributes . element
-            , toAttributes . concat
-            , toAttributes . hasDomainValues
+  parseAttribute attr =
+    typed @Hook (parseAttribute attr)
+      Monad.>=> typed @Smtlib (parseAttribute attr)
+      Monad.>=> typed @Unit (parseAttribute attr)
+      Monad.>=> typed @Element (parseAttribute attr)
+      Monad.>=> typed @Concat (parseAttribute attr)
+      Monad.>=> typed @HasDomainValues (parseAttribute attr)
+
+  toAttributes =
+    mconcat
+      . sequence
+          [ toAttributes . hook,
+            toAttributes . smtlib,
+            toAttributes . unit,
+            toAttributes . element,
+            toAttributes . concat,
+            toAttributes . hasDomainValues
             ]

--- a/kore/src/Kore/Attribute/Sort/Concat.hs
+++ b/kore/src/Kore/Attribute/Sort/Concat.hs
@@ -7,51 +7,57 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Sort.Concat
-    ( Concat (..)
-    , concatId, concatSymbol, concatAttribute
-    ) where
+  ( Concat (..),
+    concatId,
+    concatSymbol,
+    concatAttribute
+    )
+where
 
 import Control.DeepSeq
-       ( NFData )
+  ( NFData
+    )
 import Data.Default
 import GHC.Generics
-       ( Generic )
-
+  ( Generic
+    )
 import Kore.Attribute.Parser
 
 -- | @Concat@ represents the @concat@ attribute for sorts.
-newtype Concat = Concat { getConcat :: Maybe SymbolOrAlias }
-    deriving (Generic, Eq, Ord, Show)
+newtype Concat = Concat {getConcat :: Maybe SymbolOrAlias}
+  deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Concat where
-    (<>) a@(Concat (Just _)) _ = a
-    (<>) _                     b = b
+  (<>) a@(Concat (Just _)) _ = a
+  (<>) _ b = b
 
 instance Monoid Concat where
-    mempty = Concat { getConcat = Nothing }
+  mempty = Concat {getConcat = Nothing}
 
 instance Default Concat where
-    def = mempty
+  def = mempty
 
 instance NFData Concat
 
 instance ParseAttributes Concat where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Concat { getConcat }
-          | Just _ <- getConcat = failDuplicate'
-          | otherwise = do
+
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Concat {getConcat}
+        | Just _ <- getConcat = failDuplicate'
+        | otherwise =
+          do
             getZeroParams params
             arg <- getOneArgument args
             symbol <- getSymbolOrAlias arg
-            return Concat { getConcat = Just symbol }
-        withApplication' = withApplication concatId
-        failDuplicate' = failDuplicate concatId
+            return Concat {getConcat = Just symbol}
+      withApplication' = withApplication concatId
+      failDuplicate' = failDuplicate concatId
 
-    toAttributes =
-        maybe def toAttribute . getConcat
-      where
-        toAttribute = Attributes . (: []) . concatAttribute
+  toAttributes =
+    maybe def toAttribute . getConcat
+    where
+      toAttribute = Attributes . (: []) . concatAttribute
 
 -- | Kore identifier representing the @concat@ attribute symbol.
 concatId :: Id
@@ -60,12 +66,12 @@ concatId = "concat"
 -- | Kore symbol representing the @concat@ attribute.
 concatSymbol :: SymbolOrAlias
 concatSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = concatId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = concatId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @concat@ attribute.
 concatAttribute :: SymbolOrAlias -> AttributePattern
 concatAttribute symbol =
-    attributePattern concatSymbol [attributePattern_ symbol]
+  attributePattern concatSymbol [attributePattern_ symbol]

--- a/kore/src/Kore/Attribute/Sort/Element.hs
+++ b/kore/src/Kore/Attribute/Sort/Element.hs
@@ -3,31 +3,35 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 module Kore.Attribute.Sort.Element
-    ( Element (..)
-    , elementId, elementSymbol, elementAttribute
-    ) where
+  ( Element (..),
+    elementId,
+    elementSymbol,
+    elementAttribute
+    )
+where
 
 import Control.DeepSeq
-       ( NFData )
+  ( NFData
+    )
 import Data.Default
 import GHC.Generics
-       ( Generic )
-
+  ( Generic
+    )
 import Kore.Attribute.Parser
 
 -- | @Element@ represents the @element@ attribute for sorts.
-newtype Element = Element { getElement :: Maybe SymbolOrAlias }
-    deriving (Generic, Eq, Ord, Show)
+newtype Element = Element {getElement :: Maybe SymbolOrAlias}
+  deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Element where
-    (<>) a@(Element (Just _))  _ = a
-    (<>) _                     b = b
+  (<>) a@(Element (Just _)) _ = a
+  (<>) _ b = b
 
 instance Monoid Element where
-    mempty = Element { getElement = Nothing }
+  mempty = Element {getElement = Nothing}
 
 instance Default Element where
-    def = mempty
+  def = mempty
 
 instance NFData Element
 
@@ -38,30 +42,32 @@ elementId = "element"
 -- | Kore symbol representing the @element@ attribute.
 elementSymbol :: SymbolOrAlias
 elementSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = elementId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = elementId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @element@ attribute.
 elementAttribute :: SymbolOrAlias -> AttributePattern
 elementAttribute symbol =
-    attributePattern elementSymbol [attributePattern_ symbol]
+  attributePattern elementSymbol [attributePattern_ symbol]
 
 instance ParseAttributes Element where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Element { getElement }
-          | Just _ <- getElement = failDuplicate'
-          | otherwise = do
+
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Element {getElement}
+        | Just _ <- getElement = failDuplicate'
+        | otherwise =
+          do
             getZeroParams params
             arg <- getOneArgument args
             symbol <- getSymbolOrAlias arg
-            return Element { getElement = Just symbol }
-        withApplication' = withApplication elementId
-        failDuplicate' = failDuplicate elementId
+            return Element {getElement = Just symbol}
+      withApplication' = withApplication elementId
+      failDuplicate' = failDuplicate elementId
 
-    toAttributes =
-        maybe def toAttribute . getElement
-      where
-        toAttribute = Attributes . (: []) . elementAttribute
+  toAttributes =
+    maybe def toAttribute . getElement
+    where
+      toAttribute = Attributes . (: []) . elementAttribute

--- a/kore/src/Kore/Attribute/Sort/HasDomainValues.hs
+++ b/kore/src/Kore/Attribute/Sort/HasDomainValues.hs
@@ -5,31 +5,32 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Attribute.Sort.HasDomainValues
-    ( HasDomainValues (..)
-    , hasDomainValuesId, hasDomainValuesSymbol, hasDomainValuesAttribute
-    ) where
+  ( HasDomainValues (..),
+    hasDomainValuesId,
+    hasDomainValuesSymbol,
+    hasDomainValuesAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @HasDomainValues@ represents the @hasDomainValues@ attribute for symbols.
-newtype HasDomainValues = HasDomainValues { getHasDomainValues :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype HasDomainValues = HasDomainValues {getHasDomainValues :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup HasDomainValues where
-    (<>) (HasDomainValues a) (HasDomainValues b) = HasDomainValues (a || b)
+  (<>) (HasDomainValues a) (HasDomainValues b) = HasDomainValues (a || b)
 
 instance Monoid HasDomainValues where
-    mempty = HasDomainValues False
+  mempty = HasDomainValues False
 
 instance Default HasDomainValues where
-    def = mempty
+  def = mempty
 
 instance NFData HasDomainValues
 
@@ -46,27 +47,28 @@ hasDomainValuesId = "hasDomainValues"
 -- | Kore symbol representing the @hasDomainValues@ attribute.
 hasDomainValuesSymbol :: SymbolOrAlias
 hasDomainValuesSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = hasDomainValuesId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = hasDomainValuesId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @hasDomainValues@ attribute.
 hasDomainValuesAttribute :: AttributePattern
 hasDomainValuesAttribute = attributePattern hasDomainValuesSymbol []
 
 instance ParseAttributes HasDomainValues where
-    parseAttribute =
-        withApplication' $ \params args HasDomainValues { getHasDomainValues }
-            -> do
-                Parser.getZeroParams params
-                Parser.getZeroArguments args
-                Monad.when getHasDomainValues failDuplicate'
-                return HasDomainValues { getHasDomainValues = True }
-      where
-        withApplication' = Parser.withApplication hasDomainValuesId
-        failDuplicate' = Parser.failDuplicate hasDomainValuesId
 
-    toAttributes HasDomainValues { getHasDomainValues } =
-        Attributes $
-            if getHasDomainValues then [hasDomainValuesAttribute] else []
+  parseAttribute =
+    withApplication' $ \params args HasDomainValues {getHasDomainValues} ->
+      do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when getHasDomainValues failDuplicate'
+        return HasDomainValues {getHasDomainValues = True}
+    where
+      withApplication' = Parser.withApplication hasDomainValuesId
+      failDuplicate' = Parser.failDuplicate hasDomainValuesId
+
+  toAttributes HasDomainValues {getHasDomainValues} =
+    Attributes
+      $ if getHasDomainValues then [hasDomainValuesAttribute] else []

--- a/kore/src/Kore/Attribute/Sort/Unit.hs
+++ b/kore/src/Kore/Attribute/Sort/Unit.hs
@@ -7,51 +7,57 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.Sort.Unit
-    ( Unit (..)
-    , unitId, unitSymbol, unitAttribute
-    ) where
+  ( Unit (..),
+    unitId,
+    unitSymbol,
+    unitAttribute
+    )
+where
 
 import Control.DeepSeq
-       ( NFData )
+  ( NFData
+    )
 import Data.Default
 import GHC.Generics
-       ( Generic )
-
+  ( Generic
+    )
 import Kore.Attribute.Parser
 
 -- | @Unit@ represents the @unit@ attribute for sorts.
-newtype Unit = Unit { getUnit :: Maybe SymbolOrAlias }
-    deriving (Generic, Eq, Ord, Show)
+newtype Unit = Unit {getUnit :: Maybe SymbolOrAlias}
+  deriving (Generic, Eq, Ord, Show)
 
 instance Semigroup Unit where
-    (<>) a@(Unit (Just _)) _ = a
-    (<>) _                     b = b
+  (<>) a@(Unit (Just _)) _ = a
+  (<>) _ b = b
 
 instance Monoid Unit where
-    mempty = Unit { getUnit = Nothing }
+  mempty = Unit {getUnit = Nothing}
 
 instance Default Unit where
-    def = mempty
+  def = mempty
 
 instance NFData Unit
 
 instance ParseAttributes Unit where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Unit { getUnit }
-          | Just _ <- getUnit = failDuplicate'
-          | otherwise = do
+
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Unit {getUnit}
+        | Just _ <- getUnit = failDuplicate'
+        | otherwise =
+          do
             getZeroParams params
             arg <- getOneArgument args
             symbol <- getSymbolOrAlias arg
-            return Unit { getUnit = Just symbol }
-        withApplication' = withApplication unitId
-        failDuplicate' = failDuplicate unitId
+            return Unit {getUnit = Just symbol}
+      withApplication' = withApplication unitId
+      failDuplicate' = failDuplicate unitId
 
-    toAttributes =
-        maybe def toAttribute . getUnit
-      where
-        toAttribute = Attributes . (: []) . unitAttribute
+  toAttributes =
+    maybe def toAttribute . getUnit
+    where
+      toAttribute = Attributes . (: []) . unitAttribute
 
 -- | Kore identifier representing the @unit@ attribute symbol.
 unitId :: Id
@@ -60,10 +66,10 @@ unitId = "unit"
 -- | Kore symbol representing the @unit@ attribute.
 unitSymbol :: SymbolOrAlias
 unitSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = unitId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = unitId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @unit@ attribute.
 unitAttribute :: SymbolOrAlias -> AttributePattern

--- a/kore/src/Kore/Attribute/SortInjection.hs
+++ b/kore/src/Kore/Attribute/SortInjection.hs
@@ -7,29 +7,31 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 -}
 module Kore.Attribute.SortInjection
-    ( SortInjection (..)
-    , sortInjectionId, sortInjectionSymbol, sortInjectionAttribute
-    ) where
+  ( SortInjection (..),
+    sortInjectionId,
+    sortInjectionSymbol,
+    sortInjectionAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @SortInjection@ represents the @sortInjection@ attribute for symbols.
-newtype SortInjection = SortInjection { isSortInjection :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype SortInjection = SortInjection {isSortInjection :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup SortInjection where
-    (<>) (SortInjection a) (SortInjection b) = SortInjection (a || b)
+  (<>) (SortInjection a) (SortInjection b) = SortInjection (a || b)
 
 instance Monoid SortInjection where
-    mempty = SortInjection False
+  mempty = SortInjection False
 
 instance Default SortInjection where
-    def = mempty
+  def = mempty
 
 instance NFData SortInjection
 
@@ -46,25 +48,26 @@ sortInjectionId = "sortInjection"
 -- | Kore symbol representing the @sortInjection@ attribute.
 sortInjectionSymbol :: SymbolOrAlias
 sortInjectionSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = sortInjectionId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = sortInjectionId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @sortInjection@ attribute.
 sortInjectionAttribute :: AttributePattern
 sortInjectionAttribute = attributePattern sortInjectionSymbol []
 
 instance ParseAttributes SortInjection where
-    parseAttribute =
-        withApplication' $ \params args SortInjection { isSortInjection } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isSortInjection failDuplicate'
-            return SortInjection { isSortInjection = True }
-      where
-        withApplication' = Parser.withApplication sortInjectionId
-        failDuplicate' = Parser.failDuplicate sortInjectionId
 
-    toAttributes SortInjection { isSortInjection } =
-        Attributes [sortInjectionAttribute | isSortInjection]
+  parseAttribute =
+    withApplication' $ \params args SortInjection {isSortInjection} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isSortInjection failDuplicate'
+      return SortInjection {isSortInjection = True}
+    where
+      withApplication' = Parser.withApplication sortInjectionId
+      failDuplicate' = Parser.failDuplicate sortInjectionId
+
+  toAttributes SortInjection {isSortInjection} =
+    Attributes [sortInjectionAttribute | isSortInjection]

--- a/kore/src/Kore/Attribute/Source.hs
+++ b/kore/src/Kore/Attribute/Source.hs
@@ -7,29 +7,36 @@ Maintainer  : vladimir.ciobanu@runtimeverification.com
 
 -}
 module Kore.Attribute.Source
-    ( Source (..)
-    ) where
+  ( Source (..)
+    )
+where
 
-import           Control.Applicative
-                 ( many )
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Default
-import           Data.Maybe
+import Control.Applicative
+  ( many
+    )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Default
+import Data.Maybe
 import qualified Data.Text as Text
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-import           Text.Megaparsec
-                 ( Parsec, noneOf, parseMaybe )
-import           Text.Megaparsec.Char
-
-import           Kore.Attribute.Parser as AttributeParser
-import           Kore.Debug
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Parser as AttributeParser
+import Kore.Debug
 import qualified Kore.Error
+import Text.Megaparsec
+  ( Parsec,
+    noneOf,
+    parseMaybe
+    )
+import Text.Megaparsec.Char
 
-newtype Source = Source
-    { unSource :: Maybe String
-    } deriving (Eq, GHC.Generic, Ord, Show)
+newtype Source
+  = Source
+      { unSource :: Maybe String
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Source
 
@@ -40,40 +47,40 @@ instance Debug Source
 instance NFData Source
 
 instance Default Source where
-    def = Source Nothing
+  def = Source Nothing
 
 -- | Kore identifier representing the @location@ attribute symbol.
 sourceId :: Id
 sourceId = "org'Stop'kframework'Stop'attributes'Stop'Source"
 
 instance ParseAttributes Source where
-    parseAttribute = AttributeParser.withApplication sourceId parseApplication
-      where
 
-        parseApplication
-            :: [Sort]
-            -> [AttributePattern]
-            -> Source
-            -> AttributeParser.Parser Source
-        parseApplication params args s@(Source Nothing) = do
-            AttributeParser.getZeroParams params
-            case args of
-                [] -> pure s
-                [_] -> do
-                    arg <- AttributeParser.getOneArgument args
-                    StringLiteral str <- AttributeParser.getStringLiteral arg
-                    pure
-                        . fromMaybe def
-                        . parseMaybe sourceParser
-                        $ Text.unpack str
-                _ ->
-                    Kore.Error.koreFail
-                        ("expected one argument, found " ++ show (length args))
-        parseApplication _ _ _ =
-            AttributeParser.failDuplicate sourceId
+  parseAttribute = AttributeParser.withApplication sourceId parseApplication
+    where
+      parseApplication
+        :: [Sort]
+        -> [AttributePattern]
+        -> Source
+        -> AttributeParser.Parser Source
+      parseApplication params args s@(Source Nothing) = do
+        AttributeParser.getZeroParams params
+        case args of
+          [] -> pure s
+          [_] -> do
+            arg <- AttributeParser.getOneArgument args
+            StringLiteral str <- AttributeParser.getStringLiteral arg
+            pure
+              . fromMaybe def
+              . parseMaybe sourceParser
+              $ Text.unpack str
+          _ ->
+            Kore.Error.koreFail
+              ("expected one argument, found " ++ show (length args))
+      parseApplication _ _ _ =
+        AttributeParser.failDuplicate sourceId
 
-    -- TODO (thomas.tuegel): Implement
-    toAttributes _ = def
+  -- TODO (thomas.tuegel): Implement
+  toAttributes _ = def
 
 -- | This parser is used to parse the inner representation of the attribute.
 -- The expected format is "Source(path)" where path is a FilePath.
@@ -84,7 +91,6 @@ sourceParser = Source <$> (Just <$> sourceParser0)
   where
     sourceParser0 :: StringParser String
     sourceParser0 =
-        string "Source(" *> many (noneOf excludedChars) <* string ")"
-
+      string "Source(" *> many (noneOf excludedChars) <* string ")"
     excludedChars :: String
     excludedChars = ")"

--- a/kore/src/Kore/Attribute/SourceLocation.hs
+++ b/kore/src/Kore/Attribute/SourceLocation.hs
@@ -6,37 +6,45 @@ License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 
 -}
-
 module Kore.Attribute.SourceLocation
-    ( SourceLocation (..)
-    , Source (..)
-    , Location (..)
-    ) where
+  ( SourceLocation (..),
+    Source (..),
+    Location (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Control.Monad
-                 ( (>=>) )
-import           Data.Default
-import           Data.Generics.Product
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty )
+import Control.DeepSeq
+  ( NFData
+    )
+import Control.Monad
+  ( (>=>)
+    )
+import Data.Default
+import Data.Generics.Product
+import Data.Text.Prettyprint.Doc
+  ( Pretty
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Location
-       ( LineColumn (..), Location (..) )
+  ( LineColumn (..),
+    Location (..)
+    )
 import Kore.Attribute.Parser
-       ( ParseAttributes (..) )
+  ( ParseAttributes (..)
+    )
 import Kore.Attribute.Source
-       ( Source (..) )
+  ( Source (..)
+    )
 import Kore.Debug
 
-data SourceLocation = SourceLocation
-    { location :: !Location
-    , source   :: !Source
-    } deriving (Eq, GHC.Generic, Ord, Show)
+data SourceLocation
+  = SourceLocation
+      { location :: !Location,
+        source :: !Source
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic SourceLocation
 
@@ -47,39 +55,38 @@ instance Debug SourceLocation
 instance NFData SourceLocation
 
 instance Default SourceLocation where
-    def = SourceLocation def def
+  def = SourceLocation def def
 
 instance ParseAttributes SourceLocation where
-    parseAttribute attr =
-        typed @Location (parseAttribute attr)
-        >=> typed @Source (parseAttribute attr)
 
-    -- TODO (thomas.tuegel): Implement
-    toAttributes _ = def
+  parseAttribute attr =
+    typed @Location (parseAttribute attr)
+      >=> typed @Source (parseAttribute attr)
+
+  -- TODO (thomas.tuegel): Implement
+  toAttributes _ = def
 
 instance Pretty SourceLocation where
-    pretty SourceLocation
-        { location = Location { start , end }
-        , source = (Source (Just file))
-        }
-      = Pretty.pretty file <> loc
-
+  pretty
+    SourceLocation
+      { location = Location {start, end},
+        source = (Source (Just file))
+        } =
+      Pretty.pretty file <> loc
       where
         loc :: Pretty.Doc ann
         loc =
-            case start of
-                Just lc -> ":" <> prettyLC lc <> maybeLC end
-                Nothing -> Pretty.emptyDoc
-
+          case start of
+            Just lc -> ":" <> prettyLC lc <> maybeLC end
+            Nothing -> Pretty.emptyDoc
         prettyLC :: LineColumn -> Pretty.Doc ann
-        prettyLC LineColumn { line, column } =
-            Pretty.hcat
-                [ Pretty.pretty line
-                , ":"
-                , Pretty.pretty column
-                ]
-
+        prettyLC LineColumn {line, column} =
+          Pretty.hcat
+            [ Pretty.pretty line,
+              ":",
+              Pretty.pretty column
+              ]
         maybeLC :: Maybe LineColumn -> Pretty.Doc ann
         maybeLC Nothing = Pretty.emptyDoc
         maybeLC (Just elc) = "-" <> prettyLC elc
-    pretty _ = ""
+  pretty _ = ""

--- a/kore/src/Kore/Attribute/Subsort.hs
+++ b/kore/src/Kore/Attribute/Subsort.hs
@@ -7,24 +7,25 @@ License     : NCSA
 module Kore.Attribute.Subsort where
 
 import Data.Hashable
-       ( Hashable )
-
+  ( Hashable
+    )
 import Kore.Attribute.Parser as Parser
 
 {- | The @subsort@ attribute. -}
-data Subsort = Subsort
-    { subsort :: Sort
-    , supersort :: Sort
-    }
-    deriving (Eq, Generic, Ord, Show)
+data Subsort
+  = Subsort
+      { subsort :: Sort,
+        supersort :: Sort
+        }
+  deriving (Eq, Generic, Ord, Show)
 
 instance Hashable Subsort
 
-newtype Subsorts = Subsorts { getSubsorts :: [Subsort] }
-    deriving (Eq, Ord, Show)
+newtype Subsorts = Subsorts {getSubsorts :: [Subsort]}
+  deriving (Eq, Ord, Show)
 
 instance Default Subsorts where
-    def = Subsorts []
+  def = Subsorts []
 
 -- | Kore identifier representing a @subsort@ attribute symbol.
 subsortId :: Id
@@ -38,10 +39,10 @@ where @Sub@ is the subsort and @Super@ is the supersort.
  -}
 subsortSymbol :: Sort -> Sort -> SymbolOrAlias
 subsortSymbol subsort supersort =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = subsortId
-        , symbolOrAliasParams = [ subsort, supersort ]
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = subsortId,
+      symbolOrAliasParams = [subsort, supersort]
+      }
 
 {- | Kore pattern representing a @subsort@ attribute.
 
@@ -51,7 +52,7 @@ where @Sub@ is the subsort and @Super@ is the supersort.
  -}
 subsortAttribute :: Sort -> Sort -> AttributePattern
 subsortAttribute subsort supersort =
-    attributePattern_ $ subsortSymbol subsort supersort
+  attributePattern_ $ subsortSymbol subsort supersort
 
 {- | Parse @subsort@ Kore attributes, if present.
 
@@ -62,16 +63,17 @@ subsortAttribute subsort supersort =
 
  -}
 instance ParseAttributes Subsorts where
-    parseAttribute =
-        withApplication' $ \params args (Subsorts subsorts) -> do
-            Parser.getZeroArguments args
-            (subsort, supersort) <- Parser.getTwoParams params
-            let relation = Subsort subsort supersort
-            return (Subsorts $ relation : subsorts)
-      where
-        withApplication' = Parser.withApplication subsortId
 
-    toAttributes =
-        Attributes . map toAttribute . getSubsorts
-      where
-        toAttribute = subsortAttribute <$> subsort <*> supersort
+  parseAttribute =
+    withApplication' $ \params args (Subsorts subsorts) -> do
+      Parser.getZeroArguments args
+      (subsort, supersort) <- Parser.getTwoParams params
+      let relation = Subsort subsort supersort
+      return (Subsorts $ relation : subsorts)
+    where
+      withApplication' = Parser.withApplication subsortId
+
+  toAttributes =
+    Attributes . map toAttribute . getSubsorts
+    where
+      toAttribute = subsortAttribute <$> subsort <*> supersort

--- a/kore/src/Kore/Attribute/Symbol.hs
+++ b/kore/src/Kore/Attribute/Symbol.hs
@@ -9,62 +9,64 @@ import qualified Kore.Attribute.Symbol as Attribute
 @
 
  -}
-
 module Kore.Attribute.Symbol
-    ( Symbol (..)
-    , StepperAttributes
-    , defaultSymbolAttributes
+  ( Symbol (..),
+    StepperAttributes,
+    defaultSymbolAttributes,
     -- * Function symbols
-    , Function (..)
-    , functionAttribute
+    Function (..),
+    functionAttribute,
     -- * Functional symbols
-    , Functional (..)
-    , functionalAttribute
+    Functional (..),
+    functionalAttribute,
     -- * Constructor symbols
-    , Constructor (..)
-    , constructorAttribute
+    Constructor (..),
+    constructorAttribute,
     -- * Injective symbols
-    , Injective (..)
-    , injectiveAttribute
+    Injective (..),
+    injectiveAttribute,
     -- * Anywhere symbols
-    , Anywhere (..)
-    , anywhereAttribute
+    Anywhere (..),
+    anywhereAttribute,
     -- * Sort injection symbols
-    , SortInjection (..)
-    , sortInjectionAttribute
+    SortInjection (..),
+    sortInjectionAttribute,
     -- * Hooked symbols
-    , Hook (..)
-    , hookAttribute
+    Hook (..),
+    hookAttribute,
     -- * SMT symbols
-    , Smthook (..)
-    , smthookAttribute
-    , Smtlib (..)
-    , smtlibAttribute
+    Smthook (..),
+    smthookAttribute,
+    Smtlib (..),
+    smtlibAttribute,
     -- * Derived attributes
-    , isNonSimplifiable
-    , isFunctional
-    , isFunction
-    , isTotal
-    , isInjective
-    ) where
+    isNonSimplifiable,
+    isFunctional,
+    isFunction,
+    isTotal,
+    isInjective
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Control.Lens as Lens
-import           Control.Monad
-                 ( (>=>) )
-import           Data.Default
-import           Data.Generics.Product
-import qualified Generics.SOP as SOP
+import Control.Monad
+  ( (>=>)
+    )
+import Data.Default
+import Data.Generics.Product
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Constructor
 import Kore.Attribute.Function
 import Kore.Attribute.Functional
 import Kore.Attribute.Hook
 import Kore.Attribute.Injective
 import Kore.Attribute.Parser
-       ( ParseAttributes (..) )
+  ( ParseAttributes (..)
+    )
 import Kore.Attribute.Smthook
 import Kore.Attribute.Smtlib
 import Kore.Attribute.SortInjection
@@ -79,25 +81,25 @@ injective, even if their declaration is not given the @injective@ attribute. To
 view the effective attributes, use the functions defined in this module.
 
  -}
-data Symbol =
-    Symbol
-    { function      :: !Function
-      -- ^ Whether a symbol represents a function
-    , functional    :: !Functional
-      -- ^ Whether a symbol is functional
-    , constructor   :: !Constructor
-      -- ^ Whether a symbol represents a constructor
-    , injective     :: !Injective
-      -- ^ Whether a symbol represents an injective function
-    , sortInjection :: !SortInjection
-      -- ^ Whether a symbol is a sort injection
-    , anywhere      :: !Anywhere
-    , hook          :: !Hook
-      -- ^ The builtin sort or symbol hooked to a sort or symbol
-    , smtlib        :: !Smtlib
-    , smthook       :: !Smthook
-    }
-    deriving (Eq, Ord, GHC.Generic, Show)
+data Symbol
+  = Symbol
+      { function :: !Function,
+        -- ^ Whether a symbol represents a function
+        functional :: !Functional,
+        -- ^ Whether a symbol is functional
+        constructor :: !Constructor,
+        -- ^ Whether a symbol represents a constructor
+        injective :: !Injective,
+        -- ^ Whether a symbol represents an injective function
+        sortInjection :: !SortInjection,
+        -- ^ Whether a symbol is a sort injection
+        anywhere :: !Anywhere,
+        hook :: !Hook,
+        -- ^ The builtin sort or symbol hooked to a sort or symbol
+        smtlib :: !Smtlib,
+        smthook :: !Smthook
+        }
+  deriving (Eq, Ord, GHC.Generic, Show)
 
 instance NFData Symbol
 
@@ -108,58 +110,60 @@ instance SOP.HasDatatypeInfo Symbol
 instance Debug Symbol
 
 instance ParseAttributes Symbol where
-    parseAttribute attr =
-        typed @Function (parseAttribute attr)
-        >=> typed @Functional (parseAttribute attr)
-        >=> typed @Constructor (parseAttribute attr)
-        >=> typed @SortInjection (parseAttribute attr)
-        >=> typed @Injective (parseAttribute attr)
-        >=> typed @Anywhere (parseAttribute attr)
-        >=> typed @Hook (parseAttribute attr)
-        >=> typed @Smtlib (parseAttribute attr)
-        >=> typed @Smthook (parseAttribute attr)
 
-    toAttributes =
-        mconcat . sequence
-            [ toAttributes . function
-            , toAttributes . functional
-            , toAttributes . constructor
-            , toAttributes . injective
-            , toAttributes . sortInjection
-            , toAttributes . anywhere
-            , toAttributes . hook
-            , toAttributes . smtlib
-            , toAttributes . smthook
+  parseAttribute attr =
+    typed @Function (parseAttribute attr)
+      >=> typed @Functional (parseAttribute attr)
+      >=> typed @Constructor (parseAttribute attr)
+      >=> typed @SortInjection (parseAttribute attr)
+      >=> typed @Injective (parseAttribute attr)
+      >=> typed @Anywhere (parseAttribute attr)
+      >=> typed @Hook (parseAttribute attr)
+      >=> typed @Smtlib (parseAttribute attr)
+      >=> typed @Smthook (parseAttribute attr)
+
+  toAttributes =
+    mconcat
+      . sequence
+          [ toAttributes . function,
+            toAttributes . functional,
+            toAttributes . constructor,
+            toAttributes . injective,
+            toAttributes . sortInjection,
+            toAttributes . anywhere,
+            toAttributes . hook,
+            toAttributes . smtlib,
+            toAttributes . smthook
             ]
 
 type StepperAttributes = Symbol
 
 defaultSymbolAttributes :: Symbol
 defaultSymbolAttributes =
-    Symbol
-        { function       = def
-        , functional     = def
-        , constructor    = def
-        , injective      = def
-        , sortInjection  = def
-        , anywhere       = def
-        , hook           = def
-        , smtlib         = def
-        , smthook        = def
-        }
+  Symbol
+    { function = def,
+      functional = def,
+      constructor = def,
+      injective = def,
+      sortInjection = def,
+      anywhere = def,
+      hook = def,
+      smtlib = def,
+      smthook = def
+      }
 
 -- | See also: 'defaultSymbolAttributes'
 instance Default Symbol where
-    def = defaultSymbolAttributes
+  def = defaultSymbolAttributes
 
 -- | Is a symbol non-simplifiable?
 isNonSimplifiable :: StepperAttributes -> Bool
 isNonSimplifiable = do
-    -- TODO(virgil): Add a 'non-simplifiable' attribute so that we can include
-    -- more symbols here (e.g. Map.concat)
-    Constructor isConstructor' <- constructor
-    SortInjection isSortInjection' <- sortInjection
-    return (isSortInjection' || isConstructor')
+  -- TODO(virgil): Add a 'non-simplifiable' attribute so that we can include
+  -- more symbols here (e.g. Map.concat)
+  Constructor isConstructor' <- constructor
+  SortInjection isSortInjection' <- sortInjection
+  return (isSortInjection' || isConstructor')
 
 {- | Is the symbol a function?
 
@@ -171,9 +175,9 @@ See also: 'functionAttribute', 'isFunctional'
  -}
 isFunction :: StepperAttributes -> Bool
 isFunction = do
-    Function isFunction' <- Lens.view typed
-    isFunctional' <- isFunctional
-    return (isFunction' || isFunctional')
+  Function isFunction' <- Lens.view typed
+  isFunctional' <- isFunctional
+  return (isFunction' || isFunctional')
 
 {- | Is the symbol functional?
 
@@ -185,17 +189,17 @@ See also: 'functionalAttribute', 'sortInjectionAttribute'
  -}
 isFunctional :: StepperAttributes -> Bool
 isFunctional = do
-    Functional isFunctional' <- functional
-    SortInjection isSortInjection' <- sortInjection
-    return (isFunctional' || isSortInjection')
+  Functional isFunctional' <- functional
+  SortInjection isSortInjection' <- sortInjection
+  return (isFunctional' || isSortInjection')
 
 -- | Is a symbol total (non-@\\bottom@)?
 isTotal :: StepperAttributes -> Bool
 isTotal = do
-    isFunctional' <- isFunctional
-    -- TODO (thomas.tuegel): Constructors are not total.
-    Constructor isConstructor' <- Lens.view typed
-    return (isFunctional' || isConstructor')
+  isFunctional' <- isFunctional
+  -- TODO (thomas.tuegel): Constructors are not total.
+  Constructor isConstructor' <- Lens.view typed
+  return (isFunctional' || isConstructor')
 
 {- | Is the symbol injective?
 
@@ -207,8 +211,9 @@ See also: 'injectiveAttribute', 'constructorAttribute', 'sortInjectionAttribute'
  -}
 isInjective :: StepperAttributes -> Bool
 isInjective =
-    or . sequence
-        [ isDeclaredInjective . injective
-        , isConstructor       . constructor
-        , isSortInjection     . sortInjection
-        ]
+  or
+    . sequence
+        [ isDeclaredInjective . injective,
+          isConstructor . constructor,
+          isSortInjection . sortInjection
+          ]

--- a/kore/src/Kore/Attribute/Symbol/Anywhere.hs
+++ b/kore/src/Kore/Attribute/Symbol/Anywhere.hs
@@ -3,31 +3,32 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Symbol.Anywhere
-    ( Anywhere (..)
-    , anywhereId, anywhereSymbol, anywhereAttribute
-    ) where
+  ( Anywhere (..),
+    anywhereId,
+    anywhereSymbol,
+    anywhereAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 -- | @Anywhere@ represents the @anywhere@ attribute for symbols.
-newtype Anywhere = Anywhere { isAnywhere :: Bool }
-    deriving (GHC.Generic, Eq, Ord, Show)
+newtype Anywhere = Anywhere {isAnywhere :: Bool}
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance Semigroup Anywhere where
-    (<>) (Anywhere a) (Anywhere b) = Anywhere (a || b)
+  (<>) (Anywhere a) (Anywhere b) = Anywhere (a || b)
 
 instance Monoid Anywhere where
-    mempty = Anywhere False
+  mempty = Anywhere False
 
 instance Default Anywhere where
-    def = mempty
+  def = mempty
 
 instance NFData Anywhere
 
@@ -44,25 +45,26 @@ anywhereId = "anywhere"
 -- | Kore symbol representing the @anywhere@ attribute.
 anywhereSymbol :: SymbolOrAlias
 anywhereSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = anywhereId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = anywhereId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @anywhere@ attribute.
 anywhereAttribute :: AttributePattern
 anywhereAttribute = attributePattern_ anywhereSymbol
 
 instance ParseAttributes Anywhere where
-    parseAttribute = withApplication' parseApplication
-      where
-        parseApplication params args Anywhere { isAnywhere } = do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isAnywhere failDuplicate'
-            return Anywhere { isAnywhere = True }
-        withApplication' = Parser.withApplication anywhereId
-        failDuplicate' = Parser.failDuplicate anywhereId
 
-    toAttributes Anywhere { isAnywhere } =
-        Attributes [anywhereAttribute | isAnywhere]
+  parseAttribute = withApplication' parseApplication
+    where
+      parseApplication params args Anywhere {isAnywhere} = do
+        Parser.getZeroParams params
+        Parser.getZeroArguments args
+        Monad.when isAnywhere failDuplicate'
+        return Anywhere {isAnywhere = True}
+      withApplication' = Parser.withApplication anywhereId
+      failDuplicate' = Parser.failDuplicate anywhereId
+
+  toAttributes Anywhere {isAnywhere} =
+    Attributes [anywhereAttribute | isAnywhere]

--- a/kore/src/Kore/Attribute/Synthetic.hs
+++ b/kore/src/Kore/Attribute/Synthetic.hs
@@ -4,22 +4,27 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Attribute.Synthetic
-    ( Synthetic (..)
-    , resynthesize, resynthesizeAux
-    , synthesize, synthesizeAux
-    ) where
+  ( Synthetic (..),
+    resynthesize,
+    resynthesizeAux,
+    synthesize,
+    synthesizeAux
+    )
+where
 
-import           Control.Comonad.Trans.Cofree
-                 ( CofreeF (..) )
+import Control.Comonad.Trans.Cofree
+  ( CofreeF (..)
+    )
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Data.Functor.Const
-import           Data.Functor.Foldable
-                 ( Base, Corecursive, Recursive )
+import Data.Functor.Const
+import Data.Functor.Foldable
+  ( Base,
+    Corecursive,
+    Recursive
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           GHC.Generics
-
+import GHC.Generics
 import Generically
 
 {- | @Synthetic@ is the class of synthetic attribute types @syn@.
@@ -29,37 +34,37 @@ that is, a 'Cofree' tree with branching described by a @'Functor' base@.
 
  -}
 class Functor base => Synthetic syn base where
-    -- | @synthetic@ is the @base@-algebra for synthesizing the attribute @syn@.
-    synthetic :: base syn -> syn
+  -- | @synthetic@ is the @base@-algebra for synthesizing the attribute @syn@.
+  synthetic :: base syn -> syn
 
 instance Synthetic a (Const a) where
-    synthetic (Const a) = a
-    {-# INLINE synthetic #-}
+  synthetic (Const a) = a
+  {-# INLINE synthetic #-}
 
 instance
-    (Functor base, Generic1 base, Synthetic syn (Rep1 base))
-    => Synthetic syn (Generically1 base)
+  (Functor base, Generic1 base, Synthetic syn (Rep1 base))
+  => Synthetic syn (Generically1 base)
   where
-    synthetic = synthetic . from1 . unGenerically1
-    {-# INLINE synthetic #-}
+  synthetic = synthetic . from1 . unGenerically1
+  {-# INLINE synthetic #-}
 
 instance (Functor base, Synthetic syn base) => Synthetic syn (M1 i c base) where
-    synthetic = synthetic . unM1
-    {-# INLINE synthetic #-}
+  synthetic = synthetic . unM1
+  {-# INLINE synthetic #-}
 
 instance
-    (Functor l, Synthetic syn l, Functor r, Synthetic syn r)
-    => Synthetic syn (l :+: r)
+  (Functor l, Synthetic syn l, Functor r, Synthetic syn r)
+  => Synthetic syn (l :+: r)
   where
-    synthetic =
-        \case
-            L1 lsyn -> synthetic lsyn
-            R1 rsyn -> synthetic rsyn
-    {-# INLINE synthetic #-}
+  synthetic =
+    \case
+      L1 lsyn -> synthetic lsyn
+      R1 rsyn -> synthetic rsyn
+  {-# INLINE synthetic #-}
 
 instance (Functor base, Synthetic syn base) => Synthetic syn (Rec1 base) where
-    synthetic = synthetic . unRec1
-    {-# INLINE synthetic #-}
+  synthetic = synthetic . unRec1
+  {-# INLINE synthetic #-}
 
 {- | @/synthesize/@ attribute @b@ bottom-up along a tree @s@.
 
@@ -73,15 +78,15 @@ See also:
 
  -}
 resynthesize
-    ::  ( Recursive s
-        , Corecursive t
-        , Recursive t
-        , Base s ~ CofreeF base inh
-        , Base t ~ CofreeF base syn
-        , Synthetic syn base
-        )
-    => s  -- ^ Original tree with attributes @a@
-    -> t
+  :: ( Recursive s,
+       Corecursive t,
+       Recursive t,
+       Base s ~ CofreeF base inh,
+       Base t ~ CofreeF base syn,
+       Synthetic syn base
+       )
+  => s -- ^ Original tree with attributes @a@
+  -> t
 resynthesize = resynthesizeAux synthetic
 {-# INLINE resynthesize #-}
 
@@ -96,18 +101,18 @@ See also:
 
  -}
 resynthesizeAux
-    ::  ( Functor f
-        , Recursive s
-        , Corecursive t
-        , Recursive t
-        , Base s ~ CofreeF f a
-        , Base t ~ CofreeF f b
-        )
-    => (f b -> b)  -- ^ @(Base s)@-algebra synthesizing @b@
-    -> s  -- ^ Original tree with attributes @a@
-    -> t
+  :: ( Functor f,
+       Recursive s,
+       Corecursive t,
+       Recursive t,
+       Base s ~ CofreeF f a,
+       Base t ~ CofreeF f b
+       )
+  => (f b -> b) -- ^ @(Base s)@-algebra synthesizing @b@
+  -> s -- ^ Original tree with attributes @a@
+  -> t
 resynthesizeAux synth =
-    Recursive.fold worker
+  Recursive.fold worker
   where
     worker (_ :< ft) = synthesizeAux synth ft
 {-# INLINE resynthesizeAux #-}
@@ -115,23 +120,26 @@ resynthesizeAux synth =
 {- | @/synthesize/@ an attribute @a@ from one level of a tree @s@.
  -}
 synthesize
-    ::  ( Functor f, Synthetic a f
-        , Corecursive s, Recursive s, Base s ~ CofreeF f a
-        )
-    => f s
-    -> s
+  :: ( Functor f,
+       Synthetic a f,
+       Corecursive s,
+       Recursive s,
+       Base s ~ CofreeF f a
+       )
+  => f s
+  -> s
 synthesize = synthesizeAux synthetic
 {-# INLINE synthesize #-}
 
 {- | @/synthesize/@ an attribute @a@ using the provided algebra.
  -}
 synthesizeAux
-    :: (Functor f, Corecursive s, Recursive s, Base s ~ CofreeF f a)
-    => (f a -> a)  -- ^ Algebra
-    -> f s
-    -> s
+  :: (Functor f, Corecursive s, Recursive s, Base s ~ CofreeF f a)
+  => (f a -> a) -- ^ Algebra
+  -> f s
+  -> s
 synthesizeAux synth fs =
-    Recursive.embed (synth fa :< fs)
+  Recursive.embed (synth fa :< fs)
   where
     fa = Cofree.headF . Recursive.project <$> fs
 {-# INLINE synthesizeAux #-}

--- a/kore/src/Kore/Attribute/Trusted.hs
+++ b/kore/src/Kore/Attribute/Trusted.hs
@@ -11,21 +11,23 @@ which can be used as a circularity without needing to be proven.
 
 -}
 module Kore.Attribute.Trusted
-    ( Trusted (..)
-    , trustedId, trustedSymbol, trustedAttribute
-    ) where
+  ( Trusted (..),
+    trustedId,
+    trustedSymbol,
+    trustedAttribute
+    )
+where
 
 import qualified Control.Monad as Monad
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Trusted@ represents the @trusted@ attribute for claim sentences.
  -}
-newtype Trusted = Trusted { isTrusted :: Bool }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype Trusted = Trusted {isTrusted :: Bool}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic Trusted
 
@@ -36,7 +38,7 @@ instance Debug Trusted
 instance NFData Trusted
 
 instance Default Trusted where
-    def = Trusted False
+  def = Trusted False
 
 -- | Kore identifier representing the @trusted@ attribute symbol.
 trustedId :: Id
@@ -45,25 +47,26 @@ trustedId = "trusted"
 -- | Kore symbol representing the @trusted@ attribute.
 trustedSymbol :: SymbolOrAlias
 trustedSymbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = trustedId
-        , symbolOrAliasParams = []
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = trustedId,
+      symbolOrAliasParams = []
+      }
 
 -- | Kore pattern representing the @trusted@ attribute.
 trustedAttribute :: AttributePattern
 trustedAttribute = attributePattern_ trustedSymbol
 
 instance ParseAttributes Trusted where
-    parseAttribute =
-        withApplication' $ \params args Trusted { isTrusted } -> do
-            Parser.getZeroParams params
-            Parser.getZeroArguments args
-            Monad.when isTrusted failDuplicate'
-            return Trusted { isTrusted = True }
-      where
-        withApplication' = Parser.withApplication trustedId
-        failDuplicate' = Parser.failDuplicate trustedId
 
-    toAttributes Trusted { isTrusted } =
-        Attributes [trustedAttribute | isTrusted]
+  parseAttribute =
+    withApplication' $ \params args Trusted {isTrusted} -> do
+      Parser.getZeroParams params
+      Parser.getZeroArguments args
+      Monad.when isTrusted failDuplicate'
+      return Trusted {isTrusted = True}
+    where
+      withApplication' = Parser.withApplication trustedId
+      failDuplicate' = Parser.failDuplicate trustedId
+
+  toAttributes Trusted {isTrusted} =
+    Attributes [trustedAttribute | isTrusted]

--- a/kore/src/Kore/Builtin.hs
+++ b/kore/src/Kore/Builtin.hs
@@ -14,44 +14,49 @@ This module is intended to be imported qualified.
 @
  -}
 module Kore.Builtin
-    ( Builtin.Verifiers (..)
-    , Builtin.DomainValueVerifiers
-    , Builtin.Function
-    , Builtin
-    , Builtin.SymbolVerifier (..)
-    , Builtin.SortVerifier (..)
-    , Builtin.sortDeclVerifier
-    , Builtin.symbolVerifier
-    , Builtin.verifyDomainValue
-    , koreVerifiers
-    , koreEvaluators
-    , evaluators
-    , externalizePattern
-    , internalize
-    , renormalize
-    ) where
+  ( Builtin.Verifiers (..),
+    Builtin.DomainValueVerifiers,
+    Builtin.Function,
+    Builtin,
+    Builtin.SymbolVerifier (..),
+    Builtin.SortVerifier (..),
+    Builtin.sortDeclVerifier,
+    Builtin.symbolVerifier,
+    Builtin.verifyDomainValue,
+    koreVerifiers,
+    koreEvaluators,
+    evaluators,
+    externalizePattern,
+    internalize,
+    renormalize
+    )
+where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
 import qualified Control.Lens as Lens
-import           Data.Function
+import Data.Function
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Generics.Product
+import Data.Generics.Product
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map
-                 ( Map )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.Semigroup
-                 ( (<>) )
-import           Data.Text
-                 ( Text )
+import Data.Semigroup
+  ( (<>)
+    )
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Stack as GHC
-
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Attribute.Hook
-                 ( Hook (..) )
+import Kore.Attribute.Hook
+  ( Hook (..)
+    )
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
+import Kore.Attribute.Symbol
+  ( StepperAttributes
+    )
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.AssociativeCommutative as Ac
 import qualified Kore.Builtin.Bool as Bool
@@ -64,21 +69,26 @@ import qualified Kore.Builtin.Map as Map
 import qualified Kore.Builtin.Set as Set
 import qualified Kore.Builtin.String as String
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.IndexedModule
-                 ( IndexedModule (..), VerifiedModule )
+import Kore.IndexedModule.IndexedModule
+  ( IndexedModule (..),
+    VerifiedModule
+    )
 import qualified Kore.IndexedModule.IndexedModule as IndexedModule
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
 import qualified Kore.Internal.Alias as Alias
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Internal.TermLike
-import           Kore.Step.Axiom.Identifier
-                 ( AxiomIdentifier )
+import Kore.Internal.TermLike
+import Kore.Step.Axiom.Identifier
+  ( AxiomIdentifier
+    )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
-                 ( AxiomIdentifier (..) )
+  ( AxiomIdentifier (..)
+    )
 import qualified Kore.Syntax.Pattern as Syntax
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 {- | Verifiers for Kore builtin sorts.
 
@@ -87,30 +97,30 @@ import           Kore.Variables.Fresh
  -}
 koreVerifiers :: Builtin.Verifiers
 koreVerifiers =
-    Builtin.Verifiers
+  Builtin.Verifiers
     { sortDeclVerifiers =
-           Bool.sortDeclVerifiers
-        <> Int.sortDeclVerifiers
-        <> List.sortDeclVerifiers
-        <> Map.sortDeclVerifiers
-        <> Set.sortDeclVerifiers
-        <> String.sortDeclVerifiers
-    , symbolVerifiers =
-           Bool.symbolVerifiers
-        <> Int.symbolVerifiers
-        <> List.symbolVerifiers
-        <> Map.symbolVerifiers
-        <> KEqual.symbolVerifiers
-        <> Set.symbolVerifiers
-        <> String.symbolVerifiers
-        <> Krypto.symbolVerifiers
-    , domainValueVerifiers =
+        Bool.sortDeclVerifiers
+          <> Int.sortDeclVerifiers
+          <> List.sortDeclVerifiers
+          <> Map.sortDeclVerifiers
+          <> Set.sortDeclVerifiers
+          <> String.sortDeclVerifiers,
+      symbolVerifiers =
+        Bool.symbolVerifiers
+          <> Int.symbolVerifiers
+          <> List.symbolVerifiers
+          <> Map.symbolVerifiers
+          <> KEqual.symbolVerifiers
+          <> Set.symbolVerifiers
+          <> String.symbolVerifiers
+          <> Krypto.symbolVerifiers,
+      domainValueVerifiers =
         HashMap.fromList
-            [ (Bool.sort, Bool.patternVerifier)
-            , (Int.sort, Int.patternVerifier)
-            , (String.sort, String.patternVerifier)
+          [ (Bool.sort, Bool.patternVerifier),
+            (Int.sort, Int.patternVerifier),
+            (String.sort, String.patternVerifier)
             ]
-    }
+      }
 
 {- | Construct an evaluation context for Kore builtin functions.
 
@@ -121,23 +131,23 @@ koreVerifiers =
 
  -}
 koreEvaluators
-    :: VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ Module under which evaluation takes place
-    -> Map AxiomIdentifier Builtin.Function
+  :: VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ Module under which evaluation takes place
+  -> Map AxiomIdentifier Builtin.Function
 koreEvaluators = evaluators builtins
   where
     builtins :: Map Text Builtin.Function
     builtins =
-        Map.unions
-            [ Bool.builtinFunctions
-            , Int.builtinFunctions
-            , KEqual.builtinFunctions
-            , List.builtinFunctions
-            , Map.builtinFunctions
-            , Set.builtinFunctions
-            , String.builtinFunctions
-            , Krypto.builtinFunctions
-            ]
+      Map.unions
+        [ Bool.builtinFunctions,
+          Int.builtinFunctions,
+          KEqual.builtinFunctions,
+          List.builtinFunctions,
+          Map.builtinFunctions,
+          Set.builtinFunctions,
+          String.builtinFunctions,
+          Krypto.builtinFunctions
+          ]
 
 {- | Construct an evaluation context for the given builtin functions.
 
@@ -148,41 +158,39 @@ koreEvaluators = evaluators builtins
 
  -}
 evaluators
-    :: Map Text Builtin.Function
-    -- ^ Builtin functions indexed by name
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ Module under which evaluation takes place
-    -> Map AxiomIdentifier Builtin.Function
+  :: Map Text Builtin.Function
+  -- ^ Builtin functions indexed by name
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ Module under which evaluation takes place
+  -> Map AxiomIdentifier Builtin.Function
 evaluators builtins indexedModule =
-    Map.mapMaybe
-        lookupBuiltins
-        (Map.mapKeys
-            AxiomIdentifier.Application
-            (hookedSymbolAttributes indexedModule)
-        )
+  Map.mapMaybe
+    lookupBuiltins
+    ( Map.mapKeys
+        AxiomIdentifier.Application
+        (hookedSymbolAttributes indexedModule)
+      )
   where
     hookedSymbolAttributes
-        :: VerifiedModule StepperAttributes Attribute.Axiom
-        -> Map Id StepperAttributes
+      :: VerifiedModule StepperAttributes Attribute.Axiom
+      -> Map Id StepperAttributes
     hookedSymbolAttributes im =
-        Map.union
-            (justAttributes <$> IndexedModule.hookedObjectSymbolSentences im)
-            (Map.unions
-                (importHookedSymbolAttributes <$> indexedModuleImports im)
-            )
+      Map.union
+        (justAttributes <$> IndexedModule.hookedObjectSymbolSentences im)
+        ( Map.unions
+            (importHookedSymbolAttributes <$> indexedModuleImports im)
+          )
       where
         justAttributes (attrs, _) = attrs
-
     importHookedSymbolAttributes
-        :: (a, b, VerifiedModule StepperAttributes Attribute.Axiom)
-        -> Map Id StepperAttributes
+      :: (a, b, VerifiedModule StepperAttributes Attribute.Axiom)
+      -> Map Id StepperAttributes
     importHookedSymbolAttributes (_, _, im) = hookedSymbolAttributes im
-
     lookupBuiltins :: StepperAttributes -> Maybe Builtin.Function
-    lookupBuiltins Attribute.Symbol { Attribute.hook = Hook { getHook } } =
-        do
-            name <- getHook
-            Map.lookup name builtins
+    lookupBuiltins Attribute.Symbol {Attribute.hook = Hook {getHook}} =
+      do
+        name <- getHook
+        Map.lookup name builtins
 
 {- | Externalize the 'TermLike' into a 'Syntax.Pattern'.
 
@@ -192,87 +200,85 @@ See also: 'asPattern'
 
  -}
 externalizePattern
-    ::  forall variable
-    .   (Ord variable, SortedVariable variable, Unparse variable)
-    =>  TermLike variable
-    ->  Syntax.Pattern variable Attribute.Null
+  :: forall variable. (Ord variable, SortedVariable variable, Unparse variable)
+  => TermLike variable
+  -> Syntax.Pattern variable Attribute.Null
 externalizePattern =
-    Recursive.unfold externalizePatternWorker
+  Recursive.unfold externalizePatternWorker
   where
     externalizePatternWorker
-        ::  TermLike variable
-        ->  Recursive.Base
-                (Syntax.Pattern variable Attribute.Null)
-                (TermLike variable)
+      :: TermLike variable
+      -> Recursive.Base
+           (Syntax.Pattern variable Attribute.Null)
+           (TermLike variable)
     externalizePatternWorker termLike =
-        case termLikeF of
-            BuiltinF domain ->
-                case domain of
-                    Domain.BuiltinMap  builtin ->
-                        (toPatternF . Recursive.project)
-                            (Map.asTermLike builtin)
-                    Domain.BuiltinList builtin ->
-                        (toPatternF . Recursive.project)
-                            (List.asTermLike builtin)
-                    Domain.BuiltinSet  builtin ->
-                        (toPatternF . Recursive.project)
-                            (Set.asTermLike builtin)
-                    Domain.BuiltinInt  builtin ->
-                        (toPatternF . Recursive.project)
-                            (Int.asTermLike builtin)
-                    Domain.BuiltinBool builtin ->
-                        (toPatternF . Recursive.project)
-                            (Bool.asTermLike builtin)
-                    Domain.BuiltinString builtin ->
-                        (toPatternF . Recursive.project)
-                            (String.asTermLike builtin)
-            _ -> toPatternF termLikeBase
+      case termLikeF of
+        BuiltinF domain ->
+          case domain of
+            Domain.BuiltinMap builtin ->
+              (toPatternF . Recursive.project)
+                (Map.asTermLike builtin)
+            Domain.BuiltinList builtin ->
+              (toPatternF . Recursive.project)
+                (List.asTermLike builtin)
+            Domain.BuiltinSet builtin ->
+              (toPatternF . Recursive.project)
+                (Set.asTermLike builtin)
+            Domain.BuiltinInt builtin ->
+              (toPatternF . Recursive.project)
+                (Int.asTermLike builtin)
+            Domain.BuiltinBool builtin ->
+              (toPatternF . Recursive.project)
+                (Bool.asTermLike builtin)
+            Domain.BuiltinString builtin ->
+              (toPatternF . Recursive.project)
+                (String.asTermLike builtin)
+        _ -> toPatternF termLikeBase
       where
         termLikeBase@(_ :< termLikeF) = Recursive.project termLike
-
     toPatternF
-        :: GHC.HasCallStack
-        => Recursive.Base (TermLike variable) (TermLike variable)
-        -> Recursive.Base
-            (Syntax.Pattern variable Attribute.Null)
-            (TermLike variable)
+      :: GHC.HasCallStack
+      => Recursive.Base (TermLike variable) (TermLike variable)
+      -> Recursive.Base
+           (Syntax.Pattern variable Attribute.Null)
+           (TermLike variable)
     toPatternF (_ :< termLikeF) =
-        (Attribute.Null :<)
+      (Attribute.Null :<)
         $ case termLikeF of
-            AndF andF -> Syntax.AndF andF
-            ApplyAliasF applyAliasF ->
-                Syntax.ApplicationF
-                $ mapHead Alias.toSymbolOrAlias applyAliasF
-            ApplySymbolF applySymbolF ->
-                Syntax.ApplicationF
-                $ mapHead Symbol.toSymbolOrAlias applySymbolF
-            BottomF bottomF -> Syntax.BottomF bottomF
-            CeilF ceilF -> Syntax.CeilF ceilF
-            DomainValueF domainValueF -> Syntax.DomainValueF domainValueF
-            EqualsF equalsF -> Syntax.EqualsF equalsF
-            ExistsF existsF -> Syntax.ExistsF existsF
-            FloorF floorF -> Syntax.FloorF floorF
-            ForallF forallF -> Syntax.ForallF forallF
-            IffF iffF -> Syntax.IffF iffF
-            ImpliesF impliesF -> Syntax.ImpliesF impliesF
-            InF inF -> Syntax.InF inF
-            MuF muF -> Syntax.MuF muF
-            NextF nextF -> Syntax.NextF nextF
-            NotF notF -> Syntax.NotF notF
-            NuF nuF -> Syntax.NuF nuF
-            OrF orF -> Syntax.OrF orF
-            RewritesF rewritesF -> Syntax.RewritesF rewritesF
-            StringLiteralF stringLiteralF ->
-                Syntax.StringLiteralF stringLiteralF
-            CharLiteralF charLiteralF -> Syntax.CharLiteralF charLiteralF
-            TopF topF -> Syntax.TopF topF
-            VariableF variableF -> Syntax.VariableF variableF
-            InhabitantF inhabitantF -> Syntax.InhabitantF inhabitantF
-            EvaluatedF evaluatedF ->
-                Cofree.tailF
-                $ externalizePatternWorker
-                $ getEvaluated evaluatedF
-            BuiltinF _ -> error "Unexpected internal builtin"
+          AndF andF -> Syntax.AndF andF
+          ApplyAliasF applyAliasF ->
+            Syntax.ApplicationF
+              $ mapHead Alias.toSymbolOrAlias applyAliasF
+          ApplySymbolF applySymbolF ->
+            Syntax.ApplicationF
+              $ mapHead Symbol.toSymbolOrAlias applySymbolF
+          BottomF bottomF -> Syntax.BottomF bottomF
+          CeilF ceilF -> Syntax.CeilF ceilF
+          DomainValueF domainValueF -> Syntax.DomainValueF domainValueF
+          EqualsF equalsF -> Syntax.EqualsF equalsF
+          ExistsF existsF -> Syntax.ExistsF existsF
+          FloorF floorF -> Syntax.FloorF floorF
+          ForallF forallF -> Syntax.ForallF forallF
+          IffF iffF -> Syntax.IffF iffF
+          ImpliesF impliesF -> Syntax.ImpliesF impliesF
+          InF inF -> Syntax.InF inF
+          MuF muF -> Syntax.MuF muF
+          NextF nextF -> Syntax.NextF nextF
+          NotF notF -> Syntax.NotF notF
+          NuF nuF -> Syntax.NuF nuF
+          OrF orF -> Syntax.OrF orF
+          RewritesF rewritesF -> Syntax.RewritesF rewritesF
+          StringLiteralF stringLiteralF ->
+            Syntax.StringLiteralF stringLiteralF
+          CharLiteralF charLiteralF -> Syntax.CharLiteralF charLiteralF
+          TopF topF -> Syntax.TopF topF
+          VariableF variableF -> Syntax.VariableF variableF
+          InhabitantF inhabitantF -> Syntax.InhabitantF inhabitantF
+          EvaluatedF evaluatedF ->
+            Cofree.tailF
+              $ externalizePatternWorker
+              $ getEvaluated evaluatedF
+          BuiltinF _ -> error "Unexpected internal builtin"
 
 {- | Convert a 'TermLike' to its internal representation.
 
@@ -281,35 +287,36 @@ representations are fully normalized.
 
  -}
 internalize
-    :: (Ord variable, SortedVariable variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
 internalize tools =
-    Recursive.fold (internalize1 . Recursive.embed)
+  Recursive.fold (internalize1 . Recursive.embed)
   where
     internalize1 =
-            List.internalize tools
-        .   Map.internalize tools
-        .   Set.internalize tools
+      List.internalize tools
+        . Map.internalize tools
+        . Set.internalize tools
 
 {- | Renormalize builtin types after substitution.
  -}
 renormalize
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        )
-    => TermLike variable -> TermLike variable
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable
+       )
+  => TermLike variable
+  -> TermLike variable
 renormalize termLike =
-    case termLike of
-        BuiltinMap_ internalMap ->
-            Lens.traverseOf (field @"builtinAcChild") Ac.renormalize internalMap
-            & maybe bottom' mkBuiltinMap
-        BuiltinSet_ internalSet ->
-            Lens.traverseOf (field @"builtinAcChild") Ac.renormalize internalSet
-            & maybe bottom' mkBuiltinSet
-        _ -> termLike
+  case termLike of
+    BuiltinMap_ internalMap ->
+      Lens.traverseOf (field @"builtinAcChild") Ac.renormalize internalMap
+        & maybe bottom' mkBuiltinMap
+    BuiltinSet_ internalSet ->
+      Lens.traverseOf (field @"builtinAcChild") Ac.renormalize internalSet
+        & maybe bottom' mkBuiltinSet
+    _ -> termLike
   where
     bottom' = mkBottom (termLikeSort termLike)

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -14,340 +14,377 @@ builtin modules.
     import qualified Kore.Builtin.AssociativeCommutative as Ac
 @
 -}
-
 module Kore.Builtin.AssociativeCommutative
-    ( asInternal
-    , asInternalConcrete
-    , asPattern
-    , asTermLike
-    , ConcatSymbol(..)
-    , ConcreteElements (..)
-    , evalConcatNormalizedOrBottom
-    , NormalizedOrBottom (..)
-    , Opaque (..)
-    , returnAc
-    , returnConcreteAc
-    , TermWrapper (..)
-    , renormalize
-    , TermNormalizedAc
-    , unifyEqualsNormalized
-    , UnitSymbol(..)
-    , VariableElements (..)
-    ) where
+  ( asInternal,
+    asInternalConcrete,
+    asPattern,
+    asTermLike,
+    ConcatSymbol (..),
+    ConcreteElements (..),
+    evalConcatNormalizedOrBottom,
+    NormalizedOrBottom (..),
+    Opaque (..),
+    returnAc,
+    returnConcreteAc,
+    TermWrapper (..),
+    renormalize,
+    TermNormalizedAc,
+    unifyEqualsNormalized,
+    UnitSymbol (..),
+    VariableElements (..)
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Error
-                 ( MaybeT, partitionEithers )
-import           Control.Monad
-                 ( (>=>) )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Error
+  ( MaybeT,
+    partitionEithers
+    )
+import Control.Monad
+  ( (>=>)
+    )
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
 import qualified Data.List as List
 import qualified Data.List
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Reflection
-                 ( Given )
+import Data.Reflection
+  ( Given
+    )
 import qualified Data.Reflection as Reflection
-import           Data.Text.Prettyprint.Doc
-                 ( Doc )
-import           GHC.Stack
-                 ( HasCallStack )
-
+import Data.Text.Prettyprint.Doc
+  ( Doc
+    )
+import GHC.Stack
+  ( HasCallStack
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
+  ( Symbol
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.MapSymbols as Map
 import qualified Kore.Builtin.SetSymbols as Set
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
-import           Kore.Internal.Conditional
-                 ( Conditional, andCondition, withCondition )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
+import Kore.Internal.Conditional
+  ( Conditional,
+    andCondition,
+    withCondition
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.Symbol
-                 ( Symbol )
-import           Kore.Internal.TermLike
-                 ( pattern App_, pattern BuiltinMap_, pattern BuiltinSet_,
-                 Concrete, pattern ElemVar_, TermLike, pattern Var_,
-                 mkApplySymbol, mkBuiltin, mkElemVar, termLikeSort )
+import Kore.Internal.Symbol
+  ( Symbol
+    )
+import Kore.Internal.TermLike
+  ( Concrete,
+    TermLike,
+    mkApplySymbol,
+    mkBuiltin,
+    mkElemVar,
+    termLikeSort,
+    pattern App_,
+    pattern BuiltinMap_,
+    pattern BuiltinSet_,
+    pattern ElemVar_,
+    pattern Var_
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Sort
-                 ( Sort )
-import           Kore.Step.Simplification.Data as Simplifier
-import           Kore.Step.Simplification.Data
-                 ( AttemptedAxiom, emptyAttemptedAxiom )
-import           Kore.Syntax.ElementVariable
-                 ( ElementVariable (getElementVariable) )
-import           Kore.Syntax.Variable
-                 ( SortedVariable, sortedVariableSort )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Sort
+  ( Sort
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Data
+  ( AttemptedAxiom,
+    emptyAttemptedAxiom
+    )
+import Kore.Syntax.ElementVariable
+  ( ElementVariable (getElementVariable)
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable,
+    sortedVariableSort
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse, unparse, unparseToString )
+import Kore.Unparser
+  ( Unparse,
+    unparse,
+    unparseToString
+    )
 import qualified Kore.Unparser as Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 {- | Class for things that can fill the @builtinAcChild@ value of a
 @InternalAc@ struct inside a @Domain.Builtin.Builtin@ value.
 -}
 class
-    Domain.AcWrapper (normalized :: * -> * -> *)
-    => TermWrapper normalized
-  where
-    {- | Render a normalized value (e.g. 'NormalizedSet') as a Domain.Builtin.
+  Domain.AcWrapper (normalized :: * -> * -> *)
+  => TermWrapper normalized where
 
-    The result sort must be hooked to the builtin normalized sort (e.g. @Set@).
-    -}
-    asInternalBuiltin
-        :: SmtMetadataTools Attribute.Symbol
-        -> Sort
-        -> normalized key child
-        -> Domain.Builtin key child
+  {- | Render a normalized value (e.g. 'NormalizedSet') as a Domain.Builtin.
+  
+  The result sort must be hooked to the builtin normalized sort (e.g. @Set@).
+  -}
+  asInternalBuiltin
+    :: SmtMetadataTools Attribute.Symbol
+    -> Sort
+    -> normalized key child
+    -> Domain.Builtin key child
 
-    {- |Transforms a @TermLike@ representation into a @NormalizedOrBottom@.
+  {- |Transforms a @TermLike@ representation into a @NormalizedOrBottom@.
+  
+  The term may become bottom if we had conflicts between elements that were
+  not detected before, e.g.
+  
+  @
+  concat({1}, concat(X:Set, {1}))
+  concat(elem(Y:Int), concat({1}, elem(Y:Int)))
+  concat(X:Set, concat({1}, X:Set))
+  @
+  -}
+  toNormalized
+    :: Ord variable
+    => TermLike variable
+    -> NormalizedOrBottom normalized variable
 
-    The term may become bottom if we had conflicts between elements that were
-    not detected before, e.g.
-
-    @
-    concat({1}, concat(X:Set, {1}))
-    concat(elem(Y:Int), concat({1}, elem(Y:Int)))
-    concat(X:Set, concat({1}, X:Set))
-    @
-    -}
-    toNormalized
-        :: Ord variable
-        => TermLike variable
-        -> NormalizedOrBottom normalized variable
-
-    {- | Pattern match on a 'TermLike' to return a 'normalized'.
-
-    @matchBuiltin@ returns 'Nothing' if the 'TermLike' does not wrap a
-    'normalized' value.
-
-     -}
-    matchBuiltin
-        :: TermLike variable
-        -> Maybe (normalized (TermLike Concrete) (TermLike variable))
+  {- | Pattern match on a 'TermLike' to return a 'normalized'.
+  
+  @matchBuiltin@ returns 'Nothing' if the 'TermLike' does not wrap a
+  'normalized' value.
+  
+   -}
+  matchBuiltin
+    :: TermLike variable
+    -> Maybe (normalized (TermLike Concrete) (TermLike variable))
 
 instance TermWrapper Domain.NormalizedMap where
-    {- | Render a 'NormalizedMap' as a Domain.Builtin.
 
-    The result sort must be hooked to the builtin @Map@ sort.
-    -}
-    asInternalBuiltin tools builtinAcSort builtinAcChild =
-        Domain.BuiltinMap Domain.InternalAc
-            { builtinAcSort
-            , builtinAcUnit = Builtin.lookupSymbolUnit tools builtinAcSort
-            , builtinAcElement = Builtin.lookupSymbolElement tools builtinAcSort
-            , builtinAcConcat = Builtin.lookupSymbolConcat tools builtinAcSort
-            , builtinAcChild
-            }
+  {- | Render a 'NormalizedMap' as a Domain.Builtin.
+  
+  The result sort must be hooked to the builtin @Map@ sort.
+  -}
+  asInternalBuiltin tools builtinAcSort builtinAcChild =
+    Domain.BuiltinMap Domain.InternalAc
+      { builtinAcSort,
+        builtinAcUnit = Builtin.lookupSymbolUnit tools builtinAcSort,
+        builtinAcElement = Builtin.lookupSymbolElement tools builtinAcSort,
+        builtinAcConcat = Builtin.lookupSymbolConcat tools builtinAcSort,
+        builtinAcChild
+        }
 
-    matchBuiltin (BuiltinMap_ internalMap) =
-        Just (Domain.builtinAcChild internalMap)
-    matchBuiltin _ = Nothing
+  matchBuiltin (BuiltinMap_ internalMap) =
+    Just (Domain.builtinAcChild internalMap)
+  matchBuiltin _ = Nothing
 
-    {- |Transforms a @TermLike@ representation into a @NormalizedOrBottom@.
-
-    The map may become bottom if we had conflicts between elements that were
-    not detected before, e.g.
-
-    @
-    concat({1->"a"}, concat(X:Map, {1}))
-    concat(elem(Y:Int), concat({1}, elem(Y:Int)))
-    concat(X:Map, concat({1}, X:Map))
-    @
-    -}
-    toNormalized (BuiltinMap_ Domain.InternalAc { builtinAcChild }) =
-        maybe Bottom Normalized (renormalize builtinAcChild)
-    toNormalized (App_ symbol args)
-      | Map.isSymbolUnit symbol =
-        case args of
-            [] -> (Normalized . Domain.wrapAc) Domain.emptyNormalizedAc
-            _ -> Builtin.wrongArity "MAP.unit"
-      | Map.isSymbolElement symbol =
-        case args of
-            [key, value]
-              | Just key' <- Builtin.toKey key ->
-                (Normalized . Domain.wrapAc) Domain.NormalizedAc
-                    { elementsWithVariables = []
-                    , concreteElements =
-                        Map.singleton key' (Domain.MapValue value)
-                    , opaque = []
-                    }
-              | otherwise ->
-                (Normalized . Domain.wrapAc) Domain.NormalizedAc
-                    { elementsWithVariables = [Domain.MapElement (key, value)]
-                    , concreteElements = Map.empty
-                    , opaque = []
-                    }
-            _ -> Builtin.wrongArity "MAP.element"
-      | Map.isSymbolConcat symbol =
-        case args of
-            [set1, set2] -> toNormalized set1 <> toNormalized set2
-            _ -> Builtin.wrongArity "MAP.concat"
-    toNormalized patt =
-        (Normalized . Domain.wrapAc) Domain.NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements = Map.empty
-            , opaque = [patt]
-            }
+  {- |Transforms a @TermLike@ representation into a @NormalizedOrBottom@.
+  
+  The map may become bottom if we had conflicts between elements that were
+  not detected before, e.g.
+  
+  @
+  concat({1->"a"}, concat(X:Map, {1}))
+  concat(elem(Y:Int), concat({1}, elem(Y:Int)))
+  concat(X:Map, concat({1}, X:Map))
+  @
+  -}
+  toNormalized (BuiltinMap_ Domain.InternalAc {builtinAcChild}) =
+    maybe Bottom Normalized (renormalize builtinAcChild)
+  toNormalized (App_ symbol args)
+    | Map.isSymbolUnit symbol =
+      case args of
+        [] -> (Normalized . Domain.wrapAc) Domain.emptyNormalizedAc
+        _ -> Builtin.wrongArity "MAP.unit"
+    | Map.isSymbolElement symbol =
+      case args of
+        [key, value]
+          | Just key' <- Builtin.toKey key ->
+            (Normalized . Domain.wrapAc) Domain.NormalizedAc
+              { elementsWithVariables = [],
+                concreteElements =
+                  Map.singleton key' (Domain.MapValue value),
+                opaque = []
+                }
+          | otherwise ->
+            (Normalized . Domain.wrapAc) Domain.NormalizedAc
+              { elementsWithVariables = [Domain.MapElement (key, value)],
+                concreteElements = Map.empty,
+                opaque = []
+                }
+        _ -> Builtin.wrongArity "MAP.element"
+    | Map.isSymbolConcat symbol =
+      case args of
+        [set1, set2] -> toNormalized set1 <> toNormalized set2
+        _ -> Builtin.wrongArity "MAP.concat"
+  toNormalized patt =
+    (Normalized . Domain.wrapAc) Domain.NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements = Map.empty,
+        opaque = [patt]
+        }
 
 instance TermWrapper Domain.NormalizedSet where
-    {- | Render a 'NormalizedSet' as a Domain.Builtin.
 
-    The result sort must be hooked to the builtin @Set@ sort.
-    -}
-    asInternalBuiltin tools builtinAcSort builtinAcChild =
-        Domain.BuiltinSet Domain.InternalAc
-            { builtinAcSort
-            , builtinAcUnit = Builtin.lookupSymbolUnit tools builtinAcSort
-            , builtinAcElement = Builtin.lookupSymbolElement tools builtinAcSort
-            , builtinAcConcat = Builtin.lookupSymbolConcat tools builtinAcSort
-            , builtinAcChild
-            }
+  {- | Render a 'NormalizedSet' as a Domain.Builtin.
+  
+  The result sort must be hooked to the builtin @Set@ sort.
+  -}
+  asInternalBuiltin tools builtinAcSort builtinAcChild =
+    Domain.BuiltinSet Domain.InternalAc
+      { builtinAcSort,
+        builtinAcUnit = Builtin.lookupSymbolUnit tools builtinAcSort,
+        builtinAcElement = Builtin.lookupSymbolElement tools builtinAcSort,
+        builtinAcConcat = Builtin.lookupSymbolConcat tools builtinAcSort,
+        builtinAcChild
+        }
 
-    matchBuiltin (BuiltinSet_ internalSet) =
-        Just (Domain.builtinAcChild internalSet)
-    matchBuiltin _ = Nothing
+  matchBuiltin (BuiltinSet_ internalSet) =
+    Just (Domain.builtinAcChild internalSet)
+  matchBuiltin _ = Nothing
 
-    {- |Transforms a @TermLike@ representation into a @NormalizedSetOrBottom@.
-
-    The set may become bottom if we had conflicts between elements that were
-    not detected before, e.g.
-
-    @
-    concat({1}, concat(X:Set, {1}))
-    concat(elem(Y:Int), concat({1}, elem(Y:Int)))
-    concat(X:Set, concat({1}, X:Set))
-    @
-    -}
-    toNormalized (BuiltinSet_ Domain.InternalAc { builtinAcChild }) =
-        maybe Bottom Normalized (renormalize builtinAcChild)
-    toNormalized (App_ symbol args)
-      | Set.isSymbolUnit symbol =
-        case args of
-            [] -> (Normalized . Domain.wrapAc) Domain.emptyNormalizedAc
-            _ -> Builtin.wrongArity "SET.unit"
-      | Set.isSymbolElement symbol =
-        case args of
-            [elem1]
-              | Just elem1' <- Builtin.toKey elem1 ->
-                (Normalized . Domain.wrapAc) Domain.NormalizedAc
-                    { elementsWithVariables = []
-                    , concreteElements = Map.singleton elem1' Domain.SetValue
-                    , opaque = []
-                    }
-              | otherwise ->
-                (Normalized . Domain.wrapAc) Domain.NormalizedAc
-                    { elementsWithVariables = [Domain.SetElement elem1]
-                    , concreteElements = Map.empty
-                    , opaque = []
-                    }
-            _ -> Builtin.wrongArity "SET.element"
-      | Set.isSymbolConcat symbol =
-        case args of
-            [set1, set2] -> toNormalized set1 <> toNormalized set2
-            _ -> Builtin.wrongArity "SET.concat"
-    toNormalized patt =
-        (Normalized . Domain.wrapAc) Domain.NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements = Map.empty
-            , opaque = [patt]
-            }
+  {- |Transforms a @TermLike@ representation into a @NormalizedSetOrBottom@.
+  
+  The set may become bottom if we had conflicts between elements that were
+  not detected before, e.g.
+  
+  @
+  concat({1}, concat(X:Set, {1}))
+  concat(elem(Y:Int), concat({1}, elem(Y:Int)))
+  concat(X:Set, concat({1}, X:Set))
+  @
+  -}
+  toNormalized (BuiltinSet_ Domain.InternalAc {builtinAcChild}) =
+    maybe Bottom Normalized (renormalize builtinAcChild)
+  toNormalized (App_ symbol args)
+    | Set.isSymbolUnit symbol =
+      case args of
+        [] -> (Normalized . Domain.wrapAc) Domain.emptyNormalizedAc
+        _ -> Builtin.wrongArity "SET.unit"
+    | Set.isSymbolElement symbol =
+      case args of
+        [elem1]
+          | Just elem1' <- Builtin.toKey elem1 ->
+            (Normalized . Domain.wrapAc) Domain.NormalizedAc
+              { elementsWithVariables = [],
+                concreteElements = Map.singleton elem1' Domain.SetValue,
+                opaque = []
+                }
+          | otherwise ->
+            (Normalized . Domain.wrapAc) Domain.NormalizedAc
+              { elementsWithVariables = [Domain.SetElement elem1],
+                concreteElements = Map.empty,
+                opaque = []
+                }
+        _ -> Builtin.wrongArity "SET.element"
+    | Set.isSymbolConcat symbol =
+      case args of
+        [set1, set2] -> toNormalized set1 <> toNormalized set2
+        _ -> Builtin.wrongArity "SET.concat"
+  toNormalized patt =
+    (Normalized . Domain.wrapAc) Domain.NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements = Map.empty,
+        opaque = [patt]
+        }
 
 {- | Wrapper for terms that keeps the "concrete" vs "with variable" distinction
 after converting @TermLike Concrete@ to @TermLike variable@.
 -}
 data ConcreteOrWithVariable normalized variable
-    = ConcretePat (TermLike variable, Domain.Value normalized (TermLike variable))
-    | WithVariablePat (TermLike variable, Domain.Value normalized (TermLike variable))
+  = ConcretePat (TermLike variable, Domain.Value normalized (TermLike variable))
+  | WithVariablePat (TermLike variable, Domain.Value normalized (TermLike variable))
 
 fromConcreteOrWithVariable
-    :: ConcreteOrWithVariable normalized variable
-    -> (TermLike variable, Domain.Value normalized (TermLike variable))
+  :: ConcreteOrWithVariable normalized variable
+  -> (TermLike variable, Domain.Value normalized (TermLike variable))
 fromConcreteOrWithVariable (ConcretePat result) = result
 fromConcreteOrWithVariable (WithVariablePat result) = result
 
 {- | Particularizes @Domain.NormalizedAc@ to the most common types.
 -}
-type TermNormalizedAc normalized variable =
-    normalized (TermLike Concrete) (TermLike variable)
+type TermNormalizedAc normalized variable
+  = normalized (TermLike Concrete) (TermLike variable)
 
 {-| A normalized representation of an associative-commutative structure that
 also allows bottom values.
 -}
 data NormalizedOrBottom collection variable
-    = Normalized (TermNormalizedAc collection variable)
-    | Bottom
+  = Normalized (TermNormalizedAc collection variable)
+  | Bottom
 
 deriving instance
-    Eq (TermNormalizedAc collection variable)
-    => Eq (NormalizedOrBottom collection variable)
+  Eq (TermNormalizedAc collection variable)
+  => Eq (NormalizedOrBottom collection variable)
 
 deriving instance
-    Ord (TermNormalizedAc collection variable)
-    => Ord (NormalizedOrBottom collection variable)
+  Ord (TermNormalizedAc collection variable)
+  => Ord (NormalizedOrBottom collection variable)
 
 deriving instance
-    Show (TermNormalizedAc collection variable)
-    => Show (NormalizedOrBottom collection variable)
+  Show (TermNormalizedAc collection variable)
+  => Show (NormalizedOrBottom collection variable)
 
 {- | The semigroup defined by the `concat` operation.
 -}
 instance
-    (Ord variable, TermWrapper normalized)
-    => Semigroup (NormalizedOrBottom normalized variable)
+  (Ord variable, TermWrapper normalized)
+  => Semigroup (NormalizedOrBottom normalized variable)
   where
-    Bottom <> _ = Bottom
-    _ <> Bottom = Bottom
-    Normalized normalized1 <> Normalized normalized2 =
-        maybe Bottom Normalized $ concatNormalized normalized1 normalized2
+  Bottom <> _ = Bottom
+  _ <> Bottom = Bottom
+  Normalized normalized1 <> Normalized normalized2 =
+    maybe Bottom Normalized $ concatNormalized normalized1 normalized2
 
 concatNormalized
-    :: forall normalized variable
-    .  (TermWrapper normalized, Ord variable)
-    => normalized (TermLike Concrete) (TermLike variable)
-    -> normalized (TermLike Concrete) (TermLike variable)
-    -> Maybe (normalized (TermLike Concrete) (TermLike variable))
+  :: forall normalized variable. (TermWrapper normalized, Ord variable)
+  => normalized (TermLike Concrete) (TermLike variable)
+  -> normalized (TermLike Concrete) (TermLike variable)
+  -> Maybe (normalized (TermLike Concrete) (TermLike variable))
 concatNormalized normalized1 normalized2 = do
-    Monad.guard disjointConcreteElements
-    abstract' <-
-        updateAbstractElements $ onBoth (++) Domain.elementsWithVariables
-    let concrete' = onBoth Map.union Domain.concreteElements
-        opaque'   = Data.List.sort $ onBoth (++) Domain.opaque
-    renormalize $ Domain.wrapAc Domain.NormalizedAc
-        { elementsWithVariables = abstract'
-        , concreteElements = concrete'
-        , opaque = opaque'
-        }
+  Monad.guard disjointConcreteElements
+  abstract' <-
+    updateAbstractElements $ onBoth (++) Domain.elementsWithVariables
+  let concrete' = onBoth Map.union Domain.concreteElements
+      opaque' = Data.List.sort $ onBoth (++) Domain.opaque
+  renormalize
+    $ Domain.wrapAc Domain.NormalizedAc
+        { elementsWithVariables = abstract',
+          concreteElements = concrete',
+          opaque = opaque'
+          }
   where
     onBoth
-        ::  (a -> a -> r)
-        ->  (   Domain.NormalizedAc
-                    normalized
-                    (TermLike Concrete)
-                    (TermLike variable)
-            ->  a
-            )
-        -> r
+      :: (a -> a -> r)
+      -> ( Domain.NormalizedAc
+             normalized
+             (TermLike Concrete)
+             (TermLike variable)
+           -> a
+           )
+      -> r
     onBoth f g = Function.on f (g . Domain.unwrapAc) normalized1 normalized2
     disjointConcreteElements =
-        null $ onBoth Map.intersection Domain.concreteElements
+      null $ onBoth Map.intersection Domain.concreteElements
 
 {- | Take a (possibly de-normalized) internal representation to its normal form.
 
@@ -361,21 +398,21 @@ internal representations themselves; this "flattening" step also recurses to
 
  -}
 renormalize
-    :: (TermWrapper normalized, Ord variable)
-    => normalized (TermLike Concrete) (TermLike variable)
-    -> Maybe (normalized (TermLike Concrete) (TermLike variable))
+  :: (TermWrapper normalized, Ord variable)
+  => normalized (TermLike Concrete) (TermLike variable)
+  -> Maybe (normalized (TermLike Concrete) (TermLike variable))
 renormalize = normalizeAbstractElements >=> flattenOpaque
 
 -- | Insert the @key@-@value@ pair if it is missing from the 'Map'.
 insertMissing
-    :: Ord key
-    => key
-    -> value
-    -> Map key value
-    -> Maybe (Map key value)
+  :: Ord key
+  => key
+  -> value
+  -> Map key value
+  -> Maybe (Map key value)
 insertMissing k v m
   | Map.member k m = Nothing
-  | otherwise      = Just (Map.insert k v m)
+  | otherwise = Just (Map.insert k v m)
 
 {- | Insert the new concrete elements into the 'Map'.
 
@@ -383,10 +420,10 @@ Return 'Nothing' if there are any duplicate keys.
 
  -}
 updateConcreteElements
-    :: Ord key
-    => Map key value
-    -> [(key, value)]
-    -> Maybe (Map key value)
+  :: Ord key
+  => Map key value
+  -> [(key, value)]
+  -> Maybe (Map key value)
 updateConcreteElements = Foldable.foldrM (uncurry insertMissing)
 
 {- | Sort the abstract elements.
@@ -395,11 +432,11 @@ Return 'Nothing' if there are any duplicate keys.
 
  -}
 updateAbstractElements
-    :: (Domain.AcWrapper collection, Ord child)
-    => [Domain.Element collection child]
-    -> Maybe [Domain.Element collection child]
+  :: (Domain.AcWrapper collection, Ord child)
+  => [Domain.Element collection child]
+  -> Maybe [Domain.Element collection child]
 updateAbstractElements elements =
-    fmap (map Domain.wrapElement . Map.toList)
+  fmap (map Domain.wrapElement . Map.toList)
     $ Foldable.foldrM (uncurry insertMissing) Map.empty
     $ map Domain.unwrapElement elements
 
@@ -409,33 +446,34 @@ Return 'Nothing' if there are any duplicate (concrete or abstract) keys.
 
  -}
 normalizeAbstractElements
-    :: (TermWrapper normalized, Ord variable)
-    => normalized (TermLike Concrete) (TermLike variable)
-    -> Maybe (normalized (TermLike Concrete) (TermLike variable))
+  :: (TermWrapper normalized, Ord variable)
+  => normalized (TermLike Concrete) (TermLike variable)
+  -> Maybe (normalized (TermLike Concrete) (TermLike variable))
 normalizeAbstractElements (Domain.unwrapAc -> normalized) = do
-    concrete' <- updateConcreteElements concrete newConcrete
-    abstract' <- updateAbstractElements newAbstract
-    return $ Domain.wrapAc Domain.NormalizedAc
-        { elementsWithVariables = abstract'
-        , concreteElements = concrete'
-        , opaque = Domain.opaque normalized
-        }
+  concrete' <- updateConcreteElements concrete newConcrete
+  abstract' <- updateAbstractElements newAbstract
+  return
+    $ Domain.wrapAc Domain.NormalizedAc
+        { elementsWithVariables = abstract',
+          concreteElements = concrete',
+          opaque = Domain.opaque normalized
+          }
   where
     abstract = Domain.elementsWithVariables normalized
     concrete = Domain.concreteElements normalized
     (newConcrete, newAbstract) =
-        partitionEithers (extractConcreteElement <$> abstract)
+      partitionEithers (extractConcreteElement <$> abstract)
 
 -- | 'Left' if the element's key can be concretized, or 'Right' if it
 -- remains abstract.
 extractConcreteElement
-    ::  Domain.AcWrapper collection
-    =>  Domain.Element collection (TermLike variable)
-    ->  Either
-            (TermLike Concrete, Domain.Value collection (TermLike variable))
-            (Domain.Element collection (TermLike variable))
+  :: Domain.AcWrapper collection
+  => Domain.Element collection (TermLike variable)
+  -> Either
+       (TermLike Concrete, Domain.Value collection (TermLike variable))
+       (Domain.Element collection (TermLike variable))
 extractConcreteElement element =
-    maybe (Right element) (Left . flip (,) value) (Builtin.toKey key)
+  maybe (Right element) (Left . flip (,) value) (Builtin.toKey key)
   where
     (key, value) = Domain.unwrapElement element
 
@@ -445,79 +483,81 @@ extractConcreteElement element =
 
  -}
 flattenOpaque
-    :: (TermWrapper normalized, Ord variable)
-    => normalized (TermLike Concrete) (TermLike variable)
-    -> Maybe (normalized (TermLike Concrete) (TermLike variable))
+  :: (TermWrapper normalized, Ord variable)
+  => normalized (TermLike Concrete) (TermLike variable)
+  -> Maybe (normalized (TermLike Concrete) (TermLike variable))
 flattenOpaque (Domain.unwrapAc -> normalized) = do
-    let opaque = Domain.opaque normalized
-        (builtin, opaque') = partitionEithers (extractBuiltin <$> opaque)
-        transparent = Domain.wrapAc normalized { Domain.opaque = opaque' }
-    Foldable.foldrM concatNormalized transparent builtin
+  let opaque = Domain.opaque normalized
+      (builtin, opaque') = partitionEithers (extractBuiltin <$> opaque)
+      transparent = Domain.wrapAc normalized {Domain.opaque = opaque'}
+  Foldable.foldrM concatNormalized transparent builtin
   where
     extractBuiltin termLike =
-        maybe (Right termLike) Left (matchBuiltin termLike)
+      maybe (Right termLike) Left (matchBuiltin termLike)
 
 {- | The monoid defined by the `concat` and `unit` operations.
 -}
 instance
-    (Ord variable, TermWrapper normalized)
-    => Monoid (NormalizedOrBottom normalized variable)
+  (Ord variable, TermWrapper normalized)
+  => Monoid (NormalizedOrBottom normalized variable)
   where
-    mempty = Normalized $ Domain.wrapAc Domain.emptyNormalizedAc
+  mempty = Normalized $ Domain.wrapAc Domain.emptyNormalizedAc
 
 {- | Computes the union of two maps if they are disjoint. Returns @Nothing@
 otherwise.
 -}
 addToMapDisjoint
-    :: (Ord a, Traversable t) => Map a b -> t (a, b) -> Maybe (Map a b)
+  :: (Ord a, Traversable t) => Map a b -> t (a, b) -> Maybe (Map a b)
 addToMapDisjoint existing traversable = do
-    (_, mapResult) <- Monad.foldM addElementDisjoint ([], existing) traversable
-    return mapResult
+  (_, mapResult) <- Monad.foldM addElementDisjoint ([], existing) traversable
+  return mapResult
 
 addElementDisjoint
-    :: Ord a
-    => ([(a, b)], Map a b) -> (a, b) -> Maybe ([(a, b)], Map a b)
+  :: Ord a
+  => ([(a, b)], Map a b)
+  -> (a, b)
+  -> Maybe ([(a, b)], Map a b)
 addElementDisjoint (list, existing) (key, value) =
-    if key `Map.member` existing
+  if key `Map.member` existing
     then Nothing
     else return ((key, value) : list, Map.insert key value existing)
 
 {- | Given a @NormalizedAc@, returns it as a function result.
 -}
 returnAc
-    ::  ( MonadSimplify m
-        , Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        )
-    => Sort
-    -> TermNormalizedAc normalized variable
-    -> m (AttemptedAxiom variable)
+  :: ( MonadSimplify m,
+       Ord variable,
+       SortedVariable variable,
+       TermWrapper normalized
+       )
+  => Sort
+  -> TermNormalizedAc normalized variable
+  -> m (AttemptedAxiom variable)
 returnAc resultSort ac = do
-    tools <- Simplifier.askMetadataTools
-    Builtin.appliedFunction
-        $ Pattern.fromTermLike
-        $ asInternal tools resultSort ac
+  tools <- Simplifier.askMetadataTools
+  Builtin.appliedFunction
+    $ Pattern.fromTermLike
+    $ asInternal tools resultSort ac
 
 {- | Converts an Ac of concrete elements to a @NormalizedAc@ and returns it
 as a function result.
 -}
 returnConcreteAc
-    ::  ( MonadSimplify m
-        , Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        )
-    => Sort
-    -> Map (TermLike Concrete) (Domain.Value normalized (TermLike variable))
-    -> m (AttemptedAxiom variable)
+  :: ( MonadSimplify m,
+       Ord variable,
+       SortedVariable variable,
+       TermWrapper normalized
+       )
+  => Sort
+  -> Map (TermLike Concrete) (Domain.Value normalized (TermLike variable))
+  -> m (AttemptedAxiom variable)
 returnConcreteAc resultSort concrete =
-    returnAc resultSort
+  returnAc resultSort
     $ Domain.wrapAc Domain.NormalizedAc
-        { elementsWithVariables = []
-        , concreteElements = concrete
-        , opaque = []
-        }
+        { elementsWithVariables = [],
+          concreteElements = concrete,
+          opaque = []
+          }
 
 {- | Render an Ac structure as an internal domain value pattern of the given
 sort.
@@ -529,84 +569,84 @@ pattern.
 
 -}
 asInternal
-    ::  ( Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> TermNormalizedAc normalized variable
-    -> TermLike variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       TermWrapper normalized
+       )
+  => SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> TermNormalizedAc normalized variable
+  -> TermLike variable
 asInternal tools builtinAcSort builtinAcChild =
-    mkBuiltin $ asInternalBuiltin tools builtinAcSort builtinAcChild
+  mkBuiltin $ asInternalBuiltin tools builtinAcSort builtinAcChild
 
 {- | The same as 'asInternal', but for ac structures made only of concrete
 elements.
 -}
 asInternalConcrete
-    ::  ( Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> Map (TermLike Concrete) (Domain.Value normalized (TermLike variable))
-    -> TermLike variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       TermWrapper normalized
+       )
+  => SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> Map (TermLike Concrete) (Domain.Value normalized (TermLike variable))
+  -> TermLike variable
 asInternalConcrete tools sort1 concreteAc =
-    asInternal tools sort1
+  asInternal tools sort1
     $ Domain.wrapAc Domain.NormalizedAc
-        { elementsWithVariables = []
-        , concreteElements = concreteAc
-        , opaque = []
-        }
+        { elementsWithVariables = [],
+          concreteElements = concreteAc,
+          opaque = []
+          }
 
 elementListAsInternal
-    :: forall normalized variable
-    .   ( Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        , Unparse variable
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> [(TermLike variable, Domain.Value normalized (TermLike variable))]
-    -> Maybe (TermLike variable)
-elementListAsInternal tools sort1 terms = do
+  :: forall normalized variable. ( Ord variable,
+                                   SortedVariable variable,
+                                   TermWrapper normalized,
+                                   Unparse variable
+                                   )
+  => SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> [(TermLike variable, Domain.Value normalized (TermLike variable))]
+  -> Maybe (TermLike variable)
+elementListAsInternal tools sort1 terms =
+  do
     (asInternal tools sort1 . Domain.wrapAc)
     <$> elementListAsNormalized terms
 
 elementListAsNormalized
-    :: forall normalized variable
-    .   ( Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        , Unparse variable
-        )
-    => [(TermLike variable, Domain.Value normalized (TermLike variable))]
-    -> Maybe
-        (Domain.NormalizedAc normalized (TermLike Concrete) (TermLike variable))
+  :: forall normalized variable. ( Ord variable,
+                                   SortedVariable variable,
+                                   TermWrapper normalized,
+                                   Unparse variable
+                                   )
+  => [(TermLike variable, Domain.Value normalized (TermLike variable))]
+  -> Maybe
+       (Domain.NormalizedAc normalized (TermLike Concrete) (TermLike variable))
 elementListAsNormalized terms = do
-    let (withVariables, concrete) = splitVariableConcrete terms
-    _checkDisjoinVariables <- disjointMap withVariables
-    concreteAc <- disjointMap concrete
-    return Domain.NormalizedAc
-        { elementsWithVariables = Domain.wrapElement <$> withVariables
-        , concreteElements = concreteAc
-        , opaque = []
-        }
+  let (withVariables, concrete) = splitVariableConcrete terms
+  _checkDisjoinVariables <- disjointMap withVariables
+  concreteAc <- disjointMap concrete
+  return Domain.NormalizedAc
+    { elementsWithVariables = Domain.wrapElement <$> withVariables,
+      concreteElements = concreteAc,
+      opaque = []
+      }
 
 {- | Render a 'NormalizedAc' as an extended domain value pattern.
 -}
 asPattern
-    ::  ( Ord variable, SortedVariable variable
-        , Given (SmtMetadataTools Attribute.Symbol)
-        , TermWrapper normalized
-        )
-    => Sort
-    -> TermNormalizedAc normalized variable
-    -> Pattern variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Given (SmtMetadataTools Attribute.Symbol),
+       TermWrapper normalized
+       )
+  => Sort
+  -> TermNormalizedAc normalized variable
+  -> Pattern variable
 asPattern resultSort =
-    Pattern.fromTermLike . asInternal tools resultSort
+  Pattern.fromTermLike . asInternal tools resultSort
   where
     tools :: SmtMetadataTools Attribute.Symbol
     tools = Reflection.given
@@ -615,48 +655,45 @@ asPattern resultSort =
 NormalizedOrBottom, providind the result in the form of a function result.
 -}
 evalConcatNormalizedOrBottom
-    :: forall m normalized variable
-    .   ( MonadSimplify m
-        , Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        )
-    => Sort
-    -> NormalizedOrBottom normalized variable
-    -> NormalizedOrBottom normalized variable
-    -> MaybeT m (AttemptedAxiom variable)
+  :: forall m normalized variable. ( MonadSimplify m,
+                                     Ord variable,
+                                     SortedVariable variable,
+                                     TermWrapper normalized
+                                     )
+  => Sort
+  -> NormalizedOrBottom normalized variable
+  -> NormalizedOrBottom normalized variable
+  -> MaybeT m (AttemptedAxiom variable)
 evalConcatNormalizedOrBottom _ Bottom _ = return emptyAttemptedAxiom
 evalConcatNormalizedOrBottom _ _ Bottom = return emptyAttemptedAxiom
 evalConcatNormalizedOrBottom
-    resultSort
-    (Normalized normalized1)
-    (Normalized normalized2)
-  =
+  resultSort
+  (Normalized normalized1)
+  (Normalized normalized2) =
     maybe (return emptyAttemptedAxiom) (returnAc resultSort)
-    $ concatNormalized normalized1 normalized2
-
+      $ concatNormalized normalized1 normalized2
 
 disjointMap :: Ord a => [(a, b)] -> Maybe (Map a b)
 disjointMap input =
-    if length input == Map.size asMap
+  if length input == Map.size asMap
     then Just asMap
     else Nothing
   where
     asMap = Map.fromList input
 
 splitVariableConcrete
-    :: [(TermLike variable, a)]
-    -> ([(TermLike variable, a)], [(TermLike Concrete, a)])
+  :: [(TermLike variable, a)]
+  -> ([(TermLike variable, a)], [(TermLike Concrete, a)])
 splitVariableConcrete terms =
-    partitionEithers (map toConcreteEither terms)
+  partitionEithers (map toConcreteEither terms)
   where
     toConcreteEither
-        :: (TermLike variable, a)
-        -> Either (TermLike variable, a) (TermLike Concrete, a)
+      :: (TermLike variable, a)
+      -> Either (TermLike variable, a) (TermLike Concrete, a)
     toConcreteEither (term, a) =
-        case TermLike.asConcrete term of
-            Nothing -> Left (term, a)
-            Just result -> Right (result, a)
+      case TermLike.asConcrete term of
+        Nothing -> Left (term, a)
+        Just result -> Right (result, a)
 
 {- | Simplify the conjunction or equality of two Ac domain values in their
 normalized form.
@@ -669,483 +706,450 @@ multiple sorts are hooked to the same builtin domain, the verifier should
 reject the definition.
 -}
 unifyEqualsNormalized
-    :: forall normalized unifier variable
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , Traversable (Domain.Value normalized)
-        , FreshVariable variable
-        , TermWrapper normalized
-        , MonadUnify unifier
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
-    -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> Domain.InternalAc (TermLike Concrete) normalized (TermLike variable)
-    -> Domain.InternalAc (TermLike Concrete) normalized (TermLike variable)
-    -> MaybeT unifier (Pattern variable)
+  :: forall normalized unifier variable. ( SortedVariable variable,
+                                           Unparse variable,
+                                           Show variable,
+                                           Traversable (Domain.Value normalized),
+                                           FreshVariable variable,
+                                           TermWrapper normalized,
+                                           MonadUnify unifier
+                                           )
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
+  -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> Domain.InternalAc (TermLike Concrete) normalized (TermLike variable)
+  -> Domain.InternalAc (TermLike Concrete) normalized (TermLike variable)
+  -> MaybeT unifier (Pattern variable)
 unifyEqualsNormalized
-    tools
-    first
-    second
-    unifyEqualsChildren
-    normalized1
-    normalized2
-  = do
-    let
-        Domain.InternalAc { builtinAcChild = firstNormalized } =
+  tools
+  first
+  second
+  unifyEqualsChildren
+  normalized1
+  normalized2 =
+    do
+      let Domain.InternalAc {builtinAcChild = firstNormalized} =
             normalized1
-        Domain.InternalAc { builtinAcChild = secondNormalized } =
+          Domain.InternalAc {builtinAcChild = secondNormalized} =
             normalized2
-
-    unifierNormalized <-
+      unifierNormalized <-
         unifyEqualsNormalizedAc
-            tools
-            first
-            second
-            unifyEqualsChildren
-            firstNormalized
-            secondNormalized
-    let
-        unifierNormalizedTerm :: TermNormalizedAc normalized variable
-        unifierPredicate :: Predicate variable
-        (unifierNormalizedTerm, unifierPredicate) =
+          tools
+          first
+          second
+          unifyEqualsChildren
+          firstNormalized
+          secondNormalized
+      let unifierNormalizedTerm :: TermNormalizedAc normalized variable
+          unifierPredicate :: Predicate variable
+          (unifierNormalizedTerm, unifierPredicate) =
             Conditional.splitTerm unifierNormalized
-        normalizedTerm :: TermLike variable
-        normalizedTerm = asInternal tools sort1 unifierNormalizedTerm
-
-    -- TODO(virgil): Check whether this normalization is still needed
-    -- (the normalizedTerm may already be re-normalized) and remove it if not.
-    renormalized <- normalize1 normalizedTerm
-
-    let unifierTerm :: TermLike variable
-        unifierTerm = asInternal tools sort1 renormalized
-    return (unifierTerm `withCondition` unifierPredicate)
-  where
-    sort1 = termLikeSort first
-
-    normalize1
-        ::  ( MonadUnify unifier
-            , Ord variable
-            )
+          normalizedTerm :: TermLike variable
+          normalizedTerm = asInternal tools sort1 unifierNormalizedTerm
+      -- TODO(virgil): Check whether this normalization is still needed
+      -- (the normalizedTerm may already be re-normalized) and remove it if not.
+      renormalized <- normalize1 normalizedTerm
+      let unifierTerm :: TermLike variable
+          unifierTerm = asInternal tools sort1 renormalized
+      return (unifierTerm `withCondition` unifierPredicate)
+    where
+      sort1 = termLikeSort first
+      normalize1
+        :: ( MonadUnify unifier,
+             Ord variable
+             )
         => TermLike variable
         -> MaybeT unifier (TermNormalizedAc normalized variable)
-    normalize1 patt =
+      normalize1 patt =
         case toNormalized patt of
-            Bottom -> Monad.Trans.lift $ Monad.Unify.explainAndReturnBottom
-                "Duplicated elements in normalization."
-                first
-                second
-            Normalized n -> return n
+          Bottom ->
+            Monad.Trans.lift
+              $ Monad.Unify.explainAndReturnBottom
+                  "Duplicated elements in normalization."
+                  first
+                  second
+          Normalized n -> return n
 
 {- | Unifies two AC structs represented as @NormalizedAc@.
 
 Currently allows at most one opaque term in the two arguments taken together.
 -}
 unifyEqualsNormalizedAc
-    ::  forall normalized variable unifier
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , Traversable (Domain.Value normalized)
-        , FreshVariable variable
-        , TermWrapper normalized
-        , MonadUnify unifier
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
-    -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> TermNormalizedAc normalized variable
-    -> TermNormalizedAc normalized variable
-    -> MaybeT
-        unifier
-        (Conditional variable (TermNormalizedAc normalized variable))
+  :: forall normalized variable unifier. ( SortedVariable variable,
+                                           Unparse variable,
+                                           Show variable,
+                                           Traversable (Domain.Value normalized),
+                                           FreshVariable variable,
+                                           TermWrapper normalized,
+                                           MonadUnify unifier
+                                           )
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
+  -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> TermNormalizedAc normalized variable
+  -> TermNormalizedAc normalized variable
+  -> MaybeT
+       unifier
+       (Conditional variable (TermNormalizedAc normalized variable))
 unifyEqualsNormalizedAc
-    tools
-    first
-    second
-    unifyEqualsChildren
-    normalized1
-    normalized2
-  = do
-    (simpleUnifier, opaques) <- case (opaqueDifference1, opaqueDifference2) of
-        ([], []) -> Monad.Trans.lift $
-            unifyEqualsElementLists'
-                allElements1
-                allElements2
-                Nothing
-        ([opaque], []) ->
-            Monad.Trans.lift $
-                unifyEqualsElementLists'
-                    allElements1
-                    allElements2
-                    (Just opaque)
-        ([], [opaque]) ->
-            Monad.Trans.lift $
-                unifyEqualsElementLists'
-                    allElements2
-                    allElements1
-                    (Just opaque)
-        ([ElemVar_ v1], _)
-          | null allElements1 ->
-            unifyOpaqueVariable' v1 allElements2 opaqueDifference2
-        (_, [ElemVar_ v2])
-          | null allElements2 ->
-            unifyOpaqueVariable' v2 allElements1 opaqueDifference1
-        (_, _) -> empty
-    let (unifiedElements, unifierPredicate) =
+  tools
+  first
+  second
+  unifyEqualsChildren
+  normalized1
+  normalized2 =
+    do
+      (simpleUnifier, opaques) <-
+        case (opaqueDifference1, opaqueDifference2) of
+          ([], []) ->
+            Monad.Trans.lift
+              $ unifyEqualsElementLists'
+                  allElements1
+                  allElements2
+                  Nothing
+          ([opaque], []) ->
+            Monad.Trans.lift
+              $ unifyEqualsElementLists'
+                  allElements1
+                  allElements2
+                  (Just opaque)
+          ([], [opaque]) ->
+            Monad.Trans.lift
+              $ unifyEqualsElementLists'
+                  allElements2
+                  allElements1
+                  (Just opaque)
+          ([ElemVar_ v1], _)
+            | null allElements1 ->
+              unifyOpaqueVariable' v1 allElements2 opaqueDifference2
+          (_, [ElemVar_ v2])
+            | null allElements2 ->
+              unifyOpaqueVariable' v2 allElements1 opaqueDifference1
+          (_, _) -> empty
+      let (unifiedElements, unifierPredicate) =
             Conditional.splitTerm simpleUnifier
-    Monad.Trans.lift $ do -- unifier monad
+      Monad.Trans.lift $ do
+        -- unifier monad
         -- unify the parts not sent to unifyEqualsNormalizedElements.
         (commonElementsTerms, commonElementsPredicate) <-
-            unifyElementList (Map.toList commonElements)
+          unifyElementList (Map.toList commonElements)
         (commonVariablesTerms, commonVariablesPredicate) <-
-            unifyElementList (Map.toList commonVariables)
-
+          unifyElementList (Map.toList commonVariables)
         -- simplify results so that things like inj applications that
         -- may have been broken into smaller pieces are being put
         -- back together.
         unifiedSimplified <- mapM simplifyPair unifiedElements
         opaquesSimplified <- mapM simplify opaques
-
         buildResultFromUnifiers
-            bottomWithExplanation
-            commonElementsTerms
-            commonVariablesTerms
-            commonOpaque
-            unifiedSimplified
-            opaquesSimplified
-            [ unifierPredicate
-            , commonElementsPredicate
-            , commonVariablesPredicate
+          bottomWithExplanation
+          commonElementsTerms
+          commonVariablesTerms
+          commonOpaque
+          unifiedSimplified
+          opaquesSimplified
+          [ unifierPredicate,
+            commonElementsPredicate,
+            commonVariablesPredicate
             ]
-  where
-    listToMap :: Ord a => [a] -> Map a Int
-    listToMap = List.foldl' (\m k -> Map.insertWith (+) k 1 m) Map.empty
-    mapToList :: Map a Int -> [a]
-    mapToList =
+    where
+      listToMap :: Ord a => [a] -> Map a Int
+      listToMap = List.foldl' (\m k -> Map.insertWith (+) k 1 m) Map.empty
+      mapToList :: Map a Int -> [a]
+      mapToList =
         Map.foldrWithKey
-            (\key count result -> replicate count key ++ result)
-            []
-
-    bottomWithExplanation :: Doc () -> unifier a
-    bottomWithExplanation explanation =
+          (\key count result -> replicate count key ++ result)
+          []
+      bottomWithExplanation :: Doc () -> unifier a
+      bottomWithExplanation explanation =
         Monad.Unify.explainAndReturnBottom explanation first second
-
-    unifyEqualsElementLists' =
+      unifyEqualsElementLists' =
         unifyEqualsElementLists
-            tools
-            first
-            second
-            unifyEqualsChildren
-
-    unifyOpaqueVariable' =
+          tools
+          first
+          second
+          unifyEqualsChildren
+      unifyOpaqueVariable' =
         unifyOpaqueVariable tools bottomWithExplanation unifyEqualsChildren
-
-    Domain.NormalizedAc
-        { elementsWithVariables = preElementsWithVariables1
-        , concreteElements = concreteElements1
-        , opaque = opaque1
-        }
-        = Domain.unwrapAc normalized1
-    Domain.NormalizedAc
-        { elementsWithVariables = preElementsWithVariables2
-        , concreteElements = concreteElements2
-        , opaque = opaque2
-        }
-        = Domain.unwrapAc normalized2
-
-    opaque1Map = listToMap opaque1
-    opaque2Map = listToMap opaque2
-
-    elementsWithVariables1 = Domain.unwrapElement <$> preElementsWithVariables1
-    elementsWithVariables2 = Domain.unwrapElement <$> preElementsWithVariables2
-    elementsWithVariables1Map = Map.fromList elementsWithVariables1
-    elementsWithVariables2Map = Map.fromList elementsWithVariables2
-
-    commonElements =
+      Domain.NormalizedAc
+        { elementsWithVariables = preElementsWithVariables1,
+          concreteElements = concreteElements1,
+          opaque = opaque1
+          } =
+          Domain.unwrapAc normalized1
+      Domain.NormalizedAc
+        { elementsWithVariables = preElementsWithVariables2,
+          concreteElements = concreteElements2,
+          opaque = opaque2
+          } =
+          Domain.unwrapAc normalized2
+      opaque1Map = listToMap opaque1
+      opaque2Map = listToMap opaque2
+      elementsWithVariables1 = Domain.unwrapElement <$> preElementsWithVariables1
+      elementsWithVariables2 = Domain.unwrapElement <$> preElementsWithVariables2
+      elementsWithVariables1Map = Map.fromList elementsWithVariables1
+      elementsWithVariables2Map = Map.fromList elementsWithVariables2
+      commonElements =
         Map.intersectionWith
-            (,)
-            concreteElements1
-            concreteElements2
-    commonVariables =
+          (,)
+          concreteElements1
+          concreteElements2
+      commonVariables =
         Map.intersectionWith
-            (,)
-            elementsWithVariables1Map
-            elementsWithVariables2Map
-
-    -- Duplicates must be kept in case any of the opaque terms turns out to be
-    -- non-empty, in which case one of the terms is bottom, which
-    -- means that the unification result is bottom.
-    commonOpaqueMap = Map.intersectionWith max opaque1Map opaque2Map
-
-    commonOpaque = mapToList commonOpaqueMap
-    commonOpaqueKeys = Map.keysSet commonOpaqueMap
-
-    elementDifference1 =
+          (,)
+          elementsWithVariables1Map
+          elementsWithVariables2Map
+      -- Duplicates must be kept in case any of the opaque terms turns out to be
+      -- non-empty, in which case one of the terms is bottom, which
+      -- means that the unification result is bottom.
+      commonOpaqueMap = Map.intersectionWith max opaque1Map opaque2Map
+      commonOpaque = mapToList commonOpaqueMap
+      commonOpaqueKeys = Map.keysSet commonOpaqueMap
+      elementDifference1 =
         Map.toList (Map.difference concreteElements1 commonElements)
-    elementDifference2 =
+      elementDifference2 =
         Map.toList (Map.difference concreteElements2 commonElements)
-    elementVariableDifference1 =
+      elementVariableDifference1 =
         Map.toList (Map.difference elementsWithVariables1Map commonVariables)
-    elementVariableDifference2 =
+      elementVariableDifference2 =
         Map.toList (Map.difference elementsWithVariables2Map commonVariables)
-    opaqueDifference1 =
+      opaqueDifference1 =
         mapToList (Map.withoutKeys opaque1Map commonOpaqueKeys)
-    opaqueDifference2 =
+      opaqueDifference2 =
         mapToList (Map.withoutKeys opaque2Map commonOpaqueKeys)
-
-    allElements1 =
+      allElements1 =
         map WithVariablePat elementVariableDifference1
-        ++ map toConcretePat elementDifference1
-    allElements2 =
+          ++ map toConcretePat elementDifference1
+      allElements2 =
         map WithVariablePat elementVariableDifference2
-        ++ map toConcretePat elementDifference2
-
-    toConcretePat
+          ++ map toConcretePat elementDifference2
+      toConcretePat
         :: (TermLike Concrete, Domain.Value normalized (TermLike variable))
         -> ConcreteOrWithVariable normalized variable
-    toConcretePat (a, b) = ConcretePat (TermLike.fromConcrete a, b)
-
-    unifyElementList
-        :: forall key
-        .   [
-                (key
-                ,   ( Domain.Value normalized (TermLike variable)
-                    , Domain.Value normalized (TermLike variable)
-                    )
-                )
-            ]
+      toConcretePat (a, b) = ConcretePat (TermLike.fromConcrete a, b)
+      unifyElementList
+        :: forall key. [ ( key,
+                           ( Domain.Value normalized (TermLike variable),
+                             Domain.Value normalized (TermLike variable)
+                             )
+                           )
+                         ]
         -> unifier
-            ( [(key, Domain.Value normalized (TermLike variable))]
-            , Predicate variable
-            )
-    unifyElementList elements = do
+             ( [(key, Domain.Value normalized (TermLike variable))],
+               Predicate variable
+               )
+      unifyElementList elements = do
         result <- mapM (unifyCommonElements unifyEqualsChildren) elements
-        let
-            terms :: [(key, Domain.Value normalized (TermLike variable))]
+        let terms :: [(key, Domain.Value normalized (TermLike variable))]
             predicates :: [Predicate variable]
             (terms, predicates) = unzip (map Conditional.splitTerm result)
             predicate :: Predicate variable
-            predicate = List.foldl'
+            predicate =
+              List.foldl'
                 andCondition
                 Predicate.top
                 predicates
-
         return (terms, predicate)
-
-    simplify :: TermLike variable -> unifier (Pattern variable)
-    simplify term = alternate $ simplifyConditionalTerm term Predicate.top
-
-    simplifyPair
+      simplify :: TermLike variable -> unifier (Pattern variable)
+      simplify term = alternate $ simplifyConditionalTerm term Predicate.top
+      simplifyPair
         :: (TermLike variable, Domain.Value normalized (TermLike variable))
         -> unifier
-            (Conditional
-                variable
-                (TermLike variable, Domain.Value normalized (TermLike variable))
-            )
-    simplifyPair (key, value) = do
+             ( Conditional
+                 variable
+                 (TermLike variable, Domain.Value normalized (TermLike variable))
+               )
+      simplifyPair (key, value) = do
         simplifiedKey <- simplifyTermLike key
         let (keyTerm, keyPredicate) = Conditional.splitTerm simplifiedKey
         simplifiedValue <- traverse simplifyTermLike value
-        let
-            splitSimplifiedValue
-                :: Domain.Value
-                    normalized
-                    (TermLike variable, Predicate variable)
+        let splitSimplifiedValue
+              :: Domain.Value
+                   normalized
+                   (TermLike variable, Predicate variable)
             splitSimplifiedValue =
-                fmap Conditional.splitTerm simplifiedValue
+              fmap Conditional.splitTerm simplifiedValue
             simplifiedValueTerm :: Domain.Value normalized (TermLike variable)
             simplifiedValueTerm = fmap fst splitSimplifiedValue
             simplifiedValuePredicates
-                :: Domain.Value normalized (Predicate variable)
+              :: Domain.Value normalized (Predicate variable)
             simplifiedValuePredicates = fmap snd splitSimplifiedValue
             simplifiedValuePredicate :: Predicate variable
             simplifiedValuePredicate =
-                foldr
-                    andCondition
-                    Predicate.top
-                    simplifiedValuePredicates
+              foldr
+                andCondition
+                Predicate.top
+                simplifiedValuePredicates
         return
-            ((keyTerm, simplifiedValueTerm)
-            `withCondition` keyPredicate
-            `andCondition` simplifiedValuePredicate
+          ( (keyTerm, simplifiedValueTerm)
+              `withCondition` keyPredicate
+              `andCondition` simplifiedValuePredicate
             )
-      where
-        simplifyTermLike :: TermLike variable -> unifier (Pattern variable)
-        simplifyTermLike term =
+        where
+          simplifyTermLike :: TermLike variable -> unifier (Pattern variable)
+          simplifyTermLike term =
             alternate $ simplifyConditionalTerm term Predicate.top
 
 buildResultFromUnifiers
-    :: forall normalized unifier variable
-    .   ( Monad unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        , Unparse variable
-        )
-    => (forall result . Doc () -> unifier result)
-    -> [(TermLike Concrete, Domain.Value normalized (TermLike variable))]
-    -> [(TermLike variable, Domain.Value normalized (TermLike variable))]
-    -> [TermLike variable]
-    ->  [ Conditional
-            variable
-            (TermLike variable, Domain.Value normalized (TermLike variable))
-        ]
-    -> [Pattern variable]
-    -> [Predicate variable]
-    -> unifier (Conditional variable (TermNormalizedAc normalized variable))
+  :: forall normalized unifier variable. ( Monad unifier,
+                                           Ord variable,
+                                           Show variable,
+                                           SortedVariable variable,
+                                           TermWrapper normalized,
+                                           Unparse variable
+                                           )
+  => (forall result. Doc () -> unifier result)
+  -> [(TermLike Concrete, Domain.Value normalized (TermLike variable))]
+  -> [(TermLike variable, Domain.Value normalized (TermLike variable))]
+  -> [TermLike variable]
+  -> [ Conditional
+         variable
+         (TermLike variable, Domain.Value normalized (TermLike variable))
+       ]
+  -> [Pattern variable]
+  -> [Predicate variable]
+  -> unifier (Conditional variable (TermNormalizedAc normalized variable))
 buildResultFromUnifiers
-    bottomWithExplanation
-    commonElementsTerms
-    commonVariablesTerms
-    commonOpaque
-    unifiedElementsSimplified
-    opaquesSimplified
-    predicates
-  = do -- unifier monad
-    let
-        almostResultTerms
-            ::  [   ( TermLike variable
-                    , Domain.Value normalized (TermLike variable)
-                    )
-                ]
-        almostResultPredicates :: [Predicate variable]
-        (almostResultTerms, almostResultPredicates) =
+  bottomWithExplanation
+  commonElementsTerms
+  commonVariablesTerms
+  commonOpaque
+  unifiedElementsSimplified
+  opaquesSimplified
+  predicates =
+    do
+      -- unifier monad
+      let almostResultTerms
+            :: [ ( TermLike variable,
+                   Domain.Value normalized (TermLike variable)
+                   )
+                 ]
+          almostResultPredicates :: [Predicate variable]
+          (almostResultTerms, almostResultPredicates) =
             unzip (map Conditional.splitTerm unifiedElementsSimplified)
-        (withVariableTerms, concreteTerms) =
+          (withVariableTerms, concreteTerms) =
             splitVariableConcrete almostResultTerms
-
-        (opaquesTerms, opaquesPredicates) =
+          (opaquesTerms, opaquesPredicates) =
             unzip (map Conditional.splitTerm opaquesSimplified)
-        opaquesNormalized :: NormalizedOrBottom normalized variable
-        opaquesNormalized = Foldable.foldMap toNormalized opaquesTerms
-
-    Domain.NormalizedAc
-        { elementsWithVariables = preOpaquesElementsWithVariables
-        , concreteElements = opaquesConcreteTerms
-        , opaque = opaquesOpaque
-        } <- case opaquesNormalized of
-            Bottom ->
-                bottomWithExplanation "Duplicated elements after unification."
-            Normalized result -> return (Domain.unwrapAc result)
-    let opaquesElementsWithVariables =
+          opaquesNormalized :: NormalizedOrBottom normalized variable
+          opaquesNormalized = Foldable.foldMap toNormalized opaquesTerms
+      Domain.NormalizedAc
+        { elementsWithVariables = preOpaquesElementsWithVariables,
+          concreteElements = opaquesConcreteTerms,
+          opaque = opaquesOpaque
+          } <-
+        case opaquesNormalized of
+          Bottom ->
+            bottomWithExplanation "Duplicated elements after unification."
+          Normalized result -> return (Domain.unwrapAc result)
+      let opaquesElementsWithVariables =
             Domain.unwrapElement <$> preOpaquesElementsWithVariables
-
-    -- Add back all the common objects that were removed before
-    -- unification.
-    withVariableMap <-
+      -- Add back all the common objects that were removed before
+      -- unification.
+      withVariableMap <-
         addAllDisjoint
-            bottomWithExplanation
-            Map.empty
-            (  commonVariablesTerms
-            ++ withVariableTerms
-            ++ opaquesElementsWithVariables
+          bottomWithExplanation
+          Map.empty
+          ( commonVariablesTerms
+              ++ withVariableTerms
+              ++ opaquesElementsWithVariables
             )
-    concreteMap <-
+      concreteMap <-
         addAllDisjoint
-            bottomWithExplanation
-            Map.empty
-            (  commonElementsTerms
-            ++ concreteTerms
-            ++ Map.toList opaquesConcreteTerms
+          bottomWithExplanation
+          Map.empty
+          ( commonElementsTerms
+              ++ concreteTerms
+              ++ Map.toList opaquesConcreteTerms
             )
-    let allOpaque = Data.List.sort (commonOpaque ++ opaquesOpaque)
-        -- Merge all unification predicates.
-        predicate = List.foldl'
-            andCondition
-            Predicate.top
-            (almostResultPredicates ++ opaquesPredicates ++ predicates)
-        result
+      let allOpaque = Data.List.sort (commonOpaque ++ opaquesOpaque)
+          -- Merge all unification predicates.
+          predicate =
+            List.foldl'
+              andCondition
+              Predicate.top
+              (almostResultPredicates ++ opaquesPredicates ++ predicates)
+          result
             :: Conditional variable
-                (normalized (TermLike Concrete) (TermLike variable))
-        result =
+                 (normalized (TermLike Concrete) (TermLike variable))
+          result =
             Domain.wrapAc Domain.NormalizedAc
-                { elementsWithVariables =
-                    Domain.wrapElement <$> Map.toList withVariableMap
-                , concreteElements = concreteMap
-                , opaque = allOpaque
+              { elementsWithVariables =
+                  Domain.wrapElement <$> Map.toList withVariableMap,
+                concreteElements = concreteMap,
+                opaque = allOpaque
                 }
-            `Conditional.withCondition` predicate
-
-    return result
+              `Conditional.withCondition` predicate
+      return result
 
 addAllDisjoint
-    :: (Monad unifier, Ord a)
-    => (forall result . Doc () -> unifier result)
-    -> Map a b
-    -> [(a, b)]
-    -> unifier (Map a b)
+  :: (Monad unifier, Ord a)
+  => (forall result. Doc () -> unifier result)
+  -> Map a b
+  -> [(a, b)]
+  -> unifier (Map a b)
 addAllDisjoint bottomWithExplanation existing elements =
-    case addToMapDisjoint existing elements of
-        Nothing ->
-            bottomWithExplanation "Duplicated elements after AC unification."
-        Just result -> return result
+  case addToMapDisjoint existing elements of
+    Nothing ->
+      bottomWithExplanation "Duplicated elements after AC unification."
+    Just result -> return result
 
 unifyCommonElements
-    :: forall key normalized unifier variable
-    .   ( Domain.AcWrapper normalized
-        , MonadUnify unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    ->  ( key
-        ,   ( Domain.Value normalized (TermLike variable)
-            , Domain.Value normalized (TermLike variable)
-            )
-        )
-    ->  unifier
-        ( Conditional variable
-            (key, Domain.Value normalized (TermLike variable))
-        )
+  :: forall key normalized unifier variable. ( Domain.AcWrapper normalized,
+                                               MonadUnify unifier,
+                                               Ord variable,
+                                               Show variable,
+                                               SortedVariable variable,
+                                               Traversable (Domain.Value normalized),
+                                               Unparse variable
+                                               )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> ( key,
+       ( Domain.Value normalized (TermLike variable),
+         Domain.Value normalized (TermLike variable)
+         )
+       )
+  -> unifier
+       ( Conditional variable
+           (key, Domain.Value normalized (TermLike variable))
+         )
 unifyCommonElements
-    unifier
-    (key, (firstValue, secondValue))
-  = do
-    valuesUnifier <- unifyWrappedValues unifier firstValue secondValue
-    let
-        (valuesTerm, valuePredicate) = Conditional.splitTerm valuesUnifier
-
-    return ((key, valuesTerm) `withCondition` valuePredicate)
+  unifier
+  (key, (firstValue, secondValue)) =
+    do
+      valuesUnifier <- unifyWrappedValues unifier firstValue secondValue
+      let (valuesTerm, valuePredicate) = Conditional.splitTerm valuesUnifier
+      return ((key, valuesTerm) `withCondition` valuePredicate)
 
 unifyWrappedValues
-    :: forall normalized unifier variable
-    .   ( Domain.AcWrapper normalized
-        , MonadUnify unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> Domain.Value normalized (TermLike variable)
-    -> Domain.Value normalized (TermLike variable)
-    ->  unifier
-            (Conditional variable (Domain.Value normalized (TermLike variable)))
+  :: forall normalized unifier variable. ( Domain.AcWrapper normalized,
+                                           MonadUnify unifier,
+                                           Ord variable,
+                                           Show variable,
+                                           SortedVariable variable,
+                                           Traversable (Domain.Value normalized),
+                                           Unparse variable
+                                           )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> Domain.Value normalized (TermLike variable)
+  -> Domain.Value normalized (TermLike variable)
+  -> unifier
+       (Conditional variable (Domain.Value normalized (TermLike variable)))
 unifyWrappedValues unifier firstValue secondValue = do
-    let aligned = Domain.alignValues firstValue secondValue
-    unifiedValues <- traverse (uncurry unifier) aligned
-    let
-        splitValues
-            :: Domain.Value normalized (TermLike variable, Predicate variable)
-        splitValues = fmap Pattern.splitTerm unifiedValues
-        valueUnifierTerm :: Domain.Value normalized (TermLike variable)
-        valueUnifierTerm = fmap fst splitValues
-        valuePredicates :: Domain.Value normalized (Predicate variable)
-        valuePredicates = fmap snd splitValues
-        valueUnifierPredicate :: Predicate variable
-        valueUnifierPredicate =
-            foldr Conditional.andCondition Predicate.top valuePredicates
-
-    return (valueUnifierTerm `withCondition` valueUnifierPredicate)
+  let aligned = Domain.alignValues firstValue secondValue
+  unifiedValues <- traverse (uncurry unifier) aligned
+  let splitValues
+        :: Domain.Value normalized (TermLike variable, Predicate variable)
+      splitValues = fmap Pattern.splitTerm unifiedValues
+      valueUnifierTerm :: Domain.Value normalized (TermLike variable)
+      valueUnifierTerm = fmap fst splitValues
+      valuePredicates :: Domain.Value normalized (Predicate variable)
+      valuePredicates = fmap snd splitValues
+      valueUnifierPredicate :: Predicate variable
+      valueUnifierPredicate =
+        foldr Conditional.andCondition Predicate.top valuePredicates
+  return (valueUnifierTerm `withCondition` valueUnifierPredicate)
 
 {- | Unifies two ac structures given their representation as a list of
 @ConcreteOrWithVariable@, with the first structure being allowed an additional
@@ -1155,209 +1159,207 @@ together with some part of the second structure.
 The keys of the two structures are assumend to be disjoint.
 -}
 unifyEqualsElementLists
-    ::  forall normalized variable unifier
-    .   ( Domain.AcWrapper normalized
-        , FreshVariable variable
-        , MonadUnify unifier
-        , Show variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
-    -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -- ^ unifier function
-    -> [ConcreteOrWithVariable normalized variable]
-    -- ^ First structure elements
-    -> [ConcreteOrWithVariable normalized variable]
-    -- ^ Second structure elements
-    -> Maybe (TermLike variable)
-    -- ^ Opaque part of the first structure
-    -> unifier
-        ( Conditional
-            variable
-            [(TermLike variable, Domain.Value normalized (TermLike variable))]
-        , [TermLike variable]
-        )
+  :: forall normalized variable unifier. ( Domain.AcWrapper normalized,
+                                           FreshVariable variable,
+                                           MonadUnify unifier,
+                                           Show variable,
+                                           SortedVariable variable,
+                                           TermWrapper normalized,
+                                           Traversable (Domain.Value normalized),
+                                           Unparse variable
+                                           )
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
+  -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -- ^ unifier function
+  -> [ConcreteOrWithVariable normalized variable]
+  -- ^ First structure elements
+  -> [ConcreteOrWithVariable normalized variable]
+  -- ^ Second structure elements
+  -> Maybe (TermLike variable)
+  -- ^ Opaque part of the first structure
+  -> unifier
+       ( Conditional
+           variable
+           [(TermLike variable, Domain.Value normalized (TermLike variable))],
+         [TermLike variable]
+         )
 unifyEqualsElementLists
-    _tools
-    first
-    second
-    unifyEqualsChildren
-    firstElements
-    secondElements
-    Nothing
-  | length firstElements /= length secondElements
-    -- Neither the first, not the second ac structure include an opaque term, so
-    -- the listed elements form the two structures.
-    --
-    -- Since the two lists have different counts, their structures can
-    -- never unify.
-  = Monad.Unify.explainAndReturnBottom
+  _tools
+  first
+  second
+  unifyEqualsChildren
+  firstElements
+  secondElements
+  Nothing
+    | length firstElements /= length secondElements =
+      -- Neither the first, not the second ac structure include an opaque term, so
+      -- the listed elements form the two structures.
+      --
+      -- Since the two lists have different counts, their structures can
+      -- never unify.
+      Monad.Unify.explainAndReturnBottom
         "Cannot unify ac structures with different sizes."
         first
         second
-  | otherwise = do
-    (result, remainder1, remainder2) <-
-        unifyWithPermutations firstElements secondElements
-    -- The second structure does not include an opaque term so there is nothing
-    -- to match whatever is left in remainder1. This should have been caught by
-    -- the "length" check above so, most likely, this can be an assertion.
-    Monad.unless
-        (null remainder1)
-        (remainderError firstElements secondElements remainder1)
-    -- The first structure does not include an opaque term so there is nothing
-    -- to match whatever is left in remainder2. This should have been caught by
-    -- the "length" check above so, most likely, this can be an assertion.
-    Monad.unless
-        (null remainder2)
-        (remainderError firstElements secondElements remainder2)
-
-    return (result, [])
-  where
-    unifyWithPermutations
+    | otherwise =
+      do
+        (result, remainder1, remainder2) <-
+          unifyWithPermutations firstElements secondElements
+        -- The second structure does not include an opaque term so there is nothing
+        -- to match whatever is left in remainder1. This should have been caught by
+        -- the "length" check above so, most likely, this can be an assertion.
+        Monad.unless
+          (null remainder1)
+          (remainderError firstElements secondElements remainder1)
+        -- The first structure does not include an opaque term so there is nothing
+        -- to match whatever is left in remainder2. This should have been caught by
+        -- the "length" check above so, most likely, this can be an assertion.
+        Monad.unless
+          (null remainder2)
+          (remainderError firstElements secondElements remainder2)
+        return (result, [])
+    where
+      unifyWithPermutations
         :: [ConcreteOrWithVariable normalized variable]
         -- ^ First structure elements
         -> [ConcreteOrWithVariable normalized variable]
         -- ^ Second structure elements
         -> unifier
-            (Conditional variable
-                [   ( TermLike variable
-                    , Domain.Value normalized (TermLike variable)
-                    )
-                ]
-            , [ConcreteOrWithVariable normalized variable]
-            , [ConcreteOrWithVariable normalized variable]
-            )
-    unifyWithPermutations =
+             ( Conditional variable
+                 [ ( TermLike variable,
+                     Domain.Value normalized (TermLike variable)
+                     )
+                   ],
+               [ConcreteOrWithVariable normalized variable],
+               [ConcreteOrWithVariable normalized variable]
+               )
+      unifyWithPermutations =
         unifyEqualsElementPermutations
-            (unifyEqualsConcreteOrWithVariable unifyEqualsChildren)
-    remainderError = nonEmptyRemainderError first second
+          (unifyEqualsConcreteOrWithVariable unifyEqualsChildren)
+      remainderError = nonEmptyRemainderError first second
 unifyEqualsElementLists
-    tools
-    first
-    second
-    unifyEqualsChildren
-    firstElements
-    secondElements
-    (Just opaque)
-  | length firstElements > length secondElements
-    -- The second structure does not include an opaque term, so all the
-    -- elements in the first structure must be matched by elements in the second
-    -- one. Since we don't have enough, we return bottom.
-  = Monad.Unify.explainAndReturnBottom
+  tools
+  first
+  second
+  unifyEqualsChildren
+  firstElements
+  secondElements
+  (Just opaque)
+    | length firstElements > length secondElements =
+      -- The second structure does not include an opaque term, so all the
+      -- elements in the first structure must be matched by elements in the second
+      -- one. Since we don't have enough, we return bottom.
+      Monad.Unify.explainAndReturnBottom
         "Cannot unify ac structures with different sizes."
         first
         second
-  | otherwise = do
-    (unifier, remainder1, remainder2) <-
-        unifyWithPermutations firstElements secondElements
-    -- The second structure does not include an opaque term so there is nothing
-    -- to match whatever is left in remainder1. This should have been caught by
-    -- the "length" check above so, most likely, this can be an assertion.
-    Monad.unless
-        (null remainder1)
-        (remainderError firstElements secondElements remainder1)
-
-    let remainder2Terms = map fromConcreteOrWithVariable remainder2
-
-    case elementListAsInternal tools (termLikeSort first) remainder2Terms of
-        Nothing -> Monad.Unify.explainAndReturnBottom
-            "Duplicated element in unification results"
-            first
-            second
-        Just remainderTerm -> case opaque of
+    | otherwise =
+      do
+        (unifier, remainder1, remainder2) <-
+          unifyWithPermutations firstElements secondElements
+        -- The second structure does not include an opaque term so there is nothing
+        -- to match whatever is left in remainder1. This should have been caught by
+        -- the "length" check above so, most likely, this can be an assertion.
+        Monad.unless
+          (null remainder1)
+          (remainderError firstElements secondElements remainder1)
+        let remainder2Terms = map fromConcreteOrWithVariable remainder2
+        case elementListAsInternal tools (termLikeSort first) remainder2Terms of
+          Nothing ->
+            Monad.Unify.explainAndReturnBottom
+              "Duplicated element in unification results"
+              first
+              second
+          Just remainderTerm -> case opaque of
             Var_ _ -> do
-                opaqueUnifier <- unifyEqualsChildren opaque remainderTerm
-                let
-                    (opaqueTerm, opaquePredicate) =
-                        Pattern.splitTerm opaqueUnifier
-                    result = unifier `andCondition` opaquePredicate
-
-                return (result, [opaqueTerm])
-            _ -> (error . unlines)
-                [ "Unification case that should be handled somewhere else:"
-                , "attempting normalized unification with a non-variable opaque"
-                , "term could lead to infinite loops."
-                , "first=" ++ unparseToString first
-                , "second=" ++ unparseToString second
-                ]
-
-  where
-    unifyWithPermutations =
+              opaqueUnifier <- unifyEqualsChildren opaque remainderTerm
+              let (opaqueTerm, opaquePredicate) =
+                    Pattern.splitTerm opaqueUnifier
+                  result = unifier `andCondition` opaquePredicate
+              return (result, [opaqueTerm])
+            _ ->
+              (error . unlines)
+                [ "Unification case that should be handled somewhere else:",
+                  "attempting normalized unification with a non-variable opaque",
+                  "term could lead to infinite loops.",
+                  "first=" ++ unparseToString first,
+                  "second=" ++ unparseToString second
+                  ]
+    where
+      unifyWithPermutations =
         unifyEqualsElementPermutations
-            (unifyEqualsConcreteOrWithVariable unifyEqualsChildren)
-    remainderError = nonEmptyRemainderError first second
+          (unifyEqualsConcreteOrWithVariable unifyEqualsChildren)
+      remainderError = nonEmptyRemainderError first second
 
 unifyOpaqueVariable
-    ::  ( MonadUnify unifier
-        , Ord variable
-        , SortedVariable variable
-        , TermWrapper normalized
-        , Unparse variable
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> (forall a . Doc () -> unifier a)
-    -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -- ^ unifier function
-    -> TermLike.ElementVariable variable
-    -> [ConcreteOrWithVariable normalized variable]
-    -> [TermLike variable]
-    -> MaybeT unifier
-        ( Conditional
-            variable
-            [(TermLike variable, Domain.Value normalized (TermLike variable))]
-        , [TermLike variable]
-        )
+  :: ( MonadUnify unifier,
+       Ord variable,
+       SortedVariable variable,
+       TermWrapper normalized,
+       Unparse variable
+       )
+  => SmtMetadataTools Attribute.Symbol
+  -> (forall a. Doc () -> unifier a)
+  -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -- ^ unifier function
+  -> TermLike.ElementVariable variable
+  -> [ConcreteOrWithVariable normalized variable]
+  -> [TermLike variable]
+  -> MaybeT unifier
+       ( Conditional
+           variable
+           [(TermLike variable, Domain.Value normalized (TermLike variable))],
+         [TermLike variable]
+         )
 unifyOpaqueVariable _ _ unifyChildren v1 [] [second@(ElemVar_ _)] = do
-    noCheckUnifyOpaqueChildren unifyChildren v1 second
+  noCheckUnifyOpaqueChildren unifyChildren v1 second
 unifyOpaqueVariable
-    tools
-    bottomWithExplanation
-    unifyChildren
-    v1
-    concreteOrVariableTerms
-    opaqueTerms
-  =
+  tools
+  bottomWithExplanation
+  unifyChildren
+  v1
+  concreteOrVariableTerms
+  opaqueTerms =
     case elementListAsNormalized pairs of
-        Nothing -> Monad.Trans.lift $ bottomWithExplanation
-            "Duplicated element in unification results"
-        Just elementTerm ->
-            let secondTerm =
-                    asInternal
-                        tools
-                        sort
-                        (Domain.wrapAc
-                            elementTerm {Domain.opaque = opaqueTerms}
-                        )
-            in if TermLike.isFunctionPattern secondTerm
-                then noCheckUnifyOpaqueChildren unifyChildren v1 secondTerm
-                else empty
-  where
-    sort = sortedVariableSort (getElementVariable v1)
-    pairs = map fromConcreteOrWithVariable concreteOrVariableTerms
+      Nothing ->
+        Monad.Trans.lift
+          $ bottomWithExplanation
+              "Duplicated element in unification results"
+      Just elementTerm ->
+        let secondTerm =
+              asInternal
+                tools
+                sort
+                ( Domain.wrapAc
+                    elementTerm {Domain.opaque = opaqueTerms}
+                  )
+         in if TermLike.isFunctionPattern secondTerm
+              then noCheckUnifyOpaqueChildren unifyChildren v1 secondTerm
+              else empty
+    where
+      sort = sortedVariableSort (getElementVariable v1)
+      pairs = map fromConcreteOrWithVariable concreteOrVariableTerms
 
 noCheckUnifyOpaqueChildren
-    ::  ( MonadUnify unifier
-        , Ord variable
-        , SortedVariable variable
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> TermLike.ElementVariable variable
-    -> TermLike variable
-    -> MaybeT unifier
-        ( Conditional
-            variable
-            [(TermLike variable, Domain.Value normalized (TermLike variable))]
-        , [TermLike variable]
-        )
+  :: ( MonadUnify unifier,
+       Ord variable,
+       SortedVariable variable
+       )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> TermLike.ElementVariable variable
+  -> TermLike variable
+  -> MaybeT unifier
+       ( Conditional
+           variable
+           [(TermLike variable, Domain.Value normalized (TermLike variable))],
+         [TermLike variable]
+         )
 noCheckUnifyOpaqueChildren unifyChildren v1 second = Monad.Trans.lift $ do
-    unifier <- unifyChildren (mkElemVar v1) second
-    let (opaque, predicate) = Conditional.splitTerm unifier
-    return ([] `Conditional.withCondition` predicate, [opaque])
+  unifier <- unifyChildren (mkElemVar v1) second
+  let (opaque, predicate) = Conditional.splitTerm unifier
+  return ([] `Conditional.withCondition` predicate, [opaque])
 
 {- |Unifies two patterns represented as @ConcreteOrWithVariable@, making sure
 that a concrete pattern (if any) is sent on the first position of the unify
@@ -1375,84 +1377,77 @@ and it would probably be more useful to have a concrete term as the
 unification term. Also, tests are easier to write.
 -}
 unifyEqualsConcreteOrWithVariable
-    ::  ( Domain.AcWrapper normalized
-        , MonadUnify unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> ConcreteOrWithVariable normalized variable
-    -> ConcreteOrWithVariable normalized variable
-    -> unifier
-        (Conditional
-            variable
-            (TermLike variable, Domain.Value normalized (TermLike variable))
-        )
+  :: ( Domain.AcWrapper normalized,
+       MonadUnify unifier,
+       Ord variable,
+       Show variable,
+       SortedVariable variable,
+       Traversable (Domain.Value normalized),
+       Unparse variable
+       )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> ConcreteOrWithVariable normalized variable
+  -> ConcreteOrWithVariable normalized variable
+  -> unifier
+       ( Conditional
+           variable
+           (TermLike variable, Domain.Value normalized (TermLike variable))
+         )
 unifyEqualsConcreteOrWithVariable
-    unifier
-    (ConcretePat concrete1)
-    (ConcretePat concrete2)
-  = unifyEqualsPair unifier concrete1 concrete2
+  unifier
+  (ConcretePat concrete1)
+  (ConcretePat concrete2) =
+    unifyEqualsPair unifier concrete1 concrete2
 unifyEqualsConcreteOrWithVariable
-    unifier
-    (ConcretePat concrete1)
-    (WithVariablePat withVariable2)
-  = unifyEqualsPair unifier concrete1 withVariable2
+  unifier
+  (ConcretePat concrete1)
+  (WithVariablePat withVariable2) =
+    unifyEqualsPair unifier concrete1 withVariable2
 unifyEqualsConcreteOrWithVariable
-    unifier
-    (WithVariablePat withVariable1)
-    (ConcretePat concrete2)
-  = unifyEqualsPair unifier concrete2 withVariable1
+  unifier
+  (WithVariablePat withVariable1)
+  (ConcretePat concrete2) =
+    unifyEqualsPair unifier concrete2 withVariable1
 unifyEqualsConcreteOrWithVariable
-    unifier
-    (WithVariablePat withVariable1)
-    (WithVariablePat withVariable2)
-  = unifyEqualsPair unifier withVariable1 withVariable2
+  unifier
+  (WithVariablePat withVariable1)
+  (WithVariablePat withVariable2) =
+    unifyEqualsPair unifier withVariable1 withVariable2
 
 unifyEqualsPair
-    :: forall normalized unifier variable
-    .   ( Domain.AcWrapper normalized
-        , MonadUnify unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> (TermLike variable, Domain.Value normalized (TermLike variable))
-    -> (TermLike variable, Domain.Value normalized (TermLike variable))
-    -> unifier
-        (Conditional
-            variable
-            (TermLike variable, Domain.Value normalized (TermLike variable))
-        )
+  :: forall normalized unifier variable. ( Domain.AcWrapper normalized,
+                                           MonadUnify unifier,
+                                           Ord variable,
+                                           Show variable,
+                                           SortedVariable variable,
+                                           Traversable (Domain.Value normalized),
+                                           Unparse variable
+                                           )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> (TermLike variable, Domain.Value normalized (TermLike variable))
+  -> (TermLike variable, Domain.Value normalized (TermLike variable))
+  -> unifier
+       ( Conditional
+           variable
+           (TermLike variable, Domain.Value normalized (TermLike variable))
+         )
 unifyEqualsPair
-    unifier
-    (firstKey, firstValue)
-    (secondKey, secondValue)
-  = do
-    keyUnifier <- unifier firstKey secondKey
-
-    valueUnifier <- unifyWrappedValues unifier firstValue secondValue
-
-    let
-        valueUnifierTerm :: Domain.Value normalized (TermLike variable)
-        valueUnifierPredicate :: Predicate variable
-        (valueUnifierTerm, valueUnifierPredicate) =
+  unifier
+  (firstKey, firstValue)
+  (secondKey, secondValue) =
+    do
+      keyUnifier <- unifier firstKey secondKey
+      valueUnifier <- unifyWrappedValues unifier firstValue secondValue
+      let valueUnifierTerm :: Domain.Value normalized (TermLike variable)
+          valueUnifierPredicate :: Predicate variable
+          (valueUnifierTerm, valueUnifierPredicate) =
             Conditional.splitTerm valueUnifier
-
-    let (keyUnifierTerm, keyUnifierPredicate) = Pattern.splitTerm keyUnifier
-
-    return
-        ((keyUnifierTerm, valueUnifierTerm)
+      let (keyUnifierTerm, keyUnifierPredicate) = Pattern.splitTerm keyUnifier
+      return
+        ( (keyUnifierTerm, valueUnifierTerm)
             `withCondition` keyUnifierPredicate
             `andCondition` valueUnifierPredicate
-        )
-
+          )
 
 {- | Given a unify function and two lists of unifiable things, returns
 all possible ways to unify disjoint pairs of the two that use all items
@@ -1461,35 +1456,35 @@ from at least one of the lists.
 Also returns the non-unified part os the lists (one of the two will be empty).
 -}
 unifyEqualsElementPermutations
-    ::  ( Alternative unifier
-        , Monad unifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => (a -> b -> unifier (Conditional variable c))
-    -> [a]
-    -> [b]
-    -> unifier
-        ( Conditional variable [c]
-        , [a]
-        , [b]
-        )
+  :: ( Alternative unifier,
+       Monad unifier,
+       Ord variable,
+       Show variable,
+       SortedVariable variable,
+       Unparse variable
+       )
+  => (a -> b -> unifier (Conditional variable c))
+  -> [a]
+  -> [b]
+  -> unifier
+       ( Conditional variable [c],
+         [a],
+         [b]
+         )
 unifyEqualsElementPermutations unifier firsts seconds = do
-    (unifiers, remainderFirst, remainderSecond) <-
-        if length firsts < length seconds
-        then do
-            (u, r) <-
-                kPermutationsBacktracking (flip unifier) seconds firsts
-            return (u, [], r)
-        else do
-            (u, r) <-
-                kPermutationsBacktracking unifier firsts seconds
-            return (u, r, [])
-    let (terms, predicates) = unzip (map Conditional.splitTerm unifiers)
-        predicate = foldr andCondition Predicate.top predicates
-    return (terms `withCondition` predicate, remainderFirst, remainderSecond)
+  (unifiers, remainderFirst, remainderSecond) <-
+    if length firsts < length seconds
+      then do
+        (u, r) <-
+          kPermutationsBacktracking (flip unifier) seconds firsts
+        return (u, [], r)
+      else do
+        (u, r) <-
+          kPermutationsBacktracking unifier firsts seconds
+        return (u, r, [])
+  let (terms, predicates) = unzip (map Conditional.splitTerm unifiers)
+      predicate = foldr andCondition Predicate.top predicates
+  return (terms `withCondition` predicate, remainderFirst, remainderSecond)
 
 {- |Given two lists generates k-permutation pairings and merges them using the
 provided merge function.
@@ -1506,116 +1501,117 @@ different set of previous choices, so this function could be optimized to
 at least cache pairing results.
 -}
 kPermutationsBacktracking
-    :: forall a b c m
-    .  Alternative m
-    => (a -> b -> m c) -> [a] -> [b] -> m ([c], [a])
+  :: forall a b c m. Alternative m
+  => (a -> b -> m c)
+  -> [a]
+  -> [b]
+  -> m ([c], [a])
 kPermutationsBacktracking _ first [] = pure ([], first)
 kPermutationsBacktracking transform firstList secondList =
-    generateKPermutationsWorker firstList [] secondList
+  generateKPermutationsWorker firstList [] secondList
   where
     generateKPermutationsWorker :: [a] -> [a] -> [b] -> m ([c], [a])
-    generateKPermutationsWorker _ (_:_) [] =
-        error "Unexpected non-empty skipped list with empty pair opportunities"
+    generateKPermutationsWorker _ (_ : _) [] =
+      error "Unexpected non-empty skipped list with empty pair opportunities"
     generateKPermutationsWorker [] [] [] = pure ([], [])
     generateKPermutationsWorker [] _ _ = empty
     generateKPermutationsWorker first [] [] = pure ([], first)
     generateKPermutationsWorker (first : firsts) skipped (second : seconds) =
-        pickElement <|> skipElement
+      pickElement <|> skipElement
       where
         pickElement =
-            addToFirst
-                <$> transform first second
-                <*> generateKPermutationsWorker (skipped ++ firsts) [] seconds
-
+          addToFirst
+            <$> transform first second
+            <*> generateKPermutationsWorker (skipped ++ firsts) [] seconds
         addToFirst :: x -> ([x], y) -> ([x], y)
         addToFirst x (xs, y) = (x : xs, y)
-
         skipElement =
-            generateKPermutationsWorker
-                firsts (first : skipped) (second : seconds)
-
+          generateKPermutationsWorker
+            firsts
+            (first : skipped)
+            (second : seconds)
 
 nonEmptyRemainderError
-    :: forall a normalized variable
-    .   ( HasCallStack
-        , SortedVariable variable
-        , Unparse variable
-        , Domain.AcWrapper normalized
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> [ConcreteOrWithVariable normalized variable]
-    -> [ConcreteOrWithVariable normalized variable]
-    -> [ConcreteOrWithVariable normalized variable]
-    -> a
+  :: forall a normalized variable. ( HasCallStack,
+                                     SortedVariable variable,
+                                     Unparse variable,
+                                     Domain.AcWrapper normalized
+                                     )
+  => TermLike variable
+  -> TermLike variable
+  -> [ConcreteOrWithVariable normalized variable]
+  -> [ConcreteOrWithVariable normalized variable]
+  -> [ConcreteOrWithVariable normalized variable]
+  -> a
 nonEmptyRemainderError first second input1 input2 remainder =
-    (error . unlines)
-        [ "Unexpected unused elements, should have been caught"
-        , "by checks above:"
-        , "first=" ++ unparseToString first
-        , "second=" ++ unparseToString second
-        , "input1=" ++ unlines (map unparseWrapped input1)
-        , "input2=" ++ unlines (map unparseWrapped input2)
-        , "remainder=" ++ unlines (map unparseWrapped remainder)
-        ]
+  (error . unlines)
+    [ "Unexpected unused elements, should have been caught",
+      "by checks above:",
+      "first=" ++ unparseToString first,
+      "second=" ++ unparseToString second,
+      "input1=" ++ unlines (map unparseWrapped input1),
+      "input2=" ++ unlines (map unparseWrapped input2),
+      "remainder=" ++ unlines (map unparseWrapped remainder)
+      ]
   where
     unparseWrapped =
-        Unparser.renderDefault . unparsePair . fromConcreteOrWithVariable
+      Unparser.renderDefault . unparsePair . fromConcreteOrWithVariable
     unparsePair = Domain.unparseElement unparse . Domain.wrapElement
 
 -- | Wrapper for giving names to arguments.
 newtype UnitSymbol = UnitSymbol {getUnitSymbol :: Symbol}
+
 -- | Wrapper for giving names to arguments.
 newtype ConcatSymbol = ConcatSymbol {getConcatSymbol :: Symbol}
+
 -- | Wrapper for giving names to arguments.
-newtype ConcreteElements variable =
-    ConcreteElements {getConcreteElements :: [TermLike variable]}
+newtype ConcreteElements variable
+  = ConcreteElements {getConcreteElements :: [TermLike variable]}
+
 -- | Wrapper for giving names to arguments.
-newtype VariableElements variable =
-    VariableElements {getVariableElements :: [TermLike variable]}
+newtype VariableElements variable
+  = VariableElements {getVariableElements :: [TermLike variable]}
+
 -- | Wrapper for giving names to arguments.
-newtype Opaque variable =
-    Opaque {getOpaque :: [TermLike variable]}
+newtype Opaque variable
+  = Opaque {getOpaque :: [TermLike variable]}
 
 {- | Externalizes a 'Domain.InternalAc' as a 'TermLike'.
 -}
 asTermLike
-    :: forall variable
-    .  (Ord variable, SortedVariable variable, Unparse variable)
-    => UnitSymbol
-    -> ConcatSymbol
-    -> ConcreteElements variable
-    -> VariableElements variable
-    -> Opaque variable
-    -> TermLike variable
+  :: forall variable. (Ord variable, SortedVariable variable, Unparse variable)
+  => UnitSymbol
+  -> ConcatSymbol
+  -> ConcreteElements variable
+  -> VariableElements variable
+  -> Opaque variable
+  -> TermLike variable
 asTermLike
-    (UnitSymbol unitSymbol)
-    (ConcatSymbol concatSymbol)
-    (ConcreteElements concreteElements)
-    (VariableElements variableElements)
-    (Opaque opaque)
-  =
+  (UnitSymbol unitSymbol)
+  (ConcatSymbol concatSymbol)
+  (ConcreteElements concreteElements)
+  (VariableElements variableElements)
+  (Opaque opaque) =
     case splitLastInit concreteElements of
-        Nothing -> case splitLastInit opaque of
-            Nothing -> case splitLastInit variableElements of
-                Nothing -> mkApplySymbol unitSymbol []
-                Just (ves, ve) -> addTerms ves ve
-            Just (opaqs, opaq) ->
-                addTerms variableElements (addTerms opaqs opaq)
-        Just (concretes, concrete) ->
-            addTerms variableElements
-            $ addTerms opaque
-            $ addTerms concretes concrete
-  where
-    addTerms :: [TermLike variable] -> TermLike variable -> TermLike variable
-    addTerms terms term = List.foldr concat' term terms
-
-    concat' :: TermLike variable -> TermLike variable -> TermLike variable
-    concat' map1 map2 = mkApplySymbol concatSymbol [map1, map2]
+      Nothing -> case splitLastInit opaque of
+        Nothing -> case splitLastInit variableElements of
+          Nothing -> mkApplySymbol unitSymbol []
+          Just (ves, ve) -> addTerms ves ve
+        Just (opaqs, opaq) ->
+          addTerms variableElements (addTerms opaqs opaq)
+      Just (concretes, concrete) ->
+        addTerms variableElements
+          $ addTerms opaque
+          $ addTerms concretes concrete
+    where
+      addTerms :: [TermLike variable] -> TermLike variable -> TermLike variable
+      addTerms terms term = List.foldr concat' term terms
+      concat' :: TermLike variable -> TermLike variable -> TermLike variable
+      concat' map1 map2 = mkApplySymbol concatSymbol [map1, map2]
 
 splitLastInit :: [a] -> Maybe ([a], a)
 splitLastInit [] = Nothing
 splitLastInit [a] = Just ([], a)
-splitLastInit (a:as) = do
-    (initA, lastA) <- splitLastInit as
-    return (a:initA, lastA)
+splitLastInit (a : as) = do
+  (initA, lastA) <- splitLastInit as
+  return (a : initA, lastA)

--- a/kore/src/Kore/Builtin/Attributes.hs
+++ b/kore/src/Kore/Builtin/Attributes.hs
@@ -11,29 +11,35 @@ Portability : portable
 TODO(virgil): Get rid of this module and implement everything with normal
               attributes.
 -}
-
 module Kore.Builtin.Attributes
-    ( isConstructorModulo_
-    , isConstructorModuloLike_
-    ) where
+  ( isConstructorModulo_,
+    isConstructorModuloLike_
+    )
+where
 
 import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.MapSymbols as Map
 import qualified Kore.Builtin.SetSymbols as Set
-import           Kore.Internal.Symbol
+import Kore.Internal.Symbol
 
 -- | Is the symbol a constructor modulo associativity, commutativity and
 -- neutral element?
 isConstructorModulo_ :: Symbol -> Bool
 isConstructorModulo_ symbol =
-    any (apply symbol)
-        [ List.isSymbolConcat, List.isSymbolElement, List.isSymbolUnit
-        ,  Map.isSymbolConcat,  Map.isSymbolElement,  Map.isSymbolUnit
-        ,  Set.isSymbolConcat,  Set.isSymbolElement,  Set.isSymbolUnit
-        ]
+  any (apply symbol)
+    [ List.isSymbolConcat,
+      List.isSymbolElement,
+      List.isSymbolUnit,
+      Map.isSymbolConcat,
+      Map.isSymbolElement,
+      Map.isSymbolUnit,
+      Set.isSymbolConcat,
+      Set.isSymbolElement,
+      Set.isSymbolUnit
+      ]
   where
     apply pattHead f = f pattHead
 
 isConstructorModuloLike_ :: Symbol -> Bool
 isConstructorModuloLike_ =
-    or <$> sequence [isConstructorModulo_, isConstructor, isSortInjection]
+  or <$> sequence [isConstructorModulo_, isConstructor, isSortInjection]

--- a/kore/src/Kore/Builtin/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool.hs
@@ -15,48 +15,52 @@ builtin modules.
 @
  -}
 module Kore.Builtin.Bool
-    ( sort
-    , assertSort
-    , sortDeclVerifiers
-    , symbolVerifiers
-    , patternVerifier
-    , builtinFunctions
-    , asInternal
-    , asTermLike
-    , asPattern
-    , extractBoolDomainValue
-    , parse
-      -- * Keys
-    , orKey
-    , andKey
-    , xorKey
-    , neKey
-    , eqKey
-    , notKey
-    , impliesKey
-    , andThenKey
-    , orElseKey
-    ) where
+  ( sort,
+    assertSort,
+    sortDeclVerifiers,
+    symbolVerifiers,
+    patternVerifier,
+    builtinFunctions,
+    asInternal,
+    asTermLike,
+    asPattern,
+    extractBoolDomainValue,
+    parse,
+    -- * Keys
+    orKey,
+    andKey,
+    xorKey,
+    neKey,
+    eqKey,
+    notKey,
+    impliesKey,
+    andThenKey,
+    orElseKey
+    )
+where
 
-import           Data.Functor
-                 ( ($>) )
+import Data.Functor
+  ( ($>)
+    )
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map
-                 ( Map )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.String
-                 ( IsString )
-import           Data.Text
-                 ( Text )
+import Data.String
+  ( IsString
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import qualified Text.Megaparsec as Parsec
-import qualified Text.Megaparsec.Char as Parsec
-
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Error
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import qualified Text.Megaparsec as Parsec
+import qualified Text.Megaparsec.Char as Parsec
 
 {- | Builtin name of the @Bool@ sort.
  -}
@@ -77,7 +81,7 @@ assertSort = Builtin.verifySort sort
 
  -}
 sortDeclVerifiers :: Builtin.SortDeclVerifiers
-sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
+sortDeclVerifiers = HashMap.fromList [(sort, Builtin.verifySortDecl)]
 
 {- | Verify that hooked symbol declarations are well-formed.
 
@@ -86,50 +90,50 @@ sortDeclVerifiers = HashMap.fromList [ (sort, Builtin.verifySortDecl) ]
  -}
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
-    HashMap.fromList
-    [ (orKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (andKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (xorKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (neKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (eqKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (notKey, Builtin.verifySymbol assertSort [assertSort])
-    , (impliesKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (andThenKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    , (orElseKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
-    ]
+  HashMap.fromList
+    [ (orKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (andKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (xorKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (neKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (eqKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (notKey, Builtin.verifySymbol assertSort [assertSort]),
+      (impliesKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (andThenKey, Builtin.verifySymbol assertSort [assertSort, assertSort]),
+      (orElseKey, Builtin.verifySymbol assertSort [assertSort, assertSort])
+      ]
 
 {- | Verify that domain value patterns are well-formed.
  -}
 patternVerifier :: Builtin.DomainValueVerifier (TermLike variable)
 patternVerifier =
-    Builtin.makeEncodedDomainValueVerifier sort patternVerifierWorker
+  Builtin.makeEncodedDomainValueVerifier sort patternVerifierWorker
   where
     patternVerifierWorker domainValue =
-        case externalChild of
-            StringLiteral_ lit -> do
-                builtinBoolValue <- Builtin.parseString parse lit
-                (return . Domain.BuiltinBool)
-                    Domain.InternalBool
-                        { builtinBoolSort = domainValueSort
-                        , builtinBoolValue
-                        }
-            _ -> Kore.Error.koreFail "Expected literal string"
+      case externalChild of
+        StringLiteral_ lit -> do
+          builtinBoolValue <- Builtin.parseString parse lit
+          (return . Domain.BuiltinBool) Domain.InternalBool
+            { builtinBoolSort = domainValueSort,
+              builtinBoolValue
+              }
+        _ -> Kore.Error.koreFail "Expected literal string"
       where
-        DomainValue { domainValueSort } = domainValue
-        DomainValue { domainValueChild = externalChild } = domainValue
+        DomainValue {domainValueSort} = domainValue
+        DomainValue {domainValueChild = externalChild} = domainValue
 
 -- | get the value from a (possibly encoded) domain value
 extractBoolDomainValue
-    :: Text -- ^ error message Context
-    -> Builtin child
-    -> Bool
+  :: Text -- ^ error message Context
+  -> Builtin child
+  -> Bool
 extractBoolDomainValue ctx =
-    \case
-        Domain.BuiltinBool Domain.InternalBool { builtinBoolValue } ->
-            builtinBoolValue
-        _ ->
-            Builtin.verifierBug
-            $ Text.unpack ctx ++ ": Bool builtin should be internal"
+  \case
+    Domain.BuiltinBool Domain.InternalBool {builtinBoolValue} ->
+      builtinBoolValue
+    _ ->
+      Builtin.verifierBug
+        $ Text.unpack ctx
+        ++ ": Bool builtin should be internal"
 
 {- | Parse an integer string literal.
  -}
@@ -148,16 +152,15 @@ parse = (Parsec.<|>) true false
 
  -}
 asInternal
-    :: (Ord variable, SortedVariable variable)
-    => Sort  -- ^ resulting sort
-    -> Bool  -- ^ builtin value to render
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort -- ^ resulting sort
+  -> Bool -- ^ builtin value to render
+  -> TermLike variable
 asInternal builtinBoolSort builtinBoolValue =
-    (mkBuiltin . Domain.BuiltinBool)
-        Domain.InternalBool
-            { builtinBoolSort
-            , builtinBoolValue
-            }
+  (mkBuiltin . Domain.BuiltinBool) Domain.InternalBool
+    { builtinBoolSort,
+      builtinBoolValue
+      }
 
 {- | Render a 'Bool' as a domain value pattern of the given sort.
 
@@ -168,48 +171,48 @@ asInternal builtinBoolSort builtinBoolValue =
 
  -}
 asTermLike
-    :: (Ord variable, SortedVariable variable)
-    => Domain.InternalBool  -- ^ builtin value to render
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Domain.InternalBool -- ^ builtin value to render
+  -> TermLike variable
 asTermLike builtin =
-    mkDomainValue DomainValue
-        { domainValueSort = builtinBoolSort
-        , domainValueChild = mkStringLiteral literal
-        }
+  mkDomainValue DomainValue
+    { domainValueSort = builtinBoolSort,
+      domainValueChild = mkStringLiteral literal
+      }
   where
-    Domain.InternalBool { builtinBoolSort } = builtin
-    Domain.InternalBool { builtinBoolValue = bool } = builtin
+    Domain.InternalBool {builtinBoolSort} = builtin
+    Domain.InternalBool {builtinBoolValue = bool} = builtin
     literal
-      | bool      = "true"
+      | bool = "true"
       | otherwise = "false"
 
 asPattern
-    :: (Ord variable, SortedVariable variable)
-    => Sort  -- ^ resulting sort
-    -> Bool  -- ^ builtin value to render
-    -> Pattern variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort -- ^ resulting sort
+  -> Bool -- ^ builtin value to render
+  -> Pattern variable
 asPattern resultSort = Pattern.fromTermLike . asInternal resultSort
 
 {- | @builtinFunctions@ are builtin functions on the 'Bool' sort.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
-    Map.fromList
-    [ (orKey, binaryOperator orKey (||))
-    , (andKey, binaryOperator andKey (&&))
-    , (xorKey, binaryOperator xorKey xor)
-    , (neKey, binaryOperator neKey (/=))
-    , (eqKey, binaryOperator eqKey (==))
-    , (notKey, unaryOperator notKey not)
-    , (impliesKey, binaryOperator impliesKey implies)
-    , (andThenKey, binaryOperator andThenKey (&&))
-    , (orElseKey, binaryOperator orElseKey (||))
-    ]
+  Map.fromList
+    [ (orKey, binaryOperator orKey (||)),
+      (andKey, binaryOperator andKey (&&)),
+      (xorKey, binaryOperator xorKey xor),
+      (neKey, binaryOperator neKey (/=)),
+      (eqKey, binaryOperator eqKey (==)),
+      (notKey, unaryOperator notKey not),
+      (impliesKey, binaryOperator impliesKey implies),
+      (andThenKey, binaryOperator andThenKey (&&)),
+      (orElseKey, binaryOperator orElseKey (||))
+      ]
   where
     unaryOperator =
-        Builtin.unaryOperator extractBoolDomainValue asPattern
+      Builtin.unaryOperator extractBoolDomainValue asPattern
     binaryOperator =
-        Builtin.binaryOperator extractBoolDomainValue asPattern
+      Builtin.binaryOperator extractBoolDomainValue asPattern
     xor a b = (a && not b) || (not a && b)
     implies a b = not a || b
 

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -15,83 +15,91 @@ builtin modules.
 @
  -}
 module Kore.Builtin.Builtin
-    (
-      -- * Using builtin verifiers
-      Verifiers (..)
-    , SymbolVerifier (..), SymbolVerifiers
-    , SortDeclVerifier, SortDeclVerifiers
-    , DomainValueVerifier, DomainValueVerifiers
-    , SortVerifier (..)
-    , Function
-    , Parser
-    , symbolVerifier
-    , sortDeclVerifier
-      -- * Smart constructors for DomainValueVerifier
-    , makeEncodedDomainValueVerifier
-      -- * Declaring builtin verifiers
-    , verifySortDecl
-    , getUnitId
-    , getElementId
-    , getConcatId
-    , assertSymbolHook
-    , assertSymbolResultSort
-    , verifySort
-    , acceptAnySort
-    , verifySymbol
-    , verifySymbolArguments
-    , verifyDomainValue
-    , parseString
-      -- * Implementing builtin functions
-    , notImplemented
-    , unaryOperator
-    , binaryOperator
-    , ternaryOperator
-    , FunctionImplementation
-    , functionEvaluator
-    , verifierBug
-    , wrongArity
-    , runParser
-    , appliedFunction
-    , lookupSymbol
-    , lookupSymbolUnit
-    , lookupSymbolElement
-    , lookupSymbolConcat
-    , isSymbol
-    , isSort
-    , toKey
-    , getAttemptedAxiom
-      -- * Implementing builtin unification
-    , unifyEqualsUnsolved
-    ) where
+  ( -- * Using builtin verifiers
+    Verifiers (..),
+    SymbolVerifier (..),
+    SymbolVerifiers,
+    SortDeclVerifier,
+    SortDeclVerifiers,
+    DomainValueVerifier,
+    DomainValueVerifiers,
+    SortVerifier (..),
+    Function,
+    Parser,
+    symbolVerifier,
+    sortDeclVerifier,
+    -- * Smart constructors for DomainValueVerifier
+    makeEncodedDomainValueVerifier,
+    -- * Declaring builtin verifiers
+    verifySortDecl,
+    getUnitId,
+    getElementId,
+    getConcatId,
+    assertSymbolHook,
+    assertSymbolResultSort,
+    verifySort,
+    acceptAnySort,
+    verifySymbol,
+    verifySymbolArguments,
+    verifyDomainValue,
+    parseString,
+    -- * Implementing builtin functions
+    notImplemented,
+    unaryOperator,
+    binaryOperator,
+    ternaryOperator,
+    FunctionImplementation,
+    functionEvaluator,
+    verifierBug,
+    wrongArity,
+    runParser,
+    appliedFunction,
+    lookupSymbol,
+    lookupSymbolUnit,
+    lookupSymbolElement,
+    lookupSymbolConcat,
+    isSymbol,
+    isSort,
+    toKey,
+    getAttemptedAxiom,
+    -- * Implementing builtin unification
+    unifyEqualsUnsolved
+    )
+where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Control.Error
-                 ( MaybeT (..), fromMaybe )
-import           Control.Monad
-                 ( zipWithM_ )
+import Control.Error
+  ( MaybeT (..),
+    fromMaybe
+    )
+import Control.Monad
+  ( zipWithM_
+    )
 import qualified Control.Monad as Monad
-import           Data.Function
+import Data.Function
 import qualified Data.Functor.Foldable as Recursive
-import           Data.HashMap.Strict
-                 ( HashMap )
+import Data.HashMap.Strict
+  ( HashMap
+    )
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           Data.Void
-                 ( Void )
-import           GHC.Stack
-                 ( HasCallStack )
-import           Text.Megaparsec
-                 ( Parsec )
-import qualified Text.Megaparsec as Parsec
-
+import Data.Void
+  ( Void
+    )
+import GHC.Stack
+  ( HasCallStack
+    )
 import qualified Kore.AST.Error as Kore.Error
 import qualified Kore.ASTVerifier.AttributesVerifier as Verifier.Attributes
-import           Kore.ASTVerifier.Error
-                 ( VerifyError )
-import           Kore.Attribute.Hook
-                 ( Hook (..) )
+import Kore.ASTVerifier.Error
+  ( VerifyError
+    )
+import Kore.Attribute.Hook
+  ( Hook (..)
+    )
 import qualified Kore.Attribute.Null as Attribute
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Sort as Attribute
@@ -99,78 +107,100 @@ import qualified Kore.Attribute.Sort.Concat as Attribute.Sort
 import qualified Kore.Attribute.Sort.Element as Attribute.Sort
 import qualified Kore.Attribute.Sort.Unit as Attribute.Sort
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Builtin.Error
-import           Kore.Error
-                 ( Error )
+import Kore.Builtin.Error
+import Kore.Error
+  ( Error
+    )
 import qualified Kore.Error
-import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule, VerifiedModule )
-import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools (MetadataTools), SmtMetadataTools )
+import Kore.IndexedModule.IndexedModule
+  ( KoreIndexedModule,
+    VerifiedModule
+    )
+import Kore.IndexedModule.MetadataTools
+  ( MetadataTools (MetadataTools),
+    SmtMetadataTools
+    )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.IndexedModule.Resolvers as IndexedModule
-import           Kore.Internal.ApplicationSorts
+import Kore.Internal.ApplicationSorts
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
-import           Kore.Internal.Pattern as Pattern
-                 ( top )
-import           Kore.Internal.TermLike as TermLike
-import           Kore.Predicate.Predicate
-                 ( makeCeilPredicate, makeEqualsPredicate )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
+import Kore.Internal.Pattern as Pattern
+  ( top
+    )
+import Kore.Internal.TermLike as TermLike
+import Kore.Predicate.Predicate
+  ( makeCeilPredicate,
+    makeEqualsPredicate
+    )
 import qualified Kore.Proof.Value as Value
-import           Kore.Sort
-                 ( predicateSort )
-import           Kore.Step.Simplification.Data
-                 ( AttemptedAxiom (..),
-                 AttemptedAxiomResults (AttemptedAxiomResults),
-                 BuiltinAndAxiomSimplifier (BuiltinAndAxiomSimplifier),
-                 BuiltinAndAxiomSimplifierMap, MonadSimplify,
-                 PredicateSimplifier, SimplificationType, TermLikeSimplifier,
-                 applicationAxiomSimplifier )
+import Kore.Sort
+  ( predicateSort
+    )
+import Kore.Step.Simplification.Data
+  ( AttemptedAxiom (..),
+    AttemptedAxiomResults (AttemptedAxiomResults),
+    BuiltinAndAxiomSimplifier (BuiltinAndAxiomSimplifier),
+    BuiltinAndAxiomSimplifierMap,
+    MonadSimplify,
+    PredicateSimplifier,
+    SimplificationType,
+    TermLikeSimplifier,
+    applicationAxiomSimplifier
+    )
 import qualified Kore.Step.Simplification.Data as SimplificationType
-                 ( SimplificationType (..) )
+  ( SimplificationType (..)
+    )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
-                 ( AttemptedAxiomResults (..) )
-import           Kore.Syntax.Definition
-                 ( ParsedSentenceSort, ParsedSentenceSymbol, SentenceSort (..),
-                 SentenceSymbol (..) )
-import           Kore.Unparser
+  ( AttemptedAxiomResults (..)
+    )
+import Kore.Syntax.Definition
+  ( ParsedSentenceSort,
+    ParsedSentenceSymbol,
+    SentenceSort (..),
+    SentenceSymbol (..)
+    )
+import Kore.Unparser
 import qualified Kore.Verified as Verified
+import Text.Megaparsec
+  ( Parsec
+    )
+import qualified Text.Megaparsec as Parsec
 
 type Parser = Parsec Void Text
 
 type Function = BuiltinAndAxiomSimplifier
 
 -- | Verify a sort declaration.
-type SortDeclVerifier =
-        KoreIndexedModule Attribute.Null Attribute.Null
-    -- ^ Indexed module, to look up symbol declarations
-    ->  ParsedSentenceSort
-    -- ^ Sort declaration to verify
-    ->  Attribute.Sort
-    -- ^ Declared sort attributes
-    ->  Either (Error VerifyError) ()
+type SortDeclVerifier
+  = KoreIndexedModule Attribute.Null Attribute.Null
+  -- ^ Indexed module, to look up symbol declarations
+  -> ParsedSentenceSort
+  -- ^ Sort declaration to verify
+  -> Attribute.Sort
+  -- ^ Declared sort attributes
+  -> Either (Error VerifyError) ()
 
-newtype SortVerifier =
-    SortVerifier
-        { runSortVerifier
-            :: forall patternType
-            .  (Id -> Either (Error VerifyError) (SentenceSort patternType))
-            -> Sort
-            -> Either (Error VerifyError) ()
+newtype SortVerifier
+  = SortVerifier
+      { runSortVerifier
+          :: forall patternType. (Id -> Either (Error VerifyError) (SentenceSort patternType))
+          -> Sort
+          -> Either (Error VerifyError) ()
         }
 
 -- | @SortDeclVerifiers@ associates a sort verifier with its builtin sort name.
 type SortDeclVerifiers = HashMap Text SortDeclVerifier
 
-newtype SymbolVerifier =
-    SymbolVerifier
-        { runSymbolVerifier
-            :: forall patternType
-            .  (Id -> Either (Error VerifyError) (SentenceSort patternType))
-            -> ParsedSentenceSymbol
-            -> Either (Error VerifyError) ()
+newtype SymbolVerifier
+  = SymbolVerifier
+      { runSymbolVerifier
+          :: forall patternType. (Id -> Either (Error VerifyError) (SentenceSort patternType))
+          -> ParsedSentenceSymbol
+          -> Either (Error VerifyError) ()
         }
 
 {- | @SymbolVerifiers@ associates a @SymbolVerifier@ with each builtin
@@ -182,21 +212,21 @@ type SymbolVerifiers = HashMap Text SymbolVerifier
   represention parameterized over @m@, the verification monad.
 
 -}
-type DomainValueVerifier child =
-       DomainValue Sort child -> Either (Error VerifyError) (Builtin child)
+type DomainValueVerifier child
+  = DomainValue Sort child -> Either (Error VerifyError) (Builtin child)
 
 -- | @DomainValueVerifiers@  associates a @DomainValueVerifier@ with each
 -- builtin
 type DomainValueVerifiers child = (HashMap Text (DomainValueVerifier child))
 
-
 {- | Verify builtin sorts, symbols, and patterns.
  -}
-data Verifiers = Verifiers
-    { sortDeclVerifiers    :: SortDeclVerifiers
-    , symbolVerifiers      :: SymbolVerifiers
-    , domainValueVerifiers :: DomainValueVerifiers Verified.Pattern
-    }
+data Verifiers
+  = Verifiers
+      { sortDeclVerifiers :: SortDeclVerifiers,
+        symbolVerifiers :: SymbolVerifiers,
+        domainValueVerifiers :: DomainValueVerifiers Verified.Pattern
+        }
 
 {- | Look up and apply a builtin sort declaration verifier.
 
@@ -205,21 +235,19 @@ not recognized, verification succeeds.
 
  -}
 sortDeclVerifier :: Verifiers -> Hook -> SortDeclVerifier
-sortDeclVerifier Verifiers { sortDeclVerifiers } hook =
-    let
-        hookedSortVerifier = do
-            -- Get the builtin sort name.
-            sortName <- getHook hook
-            HashMap.lookup sortName sortDeclVerifiers
-    in
-        fromMaybe
-            -- There is nothing to verify because either
-            -- 1. the sort is not hooked, or
-            -- 2. there is no SortVerifier registered to the hooked name.
-            -- In either case, there is nothing more to do.
-            (\_ _ _ -> pure ())
-            -- Invoke the verifier that is registered to this builtin sort.
-            hookedSortVerifier
+sortDeclVerifier Verifiers {sortDeclVerifiers} hook =
+  let hookedSortVerifier = do
+        -- Get the builtin sort name.
+        sortName <- getHook hook
+        HashMap.lookup sortName sortDeclVerifiers
+   in fromMaybe
+        -- There is nothing to verify because either
+        -- 1. the sort is not hooked, or
+        -- 2. there is no SortVerifier registered to the hooked name.
+        -- In either case, there is nothing more to do.
+        (\_ _ _ -> pure ())
+        -- Invoke the verifier that is registered to this builtin sort.
+        hookedSortVerifier
 
 {- | Look up and apply a builtin symbol verifier.
 
@@ -228,25 +256,23 @@ not recognized, verification succeeds.
 
  -}
 symbolVerifier :: Verifiers -> Hook -> SymbolVerifier
-symbolVerifier Verifiers { symbolVerifiers } hook =
-    let
-        hookedSymbolVerifier = do
-            -- Get the builtin sort name.
-            symbolName <- getHook hook
-            HashMap.lookup symbolName symbolVerifiers
-    in
-        fromMaybe
-            -- There is nothing to verify because either
-            -- 1. the symbol is not hooked, or
-            -- 2. there is no SymbolVerifier registered to the hooked name.
-            -- In either case, there is nothing more to do.
-            (SymbolVerifier $ \_ _ -> pure ())
-            -- Invoke the verifier that is registered to this builtin symbol.
-            hookedSymbolVerifier
+symbolVerifier Verifiers {symbolVerifiers} hook =
+  let hookedSymbolVerifier = do
+        -- Get the builtin sort name.
+        symbolName <- getHook hook
+        HashMap.lookup symbolName symbolVerifiers
+   in fromMaybe
+        -- There is nothing to verify because either
+        -- 1. the symbol is not hooked, or
+        -- 2. there is no SymbolVerifier registered to the hooked name.
+        -- In either case, there is nothing more to do.
+        (SymbolVerifier $ \_ _ -> pure ())
+        -- Invoke the verifier that is registered to this builtin symbol.
+        hookedSymbolVerifier
 
 notImplemented :: Function
 notImplemented =
-    BuiltinAndAxiomSimplifier notImplemented0
+  BuiltinAndAxiomSimplifier notImplemented0
   where
     notImplemented0 _ _ _ _ _ = pure NotApplicable
 
@@ -256,18 +282,18 @@ notImplemented =
 
  -}
 verifySortDecl :: SortDeclVerifier
-verifySortDecl _ SentenceSort { sentenceSortParameters } _ =
-    getZeroParams sentenceSortParameters
+verifySortDecl _ SentenceSort {sentenceSortParameters} _ =
+  getZeroParams sentenceSortParameters
 
 {- | Throw a 'VerifyError' if there are any sort parameters.
  -}
 getZeroParams :: [SortVariable] -> Either (Error VerifyError) ()
 getZeroParams =
-    \case
-        [] -> return ()
-        params ->
-            Kore.Error.koreFail
-                ("Expected 0 sort parameters, found " ++ show (length params))
+  \case
+    [] -> return ()
+    params ->
+      Kore.Error.koreFail
+        ("Expected 0 sort parameters, found " ++ show (length params))
 
 {- | Get the identifier of the @unit@ sort attribute.
 
@@ -275,14 +301,14 @@ Fail if the attribute is missing.
 
  -}
 getUnitId
-    :: Attribute.Sort
-    -- ^ Sort attributes
-    -> Either (Error VerifyError) Id
-getUnitId Attribute.Sort { unit = Attribute.Sort.Unit sortUnit } =
-    case sortUnit of
-        Just SymbolOrAlias { symbolOrAliasConstructor } ->
-            return symbolOrAliasConstructor
-        Nothing -> Kore.Error.koreFail "Missing 'unit' attribute."
+  :: Attribute.Sort
+  -- ^ Sort attributes
+  -> Either (Error VerifyError) Id
+getUnitId Attribute.Sort {unit = Attribute.Sort.Unit sortUnit} =
+  case sortUnit of
+    Just SymbolOrAlias {symbolOrAliasConstructor} ->
+      return symbolOrAliasConstructor
+    Nothing -> Kore.Error.koreFail "Missing 'unit' attribute."
 
 {- | Get the identifier of the @element@ sort attribute.
 
@@ -290,14 +316,14 @@ Fail if the attribute is missing.
 
  -}
 getElementId
-    :: Attribute.Sort
-    -- ^ Sort attributes
-    -> Either (Error VerifyError) Id
-getElementId Attribute.Sort { element = Attribute.Sort.Element sortElement } =
-    case sortElement of
-        Just SymbolOrAlias { symbolOrAliasConstructor } ->
-            return symbolOrAliasConstructor
-        Nothing -> Kore.Error.koreFail "Missing 'element' attribute."
+  :: Attribute.Sort
+  -- ^ Sort attributes
+  -> Either (Error VerifyError) Id
+getElementId Attribute.Sort {element = Attribute.Sort.Element sortElement} =
+  case sortElement of
+    Just SymbolOrAlias {symbolOrAliasConstructor} ->
+      return symbolOrAliasConstructor
+    Nothing -> Kore.Error.koreFail "Missing 'element' attribute."
 
 {- | Get the identifier of the @concat@ sort attribute.
 
@@ -305,14 +331,14 @@ Fail if the attribute is missing.
 
  -}
 getConcatId
-    :: Attribute.Sort
-    -- ^ Sort attributes
-    -> Either (Error VerifyError) Id
-getConcatId Attribute.Sort { concat = Attribute.Sort.Concat sortConcat } =
-    case sortConcat of
-        Just SymbolOrAlias { symbolOrAliasConstructor } ->
-            return symbolOrAliasConstructor
-        Nothing -> Kore.Error.koreFail "Missing 'concat' attribute."
+  :: Attribute.Sort
+  -- ^ Sort attributes
+  -> Either (Error VerifyError) Id
+getConcatId Attribute.Sort {concat = Attribute.Sort.Concat sortConcat} =
+  case sortConcat of
+    Just SymbolOrAlias {symbolOrAliasConstructor} ->
+      return symbolOrAliasConstructor
+    Nothing -> Kore.Error.koreFail "Missing 'concat' attribute."
 
 {- | Check that the symbol's @hook@ attribute matches the expected value.
 
@@ -320,29 +346,28 @@ Fail if the symbol is not defined or the attribute is missing.
 
  -}
 assertSymbolHook
-    :: KoreIndexedModule declAttrs axiomAttrs
-    -> Id
-    -- ^ Symbol identifier
-    -> Text
-    -- ^ Expected hook
-    -> Either (Error VerifyError) ()
+  :: KoreIndexedModule declAttrs axiomAttrs
+  -> Id
+  -- ^ Symbol identifier
+  -> Text
+  -- ^ Expected hook
+  -> Either (Error VerifyError) ()
 assertSymbolHook indexedModule symbolId expected = do
-    (_, decl) <- IndexedModule.resolveSymbol indexedModule symbolId
-    let
-        SentenceSymbol { sentenceSymbolAttributes = attrs } = decl
-        SentenceSymbol { sentenceSymbolSymbol = symbol } = decl
-    Hook { getHook } <- Verifier.Attributes.parseAttributes attrs
-    case getHook of
-        Just hook
-          | hook == expected -> return ()
-          | otherwise ->
-            Kore.Error.koreFailWithLocations
-                [symbol]
-                ("Symbol is not hooked to builtin symbol '" <> expected <> "'")
-        Nothing ->
-            Kore.Error.koreFailWithLocations
-                [symbol]
-                "Missing 'hook' attribute"
+  (_, decl) <- IndexedModule.resolveSymbol indexedModule symbolId
+  let SentenceSymbol {sentenceSymbolAttributes = attrs} = decl
+      SentenceSymbol {sentenceSymbolSymbol = symbol} = decl
+  Hook {getHook} <- Verifier.Attributes.parseAttributes attrs
+  case getHook of
+    Just hook
+      | hook == expected -> return ()
+      | otherwise ->
+        Kore.Error.koreFailWithLocations
+          [symbol]
+          ("Symbol is not hooked to builtin symbol '" <> expected <> "'")
+    Nothing ->
+      Kore.Error.koreFailWithLocations
+        [symbol]
+        "Missing 'hook' attribute"
 
 {- | Check that the symbol's result sort matches the expected value.
 
@@ -350,22 +375,23 @@ Fail if the symbol is not defined.
 
  -}
 assertSymbolResultSort
-    :: KoreIndexedModule declAttrs axiomAttrs
-    -> Id
-    -- ^ Symbol identifier
-    -> Sort
-    -- ^ Expected result sort
-    -> Either (Error VerifyError) ()
+  :: KoreIndexedModule declAttrs axiomAttrs
+  -> Id
+  -- ^ Symbol identifier
+  -> Sort
+  -- ^ Expected result sort
+  -> Either (Error VerifyError) ()
 assertSymbolResultSort indexedModule symbolId expectedSort = do
-    (_, decl) <- IndexedModule.resolveSymbol indexedModule symbolId
-    let
-        SentenceSymbol { sentenceSymbolResultSort = actualSort } = decl
-        SentenceSymbol { sentenceSymbolSymbol = symbol } = decl
-    Monad.unless (actualSort == expectedSort)
-        $ Kore.Error.koreFailWithLocations
-            [symbol]
-            ("Symbol does not return sort '"
-                <> unparseToText expectedSort <> "'")
+  (_, decl) <- IndexedModule.resolveSymbol indexedModule symbolId
+  let SentenceSymbol {sentenceSymbolResultSort = actualSort} = decl
+      SentenceSymbol {sentenceSymbolSymbol = symbol} = decl
+  Monad.unless (actualSort == expectedSort)
+    $ Kore.Error.koreFailWithLocations
+        [symbol]
+        ( "Symbol does not return sort '"
+            <> unparseToText expectedSort
+            <> "'"
+          )
 
 {- | Verify the occurrence of a builtin sort.
 
@@ -374,28 +400,31 @@ assertSymbolResultSort indexedModule symbolId expectedSort = do
 
  -}
 verifySort
-    :: Text
-    -> SortVerifier
+  :: Text
+  -> SortVerifier
 verifySort builtinName =
-    SortVerifier worker
+  SortVerifier worker
   where
     worker
-        :: forall patternType
-        .  (Id -> Either (Error VerifyError) (SentenceSort patternType))
-        -> Sort
-        -> Either (Error VerifyError) ()
-    worker findSort (SortActualSort SortActual { sortActualName }) = do
-        SentenceSort { sentenceSortAttributes } <- findSort sortActualName
-        let expectHook = Hook (Just builtinName)
-        declHook <- Verifier.Attributes.parseAttributes sentenceSortAttributes
-        Kore.Error.koreFailWhen (expectHook /= declHook)
-            ("Sort '" ++ getIdForError sortActualName
-                ++ "' is not hooked to builtin sort '"
-                ++ Text.unpack builtinName ++ "'")
-    worker _ (SortVariableSort SortVariable { getSortVariable }) =
-        Kore.Error.koreFail
-            ("unexpected sort variable '"
-                ++ getIdForError getSortVariable ++ "'")
+      :: forall patternType. (Id -> Either (Error VerifyError) (SentenceSort patternType))
+      -> Sort
+      -> Either (Error VerifyError) ()
+    worker findSort (SortActualSort SortActual {sortActualName}) = do
+      SentenceSort {sentenceSortAttributes} <- findSort sortActualName
+      let expectHook = Hook (Just builtinName)
+      declHook <- Verifier.Attributes.parseAttributes sentenceSortAttributes
+      Kore.Error.koreFailWhen (expectHook /= declHook)
+        ( "Sort '" ++ getIdForError sortActualName
+            ++ "' is not hooked to builtin sort '"
+            ++ Text.unpack builtinName
+            ++ "'"
+          )
+    worker _ (SortVariableSort SortVariable {getSortVariable}) =
+      Kore.Error.koreFail
+        ( "unexpected sort variable '"
+            ++ getIdForError getSortVariable
+            ++ "'"
+          )
 
 -- | Wildcard for sort verification on parameterized builtin sorts
 acceptAnySort :: SortVerifier
@@ -403,16 +432,16 @@ acceptAnySort = SortVerifier $ \_ _ -> return ()
 
 {- | Find the hooked sort for a domain value sort. -}
 lookupHookSort
-    :: (Id -> Either (Error VerifyError) (SentenceSort patternType))
-    -> Sort
-    -> Either (Error VerifyError) (Maybe Text)
-lookupHookSort findSort (SortActualSort SortActual { sortActualName }) = do
-    SentenceSort { sentenceSortAttributes } <- findSort sortActualName
-    Hook mHookSort <- Verifier.Attributes.parseAttributes sentenceSortAttributes
-    return mHookSort
-lookupHookSort _ (SortVariableSort SortVariable { getSortVariable }) =
-    Kore.Error.koreFail
-        ("unexpected sort variable '" ++ getIdForError getSortVariable ++ "'")
+  :: (Id -> Either (Error VerifyError) (SentenceSort patternType))
+  -> Sort
+  -> Either (Error VerifyError) (Maybe Text)
+lookupHookSort findSort (SortActualSort SortActual {sortActualName}) = do
+  SentenceSort {sentenceSortAttributes} <- findSort sortActualName
+  Hook mHookSort <- Verifier.Attributes.parseAttributes sentenceSortAttributes
+  return mHookSort
+lookupHookSort _ (SortVariableSort SortVariable {getSortVariable}) =
+  Kore.Error.koreFail
+    ("unexpected sort variable '" ++ getIdForError getSortVariable ++ "'")
 
 {- | Verify a builtin symbol declaration.
 
@@ -422,15 +451,15 @@ lookupHookSort _ (SortVariableSort SortVariable { getSortVariable }) =
 
  -}
 verifySymbol
-    :: SortVerifier  -- ^ Builtin result sort
-    -> [SortVerifier]  -- ^ Builtin argument sorts
-    -> SymbolVerifier
+  :: SortVerifier -- ^ Builtin result sort
+  -> [SortVerifier] -- ^ Builtin argument sorts
+  -> SymbolVerifier
 verifySymbol verifyResult verifyArguments =
-    SymbolVerifier $ \findSort decl -> do
-        let SentenceSymbol { sentenceSymbolResultSort = result } = decl
-        Kore.Error.withContext "In result sort"
-            (runSortVerifier verifyResult findSort result)
-        runSymbolVerifier (verifySymbolArguments verifyArguments) findSort decl
+  SymbolVerifier $ \findSort decl -> do
+    let SentenceSymbol {sentenceSymbolResultSort = result} = decl
+    Kore.Error.withContext "In result sort"
+      (runSortVerifier verifyResult findSort result)
+    runSymbolVerifier (verifySymbolArguments verifyArguments) findSort decl
 
 {- | Verify the arguments of a builtin sort declaration.
 
@@ -442,72 +471,73 @@ verifySymbol verifyResult verifyArguments =
 
  -}
 verifySymbolArguments
-    :: [SortVerifier]  -- ^ Builtin argument sorts
-    -> SymbolVerifier
+  :: [SortVerifier] -- ^ Builtin argument sorts
+  -> SymbolVerifier
 verifySymbolArguments verifyArguments =
-    SymbolVerifier $ \findSort sentenceSymbol ->
-        Kore.Error.withContext "In argument sorts" $ do
-            let SentenceSymbol { sentenceSymbolSorts = sorts } = sentenceSymbol
-                builtinArity = length verifyArguments
-                arity = length sorts
-            Kore.Error.koreFailWhen (arity /= builtinArity)
-                ("Expected " ++ show builtinArity
-                ++ " arguments, found " ++ show arity)
-            zipWithM_ (\verify sort -> verify findSort sort)
-                (runSortVerifier <$> verifyArguments)
-                sorts
+  SymbolVerifier $ \findSort sentenceSymbol ->
+    Kore.Error.withContext "In argument sorts" $ do
+      let SentenceSymbol {sentenceSymbolSorts = sorts} = sentenceSymbol
+          builtinArity = length verifyArguments
+          arity = length sorts
+      Kore.Error.koreFailWhen (arity /= builtinArity)
+        ( "Expected " ++ show builtinArity
+            ++ " arguments, found "
+            ++ show arity
+          )
+      zipWithM_ (\verify sort -> verify findSort sort)
+        (runSortVerifier <$> verifyArguments)
+        sorts
 
 {- | Run a DomainValueVerifier.
 -}
 verifyDomainValue
-    :: DomainValueVerifiers (TermLike variable)
-    -> (Id -> Either (Error VerifyError) (SentenceSort patternType))
-    -> DomainValue Sort (TermLike variable)
-    -> Either (Error VerifyError) (TermLikeF variable (TermLike variable))
+  :: DomainValueVerifiers (TermLike variable)
+  -> (Id -> Either (Error VerifyError) (SentenceSort patternType))
+  -> DomainValue Sort (TermLike variable)
+  -> Either (Error VerifyError) (TermLikeF variable (TermLike variable))
 verifyDomainValue
-    verifiers
-    findSort
-    domain
-  =
+  verifiers
+  findSort
+  domain =
     case domainValueSort of
-        SortActualSort _ -> do
-            hookSort <- lookupHookSort findSort domainValueSort
-            fromMaybe (external domain) $ do
-                hook <- hookSort
-                verifier <- HashMap.lookup hook verifiers
-                let context =
-                        "Verifying builtin sort '" ++ Text.unpack hook ++ "'"
-                    verify = Kore.Error.withContext context . verifier
-                pure (BuiltinF <$> verify domain)
-        SortVariableSort _ -> external domain
-  where
-    external = return . DomainValueF
-    DomainValue { domainValueSort } = domain
+      SortActualSort _ -> do
+        hookSort <- lookupHookSort findSort domainValueSort
+        fromMaybe (external domain) $ do
+          hook <- hookSort
+          verifier <- HashMap.lookup hook verifiers
+          let context =
+                "Verifying builtin sort '" ++ Text.unpack hook ++ "'"
+              verify = Kore.Error.withContext context . verifier
+          pure (BuiltinF <$> verify domain)
+      SortVariableSort _ -> external domain
+    where
+      external = return . DomainValueF
+      DomainValue {domainValueSort} = domain
 
 -- | Construct a 'DomainValueVerifier' for an encodable sort.
 makeEncodedDomainValueVerifier
-    :: Text
-    -- ^ Builtin sort identifier
-    -> (DomainValue Sort child -> Either (Error VerifyError) (Builtin child))
-    -- ^ encoding function for the builtin sort
-    -> DomainValueVerifier child
+  :: Text
+  -- ^ Builtin sort identifier
+  -> (DomainValue Sort child -> Either (Error VerifyError) (Builtin child))
+  -- ^ encoding function for the builtin sort
+  -> DomainValueVerifier child
 makeEncodedDomainValueVerifier _builtinSort encodeSort domain =
-    Kore.Error.withContext "While parsing domain value"
-        (encodeSort domain)
+  Kore.Error.withContext "While parsing domain value"
+    (encodeSort domain)
 
 {- | Run a parser on a string.
 
  -}
 parseString
-    :: Parser a
-    -> Text
-    -> Either (Error VerifyError) a
+  :: Parser a
+  -> Text
+  -> Either (Error VerifyError) a
 parseString parser lit =
-    let parsed = Parsec.parse (parser <* Parsec.eof) "<string literal>" lit
-    in castParseError parsed
+  let parsed = Parsec.parse (parser <* Parsec.eof) "<string literal>" lit
+   in castParseError parsed
   where
     castParseError =
-        either (Kore.Error.koreFail . Parsec.errorBundlePretty) pure
+      either (Kore.Error.koreFail . Parsec.errorBundlePretty) pure
 
 {- | Return the supplied pattern as an 'AttemptedAxiom'.
 
@@ -516,14 +546,15 @@ parseString parser lit =
   See also: 'Pattern'
  -}
 appliedFunction
-    :: (Monad m, Ord variable)
-    => Pattern variable
-    -> m (AttemptedAxiom variable)
+  :: (Monad m, Ord variable)
+  => Pattern variable
+  -> m (AttemptedAxiom variable)
 appliedFunction epat =
-    return $ Applied AttemptedAxiomResults
-        { results = OrPattern.fromPattern epat
-        , remainders = OrPattern.bottom
-        }
+  return
+    $ Applied AttemptedAxiomResults
+        { results = OrPattern.fromPattern epat,
+          remainders = OrPattern.bottom
+          }
 
 {- | Construct a builtin unary operator.
 
@@ -535,44 +566,43 @@ appliedFunction epat =
 
  -}
 unaryOperator
-    :: forall a b
-    .   (forall variable. Text -> Builtin (TermLike variable) -> a)
-    -- ^ Parse operand
-    ->  (forall variable
-            .   (Ord variable, SortedVariable variable)
-            =>  Sort -> b -> Pattern variable
-        )
-    -- ^ Render result as pattern with given sort
-    -> Text
-    -- ^ Builtin function name (for error messages)
-    -> (a -> b)
-    -- ^ Operation on builtin types
-    -> Function
+  :: forall a b. (forall variable. Text -> Builtin (TermLike variable) -> a)
+  -> -- ^ Parse operand
+  ( forall variable. (Ord variable, SortedVariable variable)
+    => Sort
+    -> b
+    -> Pattern variable
+    )
+  -> -- ^ Render result as pattern with given sort
+  Text
+  -- ^ Builtin function name (for error messages)
+  -> (a -> b)
+  -- ^ Operation on builtin types
+  -> Function
 unaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+  extractVal
+  asPattern
+  ctx
+  op =
     functionEvaluator unaryOperator0
-  where
-    get :: Builtin (TermLike variable) -> a
-    get = extractVal ctx
-    unaryOperator0
+    where
+      get :: Builtin (TermLike variable) -> a
+      get = extractVal ctx
+      unaryOperator0
         :: (Ord variable, SortedVariable variable)
         => MonadSimplify m
         => TermLikeSimplifier
         -> Sort
         -> [TermLike variable]
         -> m (AttemptedAxiom variable)
-    unaryOperator0 _ resultSort children =
+      unaryOperator0 _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
-            [BuiltinF a] -> do
-                -- Apply the operator to a domain value
-                let r = op (get a)
-                (appliedFunction . asPattern resultSort) r
-            [_] -> return NotApplicable
-            _ -> wrongArity (Text.unpack ctx)
+          [BuiltinF a] -> do
+            -- Apply the operator to a domain value
+            let r = op (get a)
+            (appliedFunction . asPattern resultSort) r
+          [_] -> return NotApplicable
+          _ -> wrongArity (Text.unpack ctx)
 
 {- | Construct a builtin binary operator.
 
@@ -585,44 +615,43 @@ unaryOperator
 
  -}
 binaryOperator
-    :: forall a b
-    .  (forall variable. Text -> Builtin (TermLike variable) -> a)
-    -- ^ Extract domain value
-    ->  (forall variable
-            .   (Ord variable, SortedVariable variable)
-            =>  Sort -> b -> Pattern variable
-        )
-    -- ^ Render result as pattern with given sort
-    -> Text
-    -- ^ Builtin function name (for error messages)
-    -> (a -> a -> b)
-    -- ^ Operation on builtin types
-    -> Function
+  :: forall a b. (forall variable. Text -> Builtin (TermLike variable) -> a)
+  -- ^ Extract domain value
+  -> ( forall variable. (Ord variable, SortedVariable variable)
+       => Sort
+       -> b
+       -> Pattern variable
+       )
+  -> -- ^ Render result as pattern with given sort
+  Text
+  -- ^ Builtin function name (for error messages)
+  -> (a -> a -> b)
+  -- ^ Operation on builtin types
+  -> Function
 binaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+  extractVal
+  asPattern
+  ctx
+  op =
     functionEvaluator binaryOperator0
-  where
-    get :: Builtin (TermLike variable) -> a
-    get = extractVal ctx
-    binaryOperator0
+    where
+      get :: Builtin (TermLike variable) -> a
+      get = extractVal ctx
+      binaryOperator0
         :: (Ord variable, SortedVariable variable)
         => MonadSimplify m
         => TermLikeSimplifier
         -> Sort
         -> [TermLike variable]
         -> m (AttemptedAxiom variable)
-    binaryOperator0 _ resultSort children =
+      binaryOperator0 _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
-            [BuiltinF a, BuiltinF b] -> do
-                -- Apply the operator to two domain values
-                let r = op (get a) (get b)
-                (appliedFunction . asPattern resultSort) r
-            [_, _] -> return NotApplicable
-            _ -> wrongArity (Text.unpack ctx)
+          [BuiltinF a, BuiltinF b] -> do
+            -- Apply the operator to two domain values
+            let r = op (get a) (get b)
+            (appliedFunction . asPattern resultSort) r
+          [_, _] -> return NotApplicable
+          _ -> wrongArity (Text.unpack ctx)
 
 {- | Construct a builtin ternary operator.
 
@@ -635,74 +664,72 @@ binaryOperator
 
  -}
 ternaryOperator
-    :: forall a b
-    .  (forall variable. Text -> Builtin (TermLike variable) -> a)
-    -- ^ Extract domain value
-    ->  (forall variable
-            .   (Ord variable, SortedVariable variable)
-            =>  Sort -> b -> Pattern variable
-        )
-    -- ^ Render result as pattern with given sort
-    -> Text
-    -- ^ Builtin function name (for error messages)
-    -> (a -> a -> a -> b)
-    -- ^ Operation on builtin types
-    -> Function
+  :: forall a b. (forall variable. Text -> Builtin (TermLike variable) -> a)
+  -- ^ Extract domain value
+  -> ( forall variable. (Ord variable, SortedVariable variable)
+       => Sort
+       -> b
+       -> Pattern variable
+       )
+  -> -- ^ Render result as pattern with given sort
+  Text
+  -- ^ Builtin function name (for error messages)
+  -> (a -> a -> a -> b)
+  -- ^ Operation on builtin types
+  -> Function
 ternaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+  extractVal
+  asPattern
+  ctx
+  op =
     functionEvaluator ternaryOperator0
-  where
-    get :: Builtin (TermLike variable) -> a
-    get = extractVal ctx
-    ternaryOperator0
+    where
+      get :: Builtin (TermLike variable) -> a
+      get = extractVal ctx
+      ternaryOperator0
         :: (Ord variable, SortedVariable variable)
         => MonadSimplify m
         => TermLikeSimplifier
         -> Sort
         -> [TermLike variable]
         -> m (AttemptedAxiom variable)
-    ternaryOperator0 _ resultSort children =
+      ternaryOperator0 _ resultSort children =
         case Cofree.tailF . Recursive.project <$> children of
-            [ BuiltinF a, BuiltinF b, BuiltinF c ] -> do
-                -- Apply the operator to three domain values
-                let r = op (get a) (get b) (get c)
-                (appliedFunction . asPattern resultSort) r
-            [_, _, _] -> return NotApplicable
-            _ -> wrongArity (Text.unpack ctx)
+          [BuiltinF a, BuiltinF b, BuiltinF c] -> do
+            -- Apply the operator to three domain values
+            let r = op (get a) (get b) (get c)
+            (appliedFunction . asPattern resultSort) r
+          [_, _, _] -> return NotApplicable
+          _ -> wrongArity (Text.unpack ctx)
 
 type FunctionImplementation
-    = forall variable m
-        .  (Ord variable, SortedVariable variable)
-        => MonadSimplify m
-        => TermLikeSimplifier
-        -> Sort
-        -> [TermLike variable]
-        -> m (AttemptedAxiom variable)
+  = forall variable m. (Ord variable, SortedVariable variable)
+  => MonadSimplify m
+  => TermLikeSimplifier
+  -> Sort
+  -> [TermLike variable]
+  -> m (AttemptedAxiom variable)
 
 functionEvaluator :: FunctionImplementation -> Function
 functionEvaluator impl =
-    applicationAxiomSimplifier evaluator
+  applicationAxiomSimplifier evaluator
   where
     evaluator
-        :: (Ord variable, Show variable, SortedVariable variable)
-        => MonadSimplify simplifier
-        => PredicateSimplifier
-        -> TermLikeSimplifier
-        -> BuiltinAndAxiomSimplifierMap
-        -> CofreeF
-            (Application Symbol)
-            (Attribute.Pattern variable)
-            (TermLike variable)
-        -> simplifier (AttemptedAxiom variable)
+      :: (Ord variable, Show variable, SortedVariable variable)
+      => MonadSimplify simplifier
+      => PredicateSimplifier
+      -> TermLikeSimplifier
+      -> BuiltinAndAxiomSimplifierMap
+      -> CofreeF
+           (Application Symbol)
+           (Attribute.Pattern variable)
+           (TermLike variable)
+      -> simplifier (AttemptedAxiom variable)
     evaluator _ simplifier _axiomIdToSimplifier (valid :< app) =
-        impl simplifier resultSort applicationChildren
+      impl simplifier resultSort applicationChildren
       where
-        Application { applicationChildren } = app
-        Attribute.Pattern { Attribute.patternSort = resultSort } = valid
+        Application {applicationChildren} = app
+        Attribute.Pattern {Attribute.patternSort = resultSort} = valid
 
 {- | Run a parser on a verified domain value.
 
@@ -712,32 +739,32 @@ functionEvaluator impl =
  -}
 runParser :: HasCallStack => Text -> Either (Error e) a -> a
 runParser ctx result =
-    case result of
-        Left e ->
-            verifierBug $ Text.unpack ctx ++ ": " ++ Kore.Error.printError e
-        Right a -> a
+  case result of
+    Left e ->
+      verifierBug $ Text.unpack ctx ++ ": " ++ Kore.Error.printError e
+    Right a -> a
 
 {- | Look up the symbol hooked to the named builtin in the provided module.
  -}
 lookupSymbol
-    :: Text
-    -- ^ builtin name
-    -> Sort
-    -- ^ the hooked sort
-    -> VerifiedModule Attribute.Symbol axiomAtts
-    -> Either (Error e) Symbol
+  :: Text
+  -- ^ builtin name
+  -> Sort
+  -- ^ the hooked sort
+  -> VerifiedModule Attribute.Symbol axiomAtts
+  -> Either (Error e) Symbol
 lookupSymbol builtinName builtinSort indexedModule = do
-    symbolConstructor <-
-        IndexedModule.resolveHook indexedModule builtinName builtinSort
-    (symbolAttributes, sentenceSymbol) <-
-        IndexedModule.resolveSymbol indexedModule symbolConstructor
-    symbolSorts <- symbolOrAliasSorts [] sentenceSymbol
-    return Symbol
-        { symbolConstructor
-        , symbolParams = []
-        , symbolAttributes
-        , symbolSorts
-        }
+  symbolConstructor <-
+    IndexedModule.resolveHook indexedModule builtinName builtinSort
+  (symbolAttributes, sentenceSymbol) <-
+    IndexedModule.resolveSymbol indexedModule symbolConstructor
+  symbolSorts <- symbolOrAliasSorts [] sentenceSymbol
+  return Symbol
+    { symbolConstructor,
+      symbolParams = [],
+      symbolAttributes,
+      symbolSorts
+      }
 
 {- | Find the symbol hooked to @unit@.
 
@@ -750,29 +777,30 @@ declared attributes, because it is intended only for unparsing.
  -}
 -- TODO (thomas.tuegel): Resolve this symbol during syntax verification.
 lookupSymbolUnit
-    :: SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> Symbol
+  :: SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> Symbol
 lookupSymbolUnit tools builtinSort =
-    Symbol
-        { symbolConstructor
-        , symbolParams
-        , symbolAttributes
-        , symbolSorts
-        }
+  Symbol
+    { symbolConstructor,
+      symbolParams,
+      symbolAttributes,
+      symbolSorts
+      }
   where
     unit = Attribute.unit (MetadataTools.sortAttributes tools builtinSort)
     symbolOrAlias =
-        Attribute.Sort.getUnit unit
+      Attribute.Sort.getUnit unit
         & fromMaybe missingUnitAttribute
     symbolConstructor = symbolOrAliasConstructor symbolOrAlias
     symbolParams = symbolOrAliasParams symbolOrAlias
     symbolSorts = MetadataTools.applicationSorts tools symbolOrAlias
     symbolAttributes = MetadataTools.symbolAttributes tools symbolConstructor
     missingUnitAttribute =
-        verifierBug
+      verifierBug
         $ "missing 'unit' attribute of sort '"
-        ++ unparseToString builtinSort ++ "'"
+        ++ unparseToString builtinSort
+        ++ "'"
 
 {- | Find the symbol hooked to @element@.
 
@@ -785,29 +813,30 @@ declared attributes, because it is intended only for unparsing.
  -}
 -- TODO (thomas.tuegel): Resolve this symbol during syntax verification.
 lookupSymbolElement
-    :: SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> Symbol
+  :: SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> Symbol
 lookupSymbolElement tools builtinSort =
-    Symbol
-        { symbolConstructor
-        , symbolParams
-        , symbolAttributes
-        , symbolSorts
-        }
+  Symbol
+    { symbolConstructor,
+      symbolParams,
+      symbolAttributes,
+      symbolSorts
+      }
   where
     element = Attribute.element (MetadataTools.sortAttributes tools builtinSort)
     symbolOrAlias =
-        Attribute.Sort.getElement element
+      Attribute.Sort.getElement element
         & fromMaybe missingElementAttribute
     symbolConstructor = symbolOrAliasConstructor symbolOrAlias
     symbolParams = symbolOrAliasParams symbolOrAlias
     symbolSorts = MetadataTools.applicationSorts tools symbolOrAlias
     symbolAttributes = MetadataTools.symbolAttributes tools symbolConstructor
     missingElementAttribute =
-        verifierBug
+      verifierBug
         $ "missing 'element' attribute of sort '"
-        ++ unparseToString builtinSort ++ "'"
+        ++ unparseToString builtinSort
+        ++ "'"
 
 {- | Find the symbol hooked to @concat@.
 
@@ -820,38 +849,39 @@ declared attributes, because it is intended only for unparsing.
  -}
 -- TODO (thomas.tuegel): Resolve this symbol during syntax verification.
 lookupSymbolConcat
-    :: SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> Symbol
+  :: SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> Symbol
 lookupSymbolConcat tools builtinSort =
-    Symbol
-        { symbolConstructor
-        , symbolParams
-        , symbolAttributes
-        , symbolSorts
-        }
+  Symbol
+    { symbolConstructor,
+      symbolParams,
+      symbolAttributes,
+      symbolSorts
+      }
   where
     concat' = Attribute.concat (MetadataTools.sortAttributes tools builtinSort)
     symbolOrAlias =
-        Attribute.Sort.getConcat concat'
+      Attribute.Sort.getConcat concat'
         & fromMaybe missingConcatAttribute
     symbolConstructor = symbolOrAliasConstructor symbolOrAlias
     symbolParams = symbolOrAliasParams symbolOrAlias
     symbolSorts = MetadataTools.applicationSorts tools symbolOrAlias
     symbolAttributes = MetadataTools.symbolAttributes tools symbolConstructor
     missingConcatAttribute =
-        verifierBug
+      verifierBug
         $ "missing 'concat' attribute of sort '"
-        ++ unparseToString builtinSort ++ "'"
+        ++ unparseToString builtinSort
+        ++ "'"
 
 {- | Is the given symbol hooked to the named builtin?
  -}
 isSymbol
-    :: Text  -- ^ Builtin symbol
-    -> Symbol  -- ^ Kore symbol
-    -> Bool
-isSymbol builtinName Symbol { symbolAttributes = Attribute.Symbol { hook } } =
-    getHook hook == Just builtinName
+  :: Text -- ^ Builtin symbol
+  -> Symbol -- ^ Kore symbol
+  -> Bool
+isSymbol builtinName Symbol {symbolAttributes = Attribute.Symbol {hook}} =
+  getHook hook == Just builtinName
 
 {- | Is the given sort hooked to the named builtin?
 
@@ -860,14 +890,13 @@ Returns Just False if the sort is a variable.
 -}
 isSort :: Text -> SmtMetadataTools attr -> Sort -> Maybe Bool
 isSort builtinName tools sort
-  | isPredicateSort            = Nothing
+  | isPredicateSort = Nothing
   | SortVariableSort _ <- sort = Nothing
-  | otherwise                  = Just (getHook hook == Just builtinName)
+  | otherwise = Just (getHook hook == Just builtinName)
   where
     MetadataTools {sortAttributes} = tools
     Attribute.Sort {hook} = sortAttributes sort
     isPredicateSort = sort == predicateSort
-
 
 {- | Ensure that a 'TermLike' is a concrete, normalized term.
 
@@ -877,37 +906,35 @@ See also: 'Kore.Proof.Value.Value'
  -}
 toKey :: TermLike variable -> Maybe (TermLike Concrete)
 toKey purePattern = do
-    p <- TermLike.asConcrete purePattern
-    -- TODO (thomas.tuegel): Use the return value as the term.
-    _ <- Value.fromTermLike p
-    return p
+  p <- TermLike.asConcrete purePattern
+  -- TODO (thomas.tuegel): Use the return value as the term.
+  _ <- Value.fromTermLike p
+  return p
 
 {- | Run a function evaluator that can terminate early.
  -}
 getAttemptedAxiom
-    :: Monad m
-    => MaybeT m (AttemptedAxiom variable)
-    -> m (AttemptedAxiom variable)
+  :: Monad m
+  => MaybeT m (AttemptedAxiom variable)
+  -> m (AttemptedAxiom variable)
 getAttemptedAxiom attempt =
-    fromMaybe NotApplicable <$> runMaybeT attempt
+  fromMaybe NotApplicable <$> runMaybeT attempt
 
 -- | Return an unsolved unification problem.
 unifyEqualsUnsolved
-    ::  ( Monad m
-        , Ord variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        )
-    => SimplificationType
-    -> TermLike variable
-    -> TermLike variable
-    -> m (Pattern variable)
+  :: ( Monad m,
+       Ord variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable
+       )
+  => SimplificationType
+  -> TermLike variable
+  -> TermLike variable
+  -> m (Pattern variable)
 unifyEqualsUnsolved SimplificationType.And a b =
-    let
-        unified = mkAnd a b
-        predicate = makeCeilPredicate unified
-    in
-        return (pure unified) { predicate }
+  let unified = mkAnd a b
+      predicate = makeCeilPredicate unified
+   in return (pure unified) {predicate}
 unifyEqualsUnsolved SimplificationType.Equals a b =
-    return Pattern.top {predicate = makeEqualsPredicate a b}
+  return Pattern.top {predicate = makeEqualsPredicate a b}

--- a/kore/src/Kore/Builtin/Error.hs
+++ b/kore/src/Kore/Builtin/Error.hs
@@ -10,13 +10,15 @@ pattern verifier has admitted an invalid builtin domain expression.
 
  -}
 module Kore.Builtin.Error
-    ( verifierBug
-    , wrongArity
-    , notImplementedInternal
-    ) where
+  ( verifierBug,
+    wrongArity,
+    notImplementedInternal
+    )
+where
 
 import GHC.Stack
-       ( HasCallStack )
+  ( HasCallStack
+    )
 
 {- | Abort due to an internal error that should be prevented by the verifier.
 
@@ -25,11 +27,11 @@ import GHC.Stack
  -}
 verifierBug :: HasCallStack => String -> a
 verifierBug msg =
-    (error . unlines)
-        [ "Internal error: " ++ msg
-        , "This error should be prevented by the verifier."
-        , "Please report this as a bug."
-        ]
+  (error . unlines)
+    [ "Internal error: " ++ msg,
+      "This error should be prevented by the verifier.",
+      "Please report this as a bug."
+      ]
 
 {- | Evaluation failure due to a builtin call with the wrong arity.
 

--- a/kore/src/Kore/Builtin/Krypto.hs
+++ b/kore/src/Kore/Builtin/Krypto.hs
@@ -15,48 +15,54 @@ builtin modules.
 @
  -}
 module Kore.Builtin.Krypto
-    ( symbolVerifiers
-    , builtinFunctions
-    , keccakKey
-    , signatureToKey
-    ) where
-
+  ( symbolVerifiers,
+    builtinFunctions,
+    keccakKey,
+    signatureToKey
+    )
+where
 
 import Control.Exception.Base
-       ( assert )
-import GHC.Stack
-       ( HasCallStack )
-
+  ( assert
+    )
 import Crypto.Hash
-       ( Digest, Keccak_256, hash )
+  ( Digest,
+    Keccak_256,
+    hash
+    )
 import Crypto.PubKey.ECC.Prim
 import Crypto.PubKey.ECC.Types
-
-import           Data.Bits
-import           Data.ByteString
-                 ( ByteString )
+import Data.Bits
+import Data.ByteString
+  ( ByteString
+    )
 import qualified Data.ByteString as ByteString
-import           Data.Char
+import Data.Char
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map
-                 ( Map )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.String
-                 ( IsString, fromString )
-import           Data.Text
-                 ( Text )
+import Data.String
+  ( IsString,
+    fromString
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           Data.Word
-                 ( Word8 )
-
+import Data.Word
+  ( Word8
+    )
+import GHC.Stack
+  ( HasCallStack
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.Int as Int
 import qualified Kore.Builtin.String as String
 
 keccakKey, ecsdaRecover :: IsString s => s
-
 keccakKey = "KRYPTO.keccak256"
-
 ecsdaRecover = "KRYPTO.ecdsaRecover"
 
 {- | Verify that hooked symbol declarations are well-formed.
@@ -66,90 +72,90 @@ ecsdaRecover = "KRYPTO.ecdsaRecover"
 -}
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
-    HashMap.fromList
-    [ ( keccakKey
-      , Builtin.verifySymbol String.assertSort [String.assertSort]
-      )
-    , (ecsdaRecover
-      , Builtin.verifySymbol
+  HashMap.fromList
+    [ ( keccakKey,
+        Builtin.verifySymbol String.assertSort [String.assertSort]
+        ),
+      ( ecsdaRecover,
+        Builtin.verifySymbol
+          String.assertSort
+          [ String.assertSort,
+            Int.assertSort,
+            String.assertSort,
             String.assertSort
-            [ String.assertSort
-            , Int.assertSort
-            , String.assertSort
-            , String.assertSort
             ]
-      )
-    ]
+        )
+      ]
 
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
-    Map.fromList
-        [ (keccakKey, evalKeccak)
-        , (ecsdaRecover, evalECDSARecover)
-        ]
+  Map.fromList
+    [ (keccakKey, evalKeccak),
+      (ecsdaRecover, evalECDSARecover)
+      ]
 
 evalKeccak :: Builtin.Function
 evalKeccak =
-    Builtin.functionEvaluator evalKeccak0
+  Builtin.functionEvaluator evalKeccak0
   where
     evalKeccak0 :: Builtin.FunctionImplementation
     evalKeccak0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let
-                arg =
-                    case arguments of
-                      [input] -> input
-                      _ -> Builtin.wrongArity keccakKey
-            str <- String.expectBuiltinString keccakKey arg
-            let
-                digest :: Digest Keccak_256
-                digest =
-                    hash
-                    $ ByteString.pack
-                    $ map (fromIntegral . ord)
-                    $ Text.unpack str
-                result = fromString (show digest)
-            Builtin.appliedFunction $ String.asPattern resultSort result
+      Builtin.getAttemptedAxiom $ do
+        let arg =
+              case arguments of
+                [input] -> input
+                _ -> Builtin.wrongArity keccakKey
+        str <- String.expectBuiltinString keccakKey arg
+        let digest :: Digest Keccak_256
+            digest =
+              hash
+                $ ByteString.pack
+                $ map (fromIntegral . ord)
+                $ Text.unpack str
+            result = fromString (show digest)
+        Builtin.appliedFunction $ String.asPattern resultSort result
 
 evalECDSARecover :: Builtin.Function
 evalECDSARecover =
-    Builtin.functionEvaluator eval0
+  Builtin.functionEvaluator eval0
   where
     eval0 :: Builtin.FunctionImplementation
     eval0 _ resultSort [messageHash0, v0, r0, s0] =
-        Builtin.getAttemptedAxiom $ do
-            messageHash <- string2Integer . Text.unpack
-                    <$> String.expectBuiltinString "" messageHash0
-            v <- Int.expectBuiltinInt "" v0
-            r <- string2Integer . Text.unpack
-                    <$> String.expectBuiltinString "" r0
-            s <- string2Integer . Text.unpack
-                    <$> String.expectBuiltinString "" s0
-            Builtin.appliedFunction
-                $ String.asPattern resultSort
-                $ Text.pack
-                $ byteString2String
-                $ pad 64 0
-                $ signatureToKey messageHash r s v
+      Builtin.getAttemptedAxiom $ do
+        messageHash <-
+          string2Integer . Text.unpack
+            <$> String.expectBuiltinString "" messageHash0
+        v <- Int.expectBuiltinInt "" v0
+        r <-
+          string2Integer . Text.unpack
+            <$> String.expectBuiltinString "" r0
+        s <-
+          string2Integer . Text.unpack
+            <$> String.expectBuiltinString "" s0
+        Builtin.appliedFunction
+          $ String.asPattern resultSort
+          $ Text.pack
+          $ byteString2String
+          $ pad 64 0
+          $ signatureToKey messageHash r s v
     eval0 _ _ _ = Builtin.wrongArity ecsdaRecover
 
 pad :: Int -> Word8 -> ByteString -> ByteString
 pad n w s = ByteString.append s padding
   where
     padding =
-        ByteString.replicate (n - ByteString.length s) w
-
+      ByteString.replicate (n - ByteString.length s) w
 
 signatureToKey
-    :: Integer
-    -> Integer
-    -> Integer
-    -> Integer
-    -> ByteString
+  :: Integer
+  -> Integer
+  -> Integer
+  -> Integer
+  -> ByteString
 signatureToKey messageHash r s v =
-      assert (27 <= v && v <= 34)
+  assert (27 <= v && v <= 34)
     $ ByteString.drop 1
     $ encodePoint compressed
     $ recoverPublicKey recId (r, s) messageHash
@@ -158,68 +164,64 @@ signatureToKey messageHash r s v =
     compressed = v >= 31
 
 recoverPublicKey
-    :: Integer
-    -> (Integer, Integer)
-    -> Integer
-    -> Point
+  :: Integer
+  -> (Integer, Integer)
+  -> Integer
+  -> Point
 recoverPublicKey recId (r, s) e =
-      assert (recId >= 0)
+  assert (recId >= 0)
     $ assert (r >= 0)
     $ assert (s >= 0)
     $ assert (pt_x <= p)
     $ assert (pointMul p256k1 n pt == PointO)
     $ pointAddTwoMuls
-            p256k1
-            (mulMod n (invMod n r) s)
-            pt
-            (mulMod n (invMod n r) (n - e `mod` n))
-            (ecc_g curveParams)
+        p256k1
+        (mulMod n (invMod n r) s)
+        pt
+        (mulMod n (invMod n r) (n - e `mod` n))
+        (ecc_g curveParams)
   where
     p256k1@(CurveFP (CurvePrime p curveParams)) = getCurveByName SEC_p256k1
-
     n = ecc_n curveParams
-
     i = recId `div` 2
-
-    pt_x = r + i*n
-
+    pt_x = r + i * n
     pt = decompressPt pt_x (recId .&. 1 == 1)
-
     decompressPt x signBit = Point x (if signBit /= even y then y else p - y)
       where
-        y = sqrtMod p
+        y =
+          sqrtMod p
             ( powMod p x 3
-            + mulMod p (ecc_a curveParams) x
-            + ecc_b curveParams
-            )
+                + mulMod p (ecc_a curveParams) x
+                + ecc_b curveParams
+              )
 
 invMod
-    :: Integer
-    -> Integer
-    -> Integer
+  :: Integer
+  -> Integer
+  -> Integer
 invMod p x = powMod p x (p - 2)
 
 sqrtMod
-    :: Integer
-    -> Integer
-    -> Integer
+  :: Integer
+  -> Integer
+  -> Integer
 sqrtMod p x = powMod p x ((p + 1) `div` 4)
 
 mulMod
-    :: Integer
-    -> Integer
-    -> Integer
-    -> Integer
+  :: Integer
+  -> Integer
+  -> Integer
+  -> Integer
 mulMod p x y = (x * y) `mod` p
 
 powMod
-    :: Integer
-    -> Integer
-    -> Integer
-    -> Integer
+  :: Integer
+  -> Integer
+  -> Integer
+  -> Integer
 powMod _ _ 0 = 1
 powMod p x a =
-    mulMod p
+  mulMod p
     (if even a then 1 else x)
     (powMod p (mulMod p x x) (a `div` 2))
 
@@ -228,20 +230,20 @@ powMod p x a =
 -- Kept here for completeness sake, to match
 -- the code in the java backend.
 encodePoint
-    :: HasCallStack
-    => Bool
-    -> Point
-    -> ByteString
+  :: HasCallStack
+  => Bool
+  -> Point
+  -> ByteString
 encodePoint compressed (Point x y)
   | compressed =
     ByteString.cons
-        (if even y then 0x02 else 0x03)
-        (integer2ByteString x)
+      (if even y then 0x02 else 0x03)
+      (integer2ByteString x)
   | otherwise =
     ByteString.concat
-        [ ByteString.pack [0x04]
-        , integer2ByteString x
-        , integer2ByteString y
+      [ ByteString.pack [0x04],
+        integer2ByteString x,
+        integer2ByteString y
         ]
 encodePoint _ _ = error "Should never obtain point-at-infinity here!"
 
@@ -262,13 +264,13 @@ string2Integer = bstring2Integer . ByteString.pack . map (fromIntegral . ord)
 -- representation.
 bstring2Integer :: ByteString -> Integer
 bstring2Integer =
-    ByteString.foldr (\word i -> fromIntegral word + (i `shiftL` 8)) 0
-  . ByteString.reverse
+  ByteString.foldr (\word i -> fromIntegral word + (i `shiftL` 8)) 0
+    . ByteString.reverse
 
 -- | Converts an Integer to its big-endian unsigned representation.
 integer2ByteString :: Integer -> ByteString
 integer2ByteString =
-    ByteString.reverse .  ByteString.unfoldr integer2ByteStringWorker
+  ByteString.reverse . ByteString.unfoldr integer2ByteStringWorker
   where
     integer2ByteStringWorker i
       | i == 0 = Nothing

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -15,83 +15,101 @@ builtin modules.
 @
  -}
 module Kore.Builtin.List
-    ( sort
-    , assertSort
-    , sortDeclVerifiers
-    , symbolVerifiers
-    , builtinFunctions
-    , Builtin
-    , returnList
-    , asPattern
-    , asInternal
-    , asTermLike
-    , internalize
-      -- * Symbols
-    , lookupSymbolGet
-    , isSymbolConcat
-    , isSymbolElement
-    , isSymbolUnit
-    , unifyEquals
-      -- * keys
-    , concatKey
-    , elementKey
-    , unitKey
-    , getKey
-    , expectConcreteBuiltinList
-    ) where
+  ( sort,
+    assertSort,
+    sortDeclVerifiers,
+    symbolVerifiers,
+    builtinFunctions,
+    Builtin,
+    returnList,
+    asPattern,
+    asInternal,
+    asTermLike,
+    internalize,
+    -- * Symbols
+    lookupSymbolGet,
+    isSymbolConcat,
+    isSymbolElement,
+    isSymbolUnit,
+    unifyEquals,
+    -- * keys
+    concatKey,
+    elementKey,
+    unitKey,
+    getKey,
+    expectConcreteBuiltinList
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Error
-                 ( MaybeT )
-import           Control.Monad
-                 ( join )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Error
+  ( MaybeT
+    )
+import Control.Monad
+  ( join
+    )
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Control.Monad.Trans.Maybe as Monad.Trans.Maybe
-                 ( mapMaybeT )
+  ( mapMaybeT
+    )
 import qualified Data.Function as Function
-import           Data.Functor
-                 ( (<$) )
+import Data.Functor
+  ( (<$)
+    )
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Reflection
-                 ( Given )
+import Data.Reflection
+  ( Given
+    )
 import qualified Data.Reflection as Reflection
-import           Data.Sequence
-                 ( Seq )
+import Data.Sequence
+  ( Seq
+    )
 import qualified Data.Sequence as Seq
-import           Data.String
-                 ( IsString )
-import           Data.Text
-                 ( Text )
+import Data.String
+  ( IsString
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Builtin.Builtin
-                 ( acceptAnySort )
+import Kore.Builtin.Builtin
+  ( acceptAnySort
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.Int as Int
 import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Error as Kore
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Step.Simplification.Data as Simplifier
-import           Kore.Syntax.Sentence
-                 ( SentenceSort (..) )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Internal.TermLike
+import Kore.Step.Simplification.Data as Simplifier
+import Kore.Syntax.Sentence
+  ( SentenceSort (..)
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
+import Kore.Unparser
+  ( Unparse
+    )
+import Kore.Variables.Fresh
 
 {- | Builtin variable name of the @List@ sort.
  -}
@@ -113,22 +131,22 @@ assertSort = Builtin.verifySort sort
  -}
 sortDeclVerifiers :: Builtin.SortDeclVerifiers
 sortDeclVerifiers =
-    HashMap.fromList [ (sort, verifySortDecl) ]
+  HashMap.fromList [(sort, verifySortDecl)]
   where
     verifySortDecl indexedModule sentenceSort attrs = do
-        Builtin.verifySortDecl indexedModule sentenceSort attrs
-        unitId <- Builtin.getUnitId attrs
-        Builtin.assertSymbolHook indexedModule unitId unitKey
-        Builtin.assertSymbolResultSort indexedModule unitId expectedSort
-        elementId <- Builtin.getElementId attrs
-        Builtin.assertSymbolHook indexedModule elementId elementKey
-        Builtin.assertSymbolResultSort indexedModule elementId expectedSort
-        concatId <- Builtin.getConcatId attrs
-        Builtin.assertSymbolHook indexedModule concatId concatKey
-        Builtin.assertSymbolResultSort indexedModule concatId expectedSort
-        return ()
+      Builtin.verifySortDecl indexedModule sentenceSort attrs
+      unitId <- Builtin.getUnitId attrs
+      Builtin.assertSymbolHook indexedModule unitId unitKey
+      Builtin.assertSymbolResultSort indexedModule unitId expectedSort
+      elementId <- Builtin.getElementId attrs
+      Builtin.assertSymbolHook indexedModule elementId elementKey
+      Builtin.assertSymbolResultSort indexedModule elementId expectedSort
+      concatId <- Builtin.getConcatId attrs
+      Builtin.assertSymbolHook indexedModule concatId concatKey
+      Builtin.assertSymbolResultSort indexedModule concatId expectedSort
+      return ()
       where
-        SentenceSort { sentenceSortName } = sentenceSort
+        SentenceSort {sentenceSortName} = sentenceSort
         expectedSort = mkSort sentenceSortName
 
 {- | Verify that hooked symbol declarations are well-formed.
@@ -138,20 +156,20 @@ sortDeclVerifiers =
  -}
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
-    HashMap.fromList
-    [ ( concatKey
-      , Builtin.verifySymbol assertSort [assertSort , assertSort]
-      )
-    , ( elementKey
-      , Builtin.verifySymbol assertSort [acceptAnySort]
-      )
-    , ( unitKey
-      , Builtin.verifySymbol assertSort []
-      )
-    , ( getKey
-      , Builtin.verifySymbol acceptAnySort [assertSort, Int.assertSort]
-      )
-    ]
+  HashMap.fromList
+    [ ( concatKey,
+        Builtin.verifySymbol assertSort [assertSort, assertSort]
+        ),
+      ( elementKey,
+        Builtin.verifySymbol assertSort [acceptAnySort]
+        ),
+      ( unitKey,
+        Builtin.verifySymbol assertSort []
+        ),
+      ( getKey,
+        Builtin.verifySymbol acceptAnySort [assertSort, Int.assertSort]
+        )
+      ]
 
 {- | Abort function evaluation if the argument is not a List domain value.
 
@@ -161,163 +179,161 @@ symbolVerifiers =
 
  -}
 expectBuiltinList
-    :: Monad m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Seq (TermLike variable))
+  :: Monad m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Seq (TermLike variable))
 expectBuiltinList ctx =
-    \case
-        Builtin_ domain ->
-            case domain of
-                Domain.BuiltinList Domain.InternalList { builtinListChild } ->
-                    return builtinListChild
-                _ ->
-                    Builtin.verifierBug
-                    $ Text.unpack ctx ++ ": Domain value is not a list"
-        _ -> empty
+  \case
+    Builtin_ domain ->
+      case domain of
+        Domain.BuiltinList Domain.InternalList {builtinListChild} ->
+          return builtinListChild
+        _ ->
+          Builtin.verifierBug
+            $ Text.unpack ctx
+            ++ ": Domain value is not a list"
+    _ -> empty
 
 expectConcreteBuiltinList
-    :: Monad m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Seq (TermLike Concrete))
+  :: Monad m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Seq (TermLike Concrete))
 expectConcreteBuiltinList ctx =
-    Monad.Trans.Maybe.mapMaybeT (fmap join)
-        . fmap (traverse Builtin.toKey)
-        . expectBuiltinList ctx
+  Monad.Trans.Maybe.mapMaybeT (fmap join)
+    . fmap (traverse Builtin.toKey)
+    . expectBuiltinList ctx
 
 returnList
-    :: (MonadSimplify m, Ord variable, SortedVariable variable)
-    => Sort
-    -> Seq (TermLike variable)
-    -> m (AttemptedAxiom variable)
+  :: (MonadSimplify m, Ord variable, SortedVariable variable)
+  => Sort
+  -> Seq (TermLike variable)
+  -> m (AttemptedAxiom variable)
 returnList builtinListSort builtinListChild = do
-    tools <- Simplifier.askMetadataTools
-    Builtin.appliedFunction
-        $ Reflection.give tools
-        $ asPattern builtinListSort builtinListChild
+  tools <- Simplifier.askMetadataTools
+  Builtin.appliedFunction
+    $ Reflection.give tools
+    $ asPattern builtinListSort builtinListChild
 
 evalElement :: Builtin.Function
 evalElement =
-    Builtin.functionEvaluator evalElement0
+  Builtin.functionEvaluator evalElement0
   where
     evalElement0 _ resultSort =
-        \case
-            [elem'] -> returnList resultSort (Seq.singleton elem')
-            _ -> Builtin.wrongArity elementKey
+      \case
+        [elem'] -> returnList resultSort (Seq.singleton elem')
+        _ -> Builtin.wrongArity elementKey
 
 evalGet :: Builtin.Function
 evalGet =
-    Builtin.functionEvaluator evalGet0
+  Builtin.functionEvaluator evalGet0
   where
     evalGet0
-        :: (Ord variable, SortedVariable variable, MonadSimplify simplifier)
-        => TermLikeSimplifier
-        -> Sort
-        -> [TermLike variable]
-        -> simplifier (AttemptedAxiom variable)
+      :: (Ord variable, SortedVariable variable, MonadSimplify simplifier)
+      => TermLikeSimplifier
+      -> Sort
+      -> [TermLike variable]
+      -> simplifier (AttemptedAxiom variable)
     evalGet0 _ _ = \arguments ->
-        Builtin.getAttemptedAxiom
-        (do
+      Builtin.getAttemptedAxiom
+        ( do
             let (_list, _ix) =
-                    case arguments of
-                        [_list, _ix] -> (_list, _ix)
-                        _ -> Builtin.wrongArity getKey
+                  case arguments of
+                    [_list, _ix] -> (_list, _ix)
+                    _ -> Builtin.wrongArity getKey
                 emptyList = do
-                    _list <- expectBuiltinList getKey _list
-                    if Seq.null _list
-                        then Builtin.appliedFunction Pattern.bottom
-                        else empty
+                  _list <- expectBuiltinList getKey _list
+                  if Seq.null _list
+                    then Builtin.appliedFunction Pattern.bottom
+                    else empty
                 bothConcrete = do
-                    _list <- expectBuiltinList getKey _list
-                    _ix <- fromInteger <$> Int.expectBuiltinInt getKey _ix
-                    let ix
-                            | _ix < 0 =
-                                -- negative indices count from end of list
-                                _ix + Seq.length _list
-                            | otherwise = _ix
-                    (Builtin.appliedFunction . maybeBottom)
-                        (Seq.lookup ix _list)
+                  _list <- expectBuiltinList getKey _list
+                  _ix <- fromInteger <$> Int.expectBuiltinInt getKey _ix
+                  let ix
+                        | _ix < 0 =
+                          -- negative indices count from end of list
+                          _ix + Seq.length _list
+                        | otherwise = _ix
+                  (Builtin.appliedFunction . maybeBottom)
+                    (Seq.lookup ix _list)
             emptyList <|> bothConcrete
-        )
+          )
       where
         maybeBottom =
-            maybe Pattern.bottom Pattern.fromTermLike
+          maybe Pattern.bottom Pattern.fromTermLike
 
 evalUnit :: Builtin.Function
 evalUnit =
-    Builtin.functionEvaluator evalUnit0
+  Builtin.functionEvaluator evalUnit0
   where
     evalUnit0 _ resultSort =
-        \case
-            [] -> returnList resultSort Seq.empty
-            _ -> Builtin.wrongArity "LIST.unit"
+      \case
+        [] -> returnList resultSort Seq.empty
+        _ -> Builtin.wrongArity "LIST.unit"
 
 evalConcat :: Builtin.Function
 evalConcat =
-    Builtin.functionEvaluator evalConcat0
+  Builtin.functionEvaluator evalConcat0
   where
     evalConcat0
-        :: (Ord variable, SortedVariable variable, MonadSimplify simplifier)
-        => TermLikeSimplifier
-        -> Sort
-        -> [TermLike variable]
-        -> simplifier (AttemptedAxiom variable)
+      :: (Ord variable, SortedVariable variable, MonadSimplify simplifier)
+      => TermLikeSimplifier
+      -> Sort
+      -> [TermLike variable]
+      -> simplifier (AttemptedAxiom variable)
     evalConcat0 _ resultSort = \arguments ->
-        Builtin.getAttemptedAxiom $ do
-            let (_list1, _list2) =
-                    case arguments of
-                        [_list1, _list2] -> (_list1, _list2)
-                        _ -> Builtin.wrongArity concatKey
-                leftIdentity = do
-                    _list1 <- expectBuiltinList concatKey _list1
-                    if Seq.null _list1
-                        then
-                            Builtin.appliedFunction
-                            $ Pattern.fromTermLike _list2
-                        else
-                            empty
-                rightIdentity = do
-                    _list2 <- expectBuiltinList concatKey _list2
-                    if Seq.null _list2
-                        then
-                            Builtin.appliedFunction
-                            $ Pattern.fromTermLike _list1
-                        else
-                            empty
-                bothConcrete = do
-                    _list1 <- expectBuiltinList concatKey _list1
-                    _list2 <- expectBuiltinList concatKey _list2
-                    returnList resultSort (_list1 <> _list2)
-            leftIdentity <|> rightIdentity <|> bothConcrete
+      Builtin.getAttemptedAxiom $ do
+        let (_list1, _list2) =
+              case arguments of
+                [_list1, _list2] -> (_list1, _list2)
+                _ -> Builtin.wrongArity concatKey
+            leftIdentity = do
+              _list1 <- expectBuiltinList concatKey _list1
+              if Seq.null _list1
+                then
+                  Builtin.appliedFunction
+                    $ Pattern.fromTermLike _list2
+                else empty
+            rightIdentity = do
+              _list2 <- expectBuiltinList concatKey _list2
+              if Seq.null _list2
+                then
+                  Builtin.appliedFunction
+                    $ Pattern.fromTermLike _list1
+                else empty
+            bothConcrete = do
+              _list1 <- expectBuiltinList concatKey _list1
+              _list2 <- expectBuiltinList concatKey _list2
+              returnList resultSort (_list1 <> _list2)
+        leftIdentity <|> rightIdentity <|> bothConcrete
 
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
-    Map.fromList
-        [ (concatKey, evalConcat)
-        , (elementKey, evalElement)
-        , (unitKey, evalUnit)
-        , (getKey, evalGet)
-        ]
+  Map.fromList
+    [ (concatKey, evalConcat),
+      (elementKey, evalElement),
+      (unitKey, evalUnit),
+      (getKey, evalGet)
+      ]
 
 {- | Render an 'Domain.InternalList' as a 'TermLike' domain value pattern.
 
  -}
 asTermLike
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => Domain.InternalList (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => Domain.InternalList (TermLike variable)
+  -> TermLike variable
 asTermLike builtin
   | Seq.null list = unit
   | otherwise = foldr1 concat' (element <$> list)
   where
-    Domain.InternalList { builtinListChild = list } = builtin
-    Domain.InternalList { builtinListUnit = unitSymbol } = builtin
-    Domain.InternalList { builtinListElement = elementSymbol } = builtin
-    Domain.InternalList { builtinListConcat = concatSymbol } = builtin
-
+    Domain.InternalList {builtinListChild = list} = builtin
+    Domain.InternalList {builtinListUnit = unitSymbol} = builtin
+    Domain.InternalList {builtinListElement = elementSymbol} = builtin
+    Domain.InternalList {builtinListConcat = concatSymbol} = builtin
     unit = mkApplySymbol unitSymbol []
     element elem' = mkApplySymbol elementSymbol [elem']
     concat' list1 list2 = mkApplySymbol concatSymbol [list1, list2]
@@ -325,23 +341,22 @@ asTermLike builtin
 {- | Render a 'Seq' as an expanded internal list pattern.
  -}
 asInternal
-    :: (Ord variable, SortedVariable variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> Sort
-    -> Seq (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> Sort
+  -> Seq (TermLike variable)
+  -> TermLike variable
 asInternal tools builtinListSort builtinListChild =
-    (mkBuiltin . Domain.BuiltinList)
-        Domain.InternalList
-            { builtinListSort
-            , builtinListUnit =
-                Builtin.lookupSymbolUnit tools builtinListSort
-            , builtinListElement =
-                Builtin.lookupSymbolElement tools builtinListSort
-            , builtinListConcat =
-                Builtin.lookupSymbolConcat tools builtinListSort
-            , builtinListChild
-            }
+  (mkBuiltin . Domain.BuiltinList) Domain.InternalList
+    { builtinListSort,
+      builtinListUnit =
+        Builtin.lookupSymbolUnit tools builtinListSort,
+      builtinListElement =
+        Builtin.lookupSymbolElement tools builtinListSort,
+      builtinListConcat =
+        Builtin.lookupSymbolConcat tools builtinListSort,
+      builtinListChild
+      }
 
 {- | Render a 'Seq' as an extended domain value pattern.
 
@@ -349,35 +364,36 @@ See also: 'asPattern'
 
  -}
 asPattern
-    ::  ( Ord variable, SortedVariable variable
-        , Given (SmtMetadataTools Attribute.Symbol)
-        )
-    => Sort
-    -> Seq (TermLike variable)
-    -> Pattern variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Given (SmtMetadataTools Attribute.Symbol)
+       )
+  => Sort
+  -> Seq (TermLike variable)
+  -> Pattern variable
 asPattern resultSort =
-    Pattern.fromTermLike . asInternal tools resultSort
+  Pattern.fromTermLike . asInternal tools resultSort
   where
     tools :: SmtMetadataTools Attribute.Symbol
     tools = Reflection.given
 
 internalize
-    :: (Ord variable, SortedVariable variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
 internalize tools termLike@(App_ symbol args)
-  | isSymbolUnit    symbol , [ ] <- args = asInternal' (Seq.fromList args)
-  | isSymbolElement symbol , [_] <- args = asInternal' (Seq.fromList args)
-  | isSymbolConcat  symbol =
+  | isSymbolUnit symbol, [] <- args = asInternal' (Seq.fromList args)
+  | isSymbolElement symbol, [_] <- args = asInternal' (Seq.fromList args)
+  | isSymbolConcat symbol =
     case args of
-        [BuiltinList_ list1, arg2              ]
-          | (null . Domain.builtinListChild) list1 -> arg2
-        [arg1              , BuiltinList_ list2]
-          | (null . Domain.builtinListChild) list2 -> arg1
-        [BuiltinList_ list1, BuiltinList_ list2] ->
-            asInternal' (Function.on (<>) Domain.builtinListChild list1 list2)
-        _ -> termLike
+      [BuiltinList_ list1, arg2]
+        | (null . Domain.builtinListChild) list1 -> arg2
+      [arg1, BuiltinList_ list2]
+        | (null . Domain.builtinListChild) list2 -> arg1
+      [BuiltinList_ list1, BuiltinList_ list2] ->
+        asInternal' (Function.on (<>) Domain.builtinListChild list1 list2)
+      _ -> termLike
   where
     asInternal' = asInternal tools (termLikeSort termLike)
 internalize _ termLike = termLike
@@ -385,9 +401,9 @@ internalize _ termLike = termLike
 {- | Find the symbol hooked to @LIST.get@ in an indexed module.
  -}
 lookupSymbolGet
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolGet = Builtin.lookupSymbol getKey
 
 {- | Check if the given symbol is hooked to @LIST.concat@.
@@ -415,154 +431,146 @@ isSymbolUnit = Builtin.isSymbol unitKey
     reject the definition.
  -}
 unifyEquals
-    ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        )
-    => SimplificationType
-    -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: forall variable unifier. ( Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                FreshVariable variable,
+                                MonadUnify unifier
+                                )
+  => SimplificationType
+  -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 unifyEquals
-    simplificationType
-    simplifyChild
-    first
-    second
-  =
+  simplificationType
+  simplifyChild
+  first
+  second =
     unifyEquals0 first second
-  where
-    propagatePredicates
+    where
+      propagatePredicates
         :: Traversable t
         => t (Conditional variable a)
         -> Conditional variable (t a)
-    propagatePredicates = sequenceA
-
-    unifyEquals0
+      propagatePredicates = sequenceA
+      unifyEquals0
         :: TermLike variable
         -> TermLike variable
         -> MaybeT unifier (Pattern variable)
-
-    unifyEquals0 dv1@(Builtin_ (Domain.BuiltinList builtin1)) =
+      unifyEquals0 dv1@(Builtin_ (Domain.BuiltinList builtin1)) =
         \case
-            dv2@(Builtin_ child2)
-              | Domain.BuiltinList builtin2 <- child2 ->
-                Monad.Trans.lift $ unifyEqualsConcrete builtin1 builtin2
-              | otherwise ->
-                (error . unlines)
-                    [ "Cannot unify a builtin List domain value:"
-                    , show dv1
-                    , "with:"
-                    , show dv2
-                    , "This should have been a sort error."
-                    ]
-            app@(App_ symbol2 args2)
-              | isSymbolConcat symbol2 ->
-                Monad.Trans.lift $ case args2 of
-                    [ Builtin_ (Domain.BuiltinList builtin2), x@(Var_ _) ] ->
-                        unifyEqualsFramedRight builtin1 builtin2 x
-                    [ x@(Var_ _), Builtin_ (Domain.BuiltinList builtin2) ] ->
-                        unifyEqualsFramedLeft builtin1 x builtin2
-                    [ _, _ ] ->
-                        Builtin.unifyEqualsUnsolved
-                            simplificationType
-                            dv1
-                            app
-                    _ -> Builtin.wrongArity concatKey
-              | otherwise -> empty
-            _ -> empty
-
-    unifyEquals0 pat1 =
+          dv2@(Builtin_ child2)
+            | Domain.BuiltinList builtin2 <- child2 ->
+              Monad.Trans.lift $ unifyEqualsConcrete builtin1 builtin2
+            | otherwise ->
+              (error . unlines)
+                [ "Cannot unify a builtin List domain value:",
+                  show dv1,
+                  "with:",
+                  show dv2,
+                  "This should have been a sort error."
+                  ]
+          app@(App_ symbol2 args2)
+            | isSymbolConcat symbol2 ->
+              Monad.Trans.lift $ case args2 of
+                [Builtin_ (Domain.BuiltinList builtin2), x@(Var_ _)] ->
+                  unifyEqualsFramedRight builtin1 builtin2 x
+                [x@(Var_ _), Builtin_ (Domain.BuiltinList builtin2)] ->
+                  unifyEqualsFramedLeft builtin1 x builtin2
+                [_, _] ->
+                  Builtin.unifyEqualsUnsolved
+                    simplificationType
+                    dv1
+                    app
+                _ -> Builtin.wrongArity concatKey
+            | otherwise -> empty
+          _ -> empty
+      unifyEquals0 pat1 =
         \case
-            dv@(Builtin_ (Domain.BuiltinList _)) -> unifyEquals0 dv pat1
-            _ -> empty
-
-    unifyEqualsConcrete
+          dv@(Builtin_ (Domain.BuiltinList _)) -> unifyEquals0 dv pat1
+          _ -> empty
+      unifyEqualsConcrete
         :: Domain.InternalList (TermLike variable)
         -> Domain.InternalList (TermLike variable)
         -> unifier (Pattern variable)
-    unifyEqualsConcrete builtin1 builtin2
-      | Seq.length list1 /= Seq.length list2 = bottomWithExplanation
-      | otherwise = do
-        tools <- Simplifier.askMetadataTools
-        Reflection.give tools $ do
-            unified <- sequence $ Seq.zipWith simplifyChild list1 list2
-            let
-                propagatedUnified = propagatePredicates unified
-                result = asInternal tools builtinListSort <$> propagatedUnified
-            return result
-      where
-        Domain.InternalList { builtinListSort } = builtin1
-        Domain.InternalList { builtinListChild = list1 } = builtin1
-        Domain.InternalList { builtinListChild = list2 } = builtin2
-
-    unifyEqualsFramedRight
+      unifyEqualsConcrete builtin1 builtin2
+        | Seq.length list1 /= Seq.length list2 = bottomWithExplanation
+        | otherwise =
+          do
+            tools <- Simplifier.askMetadataTools
+            Reflection.give tools $ do
+              unified <- sequence $ Seq.zipWith simplifyChild list1 list2
+              let propagatedUnified = propagatePredicates unified
+                  result = asInternal tools builtinListSort <$> propagatedUnified
+              return result
+        where
+          Domain.InternalList {builtinListSort} = builtin1
+          Domain.InternalList {builtinListChild = list1} = builtin1
+          Domain.InternalList {builtinListChild = list2} = builtin2
+      unifyEqualsFramedRight
         :: Domain.InternalList (TermLike variable)
         -> Domain.InternalList (TermLike variable)
         -> TermLike variable
         -> unifier (Pattern variable)
-    unifyEqualsFramedRight
+      unifyEqualsFramedRight
         builtin1
         builtin2
         frame2
-      | Seq.length prefix2 > Seq.length list1 = bottomWithExplanation
-      | otherwise =
-        do
-            tools <- Simplifier.askMetadataTools
-            let listSuffix1 = asInternal tools builtinListSort suffix1
-            prefixUnified <-
+          | Seq.length prefix2 > Seq.length list1 = bottomWithExplanation
+          | otherwise =
+            do
+              tools <- Simplifier.askMetadataTools
+              let listSuffix1 = asInternal tools builtinListSort suffix1
+              prefixUnified <-
                 unifyEqualsConcrete
-                    builtin1 { Domain.builtinListChild = prefix1 }
-                    builtin2
-            suffixUnified <- simplifyChild frame2 listSuffix1
-            let result = mkBuiltin internal1 <$ prefixUnified <* suffixUnified
-            return result
-      where
-        internal1 = Domain.BuiltinList builtin1
-        Domain.InternalList { builtinListSort } = builtin1
-        Domain.InternalList { builtinListChild = list1 } = builtin1
-        Domain.InternalList { builtinListChild = prefix2 } = builtin2
-        (prefix1, suffix1) = Seq.splitAt prefixLength list1
+                  builtin1 {Domain.builtinListChild = prefix1}
+                  builtin2
+              suffixUnified <- simplifyChild frame2 listSuffix1
+              let result = mkBuiltin internal1 <$ prefixUnified <* suffixUnified
+              return result
           where
-            prefixLength = Seq.length prefix2
-
-    unifyEqualsFramedLeft
+            internal1 = Domain.BuiltinList builtin1
+            Domain.InternalList {builtinListSort} = builtin1
+            Domain.InternalList {builtinListChild = list1} = builtin1
+            Domain.InternalList {builtinListChild = prefix2} = builtin2
+            (prefix1, suffix1) = Seq.splitAt prefixLength list1
+              where
+                prefixLength = Seq.length prefix2
+      unifyEqualsFramedLeft
         :: Domain.InternalList (TermLike variable)
         -> TermLike variable
         -> Domain.InternalList (TermLike variable)
         -> unifier (Pattern variable)
-    unifyEqualsFramedLeft
+      unifyEqualsFramedLeft
         builtin1
         frame2
         builtin2
-      | Seq.length suffix2 > Seq.length list1 = bottomWithExplanation
-      | otherwise =
-        do
-            tools <- Simplifier.askMetadataTools
-            let listPrefix1 = asInternal tools builtinListSort prefix1
-            prefixUnified <- simplifyChild frame2 listPrefix1
-            suffixUnified <-
+          | Seq.length suffix2 > Seq.length list1 = bottomWithExplanation
+          | otherwise =
+            do
+              tools <- Simplifier.askMetadataTools
+              let listPrefix1 = asInternal tools builtinListSort prefix1
+              prefixUnified <- simplifyChild frame2 listPrefix1
+              suffixUnified <-
                 unifyEqualsConcrete
-                    builtin1 { Domain.builtinListChild = suffix1 }
-                    builtin2
-            let result = mkBuiltin internal1 <$ prefixUnified <* suffixUnified
-            return result
-      where
-        internal1 = Domain.BuiltinList builtin1
-        Domain.InternalList { builtinListSort } = builtin1
-        Domain.InternalList { builtinListChild = list1 } = builtin1
-        Domain.InternalList { builtinListChild = suffix2 } = builtin2
-        (prefix1, suffix1) = Seq.splitAt prefixLength list1
+                  builtin1 {Domain.builtinListChild = suffix1}
+                  builtin2
+              let result = mkBuiltin internal1 <$ prefixUnified <* suffixUnified
+              return result
           where
-            prefixLength = Seq.length list1 - Seq.length suffix2
-    bottomWithExplanation = do
+            internal1 = Domain.BuiltinList builtin1
+            Domain.InternalList {builtinListSort} = builtin1
+            Domain.InternalList {builtinListChild = list1} = builtin1
+            Domain.InternalList {builtinListChild = suffix2} = builtin2
+            (prefix1, suffix1) = Seq.splitAt prefixLength list1
+              where
+                prefixLength = Seq.length list1 - Seq.length suffix2
+      bottomWithExplanation = do
         Monad.Unify.explainBottom
-            "Cannot unify lists of different length."
-            first
-            second
+          "Cannot unify lists of different length."
+          first
+          second
         return Pattern.bottom
 
 concatKey :: IsString s => s

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -13,69 +13,90 @@ builtin modules.
 @
  -}
 module Kore.Builtin.Map
-    ( sort
-    , sortDeclVerifiers
-    , symbolVerifiers
-    , builtinFunctions
-    , asTermLike
-    , internalize
+  ( sort,
+    sortDeclVerifiers,
+    symbolVerifiers,
+    builtinFunctions,
+    asTermLike,
+    internalize,
     -- * Unification
-    , unifyEquals
+    unifyEquals,
     -- * Raw evaluators
-    , evalConcat
-    , evalElement
-    ) where
+    evalConcat,
+    evalElement
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Error
-                 ( MaybeT (MaybeT), fromMaybe, hoistMaybe, runMaybeT )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Error
+  ( MaybeT (MaybeT),
+    fromMaybe,
+    hoistMaybe,
+    runMaybeT
+    )
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.AssociativeCommutative as Ac
-import           Kore.Builtin.Attributes
-                 ( isConstructorModulo_ )
+import Kore.Builtin.Attributes
+  ( isConstructorModulo_
+    )
 import qualified Kore.Builtin.Bool as Bool
-import           Kore.Builtin.Builtin
-                 ( acceptAnySort )
+import Kore.Builtin.Builtin
+  ( acceptAnySort
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.Int as Int
 import qualified Kore.Builtin.MapSymbols as Map
 import qualified Kore.Builtin.Set as Builtin.Set
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-                 ( pattern App_, pattern Builtin_, TermLike, mkApplySymbol,
-                 termLikeSort )
+import Kore.Internal.TermLike
+  ( TermLike,
+    mkApplySymbol,
+    termLikeSort,
+    pattern App_,
+    pattern Builtin_
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Sort
-                 ( Sort )
-import           Kore.Step.Simplification.Data as Simplifier
-import           Kore.Step.Simplification.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..) )
-import           Kore.Syntax.Sentence
-                 ( SentenceSort (..) )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Sort
+  ( Sort
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Data as AttemptedAxiom
+  ( AttemptedAxiom (..)
+    )
+import Kore.Syntax.Sentence
+  ( SentenceSort (..)
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
+import Kore.Unparser
+  ( Unparse
+    )
+import Kore.Variables.Fresh
 
 {- | Builtin name of the @Map@ sort.
  -}
@@ -105,22 +126,22 @@ assertSort = Builtin.verifySort sort
  -}
 sortDeclVerifiers :: Builtin.SortDeclVerifiers
 sortDeclVerifiers =
-    HashMap.fromList [ (sort, verifySortDecl) ]
+  HashMap.fromList [(sort, verifySortDecl)]
   where
     verifySortDecl indexedModule sentenceSort attrs = do
-        Builtin.verifySortDecl indexedModule sentenceSort attrs
-        unitId <- Builtin.getUnitId attrs
-        Builtin.assertSymbolHook indexedModule unitId Map.unitKey
-        Builtin.assertSymbolResultSort indexedModule unitId expectedSort
-        elementId <- Builtin.getElementId attrs
-        Builtin.assertSymbolHook indexedModule elementId Map.elementKey
-        Builtin.assertSymbolResultSort indexedModule elementId expectedSort
-        concatId <- Builtin.getConcatId attrs
-        Builtin.assertSymbolHook indexedModule concatId Map.concatKey
-        Builtin.assertSymbolResultSort indexedModule concatId expectedSort
-        return ()
+      Builtin.verifySortDecl indexedModule sentenceSort attrs
+      unitId <- Builtin.getUnitId attrs
+      Builtin.assertSymbolHook indexedModule unitId Map.unitKey
+      Builtin.assertSymbolResultSort indexedModule unitId expectedSort
+      elementId <- Builtin.getElementId attrs
+      Builtin.assertSymbolHook indexedModule elementId Map.elementKey
+      Builtin.assertSymbolResultSort indexedModule elementId expectedSort
+      concatId <- Builtin.getConcatId attrs
+      Builtin.assertSymbolHook indexedModule concatId Map.concatKey
+      Builtin.assertSymbolResultSort indexedModule concatId expectedSort
+      return ()
       where
-        SentenceSort { sentenceSortName } = sentenceSort
+        SentenceSort {sentenceSortName} = sentenceSort
         expectedSort = TermLike.mkSort sentenceSortName
 
 {- | Verify that hooked symbol declarations are well-formed.
@@ -130,39 +151,39 @@ sortDeclVerifiers =
  -}
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
-    HashMap.fromList
-    [ ( Map.concatKey
-      , Builtin.verifySymbol assertSort [assertSort , assertSort]
-      )
-    , ( Map.elementKey
-      , Builtin.verifySymbol assertSort [acceptAnySort, acceptAnySort]
-      )
-    , ( Map.lookupKey
-      , Builtin.verifySymbol acceptAnySort [assertSort, acceptAnySort]
-      )
-    , ( Map.unitKey
-      , Builtin.verifySymbol assertSort []
-      )
-    , ( Map.updateKey
-      , Builtin.verifySymbol assertSort
-            [assertSort, acceptAnySort, acceptAnySort]
-      )
-    , ( Map.in_keysKey
-      , Builtin.verifySymbol Bool.assertSort [acceptAnySort, assertSort]
-      )
-    , ( Map.keysKey
-      , Builtin.verifySymbol Builtin.Set.assertSort [assertSort]
-      )
-    , ( Map.removeKey
-      , Builtin.verifySymbol assertSort [assertSort, acceptAnySort]
-      )
-    , ( Map.removeAllKey
-      , Builtin.verifySymbol assertSort [assertSort, Builtin.Set.assertSort]
-      )
-    , ( Map.sizeKey
-      , Builtin.verifySymbol Int.assertSort [assertSort]
-      )
-    ]
+  HashMap.fromList
+    [ ( Map.concatKey,
+        Builtin.verifySymbol assertSort [assertSort, assertSort]
+        ),
+      ( Map.elementKey,
+        Builtin.verifySymbol assertSort [acceptAnySort, acceptAnySort]
+        ),
+      ( Map.lookupKey,
+        Builtin.verifySymbol acceptAnySort [assertSort, acceptAnySort]
+        ),
+      ( Map.unitKey,
+        Builtin.verifySymbol assertSort []
+        ),
+      ( Map.updateKey,
+        Builtin.verifySymbol assertSort
+          [assertSort, acceptAnySort, acceptAnySort]
+        ),
+      ( Map.in_keysKey,
+        Builtin.verifySymbol Bool.assertSort [acceptAnySort, assertSort]
+        ),
+      ( Map.keysKey,
+        Builtin.verifySymbol Builtin.Set.assertSort [assertSort]
+        ),
+      ( Map.removeKey,
+        Builtin.verifySymbol assertSort [assertSort, acceptAnySort]
+        ),
+      ( Map.removeAllKey,
+        Builtin.verifySymbol assertSort [assertSort, Builtin.Set.assertSort]
+        ),
+      ( Map.sizeKey,
+        Builtin.verifySymbol Int.assertSort [assertSort]
+        )
+      ]
 
 {- | Abort function evaluation if the argument is not a Map domain value.
 
@@ -172,17 +193,18 @@ symbolVerifiers =
 
  -}
 expectBuiltinMap
-    :: Monad m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Ac.TermNormalizedAc Domain.NormalizedMap variable)
+  :: Monad m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Ac.TermNormalizedAc Domain.NormalizedMap variable)
 expectBuiltinMap ctx (Builtin_ builtin) =
-    case builtin of
-        Domain.BuiltinMap Domain.InternalAc { builtinAcChild } ->
-            return builtinAcChild
-        _ ->
-            Builtin.verifierBug
-            $ Text.unpack ctx ++ ": Domain value is not a map"
+  case builtin of
+    Domain.BuiltinMap Domain.InternalAc {builtinAcChild} ->
+      return builtinAcChild
+    _ ->
+      Builtin.verifierBug
+        $ Text.unpack ctx
+        ++ ": Domain value is not a map"
 expectBuiltinMap _ _ = empty
 
 {- | Returns @empty@ if the argument is not a @NormalizedMap@ domain value
@@ -191,299 +213,289 @@ which consists only of concrete elements.
 Returns the @Map@ of concrete elements otherwise.
 -}
 expectConcreteBuiltinMap
-    :: MonadSimplify m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Map (TermLike Concrete) (Domain.MapValue (TermLike variable)))
+  :: MonadSimplify m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Map (TermLike Concrete) (Domain.MapValue (TermLike variable)))
 expectConcreteBuiltinMap ctx _map = do
-    _map <- expectBuiltinMap ctx _map
-    case Domain.unwrapAc _map of
-        Domain.NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements
-            , opaque = []
-            } -> return concreteElements
-        _ -> empty
+  _map <- expectBuiltinMap ctx _map
+  case Domain.unwrapAc _map of
+    Domain.NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements,
+        opaque = []
+        } -> return concreteElements
+    _ -> empty
 
 {- | Converts a @Map@ of concrete elements to a @NormalizedMap@ and returns it
 as a function result.
 -}
 returnConcreteMap
-    :: (MonadSimplify m, Ord variable, SortedVariable variable)
-    => Sort
-    -> Map (TermLike Concrete) (Domain.MapValue (TermLike variable))
-    -> m (AttemptedAxiom variable)
+  :: (MonadSimplify m, Ord variable, SortedVariable variable)
+  => Sort
+  -> Map (TermLike Concrete) (Domain.MapValue (TermLike variable))
+  -> m (AttemptedAxiom variable)
 returnConcreteMap = Ac.returnConcreteAc
 
 evalLookup :: Builtin.Function
 evalLookup =
-    Builtin.functionEvaluator evalLookup0
+  Builtin.functionEvaluator evalLookup0
   where
     evalLookup0 :: Builtin.FunctionImplementation
     evalLookup0 _ _ arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_map, _key) =
-                    case arguments of
-                        [_map, _key] -> (_map, _key)
-                        _ -> Builtin.wrongArity Map.lookupKey
-                emptyMap = do
-                    _map <- expectConcreteBuiltinMap Map.lookupKey _map
-                    if Map.null _map
-                        then Builtin.appliedFunction Pattern.bottom
-                        else empty
-                bothConcrete = do
-                    _key <- hoistMaybe $ Builtin.toKey _key
-                    _map <- expectConcreteBuiltinMap Map.lookupKey _map
-                    Builtin.appliedFunction
-                        $ maybeBottom
-                            (Domain.getMapValue <$> Map.lookup _key _map)
-            emptyMap <|> bothConcrete
+      Builtin.getAttemptedAxiom $ do
+        let (_map, _key) =
+              case arguments of
+                [_map, _key] -> (_map, _key)
+                _ -> Builtin.wrongArity Map.lookupKey
+            emptyMap = do
+              _map <- expectConcreteBuiltinMap Map.lookupKey _map
+              if Map.null _map
+                then Builtin.appliedFunction Pattern.bottom
+                else empty
+            bothConcrete = do
+              _key <- hoistMaybe $ Builtin.toKey _key
+              _map <- expectConcreteBuiltinMap Map.lookupKey _map
+              Builtin.appliedFunction
+                $ maybeBottom
+                    (Domain.getMapValue <$> Map.lookup _key _map)
+        emptyMap <|> bothConcrete
       where
         maybeBottom = maybe Pattern.bottom Pattern.fromTermLike
 
 -- | evaluates the map element builtin.
 evalElement :: Builtin.Function
 evalElement =
-    Builtin.functionEvaluator evalElement0
+  Builtin.functionEvaluator evalElement0
   where
     evalElement0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_key, _value) =
-                    case arguments of
-                        [_key, _value] -> (_key, _value)
-                        _ -> Builtin.wrongArity Map.elementKey
-            case TermLike.asConcrete _key of
-                Just concrete ->
-                    returnConcreteMap
-                        resultSort
-                        (Map.singleton concrete (Domain.MapValue _value))
-                Nothing ->
-                    Ac.returnAc resultSort
-                    $ Domain.wrapAc Domain.NormalizedAc
-                        { elementsWithVariables =
-                            [Domain.MapElement (_key, _value)]
-                        , concreteElements = Map.empty
-                        , opaque = []
-                        }
+      Builtin.getAttemptedAxiom $ do
+        let (_key, _value) =
+              case arguments of
+                [_key, _value] -> (_key, _value)
+                _ -> Builtin.wrongArity Map.elementKey
+        case TermLike.asConcrete _key of
+          Just concrete ->
+            returnConcreteMap
+              resultSort
+              (Map.singleton concrete (Domain.MapValue _value))
+          Nothing ->
+            Ac.returnAc resultSort
+              $ Domain.wrapAc Domain.NormalizedAc
+                  { elementsWithVariables =
+                      [Domain.MapElement (_key, _value)],
+                    concreteElements = Map.empty,
+                    opaque = []
+                    }
 
 -- | evaluates the map concat builtin.
 evalConcat :: Builtin.Function
 evalConcat =
-    Builtin.functionEvaluator evalConcat0
+  Builtin.functionEvaluator evalConcat0
   where
     evalConcat0
-        :: forall variable m
-        .  (MonadSimplify m, Ord variable, SortedVariable variable)
-        => TermLikeSimplifier
-        -> Sort
-        -> [TermLike variable]
-        -> m (AttemptedAxiom variable)
+      :: forall variable m. (MonadSimplify m, Ord variable, SortedVariable variable)
+      => TermLikeSimplifier
+      -> Sort
+      -> [TermLike variable]
+      -> m (AttemptedAxiom variable)
     evalConcat0 _ resultSort arguments = Builtin.getAttemptedAxiom $ do
-        let (_map1, _map2) =
-                case arguments of
-                    [_map1, _map2] -> (_map1, _map2)
-                    _ -> Builtin.wrongArity Map.concatKey
-
-            normalized1 :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
-            normalized1 = Ac.toNormalized _map1
-            normalized2 :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
-            normalized2 = Ac.toNormalized _map2
-
-        Ac.evalConcatNormalizedOrBottom resultSort normalized1 normalized2
+      let (_map1, _map2) =
+            case arguments of
+              [_map1, _map2] -> (_map1, _map2)
+              _ -> Builtin.wrongArity Map.concatKey
+          normalized1 :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
+          normalized1 = Ac.toNormalized _map1
+          normalized2 :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
+          normalized2 = Ac.toNormalized _map2
+      Ac.evalConcatNormalizedOrBottom resultSort normalized1 normalized2
 
 evalUnit :: Builtin.Function
 evalUnit =
-    Builtin.functionEvaluator evalUnit0
+  Builtin.functionEvaluator evalUnit0
   where
     evalUnit0 _ resultSort =
-        \case
-            [] -> returnConcreteMap resultSort Map.empty
-            _ -> Builtin.wrongArity Map.unitKey
+      \case
+        [] -> returnConcreteMap resultSort Map.empty
+        _ -> Builtin.wrongArity Map.unitKey
 
 evalUpdate :: Builtin.Function
 evalUpdate =
-    Builtin.functionEvaluator evalUpdate0
+  Builtin.functionEvaluator evalUpdate0
   where
     evalUpdate0 _ resultSort = \arguments ->
-        Builtin.getAttemptedAxiom $ do
-            let (_map, _key, value) =
-                    case arguments of
-                        [_map, _key, value'] -> (_map, _key, value')
-                        _ -> Builtin.wrongArity Map.updateKey
-            _key <- hoistMaybe $ Builtin.toKey _key
-            _map <- expectConcreteBuiltinMap Map.updateKey _map
-            returnConcreteMap
-                resultSort
-                (Map.insert _key (Domain.MapValue value) _map)
+      Builtin.getAttemptedAxiom $ do
+        let (_map, _key, value) =
+              case arguments of
+                [_map, _key, value'] -> (_map, _key, value')
+                _ -> Builtin.wrongArity Map.updateKey
+        _key <- hoistMaybe $ Builtin.toKey _key
+        _map <- expectConcreteBuiltinMap Map.updateKey _map
+        returnConcreteMap
+          resultSort
+          (Map.insert _key (Domain.MapValue value) _map)
 
 evalInKeys :: Builtin.Function
 evalInKeys =
-    Builtin.functionEvaluator evalInKeys0
+  Builtin.functionEvaluator evalInKeys0
   where
     evalInKeys0 _ resultSort = \arguments ->
-        Builtin.getAttemptedAxiom $ do
-            let (_key, _map) =
-                    case arguments of
-                        [_key, _map] -> (_key, _map)
-                        _ -> Builtin.wrongArity Map.in_keysKey
-            _key <- hoistMaybe $ Builtin.toKey _key
-            _map <- expectConcreteBuiltinMap Map.in_keysKey _map
-            Builtin.appliedFunction
-                $ Bool.asPattern resultSort
-                $ Map.member _key _map
+      Builtin.getAttemptedAxiom $ do
+        let (_key, _map) =
+              case arguments of
+                [_key, _map] -> (_key, _map)
+                _ -> Builtin.wrongArity Map.in_keysKey
+        _key <- hoistMaybe $ Builtin.toKey _key
+        _map <- expectConcreteBuiltinMap Map.in_keysKey _map
+        Builtin.appliedFunction
+          $ Bool.asPattern resultSort
+          $ Map.member _key _map
 
 evalKeys :: Builtin.Function
 evalKeys =
-    Builtin.functionEvaluator evalKeys0
+  Builtin.functionEvaluator evalKeys0
   where
     evalKeys0 _ resultSort = \arguments ->
-        Builtin.getAttemptedAxiom $ do
-            let _map =
-                    case arguments of
-                        [_map] -> _map
-                        _ -> Builtin.wrongArity Map.lookupKey
-            _map <- expectConcreteBuiltinMap Map.lookupKey _map
-            Builtin.Set.returnConcreteSet
-                resultSort
-                (fmap (const Domain.SetValue) _map)
+      Builtin.getAttemptedAxiom $ do
+        let _map =
+              case arguments of
+                [_map] -> _map
+                _ -> Builtin.wrongArity Map.lookupKey
+        _map <- expectConcreteBuiltinMap Map.lookupKey _map
+        Builtin.Set.returnConcreteSet
+          resultSort
+          (fmap (const Domain.SetValue) _map)
 
 evalRemove :: Builtin.Function
 evalRemove =
-    Builtin.functionEvaluator evalRemove0
+  Builtin.functionEvaluator evalRemove0
   where
     evalRemove0 :: Builtin.FunctionImplementation
     evalRemove0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_map, _key) =
-                    case arguments of
-                        [_map, _key] -> (_map, _key)
-                        _ -> Builtin.wrongArity Map.removeKey
-                emptyMap = do
-                    _map <- expectConcreteBuiltinMap Map.removeKey _map
-                    if Map.null _map
-                        then returnConcreteMap resultSort Map.empty
-                        else empty
-                bothConcrete = do
-                    _map <- expectConcreteBuiltinMap Map.removeKey _map
-                    _key <- hoistMaybe $ Builtin.toKey _key
-                    returnConcreteMap resultSort $ Map.delete _key _map
-            emptyMap <|> bothConcrete
+      Builtin.getAttemptedAxiom $ do
+        let (_map, _key) =
+              case arguments of
+                [_map, _key] -> (_map, _key)
+                _ -> Builtin.wrongArity Map.removeKey
+            emptyMap = do
+              _map <- expectConcreteBuiltinMap Map.removeKey _map
+              if Map.null _map
+                then returnConcreteMap resultSort Map.empty
+                else empty
+            bothConcrete = do
+              _map <- expectConcreteBuiltinMap Map.removeKey _map
+              _key <- hoistMaybe $ Builtin.toKey _key
+              returnConcreteMap resultSort $ Map.delete _key _map
+        emptyMap <|> bothConcrete
 
 evalRemoveAll :: Builtin.Function
 evalRemoveAll =
-    Builtin.functionEvaluator evalRemoveAll0
+  Builtin.functionEvaluator evalRemoveAll0
   where
     evalRemoveAll0 :: Builtin.FunctionImplementation
     evalRemoveAll0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_map, _set) =
-                    case arguments of
-                        [_map, _set] -> (_map, _set)
-                        _ -> Builtin.wrongArity Map.removeAllKey
-                emptyMap = do
-                    _map <- expectConcreteBuiltinMap Map.removeAllKey _map
-                    if Map.null _map
-                        then returnConcreteMap resultSort Map.empty
-                        else empty
-                bothConcrete = do
-                    _map <- expectConcreteBuiltinMap Map.removeAllKey _map
-                    _set <-
-                        Builtin.Set.expectConcreteBuiltinSet
-                            Map.removeAllKey
-                            _set
-                    returnConcreteMap resultSort
-                        $ Map.difference _map _set
-            emptyMap <|> bothConcrete
+      Builtin.getAttemptedAxiom $ do
+        let (_map, _set) =
+              case arguments of
+                [_map, _set] -> (_map, _set)
+                _ -> Builtin.wrongArity Map.removeAllKey
+            emptyMap = do
+              _map <- expectConcreteBuiltinMap Map.removeAllKey _map
+              if Map.null _map
+                then returnConcreteMap resultSort Map.empty
+                else empty
+            bothConcrete = do
+              _map <- expectConcreteBuiltinMap Map.removeAllKey _map
+              _set <-
+                Builtin.Set.expectConcreteBuiltinSet
+                  Map.removeAllKey
+                  _set
+              returnConcreteMap resultSort
+                $ Map.difference _map _set
+        emptyMap <|> bothConcrete
 
 evalSize :: Builtin.Function
 evalSize =
-    Builtin.functionEvaluator evalSize0
+  Builtin.functionEvaluator evalSize0
   where
     evalSize0 :: Builtin.FunctionImplementation
     evalSize0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let _map =
-                    case arguments of
-                        [_map] -> _map
-                        _      -> Builtin.wrongArity Map.sizeKey
-            _map <- expectConcreteBuiltinMap Map.sizeKey _map
-            Builtin.appliedFunction
-                . Int.asPattern resultSort
-                . toInteger
-                . Map.size
-                $ _map
+      Builtin.getAttemptedAxiom $ do
+        let _map =
+              case arguments of
+                [_map] -> _map
+                _ -> Builtin.wrongArity Map.sizeKey
+        _map <- expectConcreteBuiltinMap Map.sizeKey _map
+        Builtin.appliedFunction
+          . Int.asPattern resultSort
+          . toInteger
+          . Map.size
+          $ _map
 
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
-    Map.fromList
-        [ (Map.concatKey, evalConcat)
-        , (Map.lookupKey, evalLookup)
-        , (Map.elementKey, evalElement)
-        , (Map.unitKey, evalUnit)
-        , (Map.updateKey, evalUpdate)
-        , (Map.in_keysKey, evalInKeys)
-        , (Map.keysKey, evalKeys)
-        , (Map.removeKey, evalRemove)
-        , (Map.removeAllKey, evalRemoveAll)
-        , (Map.sizeKey, evalSize)
-        ]
+  Map.fromList
+    [ (Map.concatKey, evalConcat),
+      (Map.lookupKey, evalLookup),
+      (Map.elementKey, evalElement),
+      (Map.unitKey, evalUnit),
+      (Map.updateKey, evalUpdate),
+      (Map.in_keysKey, evalInKeys),
+      (Map.keysKey, evalKeys),
+      (Map.removeKey, evalRemove),
+      (Map.removeAllKey, evalRemoveAll),
+      (Map.sizeKey, evalSize)
+      ]
 
 {- | Externalizes a 'Domain.InternalMap' as a 'TermLike'.
 -}
 asTermLike
-    :: forall variable
-    .  (Ord variable, SortedVariable variable, Unparse variable)
-    => Domain.InternalMap (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: forall variable. (Ord variable, SortedVariable variable, Unparse variable)
+  => Domain.InternalMap (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 asTermLike builtin =
-    Ac.asTermLike
-        (Ac.UnitSymbol unitSymbol)
-        (Ac.ConcatSymbol concatSymbol)
-        (Ac.ConcreteElements
-            (map concreteElement (Map.toAscList concreteElements))
-        )
-        (Ac.VariableElements
-            (element . Domain.unwrapElement <$> elementsWithVariables)
-        )
-        (Ac.Opaque filteredMaps)
+  Ac.asTermLike
+    (Ac.UnitSymbol unitSymbol)
+    (Ac.ConcatSymbol concatSymbol)
+    ( Ac.ConcreteElements
+        (map concreteElement (Map.toAscList concreteElements))
+      )
+    ( Ac.VariableElements
+        (element . Domain.unwrapElement <$> elementsWithVariables)
+      )
+    (Ac.Opaque filteredMaps)
   where
     filteredMaps :: [TermLike variable]
     filteredMaps = filter (not . isEmptyMap) opaque
-
     isEmptyMap :: TermLike variable -> Bool
     isEmptyMap
-        (Builtin_
-            (Domain.BuiltinMap
-                Domain.InternalAc { builtinAcChild = wrappedChild }
+      ( Builtin_
+          ( Domain.BuiltinMap
+              Domain.InternalAc {builtinAcChild = wrappedChild}
             )
-        )
-      =
+        ) =
         Domain.unwrapAc wrappedChild == Domain.emptyNormalizedAc
     isEmptyMap (App_ symbol _) = unitSymbol == symbol
     isEmptyMap _ = False
-
-    Domain.InternalAc { builtinAcChild } = builtin
-    Domain.InternalAc { builtinAcUnit = unitSymbol } = builtin
-    Domain.InternalAc { builtinAcElement = elementSymbol } = builtin
-    Domain.InternalAc { builtinAcConcat = concatSymbol } = builtin
-
+    Domain.InternalAc {builtinAcChild} = builtin
+    Domain.InternalAc {builtinAcUnit = unitSymbol} = builtin
+    Domain.InternalAc {builtinAcElement = elementSymbol} = builtin
+    Domain.InternalAc {builtinAcConcat = concatSymbol} = builtin
     normalizedAc = Domain.unwrapAc builtinAcChild
-
-    Domain.NormalizedAc { elementsWithVariables } = normalizedAc
-    Domain.NormalizedAc { concreteElements } = normalizedAc
-    Domain.NormalizedAc { opaque } = normalizedAc
-
+    Domain.NormalizedAc {elementsWithVariables} = normalizedAc
+    Domain.NormalizedAc {concreteElements} = normalizedAc
+    Domain.NormalizedAc {opaque} = normalizedAc
     concreteElement
-        :: (TermLike Concrete, Domain.MapValue (TermLike variable))
-        -> TermLike variable
+      :: (TermLike Concrete, Domain.MapValue (TermLike variable))
+      -> TermLike variable
     concreteElement (key, value) = element (TermLike.fromConcrete key, value)
     element
-        :: (TermLike variable, Domain.MapValue (TermLike variable))
-        -> TermLike variable
+      :: (TermLike variable, Domain.MapValue (TermLike variable))
+      -> TermLike variable
     element (key, Domain.MapValue value) =
-        mkApplySymbol elementSymbol [key, value]
+      mkApplySymbol elementSymbol [key, value]
 
 {- | Convert a Map-sorted 'TermLike' to its internal representation.
 
@@ -493,28 +505,27 @@ internalize subterms.
 
  -}
 internalize
-    :: (Ord variable, SortedVariable variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
 internalize tools termLike
-  | fromMaybe False (isMapSort tools sort')
-  -- Ac.toNormalized is greedy about 'normalizing' opaque terms, we should only
-  -- apply it if we know the term head is a constructor-like symbol.
-  , App_ symbol _ <- termLike
-  , isConstructorModulo_ symbol =
+  | fromMaybe False (isMapSort tools sort'),
+    -- Ac.toNormalized is greedy about 'normalizing' opaque terms, we should only
+    -- apply it if we know the term head is a constructor-like symbol.
+    App_ symbol _ <- termLike,
+    isConstructorModulo_ symbol =
     case Ac.toNormalized @Domain.NormalizedMap termLike of
-        Ac.Bottom                    -> TermLike.mkBottom sort'
-        Ac.Normalized termNormalized
-          | let unwrapped = Domain.unwrapAc termNormalized
-          , null (Domain.elementsWithVariables unwrapped)
-          , null (Domain.concreteElements unwrapped)
-          , [singleOpaqueTerm] <- Domain.opaque unwrapped
-          ->
-            -- When the 'normalized' term consists of a single opaque Map-sorted
-            -- term, we should prefer to return only that term.
-            singleOpaqueTerm
-          | otherwise -> Ac.asInternal tools sort' termNormalized
+      Ac.Bottom -> TermLike.mkBottom sort'
+      Ac.Normalized termNormalized
+        | let unwrapped = Domain.unwrapAc termNormalized,
+          null (Domain.elementsWithVariables unwrapped),
+          null (Domain.concreteElements unwrapped),
+          [singleOpaqueTerm] <- Domain.opaque unwrapped ->
+          -- When the 'normalized' term consists of a single opaque Map-sorted
+          -- term, we should prefer to return only that term.
+          singleOpaqueTerm
+        | otherwise -> Ac.asInternal tools sort' termNormalized
   | otherwise = termLike
   where
     sort' = termLikeSort termLike
@@ -529,65 +540,63 @@ multiple sorts are hooked to the same builtin domain, the verifier should
 reject the definition.
 -}
 unifyEquals
-    ::  forall variable unifier
-    .   ( SortedVariable variable
-        , FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: forall variable unifier. ( SortedVariable variable,
+                                FreshVariable variable,
+                                Show variable,
+                                Unparse variable,
+                                MonadUnify unifier
+                                )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 unifyEquals unifyEqualsChildren first second = do
-    tools <- Simplifier.askMetadataTools
-    (Monad.guard . fromMaybe False) (isMapSort tools sort1)
-    MaybeT $ do
-        unifiers <- Monad.Unify.gather (runMaybeT (unifyEquals0 first second))
-        case sequence unifiers of
-            Nothing -> return Nothing
-            Just us -> Monad.Unify.scatter (map Just us)
+  tools <- Simplifier.askMetadataTools
+  (Monad.guard . fromMaybe False) (isMapSort tools sort1)
+  MaybeT $ do
+    unifiers <- Monad.Unify.gather (runMaybeT (unifyEquals0 first second))
+    case sequence unifiers of
+      Nothing -> return Nothing
+      Just us -> Monad.Unify.scatter (map Just us)
   where
     sort1 = termLikeSort first
-
     -- | Unify the two argument patterns.
     unifyEquals0
-        :: TermLike variable
-        -> TermLike variable
-        -> MaybeT unifier (Pattern variable)
+      :: TermLike variable
+      -> TermLike variable
+      -> MaybeT unifier (Pattern variable)
     unifyEquals0
-        (Builtin_ (Domain.BuiltinMap normalized1))
-        (Builtin_ (Domain.BuiltinMap normalized2))
-      = do
-        tools <- Simplifier.askMetadataTools
-        Ac.unifyEqualsNormalized
+      (Builtin_ (Domain.BuiltinMap normalized1))
+      (Builtin_ (Domain.BuiltinMap normalized2)) =
+        do
+          tools <- Simplifier.askMetadataTools
+          Ac.unifyEqualsNormalized
             tools
             first
             second
             unifyEqualsChildren
             normalized1
             normalized2
-
     unifyEquals0 pat1 pat2 = do
-        firstDomain <- asDomain pat1
-        secondDomain <- asDomain pat2
-        unifyEquals0 firstDomain secondDomain
+      firstDomain <- asDomain pat1
+      secondDomain <- asDomain pat2
+      unifyEquals0 firstDomain secondDomain
       where
         asDomain
-            :: TermLike variable
-            -> MaybeT unifier (TermLike variable)
+          :: TermLike variable
+          -> MaybeT unifier (TermLike variable)
         asDomain patt =
-            case normalizedOrBottom of
-                Ac.Normalized normalized -> do
-                    tools <- Simplifier.askMetadataTools
-                    return (Ac.asInternal tools sort1 normalized)
-                Ac.Bottom ->
-                    Monad.Trans.lift $ Monad.Unify.explainAndReturnBottom
-                        "Duplicated elements in normalization."
-                        first
-                        second
+          case normalizedOrBottom of
+            Ac.Normalized normalized -> do
+              tools <- Simplifier.askMetadataTools
+              return (Ac.asInternal tools sort1 normalized)
+            Ac.Bottom ->
+              Monad.Trans.lift
+                $ Monad.Unify.explainAndReturnBottom
+                    "Duplicated elements in normalization."
+                    first
+                    second
           where
             normalizedOrBottom
-                :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
+              :: Ac.NormalizedOrBottom Domain.NormalizedMap variable
             normalizedOrBottom = Ac.toNormalized patt

--- a/kore/src/Kore/Builtin/MapSymbols.hs
+++ b/kore/src/Kore/Builtin/MapSymbols.hs
@@ -12,48 +12,54 @@ builtin modules.
     import qualified Kore.Builtin.MapSymbols as Map
 @
 -}
-
 module Kore.Builtin.MapSymbols
-    ( -- * Symbols
-      lookupSymbolUpdate
-    , lookupSymbolLookup
-    , lookupSymbolInKeys
-    , lookupSymbolKeys
-    , lookupSymbolRemove
-    , lookupSymbolRemoveAll
-    , lookupSymbolSize
-    , isSymbolConcat
-    , isSymbolElement
-    , isSymbolUnit
-    , isSymbolRemove
-    , isSymbolRemoveAll
-    , isSymbolSize
-      -- * keys
-    , concatKey
-    , elementKey
-    , in_keysKey
-    , keysKey
-    , lookupKey
-    , removeAllKey
-    , removeKey
-    , unitKey
-    , updateKey
-    , sizeKey
-    ) where
+  ( -- * Symbols
+    lookupSymbolUpdate,
+    lookupSymbolLookup,
+    lookupSymbolInKeys,
+    lookupSymbolKeys,
+    lookupSymbolRemove,
+    lookupSymbolRemoveAll,
+    lookupSymbolSize,
+    isSymbolConcat,
+    isSymbolElement,
+    isSymbolUnit,
+    isSymbolRemove,
+    isSymbolRemoveAll,
+    isSymbolSize,
+    -- * keys
+    concatKey,
+    elementKey,
+    in_keysKey,
+    keysKey,
+    lookupKey,
+    removeAllKey,
+    removeKey,
+    unitKey,
+    updateKey,
+    sizeKey
+    )
+where
 
-import           Data.String
-                 ( IsString )
+import Data.String
+  ( IsString
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
+  ( Symbol
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Error as Kore
-                 ( Error )
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
-import           Kore.Internal.Symbol
-                 ( Symbol )
-import           Kore.Sort
-                 ( Sort )
+  ( Error
+    )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
+import Kore.Internal.Symbol
+  ( Symbol
+    )
+import Kore.Sort
+  ( Sort
+    )
 
 concatKey :: IsString s => s
 concatKey = "MAP.concat"
@@ -88,57 +94,57 @@ sizeKey = "MAP.size"
 {- | Find the symbol hooked to @MAP.update@ in an indexed module.
  -}
 lookupSymbolUpdate
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolUpdate = Builtin.lookupSymbol updateKey
 
 {- | Find the symbol hooked to @MAP.lookup@ in an indexed module.
  -}
 lookupSymbolLookup
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolLookup = Builtin.lookupSymbol lookupKey
 
 {- | Find the symbol hooked to @MAP.in_keys@ in an indexed module.
  -}
 lookupSymbolInKeys
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolInKeys = Builtin.lookupSymbol in_keysKey
 
 {- | Find the symbol hooked to @MAP.keys@ in an indexed module.
  -}
 lookupSymbolKeys
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolKeys = Builtin.lookupSymbol keysKey
 
 {- | Find the symbol hooked to @MAP.remove@ in an indexed module.
  -}
 lookupSymbolRemove
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolRemove = Builtin.lookupSymbol removeKey
 
 {- | Find the symbol hooked to @MAP.removeAll@ in an indexed module.
  -}
 lookupSymbolRemoveAll
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolRemoveAll = Builtin.lookupSymbol removeAllKey
 
 {- | Find the symbol hooked to @MAP.size@ in an indexed module.
  -}
 lookupSymbolSize
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolSize = Builtin.lookupSymbol sizeKey
 
 {- | Check if the given symbol is hooked to @MAP.concat@.

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -13,78 +13,106 @@ builtin modules.
 @
  -}
 module Kore.Builtin.Set
-    ( sort
-    , assertSort
-    , sortDeclVerifiers
-    , isSetSort
-    , symbolVerifiers
-    , builtinFunctions
-    , Domain.Builtin
-    , returnConcreteSet
-    , asTermLike
-    , internalize
-    , expectBuiltinSet
-    , expectConcreteBuiltinSet
-      -- * Unification
-    , unifyEquals
-    ) where
+  ( sort,
+    assertSort,
+    sortDeclVerifiers,
+    isSetSort,
+    symbolVerifiers,
+    builtinFunctions,
+    Domain.Builtin,
+    returnConcreteSet,
+    asTermLike,
+    internalize,
+    expectBuiltinSet,
+    expectConcreteBuiltinSet,
+    -- * Unification
+    unifyEquals
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Error
-                 ( MaybeT (MaybeT), fromMaybe, hoistMaybe, runMaybeT )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Error
+  ( MaybeT (MaybeT),
+    fromMaybe,
+    hoistMaybe,
+    runMaybeT
+    )
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Foldable as Foldable
-                 ( toList )
+  ( toList
+    )
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
+  ( Symbol
+    )
 import qualified Kore.Builtin.AssociativeCommutative as Ac
-import           Kore.Builtin.Attributes
-                 ( isConstructorModulo_ )
+import Kore.Builtin.Attributes
+  ( isConstructorModulo_
+    )
 import qualified Kore.Builtin.Bool as Bool
-import           Kore.Builtin.Builtin
-                 ( acceptAnySort )
+import Kore.Builtin.Builtin
+  ( acceptAnySort
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Builtin.Int as Int
 import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.SetSymbols as Set
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-                 ( pattern App_, pattern Builtin_, Concrete, TermLike,
-                 mkApplySymbol, mkSort, termLikeSort )
+import Kore.Internal.TermLike
+  ( Concrete,
+    TermLike,
+    mkApplySymbol,
+    mkSort,
+    termLikeSort,
+    pattern App_,
+    pattern Builtin_
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Sort
-                 ( Sort )
-import           Kore.Step.Simplification.Data as Simplifier
-import           Kore.Step.Simplification.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..) )
-import           Kore.Syntax.Sentence
-                 ( SentenceSort (SentenceSort) )
+import Kore.Sort
+  ( Sort
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Data as AttemptedAxiom
+  ( AttemptedAxiom (..)
+    )
+import Kore.Syntax.Sentence
+  ( SentenceSort (SentenceSort)
+    )
 import qualified Kore.Syntax.Sentence as Sentence.DoNotUse
-                 ( SentenceSort (..) )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+  ( SentenceSort (..)
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.Unparser
+  ( Unparse
+    )
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 {- | Builtin name of the @Set@ sort.
  -}
@@ -114,22 +142,22 @@ assertSort = Builtin.verifySort sort
  -}
 sortDeclVerifiers :: Builtin.SortDeclVerifiers
 sortDeclVerifiers =
-    HashMap.fromList [ (sort, verifySortDecl) ]
+  HashMap.fromList [(sort, verifySortDecl)]
   where
     verifySortDecl indexedModule sentenceSort attrs = do
-        Builtin.verifySortDecl indexedModule sentenceSort attrs
-        unitId <- Builtin.getUnitId attrs
-        Builtin.assertSymbolHook indexedModule unitId Set.unitKey
-        Builtin.assertSymbolResultSort indexedModule unitId expectedSort
-        elementId <- Builtin.getElementId attrs
-        Builtin.assertSymbolHook indexedModule elementId Set.elementKey
-        Builtin.assertSymbolResultSort indexedModule elementId expectedSort
-        concatId <- Builtin.getConcatId attrs
-        Builtin.assertSymbolHook indexedModule concatId Set.concatKey
-        Builtin.assertSymbolResultSort indexedModule concatId expectedSort
-        return ()
+      Builtin.verifySortDecl indexedModule sentenceSort attrs
+      unitId <- Builtin.getUnitId attrs
+      Builtin.assertSymbolHook indexedModule unitId Set.unitKey
+      Builtin.assertSymbolResultSort indexedModule unitId expectedSort
+      elementId <- Builtin.getElementId attrs
+      Builtin.assertSymbolHook indexedModule elementId Set.elementKey
+      Builtin.assertSymbolResultSort indexedModule elementId expectedSort
+      concatId <- Builtin.getConcatId attrs
+      Builtin.assertSymbolHook indexedModule concatId Set.concatKey
+      Builtin.assertSymbolResultSort indexedModule concatId expectedSort
+      return ()
       where
-        SentenceSort { sentenceSortName } = sentenceSort
+        SentenceSort {sentenceSortName} = sentenceSort
         expectedSort = mkSort sentenceSortName
 
 {- | Verify that hooked symbol declarations are well-formed.
@@ -139,55 +167,56 @@ sortDeclVerifiers =
  -}
 symbolVerifiers :: Builtin.SymbolVerifiers
 symbolVerifiers =
-    HashMap.fromList
-    [ ( Set.concatKey
-      , Builtin.verifySymbol assertSort [assertSort , assertSort]
-      )
-    , ( Set.elementKey
-      , Builtin.verifySymbol assertSort [acceptAnySort]
-      )
-    , ( Set.unitKey
-      , Builtin.verifySymbol assertSort []
-      )
-    , ( Set.inKey
-      , Builtin.verifySymbol Bool.assertSort [acceptAnySort, assertSort]
-      )
-    , ( Set.differenceKey
-      , Builtin.verifySymbol assertSort [assertSort, assertSort]
-      )
-    , ( Set.toListKey
-      , Builtin.verifySymbol List.assertSort [assertSort]
-      )
-    , ( Set.sizeKey
-      , Builtin.verifySymbol Int.assertSort [assertSort]
-      )
-    , ( Set.intersectionKey
-      , Builtin.verifySymbol assertSort [assertSort, assertSort]
-      )
-    , ( Set.list2setKey
-      , Builtin.verifySymbol assertSort [List.assertSort]
-      )
-    ]
+  HashMap.fromList
+    [ ( Set.concatKey,
+        Builtin.verifySymbol assertSort [assertSort, assertSort]
+        ),
+      ( Set.elementKey,
+        Builtin.verifySymbol assertSort [acceptAnySort]
+        ),
+      ( Set.unitKey,
+        Builtin.verifySymbol assertSort []
+        ),
+      ( Set.inKey,
+        Builtin.verifySymbol Bool.assertSort [acceptAnySort, assertSort]
+        ),
+      ( Set.differenceKey,
+        Builtin.verifySymbol assertSort [assertSort, assertSort]
+        ),
+      ( Set.toListKey,
+        Builtin.verifySymbol List.assertSort [assertSort]
+        ),
+      ( Set.sizeKey,
+        Builtin.verifySymbol Int.assertSort [assertSort]
+        ),
+      ( Set.intersectionKey,
+        Builtin.verifySymbol assertSort [assertSort, assertSort]
+        ),
+      ( Set.list2setKey,
+        Builtin.verifySymbol assertSort [List.assertSort]
+        )
+      ]
 
 {- | Returns @empty@ if the argument is not a @NormalizedSet@ domain value.
 
 Returns the @NormalizedSet@ otherwise.
 -}
 expectBuiltinSet
-    :: MonadSimplify m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Ac.TermNormalizedAc Domain.NormalizedSet variable)
+  :: MonadSimplify m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Ac.TermNormalizedAc Domain.NormalizedSet variable)
 expectBuiltinSet ctx set =
-    case set of
-        Builtin_ domain ->
-            case domain of
-                Domain.BuiltinSet Domain.InternalAc { builtinAcChild } ->
-                    return builtinAcChild
-                _ ->
-                    Builtin.verifierBug
-                    $ Text.unpack ctx ++ ": Domain value is not a set"
-        _ -> empty
+  case set of
+    Builtin_ domain ->
+      case domain of
+        Domain.BuiltinSet Domain.InternalAc {builtinAcChild} ->
+          return builtinAcChild
+        _ ->
+          Builtin.verifierBug
+            $ Text.unpack ctx
+            ++ ": Domain value is not a set"
+    _ -> empty
 
 {- | Returns @empty@ if the argument is not a @NormalizedSet@ domain value
 which consists only of concrete elements.
@@ -195,152 +224,148 @@ which consists only of concrete elements.
 Returns the @Set@ of concrete elements otherwise.
 -}
 expectConcreteBuiltinSet
-    :: MonadSimplify m
-    => Text  -- ^ Context for error message
-    -> TermLike variable  -- ^ Operand pattern
-    -> MaybeT m (Map (TermLike Concrete) (Domain.SetValue (TermLike variable)))
+  :: MonadSimplify m
+  => Text -- ^ Context for error message
+  -> TermLike variable -- ^ Operand pattern
+  -> MaybeT m (Map (TermLike Concrete) (Domain.SetValue (TermLike variable)))
 expectConcreteBuiltinSet ctx _set = do
-    _set <- expectBuiltinSet ctx _set
-    case Domain.unwrapAc _set of
-        Domain.NormalizedAc
-            { elementsWithVariables = []
-            , concreteElements
-            , opaque = []
-            } -> return concreteElements
-        _ -> empty
+  _set <- expectBuiltinSet ctx _set
+  case Domain.unwrapAc _set of
+    Domain.NormalizedAc
+      { elementsWithVariables = [],
+        concreteElements,
+        opaque = []
+        } -> return concreteElements
+    _ -> empty
 
 {- | Converts a @Set@ of concrete elements to a @NormalizedSet@ and returns it
 as a function result.
 -}
 returnConcreteSet
-    ::  ( MonadSimplify m
-        , Ord variable
-        , SortedVariable variable
-        )
-    => Sort
-    -> Map (TermLike Concrete) (Domain.SetValue (TermLike variable))
-    -> m (AttemptedAxiom variable)
+  :: ( MonadSimplify m,
+       Ord variable,
+       SortedVariable variable
+       )
+  => Sort
+  -> Map (TermLike Concrete) (Domain.SetValue (TermLike variable))
+  -> m (AttemptedAxiom variable)
 returnConcreteSet = Ac.returnConcreteAc
 
 evalElement :: Builtin.Function
 evalElement =
-    Builtin.functionEvaluator evalElement0
+  Builtin.functionEvaluator evalElement0
   where
     evalElement0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom
-            (case arguments of
-                [_elem] ->
-                    case TermLike.asConcrete _elem of
-                        Just concrete ->
-                            returnConcreteSet
-                                resultSort
-                                (Map.singleton concrete Domain.SetValue)
-                        Nothing ->
-                            Ac.returnAc resultSort
-                            $ Domain.wrapAc Domain.NormalizedAc
-                                { elementsWithVariables =
-                                    [Domain.SetElement _elem]
-                                , concreteElements = Map.empty
-                                , opaque = []
-                                }
-                _ -> Builtin.wrongArity Set.elementKey
-            )
+      Builtin.getAttemptedAxiom
+        ( case arguments of
+            [_elem] ->
+              case TermLike.asConcrete _elem of
+                Just concrete ->
+                  returnConcreteSet
+                    resultSort
+                    (Map.singleton concrete Domain.SetValue)
+                Nothing ->
+                  Ac.returnAc resultSort
+                    $ Domain.wrapAc Domain.NormalizedAc
+                        { elementsWithVariables =
+                            [Domain.SetElement _elem],
+                          concreteElements = Map.empty,
+                          opaque = []
+                          }
+            _ -> Builtin.wrongArity Set.elementKey
+          )
 
 evalIn :: Builtin.Function
 evalIn =
-    Builtin.functionEvaluator evalIn0
+  Builtin.functionEvaluator evalIn0
   where
     evalIn0 :: Builtin.FunctionImplementation
     evalIn0 _ resultSort = \arguments ->
-        Builtin.getAttemptedAxiom $ do
-            let (_elem, _set) =
-                    case arguments of
-                        [_elem, _set] -> (_elem, _set)
-                        _ -> Builtin.wrongArity Set.inKey
-            _elem <- hoistMaybe $ Builtin.toKey _elem
-            _set <- expectConcreteBuiltinSet Set.inKey _set
-            (Builtin.appliedFunction . asExpandedBoolPattern)
-                (Map.member _elem _set)
+      Builtin.getAttemptedAxiom $ do
+        let (_elem, _set) =
+              case arguments of
+                [_elem, _set] -> (_elem, _set)
+                _ -> Builtin.wrongArity Set.inKey
+        _elem <- hoistMaybe $ Builtin.toKey _elem
+        _set <- expectConcreteBuiltinSet Set.inKey _set
+        (Builtin.appliedFunction . asExpandedBoolPattern)
+          (Map.member _elem _set)
       where
         asExpandedBoolPattern = Bool.asPattern resultSort
 
 evalUnit :: Builtin.Function
 evalUnit =
-    Builtin.functionEvaluator evalUnit0
+  Builtin.functionEvaluator evalUnit0
   where
     evalUnit0 _ resultSort =
-        \case
-            [] -> returnConcreteSet resultSort Map.empty
-            _ -> Builtin.wrongArity Set.unitKey
+      \case
+        [] -> returnConcreteSet resultSort Map.empty
+        _ -> Builtin.wrongArity Set.unitKey
 
 evalConcat :: Builtin.Function
 evalConcat =
-    Builtin.functionEvaluator evalConcat0
+  Builtin.functionEvaluator evalConcat0
   where
     evalConcat0
-        :: forall variable m
-        .  (Ord variable, SortedVariable variable)
-        => MonadSimplify m
-        => TermLikeSimplifier
-        -> Sort
-        -> [TermLike variable]
-        -> m (AttemptedAxiom variable)
+      :: forall variable m. (Ord variable, SortedVariable variable)
+      => MonadSimplify m
+      => TermLikeSimplifier
+      -> Sort
+      -> [TermLike variable]
+      -> m (AttemptedAxiom variable)
     evalConcat0 _ resultSort arguments = Builtin.getAttemptedAxiom $ do
-        let (_set1, _set2) =
-                case arguments of
-                    [_set1, _set2] -> (_set1, _set2)
-                    _ -> Builtin.wrongArity Set.concatKey
-
-            normalized1 :: Ac.NormalizedOrBottom Domain.NormalizedSet variable
-            normalized1 = Ac.toNormalized _set1
-            normalized2 :: Ac.NormalizedOrBottom Domain.NormalizedSet variable
-            normalized2 = Ac.toNormalized _set2
-
-        Ac.evalConcatNormalizedOrBottom resultSort normalized1 normalized2
+      let (_set1, _set2) =
+            case arguments of
+              [_set1, _set2] -> (_set1, _set2)
+              _ -> Builtin.wrongArity Set.concatKey
+          normalized1 :: Ac.NormalizedOrBottom Domain.NormalizedSet variable
+          normalized1 = Ac.toNormalized _set1
+          normalized2 :: Ac.NormalizedOrBottom Domain.NormalizedSet variable
+          normalized2 = Ac.toNormalized _set2
+      Ac.evalConcatNormalizedOrBottom resultSort normalized1 normalized2
 
 evalDifference :: Builtin.Function
 evalDifference =
-    Builtin.functionEvaluator evalDifference0
+  Builtin.functionEvaluator evalDifference0
   where
     ctx = Set.differenceKey
     evalDifference0 :: Builtin.FunctionImplementation
     evalDifference0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_set1, _set2) =
-                    case arguments of
-                        [_set1, _set2] -> (_set1, _set2)
-                        _ -> Builtin.wrongArity Set.differenceKey
-                rightIdentity = do
-                    _set2 <- expectConcreteBuiltinSet ctx _set2
-                    if Map.null _set2
-                        then
-                            Builtin.appliedFunction
-                            $ Pattern.fromTermLike _set1
-                        else empty
-                bothConcrete = do
-                    _set1 <- expectConcreteBuiltinSet ctx _set1
-                    _set2 <- expectConcreteBuiltinSet ctx _set2
-                    returnConcreteSet resultSort (Map.difference _set1 _set2)
-            rightIdentity <|> bothConcrete
+      Builtin.getAttemptedAxiom $ do
+        let (_set1, _set2) =
+              case arguments of
+                [_set1, _set2] -> (_set1, _set2)
+                _ -> Builtin.wrongArity Set.differenceKey
+            rightIdentity = do
+              _set2 <- expectConcreteBuiltinSet ctx _set2
+              if Map.null _set2
+                then
+                  Builtin.appliedFunction
+                    $ Pattern.fromTermLike _set1
+                else empty
+            bothConcrete = do
+              _set1 <- expectConcreteBuiltinSet ctx _set1
+              _set2 <- expectConcreteBuiltinSet ctx _set2
+              returnConcreteSet resultSort (Map.difference _set1 _set2)
+        rightIdentity <|> bothConcrete
 
 evalToList :: Builtin.Function
 evalToList = Builtin.functionEvaluator evalToList0
   where
     evalToList0 :: Builtin.FunctionImplementation
     evalToList0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let _set =
-                        case arguments of
-                            [_set] -> _set
-                            _      -> Builtin.wrongArity Set.toListKey
-            _set <- expectConcreteBuiltinSet Set.toListKey _set
-            List.returnList resultSort
-                . fmap TermLike.fromConcrete
-                . Seq.fromList
-                . map dropNoValue
-                . Map.toList
-                $ _set
-
+      Builtin.getAttemptedAxiom $ do
+        let _set =
+              case arguments of
+                [_set] -> _set
+                _ -> Builtin.wrongArity Set.toListKey
+        _set <- expectConcreteBuiltinSet Set.toListKey _set
+        List.returnList resultSort
+          . fmap TermLike.fromConcrete
+          . Seq.fromList
+          . map dropNoValue
+          . Map.toList
+          $ _set
     dropNoValue (a, Domain.SetValue) = a
 
 evalSize :: Builtin.Function
@@ -348,119 +373,113 @@ evalSize = Builtin.functionEvaluator evalSize0
   where
     evalSize0 :: Builtin.FunctionImplementation
     evalSize0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let _set =
-                        case arguments of
-                            [_set] -> _set
-                            _      -> Builtin.wrongArity Set.sizeKey
-            _set <- expectConcreteBuiltinSet Set.sizeKey _set
-            Builtin.appliedFunction
-                . Int.asPattern resultSort
-                . toInteger
-                . Map.size
-                $ _set
+      Builtin.getAttemptedAxiom $ do
+        let _set =
+              case arguments of
+                [_set] -> _set
+                _ -> Builtin.wrongArity Set.sizeKey
+        _set <- expectConcreteBuiltinSet Set.sizeKey _set
+        Builtin.appliedFunction
+          . Int.asPattern resultSort
+          . toInteger
+          . Map.size
+          $ _set
 
 evalIntersection :: Builtin.Function
 evalIntersection =
-    Builtin.functionEvaluator evalIntersection0
+  Builtin.functionEvaluator evalIntersection0
   where
     ctx = Set.intersectionKey
     evalIntersection0 :: Builtin.FunctionImplementation
     evalIntersection0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let (_set1, _set2) =
-                    case arguments of
-                        [_set1, _set2] -> (_set1, _set2)
-                        _ -> Builtin.wrongArity Set.intersectionKey
-            _set1 <- expectConcreteBuiltinSet ctx _set1
-            _set2 <- expectConcreteBuiltinSet ctx _set2
-            returnConcreteSet resultSort (Map.intersection _set1 _set2)
+      Builtin.getAttemptedAxiom $ do
+        let (_set1, _set2) =
+              case arguments of
+                [_set1, _set2] -> (_set1, _set2)
+                _ -> Builtin.wrongArity Set.intersectionKey
+        _set1 <- expectConcreteBuiltinSet ctx _set1
+        _set2 <- expectConcreteBuiltinSet ctx _set2
+        returnConcreteSet resultSort (Map.intersection _set1 _set2)
 
 evalList2set :: Builtin.Function
 evalList2set =
-    Builtin.functionEvaluator evalList2set0
+  Builtin.functionEvaluator evalList2set0
   where
     evalList2set0 :: Builtin.FunctionImplementation
     evalList2set0 _ resultSort arguments =
-        Builtin.getAttemptedAxiom $ do
-            let _list =
-                    case arguments of
-                        [_map] -> _map
-                        _      -> Builtin.wrongArity Set.list2setKey
-            _list <- List.expectConcreteBuiltinList Set.list2setKey _list
-            let _set = Map.fromList
-                            $ fmap (\x -> (x, Domain.SetValue))
-                            $ Foldable.toList _list
-            returnConcreteSet resultSort _set
+      Builtin.getAttemptedAxiom $ do
+        let _list =
+              case arguments of
+                [_map] -> _map
+                _ -> Builtin.wrongArity Set.list2setKey
+        _list <- List.expectConcreteBuiltinList Set.list2setKey _list
+        let _set =
+              Map.fromList
+                $ fmap (\x -> (x, Domain.SetValue))
+                $ Foldable.toList _list
+        returnConcreteSet resultSort _set
 
 {- | Implement builtin function evaluation.
  -}
 builtinFunctions :: Map Text Builtin.Function
 builtinFunctions =
-    Map.fromList
-        [ (Set.concatKey, evalConcat)
-        , (Set.elementKey, evalElement)
-        , (Set.unitKey, evalUnit)
-        , (Set.inKey, evalIn)
-        , (Set.differenceKey, evalDifference)
-        , (Set.toListKey, evalToList)
-        , (Set.sizeKey, evalSize)
-        , (Set.intersectionKey, evalIntersection)
-        , (Set.list2setKey, evalList2set)
-        ]
+  Map.fromList
+    [ (Set.concatKey, evalConcat),
+      (Set.elementKey, evalElement),
+      (Set.unitKey, evalUnit),
+      (Set.inKey, evalIn),
+      (Set.differenceKey, evalDifference),
+      (Set.toListKey, evalToList),
+      (Set.sizeKey, evalSize),
+      (Set.intersectionKey, evalIntersection),
+      (Set.list2setKey, evalList2set)
+      ]
 
 {- | Externalizes a 'Domain.InternalSet' as a 'TermLike'.
 -}
 asTermLike
-    :: forall variable
-    .  (Ord variable, SortedVariable variable, Unparse variable)
-    => Domain.InternalSet (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: forall variable. (Ord variable, SortedVariable variable, Unparse variable)
+  => Domain.InternalSet (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 asTermLike builtin =
-    Ac.asTermLike
-        (Ac.UnitSymbol unitSymbol)
-        (Ac.ConcatSymbol concatSymbol)
-        (Ac.ConcreteElements
-            (map concreteElement (Map.toAscList concreteElements))
-        )
-        (Ac.VariableElements
-            (element . Domain.unwrapElement <$> elementsWithVariables)
-        )
-        (Ac.Opaque filteredSets)
+  Ac.asTermLike
+    (Ac.UnitSymbol unitSymbol)
+    (Ac.ConcatSymbol concatSymbol)
+    ( Ac.ConcreteElements
+        (map concreteElement (Map.toAscList concreteElements))
+      )
+    ( Ac.VariableElements
+        (element . Domain.unwrapElement <$> elementsWithVariables)
+      )
+    (Ac.Opaque filteredSets)
   where
     filteredSets :: [TermLike variable]
     filteredSets = filter (not . isEmptySet) opaque
-
     isEmptySet :: TermLike variable -> Bool
     isEmptySet
-        (Builtin_
-            (Domain.BuiltinSet
-                Domain.InternalAc { builtinAcChild = wrappedChild }
+      ( Builtin_
+          ( Domain.BuiltinSet
+              Domain.InternalAc {builtinAcChild = wrappedChild}
             )
-        )
-      =
+        ) =
         Domain.unwrapAc wrappedChild == Domain.emptyNormalizedAc
     isEmptySet (App_ symbol _) = unitSymbol == symbol
     isEmptySet _ = False
-
-    Domain.InternalAc { builtinAcChild } = builtin
-    Domain.InternalAc { builtinAcUnit = unitSymbol } = builtin
-    Domain.InternalAc { builtinAcElement = elementSymbol } = builtin
-    Domain.InternalAc { builtinAcConcat = concatSymbol } = builtin
-
+    Domain.InternalAc {builtinAcChild} = builtin
+    Domain.InternalAc {builtinAcUnit = unitSymbol} = builtin
+    Domain.InternalAc {builtinAcElement = elementSymbol} = builtin
+    Domain.InternalAc {builtinAcConcat = concatSymbol} = builtin
     normalizedAc = Domain.unwrapAc builtinAcChild
-
-    Domain.NormalizedAc { elementsWithVariables } = normalizedAc
-    Domain.NormalizedAc { concreteElements } = normalizedAc
-    Domain.NormalizedAc { opaque } = normalizedAc
-
+    Domain.NormalizedAc {elementsWithVariables} = normalizedAc
+    Domain.NormalizedAc {concreteElements} = normalizedAc
+    Domain.NormalizedAc {opaque} = normalizedAc
     concreteElement
-        :: (TermLike Concrete, Domain.SetValue (TermLike variable))
-        -> TermLike variable
+      :: (TermLike Concrete, Domain.SetValue (TermLike variable))
+      -> TermLike variable
     concreteElement (key, value) = element (TermLike.fromConcrete key, value)
     element
-        :: (TermLike variable, Domain.SetValue (TermLike variable))
-        -> TermLike variable
+      :: (TermLike variable, Domain.SetValue (TermLike variable))
+      -> TermLike variable
     element (key, Domain.SetValue) = mkApplySymbol elementSymbol [key]
 
 {- | Convert a Set-sorted 'TermLike' to its internal representation.
@@ -471,28 +490,27 @@ internalize subterms.
 
  -}
 internalize
-    :: (Ord variable, SortedVariable variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
 internalize tools termLike
-  | fromMaybe False (isSetSort tools sort')
-  -- Ac.toNormalized is greedy about 'normalizing' opaque terms, we should only
-  -- apply it if we know the term head is a constructor-like symbol.
-  , App_ symbol _ <- termLike
-  , isConstructorModulo_ symbol =
+  | fromMaybe False (isSetSort tools sort'),
+    -- Ac.toNormalized is greedy about 'normalizing' opaque terms, we should only
+    -- apply it if we know the term head is a constructor-like symbol.
+    App_ symbol _ <- termLike,
+    isConstructorModulo_ symbol =
     case Ac.toNormalized @Domain.NormalizedSet termLike of
-        Ac.Bottom                    -> TermLike.mkBottom sort'
-        Ac.Normalized termNormalized
-          | let unwrapped = Domain.unwrapAc termNormalized
-          , null (Domain.elementsWithVariables unwrapped)
-          , null (Domain.concreteElements unwrapped)
-          , [singleOpaqueTerm] <- Domain.opaque unwrapped
-          ->
-            -- When the 'normalized' term consists of a single opaque Map-sorted
-            -- term, we should prefer to return only that term.
-            singleOpaqueTerm
-          | otherwise -> Ac.asInternal tools sort' termNormalized
+      Ac.Bottom -> TermLike.mkBottom sort'
+      Ac.Normalized termNormalized
+        | let unwrapped = Domain.unwrapAc termNormalized,
+          null (Domain.elementsWithVariables unwrapped),
+          null (Domain.concreteElements unwrapped),
+          [singleOpaqueTerm] <- Domain.opaque unwrapped ->
+          -- When the 'normalized' term consists of a single opaque Map-sorted
+          -- term, we should prefer to return only that term.
+          singleOpaqueTerm
+        | otherwise -> Ac.asInternal tools sort' termNormalized
   | otherwise = termLike
   where
     sort' = termLikeSort termLike
@@ -507,69 +525,67 @@ internalize tools termLike
     reject the definition.
  -}
 unifyEquals
-    ::  forall variable unifier
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        )
-    => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: forall variable unifier. ( SortedVariable variable,
+                                Unparse variable,
+                                Show variable,
+                                FreshVariable variable,
+                                MonadUnify unifier
+                                )
+  => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 unifyEquals
-    unifyEqualsChildren
-    first
-    second
-  = do
-    tools <- Simplifier.askMetadataTools
-    (Monad.guard . fromMaybe False) (isSetSort tools sort1)
-    MaybeT $ do
+  unifyEqualsChildren
+  first
+  second =
+    do
+      tools <- Simplifier.askMetadataTools
+      (Monad.guard . fromMaybe False) (isSetSort tools sort1)
+      MaybeT $ do
         unifiers <- Monad.Unify.gather (runMaybeT (unifyEquals0 first second))
         case sequence unifiers of
-            Nothing -> return Nothing
-            Just us -> Monad.Unify.scatter (map Just us)
-  where
-    sort1 = termLikeSort first
-
-    -- | Unify the two argument patterns.
-    unifyEquals0
+          Nothing -> return Nothing
+          Just us -> Monad.Unify.scatter (map Just us)
+    where
+      sort1 = termLikeSort first
+      -- | Unify the two argument patterns.
+      unifyEquals0
         :: TermLike variable
         -> TermLike variable
         -> MaybeT unifier (Pattern variable)
-    unifyEquals0
+      unifyEquals0
         (Builtin_ (Domain.BuiltinSet normalized1))
-        (Builtin_ (Domain.BuiltinSet normalized2))
-      = do
-        tools <- Simplifier.askMetadataTools
-        Ac.unifyEqualsNormalized
-            tools
-            first
-            second
-            unifyEqualsChildren
-            normalized1
-            normalized2
-
-    unifyEquals0 pat1 pat2 = do
+        (Builtin_ (Domain.BuiltinSet normalized2)) =
+          do
+            tools <- Simplifier.askMetadataTools
+            Ac.unifyEqualsNormalized
+              tools
+              first
+              second
+              unifyEqualsChildren
+              normalized1
+              normalized2
+      unifyEquals0 pat1 pat2 = do
         firstDomain <- asDomain pat1
         secondDomain <- asDomain pat2
         unifyEquals0 firstDomain secondDomain
-      where
-        asDomain
+        where
+          asDomain
             :: TermLike variable
             -> MaybeT unifier (TermLike variable)
-        asDomain patt =
+          asDomain patt =
             case normalizedOrBottom of
-                Ac.Normalized normalized -> do
-                    tools <- Simplifier.askMetadataTools
-                    return (Ac.asInternal tools sort1 normalized)
-                Ac.Bottom ->
-                    Monad.Trans.lift $ Monad.Unify.explainAndReturnBottom
-                        "Duplicated elements in normalization."
-                        first
-                        second
-          where
-            normalizedOrBottom
+              Ac.Normalized normalized -> do
+                tools <- Simplifier.askMetadataTools
+                return (Ac.asInternal tools sort1 normalized)
+              Ac.Bottom ->
+                Monad.Trans.lift
+                  $ Monad.Unify.explainAndReturnBottom
+                      "Duplicated elements in normalization."
+                      first
+                      second
+            where
+              normalizedOrBottom
                 :: Ac.NormalizedOrBottom Domain.NormalizedSet variable
-            normalizedOrBottom = Ac.toNormalized patt
+              normalizedOrBottom = Ac.toNormalized patt

--- a/kore/src/Kore/Builtin/SetSymbols.hs
+++ b/kore/src/Kore/Builtin/SetSymbols.hs
@@ -12,41 +12,47 @@ builtin modules.
     import qualified Kore.Builtin.SetSymbols as Set
 @
 -}
-
 module Kore.Builtin.SetSymbols
-    ( -- * Symbols
-      isSymbolConcat
-    , isSymbolElement
-    , isSymbolUnit
-    , isSymbolList2set
-    , lookupSymbolIn
-    , lookupSymbolDifference
-    , lookupSymbolList2set
-      -- * Keys
-    , concatKey
-    , differenceKey
-    , elementKey
-    , inKey
-    , intersectionKey
-    , sizeKey
-    , toListKey
-    , unitKey
-    , list2setKey
-    ) where
+  ( -- * Symbols
+    isSymbolConcat,
+    isSymbolElement,
+    isSymbolUnit,
+    isSymbolList2set,
+    lookupSymbolIn,
+    lookupSymbolDifference,
+    lookupSymbolList2set,
+    -- * Keys
+    concatKey,
+    differenceKey,
+    elementKey,
+    inKey,
+    intersectionKey,
+    sizeKey,
+    toListKey,
+    unitKey,
+    list2setKey
+    )
+where
 
-import           Data.String
-                 ( IsString )
+import Data.String
+  ( IsString
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
+  ( Symbol
+    )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Error as Kore
-                 ( Error )
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
-import           Kore.Internal.Symbol
-                 ( Symbol )
-import           Kore.Sort
-                 ( Sort )
+  ( Error
+    )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
+import Kore.Internal.Symbol
+  ( Symbol
+    )
+import Kore.Sort
+  ( Sort
+    )
 
 concatKey :: IsString s => s
 concatKey = "SET.concat"
@@ -78,25 +84,25 @@ list2setKey = "SET.list2set"
 {- | Find the symbol hooked to @SET.get@ in an indexed module.
  -}
 lookupSymbolIn
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolIn = Builtin.lookupSymbol inKey
 
 {- | Find the symbol hooked to @SET.difference@ in an indexed module.
  -}
 lookupSymbolDifference
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolDifference = Builtin.lookupSymbol differenceKey
 
 {- | Find the symbol hooked to @SET.list2set@ in an indexed module.
  -}
 lookupSymbolList2set
-    :: Sort
-    -> VerifiedModule Attribute.Symbol axiomAttrs
-    -> Either (Kore.Error e) Symbol
+  :: Sort
+  -> VerifiedModule Attribute.Symbol axiomAttrs
+  -> Either (Kore.Error e) Symbol
 lookupSymbolList2set = Builtin.lookupSymbol list2setKey
 
 {- | Check if the given symbol is hooked to @SET.concat@.

--- a/kore/src/Kore/Debug.hs
+++ b/kore/src/Kore/Debug.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -Wno-unused-top-binds    #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 {-|
 Module      : Kore.Debug
 Description : Debugging helpers.
@@ -55,62 +56,84 @@ stack -j3 test --pedantic --test-arguments --pattern=zzz 2>&1 | \
 
 Enjoy.
 -}
-
 module Kore.Debug
-    ( traceEither
-    , traceExceptT
-    , traceMaybe
-    , traceMaybeT
-    , traceMaybeTS
-    , traceNonErrorMonad
-    , traceFunction
-    , applyWhen
-    , debugArg
-    , DebugPlace (..)
-    , DebugResult (..)
-    , Debug (..)
-    , debugPrecGeneric
-    ) where
+  ( traceEither,
+    traceExceptT,
+    traceMaybe,
+    traceMaybeT,
+    traceMaybeTS,
+    traceNonErrorMonad,
+    traceFunction,
+    applyWhen,
+    debugArg,
+    DebugPlace (..),
+    DebugResult (..),
+    Debug (..),
+    debugPrecGeneric
+    )
+where
 
-import           Control.Comonad.Trans.Cofree
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Maybe
+import Control.Comonad.Trans.Cofree
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Maybe
 import qualified Data.Char as Char
 import qualified Data.Foldable as Foldable
-import           Data.Functor.Const
-                 ( Const )
-import           Data.Functor.Identity
-                 ( Identity )
-import           Data.List
-                 ( intercalate )
-import           Data.Map
-                 ( Map )
+import Data.Functor.Const
+  ( Const
+    )
+import Data.Functor.Identity
+  ( Identity
+    )
+import Data.List
+  ( intercalate
+    )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.Proxy
-import           Data.Sequence
-                 ( Seq )
-import           Data.Set
-                 ( Set )
+import Data.Proxy
+import Data.Sequence
+  ( Seq
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( Doc, (<+>) )
-import qualified Data.Text.Prettyprint.Doc as Pretty
-import           Data.Void
-                 ( Void )
-import           Debug.Trace
-import           Generics.SOP
-                 ( All, All2, Code, ConstructorInfo, DatatypeInfo (..),
-                 FieldInfo (..), Generic, HasDatatypeInfo, I (..), K (..),
-                 NP (..), NS (..), SOP (..) )
-import qualified Generics.SOP as SOP
-import           Numeric.Natural
-                 ( Natural )
-
 import Data.Sup
+import Data.Text
+  ( Text
+    )
+import Data.Text.Prettyprint.Doc
+  ( (<+>),
+    Doc
+    )
+import qualified Data.Text.Prettyprint.Doc as Pretty
+import Data.Void
+  ( Void
+    )
+import Debug.Trace
+import Generics.SOP
+  ( All,
+    All2,
+    Code,
+    ConstructorInfo,
+    DatatypeInfo (..),
+    FieldInfo (..),
+    Generic,
+    HasDatatypeInfo,
+    I (..),
+    K (..),
+    NP (..),
+    NS (..),
+    SOP (..)
+    )
+import qualified Generics.SOP as SOP
+import Numeric.Natural
+  ( Natural
+    )
 import SMT.AST
-       ( SExpr )
+  ( SExpr
+    )
 
 {-| Identifiers for places where we're doing debug.
 
@@ -118,23 +141,23 @@ The intent id to use D_Generic for places where we're adding temporary debug
 statements and the others for permanent debug statements
 -}
 data DebugPlace
-    = D_Generic !String !DebugResult
-    | D_OnePath_Step_transitionRule
-    | D_OnePath_verifyClaim
-    | D_Step
-    | D_Function_evaluatePattern
-    | D_SMT_refutePredicate
-    | D_SMT_command
-    | D_SMT_referenceCheckSort
-    | D_SMT_referenceCheckSymbol
-    | D_SMT_resolveSort
-    | D_SMT_resolveSymbol
+  = D_Generic !String !DebugResult
+  | D_OnePath_Step_transitionRule
+  | D_OnePath_verifyClaim
+  | D_Step
+  | D_Function_evaluatePattern
+  | D_SMT_refutePredicate
+  | D_SMT_command
+  | D_SMT_referenceCheckSort
+  | D_SMT_referenceCheckSymbol
+  | D_SMT_resolveSort
+  | D_SMT_resolveSymbol
   deriving (Eq, Ord, Show)
 
-data DebugArg = DebugArg { name :: !String, value :: !String }
+data DebugArg = DebugArg {name :: !String, value :: !String}
 
 instance Show DebugArg where
-    show DebugArg {name, value} = name ++ "=" ++ show value
+  show DebugArg {name, value} = name ++ "=" ++ show value
 
 {-| Whether to dispay the function/action result when the function ends.
 -}
@@ -166,43 +189,43 @@ enabledPlaces = Map.empty
 
 smt :: Map DebugPlace DebugResult
 smt =
-    id
+  id
     $ Map.insert D_SMT_command DebugResult
-    Map.empty
+        Map.empty
 
 smtStartup :: Map DebugPlace DebugResult
 smtStartup =
-    id
+  id
     $ Map.insert D_SMT_referenceCheckSort DebugResult
     $ Map.insert D_SMT_referenceCheckSymbol DebugResult
     $ Map.insert D_SMT_resolveSort DebugResult
     $ Map.insert D_SMT_resolveSymbol DebugResult
-    Map.empty
+        Map.empty
 
 onePathWithFunctionNames :: Map DebugPlace DebugResult
 onePathWithFunctionNames =
-    id
+  id
     $ Map.insert D_Function_evaluatePattern DebugNoResult
     $ Map.insert D_OnePath_verifyClaim DebugNoResult
     $ Map.insert D_OnePath_Step_transitionRule DebugResult
     $ Map.insert D_SMT_refutePredicate DebugResult
-      Map.empty
+        Map.empty
 
 executionWithFunctionNames :: Map DebugPlace DebugResult
 executionWithFunctionNames =
-    id
+  id
     $ Map.insert D_Function_evaluatePattern DebugNoResult
     $ Map.insert D_Step DebugNoResult
-      Map.empty
+        Map.empty
 
 traceWhenEnabled
-    :: DebugPlace -> (DebugResult -> a -> a) -> (a -> a)
+  :: DebugPlace -> (DebugResult -> a -> a) -> (a -> a)
 traceWhenEnabled place logger =
-    case place of
-        D_Generic _ debugResult -> logger debugResult
-        _ -> case Map.lookup place enabledPlaces of
-            Nothing -> id
-            Just debugResult -> logger debugResult
+  case place of
+    D_Generic _ debugResult -> logger debugResult
+    _ -> case Map.lookup place enabledPlaces of
+      Nothing -> id
+      Just debugResult -> logger debugResult
 
 {-|Wraps an 'ExceptT' action for printing debug messages, similar to 'trace'.
 
@@ -210,38 +233,38 @@ It prints the name and the start values before the action, and the action
 result after.
 -}
 traceExceptT
-    :: (Monad m, Show a, Show b)
-    => DebugPlace
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> ExceptT a m b
-    -- ^ Action to wrap
-    -> ExceptT a m b
+  :: (Monad m, Show a, Show b)
+  => DebugPlace
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> ExceptT a m b
+  -- ^ Action to wrap
+  -> ExceptT a m b
 traceExceptT name startValues =
-    traceWhenEnabled name (traceExceptTS (show name) startValues)
+  traceWhenEnabled name (traceExceptTS (show name) startValues)
 
 traceExceptTS
-    :: (Monad m, Show a, Show b)
-    => String
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> ExceptT a m b
-    -- ^ Action to wrap
-    -> ExceptT a m b
+  :: (Monad m, Show a, Show b)
+  => String
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> ExceptT a m b
+  -- ^ Action to wrap
+  -> ExceptT a m b
 traceExceptTS name startValues debugResult action = ExceptT $ do
-    result <-
-        startThing name startValues
-        $ runExceptT action
-    case result of
-        Left err ->
-            endThing name ("error: " ++ show err) debugResult
-            $ return (Left err)
-        Right r ->
-            endThing name ("result: " ++ show r) debugResult
-            $ return (Right r)
+  result <-
+    startThing name startValues
+      $ runExceptT action
+  case result of
+    Left err ->
+      endThing name ("error: " ++ show err) debugResult
+        $ return (Left err)
+    Right r ->
+      endThing name ("result: " ++ show r) debugResult
+        $ return (Right r)
 
 {-|Wraps a 'MaybeT' action for printing debug messages, similar to 'trace'.
 
@@ -249,38 +272,38 @@ It prints the name and the start values before the action, and the action
 result after.
 -}
 traceMaybeT
-    :: (Monad m, Show a)
-    => DebugPlace
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> MaybeT m a
-    -- ^ Action to wrap
-    -> MaybeT m a
+  :: (Monad m, Show a)
+  => DebugPlace
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> MaybeT m a
+  -- ^ Action to wrap
+  -> MaybeT m a
 traceMaybeT name startValues =
-    traceWhenEnabled
-        name
-        (traceMaybeTS (show name) startValues)
+  traceWhenEnabled
+    name
+    (traceMaybeTS (show name) startValues)
 
 traceMaybeTS
-    :: (Monad m, Show a)
-    => String
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> MaybeT m a
-    -- ^ Action to wrap
-    -> MaybeT m a
+  :: (Monad m, Show a)
+  => String
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> MaybeT m a
+  -- ^ Action to wrap
+  -> MaybeT m a
 traceMaybeTS name startValues debugResult action = MaybeT $ do
-    result <- startThing name startValues $ runMaybeT action
-    case result of
-        Nothing ->
-            endThing name "nothing" debugResult
-            $ return Nothing
-        Just r ->
-            endThing name ("result: " ++ show r) debugResult
-            $ return (Just r)
+  result <- startThing name startValues $ runMaybeT action
+  case result of
+    Nothing ->
+      endThing name "nothing" debugResult
+        $ return Nothing
+    Just r ->
+      endThing name ("result: " ++ show r) debugResult
+        $ return (Just r)
 
 {-|Wraps an 'Either' action for printing debug messages, similar to 'trace'.
 
@@ -288,38 +311,38 @@ It prints the name and the start values before the action, and the action
 result after.
 -}
 traceEither
-    :: (Show a, Show b)
-    => DebugPlace
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> Either a b
-    -- ^ Action to wrap
-    -> Either a b
+  :: (Show a, Show b)
+  => DebugPlace
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> Either a b
+  -- ^ Action to wrap
+  -> Either a b
 traceEither name startValues =
-    traceWhenEnabled
-        name
-        (traceEitherS (show name) startValues)
+  traceWhenEnabled
+    name
+    (traceEitherS (show name) startValues)
 
 traceEitherS
-    :: (Show a, Show b)
-    => String
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> Either a b
-    -- ^ Action to wrap
-    -> Either a b
+  :: (Show a, Show b)
+  => String
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> Either a b
+  -- ^ Action to wrap
+  -> Either a b
 traceEitherS name startValues debugResult action =
-    startThing name startValues
+  startThing name startValues
     $ case action of
-        Left err ->
-            endThing name ("error: " ++ show err) debugResult
-            $ Left err
-        Right r ->
-            endThing name ("result: " ++ show r) debugResult
-            $ Right r
+      Left err ->
+        endThing name ("error: " ++ show err) debugResult
+          $ Left err
+      Right r ->
+        endThing name ("result: " ++ show r) debugResult
+          $ Right r
 
 {-|Wraps a 'Maybe' action for printing debug messages, similar to 'trace'.
 
@@ -327,37 +350,37 @@ It prints the name and the start values before the action, and the action
 result after.
 -}
 traceMaybe
-    :: Show a
-    => DebugPlace
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> Maybe a
-    -- ^ Action to wrap
-    -> Maybe a
+  :: Show a
+  => DebugPlace
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> Maybe a
+  -- ^ Action to wrap
+  -> Maybe a
 traceMaybe name startValues =
-    traceWhenEnabled
-        name
-        (traceMaybeS (show name) startValues)
+  traceWhenEnabled
+    name
+    (traceMaybeS (show name) startValues)
 
 traceMaybeS
-    :: Show a
-    => String
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> Maybe a
-    -- ^ Action to wrap
-    -> Maybe a
+  :: Show a
+  => String
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> Maybe a
+  -- ^ Action to wrap
+  -> Maybe a
 traceMaybeS name startValues debugResult action =
-    startThing name startValues
+  startThing name startValues
     $ case action of
-        Nothing ->
-            endThing name "Nothing" debugResult Nothing
-        Just r ->
-            endThing name ("result: " ++ show r) debugResult
-            $ Just r
+      Nothing ->
+        endThing name "Nothing" debugResult Nothing
+      Just r ->
+        endThing name ("result: " ++ show r) debugResult
+          $ Just r
 
 {-|Wraps a generic monad action for printing debug messages, similar to 'trace'.
 
@@ -369,35 +392,35 @@ It prints the name and the start values before the action, and the action
 result after.
 -}
 traceNonErrorMonad
-    :: (Monad m, Show a)
-    => DebugPlace
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> m a
-    -- ^ Action to wrap
-    -> m a
+  :: (Monad m, Show a)
+  => DebugPlace
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> m a
+  -- ^ Action to wrap
+  -> m a
 traceNonErrorMonad name startValues =
-    traceWhenEnabled
-        name
-        (traceNonErrorMonadS (show name) startValues)
+  traceWhenEnabled
+    name
+    (traceNonErrorMonadS (show name) startValues)
 
 traceNonErrorMonadS
-    :: (Monad m, Show a)
-    => String
-    -- ^ Action name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> m a
-    -- ^ Action to wrap
-    -> m a
+  :: (Monad m, Show a)
+  => String
+  -- ^ Action name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> m a
+  -- ^ Action to wrap
+  -> m a
 traceNonErrorMonadS name startValues debugResult action =
-    startThing name startValues
+  startThing name startValues
     $ do
-        result <- action
-        endThing name ("result: " ++ show result) debugResult
-            $ return result
+      result <- action
+      endThing name ("result: " ++ show result) debugResult
+        $ return result
 
 {-|Wraps a function for printing debug messages, similar to 'Debug.trace'.
 
@@ -405,47 +428,46 @@ It prints the name and the start values before evaluating the function,
 and the function result after.
 -}
 traceFunction
-    :: (Show a)
-    => DebugPlace
-    -- ^ function name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> a
-    -- function result
-    -> a
+  :: (Show a)
+  => DebugPlace
+  -- ^ function name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> a
+  -> -- function result
+  a
 traceFunction name startValues =
-    traceWhenEnabled
-        name
-        (traceFunctionS (show name) startValues)
+  traceWhenEnabled
+    name
+    (traceFunctionS (show name) startValues)
 
 traceFunctionS
-    :: (Show a)
-    => String
-    -- ^ function name
-    -> [DebugArg]
-    -- ^ Extra debugging info (usually the inputs)
-    -> DebugResult
-    -> a
-    -- function result
-    -> a
+  :: (Show a)
+  => String
+  -- ^ function name
+  -> [DebugArg]
+  -- ^ Extra debugging info (usually the inputs)
+  -> DebugResult
+  -> a
+  -> -- function result
+  a
 traceFunctionS name startValues debugResult result =
-    startThing name startValues
+  startThing name startValues
     $ endThing name ("result: " ++ show result) debugResult result
 
 startThing :: String -> [DebugArg] -> a -> a
 startThing name startValues =
-    trace ("starting " ++ name ++ " with (" ++ formatted ++ ")")
+  trace ("starting " ++ name ++ " with (" ++ formatted ++ ")")
   where
     formatted = intercalate "," (map show startValues)
 
 endThing :: String -> String -> DebugResult -> a -> a
 endThing name result debugResult =
-    trace ("ending " ++ name ++ resultMesasge)
+  trace ("ending " ++ name ++ resultMesasge)
   where
     resultMesasge = case debugResult of
-        DebugResult -> " with " ++ result
-        DebugNoResult -> ""
-
+      DebugResult -> " with " ++ result
+      DebugNoResult -> ""
 
 {- | Insert a separator between the items and enclose them with the delimiters.
 
@@ -468,29 +490,30 @@ line,
 
  -}
 encloseSep
-    :: Doc ann   -- ^ Left delimiter
-    -> Doc ann   -- ^ Right delimiter
-    -> Doc ann   -- ^ Separator
-    -> [Doc ann] -- ^ Items
-    -> Doc ann
+  :: Doc ann -- ^ Left delimiter
+  -> Doc ann -- ^ Right delimiter
+  -> Doc ann -- ^ Separator
+  -> [Doc ann] -- ^ Items
+  -> Doc ann
 encloseSep ldelim rdelim sep =
-    \case
-        [] -> ldelim <> rdelim
-        (doc : docs) ->
-            mconcat $ concat
-                [ [ldelim <+> doc]
-                , map ((Pretty.line' <> sep) <+>) docs
-                , [Pretty.line, rdelim]
-                ]
+  \case
+    [] -> ldelim <> rdelim
+    (doc : docs) ->
+      mconcat
+        $ concat
+            [ [ldelim <+> doc],
+              map ((Pretty.line' <> sep) <+>) docs,
+              [Pretty.line, rdelim]
+              ]
 
 -- | Surround the second argument with parentheses if needed.
 parens
-    :: Bool  -- ^ Needs parentheses
-    -> Doc ann
-    -> Doc ann
+  :: Bool -- ^ Needs parentheses
+  -> Doc ann
+  -> Doc ann
 parens needsParens
-  | needsParens  = Pretty.parens
-  | otherwise    = id
+  | needsParens = Pretty.parens
+  | otherwise = id
 
 {- | 'Debug' prints data for debugging.
 
@@ -503,57 +526,53 @@ be easily loaded into GHCi, i.e. @debug@ should obey
 
  -}
 class Debug a where
-    debug :: a -> Doc ann
-    debug = debugPrec 0
 
-    debugPrec :: Int -> a -> Doc ann
-    default debugPrec
-        :: (Generic a, HasDatatypeInfo a, All2 Debug (Code a))
-        => Int  -- ^ surrounding precedence
-        -> a
-        -> Doc ann
-    debugPrec = debugPrecGeneric
+  debug :: a -> Doc ann
+  debug = debugPrec 0
 
-debugPrecGeneric
-    :: forall a ann
-    .  (Generic a, HasDatatypeInfo a, All2 Debug (Code a))
-    => Int  -- ^ Surrounding precedence
+  debugPrec :: Int -> a -> Doc ann
+
+  default debugPrec
+    :: (Generic a, HasDatatypeInfo a, All2 Debug (Code a))
+    => Int -- ^ surrounding precedence
     -> a
     -> Doc ann
+  debugPrec = debugPrecGeneric
+
+debugPrecGeneric
+  :: forall a ann. (Generic a, HasDatatypeInfo a, All2 Debug (Code a))
+  => Int -- ^ Surrounding precedence
+  -> a
+  -> Doc ann
 debugPrecGeneric precOut a =
-    debugPrecSOP precOut (SOP.datatypeInfo $ Proxy @a) (SOP.from a)
+  debugPrecSOP precOut (SOP.datatypeInfo $ Proxy @a) (SOP.from a)
 
 debugPrecSOP
-    :: forall xss ann
-    .  All2 Debug xss
-    => Int  -- ^ Surrounding precedence
-    -> DatatypeInfo xss
-    -> SOP I xss
-    -> Doc ann
+  :: forall xss ann. All2 Debug xss
+  => Int -- ^ Surrounding precedence
+  -> DatatypeInfo xss
+  -> SOP I xss
+  -> Doc ann
 debugPrecSOP precOut datatypeInfo (SOP sop) =
-    SOP.hcollapse $ SOP.hczipWith pAllDebug debugConstr constrs sop
+  SOP.hcollapse $ SOP.hczipWith pAllDebug debugConstr constrs sop
   where
     pDebug = Proxy :: Proxy Debug
     pAllDebug = Proxy :: Proxy (All Debug)
-
     constrs :: NP ConstructorInfo xss
     constrs =
-        case datatypeInfo of
-            SOP.ADT     _ _ cs -> cs
-            SOP.Newtype _ _ c  -> c :* Nil
-
+      case datatypeInfo of
+        SOP.ADT _ _ cs -> cs
+        SOP.Newtype _ _ c -> c :* Nil
     precConstr, precRecord :: Int
-    precConstr = 10  -- precedence of function application
-    precRecord = 11  -- precedence of record syntax
-
+    precConstr = 10 -- precedence of function application
+    precRecord = 11 -- precedence of record syntax
     debugConstr
-        :: All Debug xs
-        => ConstructorInfo xs  -- ^ Constructor
-        -> NP I xs             -- ^ Arguments
-        -> K (Doc ann) xs
-
+      :: All Debug xs
+      => ConstructorInfo xs -- ^ Constructor
+      -> NP I xs -- ^ Arguments
+      -> K (Doc ann) xs
     debugConstr (SOP.Constructor name) args =
-        K $ parens (precOut >= precConstr && (not . null) args')
+      K $ parens (precOut >= precConstr && (not . null) args')
         $ Pretty.nest 4
         $ Pretty.sep (name' : args')
       where
@@ -562,46 +581,47 @@ debugPrecSOP precOut datatypeInfo (SOP sop) =
             initial = head name
             needsParens = (not . Char.isLetter) initial && initial /= '('
         args' =
-            SOP.hcollapse
+          SOP.hcollapse
             $ SOP.hcmap pDebug (SOP.mapIK $ debugPrec precConstr) args
-
     debugConstr (SOP.Infix name _ precInfix) (I x :* I y :* Nil) =
-        K $ parens (precOut >= precInfix)
+      K $ parens (precOut >= precInfix)
         $ Pretty.nest 4
         $ Pretty.sep
-            [ debugPrec precInfix x
-            , Pretty.pretty name
-            , debugPrec precInfix y
-            ]
-
+            [ debugPrec precInfix x,
+              Pretty.pretty name,
+              debugPrec precInfix y
+              ]
     debugConstr (SOP.Record name fields) args =
-        K $ parens (precOut >= precRecord)
-        $ Pretty.align $ Pretty.nest 4 $ Pretty.group $ mconcat
-            [ Pretty.pretty name
-            , Pretty.line
-            , encloseSep Pretty.lbrace Pretty.rbrace Pretty.comma args'
-            ]
+      K $ parens (precOut >= precRecord)
+        $ Pretty.align
+        $ Pretty.nest 4
+        $ Pretty.group
+        $ mconcat
+            [ Pretty.pretty name,
+              Pretty.line,
+              encloseSep Pretty.lbrace Pretty.rbrace Pretty.comma args'
+              ]
       where
         args' = SOP.hcollapse $ SOP.hczipWith pDebug debugField fields args
-
     debugField :: Debug x => FieldInfo x -> I x -> K (Doc ann) x
     debugField (FieldInfo fieldName) (I arg) =
-        K $ Pretty.nest 4 $ Pretty.sep
-            [ Pretty.pretty fieldName Pretty.<+> "="
-            , debugPrec 0 arg
-            ]
+      K $ Pretty.nest 4
+        $ Pretty.sep
+            [ Pretty.pretty fieldName Pretty.<+> "=",
+              debugPrec 0 arg
+              ]
 
 instance Debug a => Debug [a] where
-    debugPrec _ =
-        Pretty.group
-        . encloseSep Pretty.lbracket Pretty.rbracket Pretty.comma
-        . map debug
+  debugPrec _ =
+    Pretty.group
+      . encloseSep Pretty.lbracket Pretty.rbracket Pretty.comma
+      . map debug
 
 instance {-# OVERLAPS #-} Debug String where
-    debugPrec p a = Pretty.pretty (showsPrec p a "")
+  debugPrec p a = Pretty.pretty (showsPrec p a "")
 
 instance Debug Text where
-    debugPrec p a = Pretty.pretty (showsPrec p a "")
+  debugPrec p a = Pretty.pretty (showsPrec p a "")
 
 instance Debug Void
 
@@ -610,16 +630,16 @@ instance Debug ()
 instance (Debug a, Debug b) => Debug (a, b)
 
 instance Debug Natural where
-    debugPrec _ = Pretty.pretty
+  debugPrec _ = Pretty.pretty
 
 instance Debug Integer where
-    debugPrec _ x = parens (x < 0) (Pretty.pretty x)
+  debugPrec _ x = parens (x < 0) (Pretty.pretty x)
 
 instance Debug Int where
-    debugPrec _ x = parens (x < 0) (Pretty.pretty x)
+  debugPrec _ x = parens (x < 0) (Pretty.pretty x)
 
 instance Debug Char where
-    debugPrec _ x = Pretty.squotes (Pretty.pretty x)
+  debugPrec _ x = Pretty.squotes (Pretty.pretty x)
 
 instance Debug a => Debug (Maybe a)
 
@@ -628,48 +648,49 @@ instance Debug a => Debug (Sup a)
 instance Debug a => Debug (Identity a)
 
 instance (Debug a, Debug (f b)) => Debug (CofreeF f a b) where
-    debugPrec precOut (a :< fb) =
-        -- Cannot have orphan instances of Generic and HasDatatypeInfo.
-        -- Use a fake instance instead.
-        debugPrecSOP precOut datatypeInfo sop
-      where
-        datatypeInfo =
-            SOP.ADT
-                "Control.Comonad.Trans.Cofree"
-                "CofreeF"
-                (constrInfo :* Nil)
-        constrInfo = SOP.Infix ":<" SOP.RightAssociative 5
-        sop = SOP (Z (I a :* I fb :* Nil))
+  debugPrec precOut (a :< fb) =
+    -- Cannot have orphan instances of Generic and HasDatatypeInfo.
+    -- Use a fake instance instead.
+    debugPrecSOP precOut datatypeInfo sop
+    where
+      datatypeInfo =
+        SOP.ADT
+          "Control.Comonad.Trans.Cofree"
+          "CofreeF"
+          (constrInfo :* Nil)
+      constrInfo = SOP.Infix ":<" SOP.RightAssociative 5
+      sop = SOP (Z (I a :* I fb :* Nil))
 
 instance
-    (Debug a, Debug (w (CofreeF f a (CofreeT f w a)))) =>
-    Debug (CofreeT f w a)
+  (Debug a, Debug (w (CofreeF f a (CofreeT f w a))))
+  => Debug (CofreeT f w a)
   where
-    debugPrec precOut (CofreeT x) =
-        -- Cannot have orphan instances of Generic and HasDatatypeInfo.
-        -- Use a fake instance instead.
-        debugPrecSOP precOut datatypeInfo sop
-      where
-        datatypeInfo =
-            SOP.Newtype
-                "Control.Comonad.Trans.Cofree"
-                "CofreeT"
-                constrInfo
-        constrInfo = SOP.Record "CofreeT" (FieldInfo "runCofreeT" :* Nil)
-        sop = SOP (Z (I x :* Nil))
+  debugPrec precOut (CofreeT x) =
+    -- Cannot have orphan instances of Generic and HasDatatypeInfo.
+    -- Use a fake instance instead.
+    debugPrecSOP precOut datatypeInfo sop
+    where
+      datatypeInfo =
+        SOP.Newtype
+          "Control.Comonad.Trans.Cofree"
+          "CofreeT"
+          constrInfo
+      constrInfo = SOP.Record "CofreeT" (FieldInfo "runCofreeT" :* Nil)
+      sop = SOP (Z (I x :* Nil))
 
 instance (Debug k, Debug a) => Debug (Map.Map k a) where
-    debugPrec precOut as =
-        parens (precOut >= 10) ("Data.Map.fromList" <+> debug (Map.toList as))
+  debugPrec precOut as =
+    parens (precOut >= 10) ("Data.Map.fromList" <+> debug (Map.toList as))
 
 instance Debug a => Debug (Set a) where
-    debugPrec precOut as =
-        parens (precOut >= 10) ("Data.Set.fromList" <+> debug (Set.toList as))
+  debugPrec precOut as =
+    parens (precOut >= 10) ("Data.Set.fromList" <+> debug (Set.toList as))
 
 instance Debug a => Debug (Seq a) where
-    debugPrec precOut as =
-        parens (precOut >= 10)
-        $ "Data.Sequence.fromList" <+> debug (Foldable.toList as)
+  debugPrec precOut as =
+    parens (precOut >= 10)
+      $ "Data.Sequence.fromList"
+      <+> debug (Foldable.toList as)
 
 instance Debug Bool
 

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -5,56 +5,61 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 -}
-
 module Kore.Domain.Builtin
-    ( Builtin (..)
-    , builtinSort
-    , InternalList (..)
+  ( Builtin (..),
+    builtinSort,
+    InternalList (..),
     --
-    , Element (..)
-    , Value (..)
-    , AcWrapper (..)
-    , wrapElement, unwrapElement
-    , InternalAc (..)
-    , NormalizedAc (..)
-    , emptyNormalizedAc
+    Element (..),
+    Value (..),
+    AcWrapper (..),
+    wrapElement,
+    unwrapElement,
+    InternalAc (..),
+    NormalizedAc (..),
+    emptyNormalizedAc,
     --
-    , InternalMap
-    , MapElement
-    , MapValue
-    , NormalizedMap (..)
+    InternalMap,
+    MapElement,
+    MapValue,
+    NormalizedMap (..),
     --
-    , InternalSet
-    , SetElement
-    , SetValue
-    , NormalizedSet (..)
+    InternalSet,
+    SetElement,
+    SetValue,
+    NormalizedSet (..),
     --
-    , InternalInt (..)
-    , InternalBool (..)
-    , InternalString (..)
-    , Domain (..)
-    ) where
+    InternalInt (..),
+    InternalBool (..),
+    InternalString (..),
+    Domain (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Control.Lens as Lens
-import           Control.Lens.Iso
+import Control.Lens.Iso
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Foldable as Foldable
-import           Data.Hashable
-import           Data.Map
-                 ( Map )
+import Data.Hashable
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.Sequence
-                 ( Seq )
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( (<+>) )
+import Data.Sequence
+  ( Seq
+    )
+import Data.Text
+  ( Text
+    )
+import Data.Text.Prettyprint.Doc
+  ( (<+>)
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -72,14 +77,14 @@ they are wrapped by the @element@ symbol.
 
  -}
 unparseConcat
-    :: Symbol  -- ^ unit symbol
-    -> Symbol  -- ^ concat symbol
-    -> [Pretty.Doc ann]      -- ^ children
-    -> Pretty.Doc ann
+  :: Symbol -- ^ unit symbol
+  -> Symbol -- ^ concat symbol
+  -> [Pretty.Doc ann] -- ^ children
+  -> Pretty.Doc ann
 unparseConcat unitSymbol concatSymbol =
-    \case
-        [] -> applyUnit
-        xs -> foldr1 applyConcat xs
+  \case
+    [] -> applyUnit
+    xs -> foldr1 applyConcat xs
   where
     applyUnit = unparse unitSymbol <> noArguments
     applyConcat set1 set2 = unparse concatSymbol <> arguments' [set1, set2]
@@ -88,15 +93,15 @@ unparseConcat unitSymbol concatSymbol =
 
 {- | Internal representation of the builtin @LIST.List@ domain.
  -}
-data InternalList child =
-    InternalList
-        { builtinListSort :: !Sort
-        , builtinListUnit :: !Symbol
-        , builtinListElement :: !Symbol
-        , builtinListConcat :: !Symbol
-        , builtinListChild :: !(Seq child)
+data InternalList child
+  = InternalList
+      { builtinListSort :: !Sort,
+        builtinListUnit :: !Symbol,
+        builtinListElement :: !Symbol,
+        builtinListConcat :: !Symbol,
+        builtinListChild :: !(Seq child)
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (InternalList child)
 
@@ -105,37 +110,38 @@ instance SOP.HasDatatypeInfo (InternalList child)
 instance Debug child => Debug (InternalList child)
 
 instance Hashable child => Hashable (InternalList child) where
-    hashWithSalt salt builtin =
-        hashWithSalt salt (Foldable.toList builtinListChild)
-      where
-        InternalList { builtinListChild } = builtin
+  hashWithSalt salt builtin =
+    hashWithSalt salt (Foldable.toList builtinListChild)
+    where
+      InternalList {builtinListChild} = builtin
 
 instance NFData child => NFData (InternalList child)
 
 instance Unparse child => Unparse (InternalList child) where
-    unparse builtinList =
-        unparseConcat
-            builtinListUnit
-            builtinListConcat
-            (element <$> Foldable.toList builtinListChild)
-      where
-        element x = unparse builtinListElement <> arguments [x]
-        InternalList { builtinListChild } = builtinList
-        InternalList { builtinListUnit } = builtinList
-        InternalList { builtinListElement } = builtinList
-        InternalList { builtinListConcat } = builtinList
 
-    unparse2 builtinList =
-        unparseConcat
-            builtinListUnit
-            builtinListConcat
-            (element <$> Foldable.toList builtinListChild)
-      where
-        element x = unparse2 builtinListElement <> arguments2 [x]
-        InternalList { builtinListChild } = builtinList
-        InternalList { builtinListUnit } = builtinList
-        InternalList { builtinListElement } = builtinList
-        InternalList { builtinListConcat } = builtinList
+  unparse builtinList =
+    unparseConcat
+      builtinListUnit
+      builtinListConcat
+      (element <$> Foldable.toList builtinListChild)
+    where
+      element x = unparse builtinListElement <> arguments [x]
+      InternalList {builtinListChild} = builtinList
+      InternalList {builtinListUnit} = builtinList
+      InternalList {builtinListElement} = builtinList
+      InternalList {builtinListConcat} = builtinList
+
+  unparse2 builtinList =
+    unparseConcat
+      builtinListUnit
+      builtinListConcat
+      (element <$> Foldable.toList builtinListChild)
+    where
+      element x = unparse2 builtinListElement <> arguments2 [x]
+      InternalList {builtinListChild} = builtinList
+      InternalList {builtinListUnit} = builtinList
+      InternalList {builtinListElement} = builtinList
+      InternalList {builtinListConcat} = builtinList
 
 -- * Builtin AC (associative-commutative) generic stuff
 
@@ -145,150 +151,169 @@ The valueWrapper is a data type holding the non-key part of elements.
 For a set, the valueWapper would be something equivalent to @Data.Empty.T@.
 For a map, it would be something equivalent to @Identity@.
 -}
-data NormalizedAc (collection :: * -> * -> *) key child = NormalizedAc
-    { elementsWithVariables :: [Element collection child]
-    -- ^ Non-concrete elements of the structure.
-    -- These would be of sorts @(Int, String)@ for a map from @Int@ to @String@.
-    , concreteElements :: Map key (Value collection child)
-    -- ^ Concrete elements of the structure.
-    -- These would be of sorts @(Int, String)@ for a map from @Int@ to @String@.
-    , opaque :: [child]
-    -- ^ Unoptimized (i.e. non-element) parts of the structure.
-    }
-    deriving (GHC.Generic)
+data NormalizedAc (collection :: * -> * -> *) key child
+  = NormalizedAc
+      { elementsWithVariables :: [Element collection child],
+        -- ^ Non-concrete elements of the structure.
+        -- These would be of sorts @(Int, String)@ for a map from @Int@ to @String@.
+        concreteElements :: Map key (Value collection child),
+        -- ^ Concrete elements of the structure.
+        -- These would be of sorts @(Int, String)@ for a map from @Int@ to @String@.
+        opaque :: [child]
+        -- ^ Unoptimized (i.e. non-element) parts of the structure.
+        }
+  deriving (GHC.Generic)
 
 deriving instance
-    ( Eq key, Eq child
-    , Eq (Element collection child), Eq (Value collection child)
-    ) =>
-    Eq (NormalizedAc collection key child)
+  ( Eq key,
+    Eq child,
+    Eq (Element collection child),
+    Eq (Value collection child)
+    )
+  => Eq (NormalizedAc collection key child)
 
 deriving instance
-    ( Ord key, Ord child
-    , Ord (Element collection child), Ord (Value collection child)
-    ) =>
-    Ord (NormalizedAc collection key child)
+  ( Ord key,
+    Ord child,
+    Ord (Element collection child),
+    Ord (Value collection child)
+    )
+  => Ord (NormalizedAc collection key child)
 
 deriving instance
-    ( Show key, Show child
-    , Show (Element collection child), Show (Value collection child)
-    ) =>
-    Show (NormalizedAc collection key child)
+  ( Show key,
+    Show child,
+    Show (Element collection child),
+    Show (Value collection child)
+    )
+  => Show (NormalizedAc collection key child)
 
 deriving instance
-    (Functor (Element collection), Functor (Value collection)) =>
-    Functor (NormalizedAc collection key)
+  (Functor (Element collection), Functor (Value collection))
+  => Functor (NormalizedAc collection key)
 
 deriving instance
-    (Foldable (Element collection), Foldable (Value collection)) =>
-    Foldable (NormalizedAc collection key)
+  (Foldable (Element collection), Foldable (Value collection))
+  => Foldable (NormalizedAc collection key)
 
 deriving instance
-    (Traversable (Element collection), Traversable (Value collection)) =>
-    Traversable (NormalizedAc collection key)
+  (Traversable (Element collection), Traversable (Value collection))
+  => Traversable (NormalizedAc collection key)
 
 instance
-    ( Hashable key, Hashable child
-    , Hashable (Element collection child), Hashable (Value collection child)
-    ) =>
-    Hashable (NormalizedAc collection key child)
+  ( Hashable key,
+    Hashable child,
+    Hashable (Element collection child),
+    Hashable (Value collection child)
+    )
+  => Hashable (NormalizedAc collection key child)
   where
-    hashWithSalt salt normalized@(NormalizedAc _ _ _) =
-        salt
-            `hashWithSalt` elementsWithVariables
-            `hashWithSalt` Map.toList concreteElements
-            `hashWithSalt` opaque
-      where
-        NormalizedAc { elementsWithVariables } = normalized
-        NormalizedAc { concreteElements } = normalized
-        NormalizedAc { opaque } = normalized
+  hashWithSalt salt normalized@(NormalizedAc _ _ _) =
+    salt
+      `hashWithSalt` elementsWithVariables
+      `hashWithSalt` Map.toList concreteElements
+      `hashWithSalt` opaque
+    where
+      NormalizedAc {elementsWithVariables} = normalized
+      NormalizedAc {concreteElements} = normalized
+      NormalizedAc {opaque} = normalized
 
 instance
-    ( NFData key, NFData child
-    , NFData (Element collection child), NFData (Value collection child)
-    ) =>
-    NFData (NormalizedAc collection key child)
+  ( NFData key,
+    NFData child,
+    NFData (Element collection child),
+    NFData (Value collection child)
+    )
+  => NFData (NormalizedAc collection key child)
 
 instance SOP.Generic (NormalizedAc key valueWrapper child)
 
 instance SOP.HasDatatypeInfo (NormalizedAc key valueWrapper child)
 
 instance
-    ( Debug key, Debug child
-    , Debug (Element collection child), Debug (Value collection child)
-    ) =>
-    Debug (NormalizedAc collection key child)
+  ( Debug key,
+    Debug child,
+    Debug (Element collection child),
+    Debug (Value collection child)
+    )
+  => Debug (NormalizedAc collection key child)
 
 emptyNormalizedAc :: NormalizedAc key valueWrapper child
 emptyNormalizedAc = NormalizedAc
-    { elementsWithVariables = []
-    , concreteElements = Map.empty
-    , opaque = []
+  { elementsWithVariables = [],
+    concreteElements = Map.empty,
+    opaque = []
     }
 
 {- | Internal representation of associative-commutative builtin terms.
 -}
-data InternalAc key (normalized :: * -> * -> *) child =
-    InternalAc
-        { builtinAcSort :: !Sort
-        , builtinAcUnit :: !Symbol
-        , builtinAcElement :: !Symbol
-        , builtinAcConcat :: !Symbol
-        , builtinAcChild :: normalized key child
+data InternalAc key (normalized :: * -> * -> *) child
+  = InternalAc
+      { builtinAcSort :: !Sort,
+        builtinAcUnit :: !Symbol,
+        builtinAcElement :: !Symbol,
+        builtinAcConcat :: !Symbol,
+        builtinAcChild :: normalized key child
         }
-    deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
+  deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
 
 {- | Establishes a bijection between value wrappers and entire-structure
 wrappers, with a few utility functions for the two.
 -}
 class AcWrapper (normalized :: * -> * -> *) where
-    -- TODO (thomas.tuegel): Make this a type family?
-    data family Value normalized child
-    data family Element normalized child
 
-    unwrapAc :: normalized key child -> NormalizedAc normalized key child
-    wrapAc :: NormalizedAc normalized key child -> normalized key child
+  -- TODO (thomas.tuegel): Make this a type family?
+  data Value normalized child
 
-    {-| Pairs the values in two wrappers as they should be paired for
-    unification.
-    -}
-    alignValues
-        :: Value normalized a
-        -> Value normalized b
-        -> Value normalized (a, b)
+  data Element normalized child
 
-    elementIso
-        :: Iso' (Element normalized child) (child, Value normalized child)
+  unwrapAc :: normalized key child -> NormalizedAc normalized key child
 
-    unparseElement
-        :: (child -> Pretty.Doc ann)
-        -> Element normalized child -> Pretty.Doc ann
+  wrapAc :: NormalizedAc normalized key child -> normalized key child
 
-    unparseConcreteElement
-        :: (key -> Pretty.Doc ann)
-        -> (child -> Pretty.Doc ann)
-        -> (key, Value normalized child) -> Pretty.Doc ann
+  {-| Pairs the values in two wrappers as they should be paired for
+  unification.
+  -}
+  alignValues
+    :: Value normalized a
+    -> Value normalized b
+    -> Value normalized (a, b)
+
+  elementIso
+    :: Iso' (Element normalized child) (child, Value normalized child)
+
+  unparseElement
+    :: (child -> Pretty.Doc ann)
+    -> Element normalized child
+    -> Pretty.Doc ann
+
+  unparseConcreteElement
+    :: (key -> Pretty.Doc ann)
+    -> (child -> Pretty.Doc ann)
+    -> (key, Value normalized child)
+    -> Pretty.Doc ann
 
 unwrapElement
-    :: AcWrapper normalized
-    => Element normalized child -> (child, Value normalized child)
+  :: AcWrapper normalized
+  => Element normalized child
+  -> (child, Value normalized child)
 unwrapElement = Lens.view elementIso
 
 wrapElement
-    :: AcWrapper normalized
-    => (child, Value normalized child) -> Element normalized child
+  :: AcWrapper normalized
+  => (child, Value normalized child)
+  -> Element normalized child
 wrapElement = Lens.review elementIso
 
 unparsedChildren
-    :: forall ann child key normalized
-    .  AcWrapper normalized
-    => Symbol
-    -> (key -> Pretty.Doc ann)
-    -> (child -> Pretty.Doc ann)
-    -> normalized key child
-    -> [Pretty.Doc ann]
+  :: forall ann child key normalized. AcWrapper normalized
+  => Symbol
+  -> (key -> Pretty.Doc ann)
+  -> (child -> Pretty.Doc ann)
+  -> normalized key child
+  -> [Pretty.Doc ann]
 unparsedChildren elementSymbol keyUnparser childUnparser wrapped =
-    (elementUnparser <$> elementsWithVariables)
+  (elementUnparser <$> elementsWithVariables)
     ++ (concreteElementUnparser <$> Map.toAscList concreteElements)
     ++ (child . childUnparser <$> opaque)
   where
@@ -296,63 +321,65 @@ unparsedChildren elementSymbol keyUnparser childUnparser wrapped =
     -- Matching needed only for getting compiler notifications when
     -- the NormalizedAc field count changes.
     unwrapped@(NormalizedAc _ _ _) = unwrapAc wrapped
-
     NormalizedAc {elementsWithVariables} = unwrapped
     NormalizedAc {concreteElements} = unwrapped
     NormalizedAc {opaque} = unwrapped
     element = (<>) ("/* element: */" <+> unparse elementSymbol)
     concreteElement = (<>) ("/* concrete element: */" <+> unparse elementSymbol)
     child = (<+>) "/* opaque child: */"
-
     elementUnparser :: Element normalized child -> Pretty.Doc ann
     elementUnparser = element . unparseElement childUnparser
-
     concreteElementUnparser :: (key, Value normalized child) -> Pretty.Doc ann
     concreteElementUnparser =
-        concreteElement . unparseConcreteElement keyUnparser childUnparser
+      concreteElement . unparseConcreteElement keyUnparser childUnparser
 
-instance Hashable (normalized key child)
-    => Hashable (InternalAc key normalized child)
+instance
+  Hashable (normalized key child)
+  => Hashable (InternalAc key normalized child)
   where
-    hashWithSalt salt builtin =
-        hashWithSalt salt builtinAcChild
-      where
-        InternalAc { builtinAcChild } = builtin
+  hashWithSalt salt builtin =
+    hashWithSalt salt builtinAcChild
+    where
+      InternalAc {builtinAcChild} = builtin
 
-instance (NFData (normalized key child))
-    => NFData (InternalAc key normalized child)
+instance
+  (NFData (normalized key child))
+  => NFData (InternalAc key normalized child)
 
 instance SOP.Generic (InternalAc key normalized child)
 
 instance SOP.HasDatatypeInfo (InternalAc key normalized child)
 
-instance (Debug (normalized key child))
-    => Debug (InternalAc key normalized child)
+instance
+  (Debug (normalized key child))
+  => Debug (InternalAc key normalized child)
 
 instance
-    ( Unparse key
-    , Unparse child
-    , AcWrapper normalized
+  ( Unparse key,
+    Unparse child,
+    AcWrapper normalized
     )
-    => Unparse (InternalAc key normalized child)
+  => Unparse (InternalAc key normalized child)
   where
-    unparse = unparseInternalAc unparse unparse
-    unparse2 = unparseInternalAc unparse2 unparse2
+
+  unparse = unparseInternalAc unparse unparse
+
+  unparse2 = unparseInternalAc unparse2 unparse2
 
 unparseInternalAc
-    :: (AcWrapper normalized)
-    => (key -> Pretty.Doc ann)
-    -> (child -> Pretty.Doc ann)
-    -> InternalAc key normalized child
-    -> Pretty.Doc ann
+  :: (AcWrapper normalized)
+  => (key -> Pretty.Doc ann)
+  -> (child -> Pretty.Doc ann)
+  -> InternalAc key normalized child
+  -> Pretty.Doc ann
 unparseInternalAc keyUnparser childUnparser builtinAc =
-    unparseConcat builtinAcUnit builtinAcConcat
+  unparseConcat builtinAcUnit builtinAcConcat
     $ unparsedChildren builtinAcElement keyUnparser childUnparser builtinAcChild
   where
-    InternalAc { builtinAcChild } = builtinAc
-    InternalAc { builtinAcUnit } = builtinAc
-    InternalAc { builtinAcElement } = builtinAc
-    InternalAc { builtinAcConcat } = builtinAc
+    InternalAc {builtinAcChild} = builtinAc
+    InternalAc {builtinAcUnit} = builtinAc
+    InternalAc {builtinAcElement} = builtinAc
+    InternalAc {builtinAcConcat} = builtinAc
 
 -- * Builtin Map
 
@@ -361,7 +388,7 @@ unparseInternalAc keyUnparser childUnparser builtinAc =
 type MapValue = Value NormalizedMap
 
 instance Hashable child => Hashable (MapValue child) where
-    hashWithSalt salt (MapValue child) = hashWithSalt salt child
+  hashWithSalt salt (MapValue child) = hashWithSalt salt child
 
 instance NFData child => NFData (MapValue child)
 
@@ -376,7 +403,7 @@ instance Debug child => Debug (MapValue child)
 type MapElement = Element NormalizedMap
 
 instance Hashable child => Hashable (MapElement child) where
-    hashWithSalt salt (MapElement child) = hashWithSalt salt child
+  hashWithSalt salt (MapElement child) = hashWithSalt salt child
 
 instance NFData child => NFData (MapElement child)
 
@@ -388,13 +415,12 @@ instance Debug child => Debug (MapElement child)
 
 {- | Wrapper for normalized maps, to be used in the `builtinAcChild` field.
 -}
-newtype NormalizedMap key child =
-    NormalizedMap {getNormalizedMap :: NormalizedAc NormalizedMap key child}
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+newtype NormalizedMap key child
+  = NormalizedMap {getNormalizedMap :: NormalizedAc NormalizedMap key child}
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-instance (Hashable key, Hashable child) => Hashable (NormalizedMap key child)
-  where
-    hashWithSalt salt (NormalizedMap m) = hashWithSalt salt m
+instance (Hashable key, Hashable child) => Hashable (NormalizedMap key child) where
+  hashWithSalt salt (NormalizedMap m) = hashWithSalt salt m
 
 instance (NFData key, NFData child) => NFData (NormalizedMap key child)
 
@@ -405,26 +431,30 @@ instance SOP.HasDatatypeInfo (NormalizedMap key child)
 instance (Debug key, Debug child) => Debug (NormalizedMap key child)
 
 instance AcWrapper NormalizedMap where
-    newtype Value NormalizedMap child = MapValue { getMapValue :: child }
-        deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-    newtype Element NormalizedMap child =
-        MapElement { getMapElement :: (child, child) }
-        deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  newtype Value NormalizedMap child = MapValue {getMapValue :: child}
+    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-    wrapAc = NormalizedMap
-    unwrapAc = getNormalizedMap
-    alignValues (MapValue a) (MapValue b) = MapValue (a, b)
+  newtype Element NormalizedMap child
+    = MapElement {getMapElement :: (child, child)}
+    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
-    elementIso =
-        Lens.iso
-            (Bifunctor.second MapValue . getMapElement)
-            (MapElement . Bifunctor.second getMapValue)
+  wrapAc = NormalizedMap
 
-    unparseElement childUnparser (MapElement (key, value)) =
-        arguments' [childUnparser key, childUnparser value]
-    unparseConcreteElement keyUnparser childUnparser (key, MapValue value) =
-        arguments' [keyUnparser key, childUnparser value]
+  unwrapAc = getNormalizedMap
+
+  alignValues (MapValue a) (MapValue b) = MapValue (a, b)
+
+  elementIso =
+    Lens.iso
+      (Bifunctor.second MapValue . getMapElement)
+      (MapElement . Bifunctor.second getMapValue)
+
+  unparseElement childUnparser (MapElement (key, value)) =
+    arguments' [childUnparser key, childUnparser value]
+
+  unparseConcreteElement keyUnparser childUnparser (key, MapValue value) =
+    arguments' [keyUnparser key, childUnparser value]
 
 {- | Internal representation of the builtin @MAP.Map@ domain.
 -}
@@ -438,7 +468,7 @@ for a given key.
 type SetValue = Value NormalizedSet
 
 instance Hashable (SetValue child) where
-    hashWithSalt salt SetValue = hashWithSalt salt (0 :: Int)
+  hashWithSalt salt SetValue = hashWithSalt salt (0 :: Int)
 
 instance NFData (SetValue child)
 
@@ -453,7 +483,7 @@ instance Debug (SetValue child)
 type SetElement = Element NormalizedSet
 
 instance Hashable child => Hashable (SetElement child) where
-    hashWithSalt salt (SetElement key) = hashWithSalt salt key
+  hashWithSalt salt (SetElement key) = hashWithSalt salt key
 
 instance NFData child => NFData (SetElement child)
 
@@ -465,14 +495,13 @@ instance Debug child => Debug (SetElement child)
 
 {- | Wrapper for normalized sets, to be used in the `builtinAcChild` field.
 -}
-newtype NormalizedSet key child =
-    NormalizedSet { getNormalizedSet :: NormalizedAc NormalizedSet key child }
-    deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
+newtype NormalizedSet key child
+  = NormalizedSet {getNormalizedSet :: NormalizedAc NormalizedSet key child}
+  deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
 
-instance (Hashable key, Hashable child) => Hashable (NormalizedSet key child)
-  where
-    hashWithSalt salt (NormalizedSet set) =
-        hashWithSalt salt set
+instance (Hashable key, Hashable child) => Hashable (NormalizedSet key child) where
+  hashWithSalt salt (NormalizedSet set) =
+    hashWithSalt salt set
 
 instance (NFData key, NFData child) => NFData (NormalizedSet key child)
 
@@ -483,23 +512,27 @@ instance SOP.HasDatatypeInfo (NormalizedSet key child)
 instance (Debug key, Debug child) => Debug (NormalizedSet key child)
 
 instance AcWrapper NormalizedSet where
-    data Value NormalizedSet child = SetValue
-        deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
 
-    newtype Element NormalizedSet child =
-        SetElement { getSetElement :: child }
-        deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
+  data Value NormalizedSet child = SetValue
+    deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
 
-    wrapAc = NormalizedSet
-    unwrapAc = getNormalizedSet
-    alignValues _ _ = SetValue
+  newtype Element NormalizedSet child
+    = SetElement {getSetElement :: child}
+    deriving (Eq, Foldable, Functor, Traversable, GHC.Generic, Ord, Show)
 
-    elementIso = Lens.iso (flip (,) SetValue . getSetElement) (SetElement . fst)
+  wrapAc = NormalizedSet
 
-    unparseElement childUnparser (SetElement key) =
-        argument' (childUnparser key)
-    unparseConcreteElement keyUnparser _childUnparser (key, SetValue) =
-        argument' (keyUnparser key)
+  unwrapAc = getNormalizedSet
+
+  alignValues _ _ = SetValue
+
+  elementIso = Lens.iso (flip (,) SetValue . getSetElement) (SetElement . fst)
+
+  unparseElement childUnparser (SetElement key) =
+    argument' (childUnparser key)
+
+  unparseConcreteElement keyUnparser _childUnparser (key, SetValue) =
+    argument' (keyUnparser key)
 
 {- | Internal representation of the builtin @SET.Set@ domain.
  -}
@@ -509,12 +542,12 @@ type InternalSet key child = InternalAc key NormalizedSet child
 
 {- | Internal representation of the builtin @INT.Int@ domain.
  -}
-data InternalInt =
-    InternalInt
-        { builtinIntSort :: !Sort
-        , builtinIntValue :: !Integer
+data InternalInt
+  = InternalInt
+      { builtinIntSort :: !Sort,
+        builtinIntValue :: !Integer
         }
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable InternalInt
 
@@ -527,26 +560,27 @@ instance SOP.HasDatatypeInfo InternalInt
 instance Debug InternalInt
 
 instance Unparse InternalInt where
-    unparse InternalInt { builtinIntSort, builtinIntValue } =
-        "\\dv"
-        <> parameters [builtinIntSort]
-        <> arguments' [Pretty.dquotes $ Pretty.pretty builtinIntValue]
 
-    unparse2 InternalInt { builtinIntSort, builtinIntValue } =
-        "\\dv2"
-        <> parameters2 [builtinIntSort]
-        <> arguments' [Pretty.dquotes $ Pretty.pretty builtinIntValue]
+  unparse InternalInt {builtinIntSort, builtinIntValue} =
+    "\\dv"
+      <> parameters [builtinIntSort]
+      <> arguments' [Pretty.dquotes $ Pretty.pretty builtinIntValue]
+
+  unparse2 InternalInt {builtinIntSort, builtinIntValue} =
+    "\\dv2"
+      <> parameters2 [builtinIntSort]
+      <> arguments' [Pretty.dquotes $ Pretty.pretty builtinIntValue]
 
 -- * Builtin Bool
 
 {- | Internal representation of the builtin @BOOL.Bool@ domain.
  -}
-data InternalBool =
-    InternalBool
-        { builtinBoolSort :: !Sort
-        , builtinBoolValue :: !Bool
+data InternalBool
+  = InternalBool
+      { builtinBoolSort :: !Sort,
+        builtinBoolValue :: !Bool
         }
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable InternalBool
 
@@ -559,34 +593,35 @@ instance SOP.HasDatatypeInfo InternalBool
 instance Debug InternalBool
 
 instance Unparse InternalBool where
-    unparse InternalBool { builtinBoolSort, builtinBoolValue } =
-        "\\dv"
-        <> parameters [builtinBoolSort]
-        <> arguments' [Pretty.dquotes value]
-      where
-        value
-          | builtinBoolValue = "true"
-          | otherwise        = "false"
 
-    unparse2 InternalBool { builtinBoolSort, builtinBoolValue } =
-        "\\dv2"
-        <> parameters2 [builtinBoolSort]
-        <> arguments' [Pretty.dquotes value]
-      where
-        value
-          | builtinBoolValue = "true"
-          | otherwise        = "false"
+  unparse InternalBool {builtinBoolSort, builtinBoolValue} =
+    "\\dv"
+      <> parameters [builtinBoolSort]
+      <> arguments' [Pretty.dquotes value]
+    where
+      value
+        | builtinBoolValue = "true"
+        | otherwise = "false"
+
+  unparse2 InternalBool {builtinBoolSort, builtinBoolValue} =
+    "\\dv2"
+      <> parameters2 [builtinBoolSort]
+      <> arguments' [Pretty.dquotes value]
+    where
+      value
+        | builtinBoolValue = "true"
+        | otherwise = "false"
 
 -- * Builtin String
 
 {- | Internal representation of the builtin @STRING.String@ domain.
  -}
-data InternalString =
-    InternalString
-        { internalStringSort :: !Sort
-        , internalStringValue :: !Text
+data InternalString
+  = InternalString
+      { internalStringSort :: !Sort,
+        internalStringValue :: !Text
         }
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable InternalString
 
@@ -599,26 +634,26 @@ instance SOP.HasDatatypeInfo InternalString
 instance Debug InternalString
 
 instance Unparse InternalString where
-    unparse InternalString { internalStringSort, internalStringValue } =
-        "\\dv"
-        <> parameters [internalStringSort]
-        <> arguments [StringLiteral internalStringValue]
 
-    unparse2 InternalString { internalStringSort, internalStringValue } =
-        "\\dv2"
-        <> parameters2 [internalStringSort]
-        <> arguments2 [StringLiteral internalStringValue]
+  unparse InternalString {internalStringSort, internalStringValue} =
+    "\\dv"
+      <> parameters [internalStringSort]
+      <> arguments [StringLiteral internalStringValue]
+
+  unparse2 InternalString {internalStringSort, internalStringValue} =
+    "\\dv2"
+      <> parameters2 [internalStringSort]
+      <> arguments2 [StringLiteral internalStringValue]
 
 -- * Builtin domain representations
-
 data Builtin key child
-    = BuiltinMap !(InternalMap key child)
-    | BuiltinList !(InternalList child)
-    | BuiltinSet !(InternalSet key child)
-    | BuiltinInt !InternalInt
-    | BuiltinBool !InternalBool
-    | BuiltinString !InternalString
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  = BuiltinMap !(InternalMap key child)
+  | BuiltinList !(InternalList child)
+  | BuiltinSet !(InternalSet key child)
+  | BuiltinInt !InternalInt
+  | BuiltinBool !InternalBool
+  | BuiltinString !InternalString
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (Builtin key child)
 
@@ -631,55 +666,58 @@ instance (Hashable key, Hashable child) => Hashable (Builtin key child)
 instance (NFData key, NFData child) => NFData (Builtin key child)
 
 instance (Unparse key, Unparse child) => Unparse (Builtin key child) where
-    unparse evaluated =
-        Pretty.sep ["/* builtin: */", unparseGeneric evaluated]
-    unparse2 evaluated =
-        Pretty.sep ["/* builtin: */", unparse2Generic evaluated]
+
+  unparse evaluated =
+    Pretty.sep ["/* builtin: */", unparseGeneric evaluated]
+
+  unparse2 evaluated =
+    Pretty.sep ["/* builtin: */", unparse2Generic evaluated]
 
 builtinSort :: Builtin key child -> Sort
 builtinSort builtin =
-    case builtin of
-        BuiltinInt InternalInt { builtinIntSort } -> builtinIntSort
-        BuiltinBool InternalBool { builtinBoolSort } -> builtinBoolSort
-        BuiltinString InternalString { internalStringSort } ->
-            internalStringSort
-        BuiltinMap InternalAc { builtinAcSort } -> builtinAcSort
-        BuiltinList InternalList { builtinListSort } -> builtinListSort
-        BuiltinSet InternalAc { builtinAcSort } -> builtinAcSort
+  case builtin of
+    BuiltinInt InternalInt {builtinIntSort} -> builtinIntSort
+    BuiltinBool InternalBool {builtinBoolSort} -> builtinBoolSort
+    BuiltinString InternalString {internalStringSort} ->
+      internalStringSort
+    BuiltinMap InternalAc {builtinAcSort} -> builtinAcSort
+    BuiltinList InternalList {builtinListSort} -> builtinListSort
+    BuiltinSet InternalAc {builtinAcSort} -> builtinAcSort
 
 instance Synthetic Sort (Builtin key) where
-    synthetic = builtinSort
-    {-# INLINE synthetic #-}
+  synthetic = builtinSort
+  {-# INLINE synthetic #-}
 
 instance Ord variable => Synthetic (FreeVariables variable) (Builtin key) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Domain (Builtin key) where
-    lensDomainValue mapDomainValue builtin =
-        getBuiltin <$> mapDomainValue original
-      where
-        original =
-            DomainValue
-                { domainValueChild = builtin
-                , domainValueSort = builtinSort builtin
-                }
-        getBuiltin
-            :: forall child
-            .  DomainValue Sort (Builtin key child)
-            -> Builtin key child
-        getBuiltin DomainValue { domainValueSort, domainValueChild } =
-            case domainValueChild of
-                BuiltinInt internal ->
-                    BuiltinInt internal { builtinIntSort = domainValueSort }
-                BuiltinBool internal ->
-                    BuiltinBool internal { builtinBoolSort = domainValueSort }
-                BuiltinString internal ->
-                    BuiltinString internal
-                        { internalStringSort = domainValueSort }
-                BuiltinMap internal ->
-                    BuiltinMap internal { builtinAcSort = domainValueSort }
-                BuiltinList internal ->
-                    BuiltinList internal { builtinListSort = domainValueSort }
-                BuiltinSet internal ->
-                    BuiltinSet internal { builtinAcSort = domainValueSort }
+  lensDomainValue mapDomainValue builtin =
+    getBuiltin <$> mapDomainValue original
+    where
+      original =
+        DomainValue
+          { domainValueChild = builtin,
+            domainValueSort = builtinSort builtin
+            }
+      getBuiltin
+        :: forall child. DomainValue Sort (Builtin key child)
+        -> Builtin key child
+      getBuiltin DomainValue {domainValueSort, domainValueChild} =
+        case domainValueChild of
+          BuiltinInt internal ->
+            BuiltinInt internal {builtinIntSort = domainValueSort}
+          BuiltinBool internal ->
+            BuiltinBool internal {builtinBoolSort = domainValueSort}
+          BuiltinString internal ->
+            BuiltinString
+              internal
+                { internalStringSort = domainValueSort
+                  }
+          BuiltinMap internal ->
+            BuiltinMap internal {builtinAcSort = domainValueSort}
+          BuiltinList internal ->
+            BuiltinList internal {builtinListSort = domainValueSort}
+          BuiltinSet internal ->
+            BuiltinSet internal {builtinAcSort = domainValueSort}

--- a/kore/src/Kore/Domain/Class.hs
+++ b/kore/src/Kore/Domain/Class.hs
@@ -5,27 +5,27 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 -}
-
 module Kore.Domain.Class where
 
 import qualified Control.Lens as Lens
-import           Data.Functor.Const
-                 ( Const )
-import           Data.Void
-                 ( Void )
-
+import Data.Functor.Const
+  ( Const
+    )
+import Data.Void
+  ( Void
+    )
 import Kore.Sort
 import Kore.Syntax.DomainValue
 
 class Functor domain => Domain domain where
-    -- | View a 'Domain' as a 'DomainValue'.
-    lensDomainValue
-        ::  forall child1 child2
-        .   Lens.Lens
-                (domain child1)
-                (domain child2)
-                (DomainValue Sort (domain child1))
-                (DomainValue Sort (domain child2))
+  -- | View a 'Domain' as a 'DomainValue'.
+  lensDomainValue
+    :: forall child1 child2. Lens.Lens
+                               (domain child1)
+                               (domain child2)
+                               (DomainValue Sort (domain child1))
+                               (DomainValue Sort (domain child2))
 
 instance Domain (Const Void) where
-    lensDomainValue _ = \case {}
+  lensDomainValue _ = \case
+

--- a/kore/src/Kore/Error.hs
+++ b/kore/src/Kore/Error.hs
@@ -8,85 +8,91 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.Error
-    ( Error (..)
-    , printError
-    , koreError
-    , koreFail
-    , koreFailText
-    , koreFailWhen
-    , koreFailWhenText
-    , withContext
-    , withTextContext
-    , castError
-    , assertRight
-    , module Control.Monad.Except
-    ) where
+  ( Error (..),
+    printError,
+    koreError,
+    koreFail,
+    koreFailText,
+    koreFailWhen,
+    koreFailWhenText,
+    withContext,
+    withTextContext,
+    castError,
+    assertRight,
+    module Control.Monad.Except
+    )
+where
 
-import           Control.Monad
-                 ( when )
-import           Control.Monad.Except
-                 ( MonadError (..) )
-import           Data.List
-                 ( intercalate )
-import           Data.Text
-                 ( Text )
+import Control.Monad
+  ( when
+    )
+import Control.Monad.Except
+  ( MonadError (..)
+    )
+import Data.List
+  ( intercalate
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
 
 {-|'Error' represents a Kore error with a stacktrace-like context.
 
 The 'a' phantom type is used to differentiate between various kinds of error.
 -}
-data Error a = Error
-    { errorContext :: ![String]
-    , errorError   :: !String
-    }
-    deriving (Eq, Show)
+data Error a
+  = Error
+      { errorContext :: ![String],
+        errorError :: !String
+        }
+  deriving (Eq, Show)
 
 {-|'printError' provides a one-line representation of a string. -}
 printError :: Error a -> String
 printError e@(Error _ _) =
-    "Error in " ++ intercalate " -> " (errorContext e) ++ ": " ++ errorError e
+  "Error in " ++ intercalate " -> " (errorContext e) ++ ": " ++ errorError e
 
 {-|'koreError' constructs an error object with an empty context. -}
 koreError :: String -> Error a
 koreError err = Error
-    { errorContext = []
-    , errorError = err
+  { errorContext = [],
+    errorError = err
     }
 
 {-|'koreFail' produces an error result with an empty context. -}
 koreFail :: MonadError (Error a) m => String -> m b
 koreFail errorMessage =
-    throwError (koreError errorMessage)
+  throwError (koreError errorMessage)
 
 {-|'koreFailText' produces an error result with an empty context. -}
 koreFailText :: MonadError (Error a) m => Text -> m b
 koreFailText errorMessage =
-    throwError (koreError (Text.unpack errorMessage))
+  throwError (koreError (Text.unpack errorMessage))
 
 {-|'koreFailWhen' produces an error result with an empty context whenever the
 provided flag is true.
 -}
 koreFailWhen :: MonadError (Error a) m => Bool -> String -> m ()
 koreFailWhen condition errorMessage =
-    when condition (koreFail errorMessage)
+  when condition (koreFail errorMessage)
 
 {-|'koreFailWhen' produces an error result with an empty context whenever the
 provided flag is true.
 -}
 koreFailWhenText :: MonadError (Error a) m => Bool -> Text -> m ()
 koreFailWhenText condition errorMessage =
-    koreFailWhen condition (Text.unpack errorMessage)
+  koreFailWhen condition (Text.unpack errorMessage)
 
 {-|'withContext' prepends the given string to the context whenever the given
 action fails.
 -}
 withContext :: MonadError (Error a) m => String -> m result -> m result
 withContext localContext action =
-    catchError action inContext
+  catchError action inContext
   where
-    inContext err@Error { errorContext } =
-        throwError err { errorContext = localContext : errorContext }
+    inContext err@Error {errorContext} =
+      throwError err {errorContext = localContext : errorContext}
 
 {-|'withContext' prepends the given text to the context whenever the given
 action fails.
@@ -98,23 +104,22 @@ withTextContext localContext = withContext (Text.unpack localContext)
 -}
 castError :: Either (Error a) result -> Either (Error b) result
 castError
-    (Left Error
-        { errorContext = context
-        , errorError = err
-        }
-    )
-  =
+  ( Left
+      Error
+        { errorContext = context,
+          errorError = err
+          }
+    ) =
     Left Error
-        { errorContext = context
-        , errorError = err
+      { errorContext = context,
+        errorError = err
         }
 castError (Right r) = Right r
-
 
 -- | `error` with a helpful message in case of `Left`.
 -- | Otherwise, return what `Right` returns.
 assertRight :: Either (Error err) desired -> desired
 assertRight wrapped =
-    case wrapped of
-        Left err      -> error (printError err)
-        Right desired -> desired
+  case wrapped of
+    Left err -> error (printError err)
+    Right desired -> desired

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -9,87 +9,123 @@ Portability : portable
 Expose concrete execution as a library
 -}
 module Kore.Exec
-    ( exec
-    , execGetExitCode
-    , search
-    , prove
-    , proveWithRepl
-    , boundedModelCheck
-    , Rewrite
-    , Equality
-    ) where
+  ( exec,
+    execGetExitCode,
+    search,
+    prove,
+    proveWithRepl,
+    boundedModelCheck,
+    Rewrite,
+    Equality
+    )
+where
 
-import           Control.Concurrent.MVar
+import Control.Concurrent.MVar
 import qualified Control.Monad as Monad
-import           Control.Monad.IO.Unlift
-                 ( MonadUnliftIO )
-import           Control.Monad.Trans.Except
-                 ( runExceptT )
+import Control.Monad.IO.Unlift
+  ( MonadUnliftIO
+    )
+import Control.Monad.Trans.Except
+  ( runExceptT
+    )
 import qualified Data.Bifunctor as Bifunctor
-import           Data.Coerce
-                 ( Coercible, coerce )
+import Data.Coerce
+  ( Coercible,
+    coerce
+    )
+import Data.Limit
+  ( Limit (..)
+    )
 import qualified Data.Map.Strict as Map
-import           System.Exit
-                 ( ExitCode (..) )
-
-import           Data.Limit
-                 ( Limit (..) )
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
+import Kore.Attribute.Symbol
+  ( StepperAttributes
+    )
 import qualified Kore.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Goal as Goal
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
 import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
-                 ( build )
-import           Kore.IndexedModule.Resolvers
-                 ( resolveSymbol )
+  ( build
+    )
+import Kore.IndexedModule.Resolvers
+  ( resolveSymbol
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Logger as Log
 import qualified Kore.ModelChecker.Bounded as Bounded
-import           Kore.OnePath.Verification
-                 ( Claim, defaultStrategy, verify )
-import           Kore.Predicate.Predicate
-                 ( makeMultipleOrPredicate, unwrapPredicate )
-import           Kore.Profiler.Data
-                 ( MonadProfiler )
+import Kore.OnePath.Verification
+  ( Claim,
+    defaultStrategy,
+    verify
+    )
+import Kore.Predicate.Predicate
+  ( makeMultipleOrPredicate,
+    unwrapPredicate
+    )
+import Kore.Profiler.Data
+  ( MonadProfiler
+    )
 import qualified Kore.Repl as Repl
 import qualified Kore.Repl.Data as Repl.Data
-import           Kore.Step
-import           Kore.Step.Axiom.EvaluationStrategy
-                 ( builtinEvaluation, simplifierWithFallback )
-import           Kore.Step.Axiom.Registry
-                 ( axiomPatternsToEvaluators, extractEqualityAxioms )
-import           Kore.Step.Rule
-                 ( EqualityRule, ImplicationRule (..), OnePathRule (..),
-                 RewriteRule (RewriteRule), RulePattern (RulePattern),
-                 extractImplicationClaims, extractOnePathClaims,
-                 extractRewriteAxioms, getRewriteRule )
-import           Kore.Step.Rule as RulePattern
-                 ( RulePattern (..) )
-import           Kore.Step.Search
-                 ( searchGraph )
+import Kore.Step
+import Kore.Step.Axiom.EvaluationStrategy
+  ( builtinEvaluation,
+    simplifierWithFallback
+    )
+import Kore.Step.Axiom.Registry
+  ( axiomPatternsToEvaluators,
+    extractEqualityAxioms
+    )
+import Kore.Step.Rule
+  ( EqualityRule,
+    ImplicationRule (..),
+    OnePathRule (..),
+    RewriteRule (RewriteRule),
+    RulePattern (RulePattern),
+    extractImplicationClaims,
+    extractOnePathClaims,
+    extractRewriteAxioms,
+    getRewriteRule
+    )
+import Kore.Step.Rule as RulePattern
+  ( RulePattern (..)
+    )
+import Kore.Step.Search
+  ( searchGraph
+    )
 import qualified Kore.Step.Search as Search
-import           Kore.Step.Simplification.Data
-                 ( BuiltinAndAxiomSimplifierMap, MonadSimplify,
-                 PredicateSimplifier (..), TermLikeSimplifier, evalSimplifier )
+import Kore.Step.Simplification.Data
+  ( BuiltinAndAxiomSimplifierMap,
+    MonadSimplify,
+    PredicateSimplifier (..),
+    TermLikeSimplifier,
+    evalSimplifier
+    )
 import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Pattern as Pattern
 import qualified Kore.Step.Simplification.Predicate as Predicate
 import qualified Kore.Step.Simplification.Rule as Rule
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
-                 ( create )
+  ( create
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           SMT
-                 ( MonadSMT, SMT )
+import SMT
+  ( MonadSMT,
+    SMT
+    )
+import System.Exit
+  ( ExitCode (..)
+    )
 
 -- | Configuration used in symbolic execution.
 type Config = Pattern Variable
@@ -103,63 +139,62 @@ type Equality = EqualityRule Variable
 type ExecutionGraph = Strategy.ExecutionGraph Config (RewriteRule Variable)
 
 -- | A collection of rules and simplifiers used during execution.
-data Initialized =
-    Initialized
-        { rewriteRules :: ![Rewrite]
-        , simplifier :: !TermLikeSimplifier
-        , substitutionSimplifier :: !PredicateSimplifier
-        , axiomIdToSimplifier :: !BuiltinAndAxiomSimplifierMap
+data Initialized
+  = Initialized
+      { rewriteRules :: ![Rewrite],
+        simplifier :: !TermLikeSimplifier,
+        substitutionSimplifier :: !PredicateSimplifier,
+        axiomIdToSimplifier :: !BuiltinAndAxiomSimplifierMap
         }
 
 -- | The products of execution: an execution graph, and assorted simplifiers.
-data Execution =
-    Execution
-        { simplifier :: !TermLikeSimplifier
-        , substitutionSimplifier :: !PredicateSimplifier
-        , axiomIdToSimplifier :: !BuiltinAndAxiomSimplifierMap
-        , executionGraph :: !ExecutionGraph
+data Execution
+  = Execution
+      { simplifier :: !TermLikeSimplifier,
+        substitutionSimplifier :: !PredicateSimplifier,
+        axiomIdToSimplifier :: !BuiltinAndAxiomSimplifierMap,
+        executionGraph :: !ExecutionGraph
         }
 
 -- | Symbolic execution
 exec
-    ::  ( Log.WithLog Log.LogMessage smt
-        , MonadProfiler smt
-        , MonadSMT smt
-        , MonadUnliftIO smt
-        )
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> ([Rewrite] -> [Strategy (Prim Rewrite)])
-    -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
-    -> TermLike Variable
-    -- ^ The input pattern
-    -> smt (TermLike Variable)
+  :: ( Log.WithLog Log.LogMessage smt,
+       MonadProfiler smt,
+       MonadSMT smt,
+       MonadUnliftIO smt
+       )
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> ([Rewrite] -> [Strategy (Prim Rewrite)])
+  -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
+  -> TermLike Variable
+  -- ^ The input pattern
+  -> smt (TermLike Variable)
 exec indexedModule strategy initialTerm =
-    evalSimplifier env $ do
-        execution <- execute indexedModule' strategy initialTerm
-        let
-            Execution { executionGraph } = execution
-            finalConfig = pickLongest executionGraph
-            finalTerm =
-                forceSort patternSort
-                $ Pattern.toTermLike finalConfig
-        return finalTerm
+  evalSimplifier env $ do
+    execution <- execute indexedModule' strategy initialTerm
+    let Execution {executionGraph} = execution
+        finalConfig = pickLongest executionGraph
+        finalTerm =
+          forceSort patternSort
+            $ Pattern.toTermLike finalConfig
+    return finalTerm
   where
     indexedModule' =
-        IndexedModule.mapPatterns
-            (Builtin.internalize metadataTools)
-            indexedModule
+      IndexedModule.mapPatterns
+        (Builtin.internalize metadataTools)
+        indexedModule
     -- It's safe to build the MetadataTools using the external IndexedModule
     -- because MetadataTools doesn't retain any knowledge of the patterns which
     -- are internalized.
     metadataTools = MetadataTools.build indexedModule
     env =
-        Simplifier.Env
-            { metadataTools
-            , simplifierTermLike = emptyTermLikeSimplifier
-            , simplifierPredicate = emptyPredicateSimplifier
-            , simplifierAxioms = emptyAxiomSimplifiers
-            }
+      Simplifier.Env
+        { metadataTools,
+          simplifierTermLike = emptyTermLikeSimplifier,
+          simplifierPredicate = emptyPredicateSimplifier,
+          simplifierAxioms = emptyAxiomSimplifiers
+          }
     patternSort = termLikeSort initialTerm
 
 emptyAxiomSimplifiers :: BuiltinAndAxiomSimplifierMap
@@ -173,289 +208,281 @@ emptyPredicateSimplifier = Predicate.create
 
 -- | Project the value of the exit cell, if it is present.
 execGetExitCode
-    ::  ( Log.WithLog Log.LogMessage smt
-        , MonadProfiler smt
-        , MonadSMT smt
-        , MonadUnliftIO smt
-        )
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> ([Rewrite] -> [Strategy (Prim Rewrite)])
-    -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
-    -> TermLike Variable
-    -- ^ The final pattern (top cell) to extract the exit code
-    -> smt ExitCode
+  :: ( Log.WithLog Log.LogMessage smt,
+       MonadProfiler smt,
+       MonadSMT smt,
+       MonadUnliftIO smt
+       )
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> ([Rewrite] -> [Strategy (Prim Rewrite)])
+  -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
+  -> TermLike Variable
+  -- ^ The final pattern (top cell) to extract the exit code
+  -> smt ExitCode
 execGetExitCode indexedModule strategy' finalTerm =
-    case resolveSymbol indexedModule $ noLocationId "LblgetExitCode" of
-        Left _ -> return ExitSuccess
-        Right (_,  exitCodeSymbol) -> do
-            exitCodePattern <-
-                -- TODO (thomas.tuegel): Run in original execution context.
-                exec indexedModule strategy'
-                $ applySymbol_ exitCodeSymbol [finalTerm]
-            case exitCodePattern of
-                Builtin_ (Domain.BuiltinInt (Domain.InternalInt _ exit))
-                  | exit == 0 -> return ExitSuccess
-                  | otherwise -> return $ ExitFailure $ fromInteger exit
-                _ -> return $ ExitFailure 111
+  case resolveSymbol indexedModule $ noLocationId "LblgetExitCode" of
+    Left _ -> return ExitSuccess
+    Right (_, exitCodeSymbol) -> do
+      exitCodePattern <-
+        -- TODO (thomas.tuegel): Run in original execution context.
+        exec indexedModule strategy'
+          $ applySymbol_ exitCodeSymbol [finalTerm]
+      case exitCodePattern of
+        Builtin_ (Domain.BuiltinInt (Domain.InternalInt _ exit))
+          | exit == 0 -> return ExitSuccess
+          | otherwise -> return $ ExitFailure $ fromInteger exit
+        _ -> return $ ExitFailure 111
 
 -- | Symbolic search
 search
-    :: (Log.WithLog Log.LogMessage smt, MonadProfiler smt, MonadSMT smt, MonadUnliftIO smt)
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> ([Rewrite] -> [Strategy (Prim Rewrite)])
-    -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
-    -> TermLike Variable
-    -- ^ The input pattern
-    -> Pattern Variable
-    -- ^ The pattern to match during execution
-    -> Search.Config
-    -- ^ The bound on the number of search matches and the search type
-    -> smt (TermLike Variable)
+  :: (Log.WithLog Log.LogMessage smt, MonadProfiler smt, MonadSMT smt, MonadUnliftIO smt)
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> ([Rewrite] -> [Strategy (Prim Rewrite)])
+  -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
+  -> TermLike Variable
+  -- ^ The input pattern
+  -> Pattern Variable
+  -- ^ The pattern to match during execution
+  -> Search.Config
+  -- ^ The bound on the number of search matches and the search type
+  -> smt (TermLike Variable)
 search verifiedModule strategy termLike searchPattern searchConfig =
-    evalSimplifier env $ do
-        execution <- execute verifiedModule strategy termLike
-        let
-            Execution { executionGraph } = execution
-            match target config = Search.matchWith target config
-        solutionsLists <-
-            searchGraph searchConfig (match searchPattern) executionGraph
-        let
-            solutions = concatMap MultiOr.extractPatterns solutionsLists
-            orPredicate =
-                makeMultipleOrPredicate (Predicate.toPredicate <$> solutions)
-        return (forceSort patternSort $ unwrapPredicate orPredicate)
+  evalSimplifier env $ do
+    execution <- execute verifiedModule strategy termLike
+    let Execution {executionGraph} = execution
+        match target config = Search.matchWith target config
+    solutionsLists <-
+      searchGraph searchConfig (match searchPattern) executionGraph
+    let solutions = concatMap MultiOr.extractPatterns solutionsLists
+        orPredicate =
+          makeMultipleOrPredicate (Predicate.toPredicate <$> solutions)
+    return (forceSort patternSort $ unwrapPredicate orPredicate)
   where
     metadataTools = MetadataTools.build verifiedModule
     env =
-        Simplifier.Env
-            { metadataTools
-            , simplifierTermLike = emptyTermLikeSimplifier
-            , simplifierPredicate = emptyPredicateSimplifier
-            , simplifierAxioms = emptyAxiomSimplifiers
-            }
+      Simplifier.Env
+        { metadataTools,
+          simplifierTermLike = emptyTermLikeSimplifier,
+          simplifierPredicate = emptyPredicateSimplifier,
+          simplifierAxioms = emptyAxiomSimplifiers
+          }
     patternSort = termLikeSort termLike
-
 
 -- | Proving a spec given as a module containing rules to be proven
 prove
-    ::  ( Log.WithLog Log.LogMessage smt
-        , MonadProfiler smt
-        , MonadUnliftIO smt
-        , MonadSMT smt
-        )
-    => Limit Natural
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The spec module
-    -> smt (Either (TermLike Variable) ())
+  :: ( Log.WithLog Log.LogMessage smt,
+       MonadProfiler smt,
+       MonadUnliftIO smt,
+       MonadSMT smt
+       )
+  => Limit Natural
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The spec module
+  -> smt (Either (TermLike Variable) ())
 prove limit definitionModule specModule =
-    evalSimplifier env $ initialize definitionModule $ \initialized -> do
-        let Initialized { rewriteRules } = initialized
-            specClaims = extractOnePathClaims specModule
-        specAxioms <- traverse simplifyRuleOnSecond specClaims
-        assertSomeClaims specAxioms
-        let
-            axioms = Goal.Rule <$> rewriteRules
-            claims = makeClaim <$> specAxioms
-        result <-
-            runExceptT
-            $ verify
-                (defaultStrategy claims axioms)
-                (map (\x -> (x,limit)) (extractUntrustedClaims' claims))
-        return $ Bifunctor.first Pattern.toTermLike result
+  evalSimplifier env $ initialize definitionModule $ \initialized -> do
+    let Initialized {rewriteRules} = initialized
+        specClaims = extractOnePathClaims specModule
+    specAxioms <- traverse simplifyRuleOnSecond specClaims
+    assertSomeClaims specAxioms
+    let axioms = Goal.Rule <$> rewriteRules
+        claims = makeClaim <$> specAxioms
+    result <-
+      runExceptT
+        $ verify
+            (defaultStrategy claims axioms)
+            (map (\x -> (x, limit)) (extractUntrustedClaims' claims))
+    return $ Bifunctor.first Pattern.toTermLike result
   where
     metadataTools = MetadataTools.build definitionModule
     env =
-        Simplifier.Env
-            { metadataTools
-            , simplifierTermLike = emptyTermLikeSimplifier
-            , simplifierPredicate = emptyPredicateSimplifier
-            , simplifierAxioms = emptyAxiomSimplifiers
-            }
+      Simplifier.Env
+        { metadataTools,
+          simplifierTermLike = emptyTermLikeSimplifier,
+          simplifierPredicate = emptyPredicateSimplifier,
+          simplifierAxioms = emptyAxiomSimplifiers
+          }
     extractUntrustedClaims' :: [OnePathRule Variable] -> [OnePathRule Variable]
     extractUntrustedClaims' =
-        filter (not . Goal.isTrusted)
+      filter (not . Goal.isTrusted)
 
 -- | Initialize and run the repl with the main and spec modules. This will loop
 -- the repl until the user exits.
 proveWithRepl
-    :: VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The spec module
-    -> MVar (Log.LogAction IO Log.LogMessage)
-    -> Repl.Data.ReplScript
-    -- ^ Optional script
-    -> Repl.Data.ReplMode
-    -- ^ Run in a specific repl mode
-    -> Repl.Data.OutputFile
-    -- ^ Optional Output file
-    -> SMT ()
+  :: VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The spec module
+  -> MVar (Log.LogAction IO Log.LogMessage)
+  -> Repl.Data.ReplScript
+  -- ^ Optional script
+  -> Repl.Data.ReplMode
+  -- ^ Run in a specific repl mode
+  -> Repl.Data.OutputFile
+  -- ^ Optional Output file
+  -> SMT ()
 proveWithRepl definitionModule specModule mvar replScript replMode outputFile =
-    evalSimplifier env $ initialize definitionModule $ \initialized -> do
-        let Initialized { rewriteRules } = initialized
-            specClaims = extractOnePathClaims specModule
-        specAxioms <- traverse simplifyRuleOnSecond specClaims
-        assertSomeClaims specAxioms
-        let
-            axioms = Goal.Rule <$> rewriteRules
-            claims = fmap makeClaim specAxioms
-        Repl.runRepl axioms claims mvar replScript replMode outputFile
+  evalSimplifier env $ initialize definitionModule $ \initialized -> do
+    let Initialized {rewriteRules} = initialized
+        specClaims = extractOnePathClaims specModule
+    specAxioms <- traverse simplifyRuleOnSecond specClaims
+    assertSomeClaims specAxioms
+    let axioms = Goal.Rule <$> rewriteRules
+        claims = fmap makeClaim specAxioms
+    Repl.runRepl axioms claims mvar replScript replMode outputFile
   where
     metadataTools = MetadataTools.build definitionModule
     env =
-        Simplifier.Env
-            { metadataTools
-            , simplifierTermLike = emptyTermLikeSimplifier
-            , simplifierPredicate = emptyPredicateSimplifier
-            , simplifierAxioms = emptyAxiomSimplifiers
-            }
+      Simplifier.Env
+        { metadataTools,
+          simplifierTermLike = emptyTermLikeSimplifier,
+          simplifierPredicate = emptyPredicateSimplifier,
+          simplifierAxioms = emptyAxiomSimplifiers
+          }
 
 -- | Bounded model check a spec given as a module containing rules to be checked
 boundedModelCheck
-    ::  ( Log.WithLog Log.LogMessage smt
-        , MonadProfiler smt
-        , MonadSMT smt
-        , MonadUnliftIO smt
-        )
-    => Limit Natural
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The spec module
-    -> Strategy.GraphSearchOrder
-    -> smt (Bounded.CheckResult (TermLike Variable))
+  :: ( Log.WithLog Log.LogMessage smt,
+       MonadProfiler smt,
+       MonadSMT smt,
+       MonadUnliftIO smt
+       )
+  => Limit Natural
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The spec module
+  -> Strategy.GraphSearchOrder
+  -> smt (Bounded.CheckResult (TermLike Variable))
 boundedModelCheck limit definitionModule specModule searchOrder =
-    evalSimplifier env $ initialize definitionModule $ \initialized -> do
-        let Initialized { rewriteRules } = initialized
-            specClaims = extractImplicationClaims specModule
-        assertSomeClaims specClaims
-        assertSingleClaim specClaims
-        let
-            axioms = fmap Bounded.Axiom rewriteRules
-            claims = fmap makeClaim specClaims
-
-        Bounded.checkClaim
-            (Bounded.bmcStrategy axioms)
-            searchOrder
-            (head claims, limit)
+  evalSimplifier env $ initialize definitionModule $ \initialized -> do
+    let Initialized {rewriteRules} = initialized
+        specClaims = extractImplicationClaims specModule
+    assertSomeClaims specClaims
+    assertSingleClaim specClaims
+    let axioms = fmap Bounded.Axiom rewriteRules
+        claims = fmap makeClaim specClaims
+    Bounded.checkClaim
+      (Bounded.bmcStrategy axioms)
+      searchOrder
+      (head claims, limit)
   where
     metadataTools = MetadataTools.build definitionModule
     env =
-        Simplifier.Env
-            { metadataTools
-            , simplifierTermLike = emptyTermLikeSimplifier
-            , simplifierPredicate = emptyPredicateSimplifier
-            , simplifierAxioms = emptyAxiomSimplifiers
-            }
+      Simplifier.Env
+        { metadataTools,
+          simplifierTermLike = emptyTermLikeSimplifier,
+          simplifierPredicate = emptyPredicateSimplifier,
+          simplifierAxioms = emptyAxiomSimplifiers
+          }
 
 assertSingleClaim :: Monad m => [claim] -> m ()
 assertSingleClaim claims =
-    Monad.when (length claims > 1) . error
-        $ "More than one claim is found in the module."
+  Monad.when (length claims > 1) . error
+    $ "More than one claim is found in the module."
 
 assertSomeClaims :: Monad m => [claim] -> m ()
 assertSomeClaims claims =
-    Monad.when (null claims) . error
-        $   "Unexpected empty set of claims.\n"
-        ++  "Possible explanation: the frontend and the backend don't agree "
-        ++  "on the representation of claims."
+  Monad.when (null claims) . error
+    $ "Unexpected empty set of claims.\n"
+    ++ "Possible explanation: the frontend and the backend don't agree "
+    ++ "on the representation of claims."
 
 makeClaim
-    :: Coercible (RulePattern Variable) claim
-    => (Attribute.Axiom, claim) -> claim
+  :: Coercible (RulePattern Variable) claim
+  => (Attribute.Axiom, claim)
+  -> claim
 makeClaim (attributes, rule) =
-    coerce RulePattern
-        { attributes = attributes
-        , left = left . coerce $ rule
-        , right = right . coerce $ rule
-        , requires = requires . coerce $ rule
-        , ensures = ensures . coerce $ rule
-        }
+  coerce RulePattern
+    { attributes = attributes,
+      left = left . coerce $ rule,
+      right = right . coerce $ rule,
+      requires = requires . coerce $ rule,
+      ensures = ensures . coerce $ rule
+      }
 
 simplifyRuleOnSecond
-    :: (MonadSimplify simplifier, Claim claim)
-    => (Attribute.Axiom, claim)
-    -> simplifier (Attribute.Axiom, claim)
+  :: (MonadSimplify simplifier, Claim claim)
+  => (Attribute.Axiom, claim)
+  -> simplifier (Attribute.Axiom, claim)
 simplifyRuleOnSecond (atts, rule) = do
-    rule' <- Rule.simplifyRewriteRule (RewriteRule . coerce $ rule)
-    return (atts, coerce . getRewriteRule $ rule')
+  rule' <- Rule.simplifyRewriteRule (RewriteRule . coerce $ rule)
+  return (atts, coerce . getRewriteRule $ rule')
 
 -- | Construct an execution graph for the given input pattern.
 execute
-    :: MonadSimplify simplifier
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -- ^ The main module
-    -> ([Rewrite] -> [Strategy (Prim Rewrite)])
-    -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
-    -> TermLike Variable
-    -- ^ The input pattern
-    -> simplifier Execution
+  :: MonadSimplify simplifier
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -- ^ The main module
+  -> ([Rewrite] -> [Strategy (Prim Rewrite)])
+  -- ^ The strategy to use for execution; see examples in "Kore.Step.Step"
+  -> TermLike Variable
+  -- ^ The input pattern
+  -> simplifier Execution
 execute verifiedModule strategy inputPattern =
-    Log.withLogScope "setUpConcreteExecution"
-    $ initialize verifiedModule $ \initialized -> do
-        let
-            Initialized { rewriteRules } = initialized
-            Initialized { simplifier } = initialized
-            Initialized { substitutionSimplifier } = initialized
-            Initialized { axiomIdToSimplifier } = initialized
-        simplifiedPatterns <-
-            Pattern.simplify (Pattern.fromTermLike inputPattern)
-        let
-            initialPattern =
-                case MultiOr.extractPatterns simplifiedPatterns of
-                    [] -> Pattern.bottomOf patternSort
-                    (config : _) -> config
-              where
-                patternSort = termLikeSort inputPattern
-            runStrategy' = runStrategy transitionRule (strategy rewriteRules)
-        executionGraph <- runStrategy' initialPattern
-        return Execution
-            { simplifier
-            , substitutionSimplifier
-            , axiomIdToSimplifier
-            , executionGraph
-            }
+  Log.withLogScope "setUpConcreteExecution"
+    $ initialize verifiedModule
+    $ \initialized -> do
+      let Initialized {rewriteRules} = initialized
+          Initialized {simplifier} = initialized
+          Initialized {substitutionSimplifier} = initialized
+          Initialized {axiomIdToSimplifier} = initialized
+      simplifiedPatterns <-
+        Pattern.simplify (Pattern.fromTermLike inputPattern)
+      let initialPattern =
+            case MultiOr.extractPatterns simplifiedPatterns of
+              [] -> Pattern.bottomOf patternSort
+              (config : _) -> config
+            where
+              patternSort = termLikeSort inputPattern
+          runStrategy' = runStrategy transitionRule (strategy rewriteRules)
+      executionGraph <- runStrategy' initialPattern
+      return Execution
+        { simplifier,
+          substitutionSimplifier,
+          axiomIdToSimplifier,
+          executionGraph
+          }
 
 -- | Collect various rules and simplifiers in preparation to execute.
 initialize
-    :: MonadSimplify simplifier
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -> (Initialized -> simplifier a)
-    -> simplifier a
+  :: MonadSimplify simplifier
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -> (Initialized -> simplifier a)
+  -> simplifier a
 initialize verifiedModule within = do
-    functionAxioms <-
-        Rule.simplifyFunctionAxioms (extractEqualityAxioms verifiedModule)
-    rewriteRules <-
-        mapM Rule.simplifyRewriteRule (extractRewriteAxioms verifiedModule)
-    let
-        functionEvaluators :: BuiltinAndAxiomSimplifierMap
-        functionEvaluators =
-            axiomPatternsToEvaluators functionAxioms
-        axiomIdToSimplifier :: BuiltinAndAxiomSimplifierMap
-        axiomIdToSimplifier =
-            Map.unionWith
-                simplifierWithFallback
-                -- builtin functions
-                (Map.map builtinEvaluation
-                    (Builtin.koreEvaluators verifiedModule)
-                )
-                -- user-defined functions
-                functionEvaluators
-        simplifier = Simplifier.create
-        substitutionSimplifier = Predicate.create
-        initialized =
-            Initialized
-                { rewriteRules
-                , simplifier
-                , substitutionSimplifier
-                , axiomIdToSimplifier
-                }
-        locally =
-            Simplifier.localSimplifierTermLike (const simplifier)
-            . Simplifier.localSimplifierPredicate (const substitutionSimplifier)
-            . Simplifier.localSimplifierAxioms (const axiomIdToSimplifier)
-    locally (within initialized)
+  functionAxioms <-
+    Rule.simplifyFunctionAxioms (extractEqualityAxioms verifiedModule)
+  rewriteRules <-
+    mapM Rule.simplifyRewriteRule (extractRewriteAxioms verifiedModule)
+  let functionEvaluators :: BuiltinAndAxiomSimplifierMap
+      functionEvaluators =
+        axiomPatternsToEvaluators functionAxioms
+      axiomIdToSimplifier :: BuiltinAndAxiomSimplifierMap
+      axiomIdToSimplifier =
+        Map.unionWith
+          simplifierWithFallback
+          -- builtin functions
+          ( Map.map builtinEvaluation
+              (Builtin.koreEvaluators verifiedModule)
+            )
+          -- user-defined functions
+          functionEvaluators
+      simplifier = Simplifier.create
+      substitutionSimplifier = Predicate.create
+      initialized =
+        Initialized
+          { rewriteRules,
+            simplifier,
+            substitutionSimplifier,
+            axiomIdToSimplifier
+            }
+      locally =
+        Simplifier.localSimplifierTermLike (const simplifier)
+          . Simplifier.localSimplifierPredicate (const substitutionSimplifier)
+          . Simplifier.localSimplifierAxioms (const axiomIdToSimplifier)
+  locally (within initialized)

--- a/kore/src/Kore/Goal.hs
+++ b/kore/src/Kore/Goal.hs
@@ -4,65 +4,79 @@ License     : NCSA
 -}
 module Kore.Goal where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Control.Monad.Trans as Monad.Trans
-import           Data.Coerce
-                 ( Coercible, coerce )
+import Data.Coerce
+  ( Coercible,
+    coerce
+    )
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
-import           Data.Hashable
-import           Data.Maybe
-                 ( mapMaybe )
+import Data.Hashable
+import Data.Maybe
+  ( mapMaybe
+    )
 import qualified Data.Set as Set
 import qualified Data.Text.Prettyprint.Doc as Pretty
+import GHC.Generics as GHC
 import qualified Generics.SOP as SOP
-import           GHC.Generics as GHC
-
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Attribute.Trusted as Trusted
-import           Kore.Debug
+import Kore.Debug
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( Predicate )
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Predicate
 import qualified Kore.Step.Result as Result
-import           Kore.Step.Rule
-                 ( OnePathRule (..), RewriteRule (..), RulePattern (..) )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
-import           Kore.Step.Simplification.Pattern
-                 ( simplifyAndRemoveTopExists )
+import Kore.Step.Rule
+  ( OnePathRule (..),
+    RewriteRule (..),
+    RulePattern (..)
+    )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
+import Kore.Step.Simplification.Pattern
+  ( simplifyAndRemoveTopExists
+    )
 import qualified Kore.Step.Step as Step
-import           Kore.Step.Strategy
-                 ( Strategy )
+import Kore.Step.Strategy
+  ( Strategy
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.TopBottom
+import Kore.TopBottom
 import qualified Kore.Unification.Procedure as Unification
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse, unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
-import           Kore.Variables.UnifiedVariable
+import Kore.Unparser
+  ( Unparse,
+    unparse
+    )
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
+import Kore.Variables.UnifiedVariable
 
 {- | The state of the all-path reachability proof strategy for @goal@.
  -}
 data ProofState goal
-    = Goal goal
+  = Goal goal
     -- ^ The indicated goal is being proven.
-    | GoalRem goal
+  | GoalRem goal
     -- ^ The indicated goal remains after rewriting.
-    | Proven
+  | Proven
     -- ^ The parent goal was proven.
-    deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic)
 
 instance Hashable goal => Hashable (ProofState goal)
 
@@ -72,13 +86,13 @@ Returns 'Nothing' if there is no remaining unproven goal.
 
  -}
 extractUnproven :: ProofState goal -> Maybe goal
-extractUnproven (Goal t)    = Just t
+extractUnproven (Goal t) = Just t
 extractUnproven (GoalRem t) = Just t
-extractUnproven Proven      = Nothing
+extractUnproven Proven = Nothing
 
 extractGoalRem :: ProofState goal -> Maybe goal
 extractGoalRem (GoalRem t) = Just t
-extractGoalRem _           = Nothing
+extractGoalRem _ = Nothing
 
 {- | The final nodes of an execution graph which were not proven.
 
@@ -86,10 +100,10 @@ See also: 'Strategy.pickFinal', 'extractUnproven'
 
  -}
 unprovenNodes
-    :: Strategy.ExecutionGraph (ProofState goal) rule
-    -> MultiOr.MultiOr goal
+  :: Strategy.ExecutionGraph (ProofState goal) rule
+  -> MultiOr.MultiOr goal
 unprovenNodes executionGraph =
-    MultiOr.MultiOr
+  MultiOr.MultiOr
     $ mapMaybe extractUnproven
     $ Strategy.pickFinal executionGraph
 
@@ -98,198 +112,197 @@ unprovenNodes executionGraph =
 proven :: Strategy.ExecutionGraph (ProofState goal) rule -> Bool
 proven = Foldable.null . unprovenNodes
 
-data ProofStateTransformer goal a =
-    ProofStateTransformer
-        { goalTransformer :: goal -> a
-        , goalRemTransformer :: goal -> a
-        , provenValue :: a
+data ProofStateTransformer goal a
+  = ProofStateTransformer
+      { goalTransformer :: goal -> a,
+        goalRemTransformer :: goal -> a,
+        provenValue :: a
         }
 
 {- | Catamorphism for 'ProofState'
 -}
 proofState
-    :: ProofStateTransformer goal a
-    -> ProofState goal
-    -> a
+  :: ProofStateTransformer goal a
+  -> ProofState goal
+  -> a
 proofState
-    ProofStateTransformer
-        {goalTransformer, goalRemTransformer, provenValue}
-  =
+  ProofStateTransformer
+    { goalTransformer,
+      goalRemTransformer,
+      provenValue
+      } =
     \case
-        Goal goal -> goalTransformer goal
-        GoalRem goal -> goalRemTransformer goal
-        Proven -> provenValue
+      Goal goal -> goalTransformer goal
+      GoalRem goal -> goalRemTransformer goal
+      Proven -> provenValue
 
 {- | The primitive transitions of the all-path reachability proof strategy.
  -}
 data Prim rule
-    = CheckProven
+  = CheckProven
     -- ^ End execution on this branch if the state is 'Proven'.
-    | CheckGoalRem
+  | CheckGoalRem
     -- ^ End execution on this branch if the state is 'GoalRem'.
-    | Simplify
-    | RemoveDestination
-    | TriviallyValid
-    | DerivePar [rule]
-    | DeriveSeq [rule]
-    deriving (Show)
+  | Simplify
+  | RemoveDestination
+  | TriviallyValid
+  | DerivePar [rule]
+  | DeriveSeq [rule]
+  deriving (Show)
 
 class Goal goal where
-    data Rule goal
 
-    -- | Remove the destination of the goal.
-    removeDestination
-        :: MonadSimplify m
-        => goal
-        -> Strategy.TransitionT (Rule goal) m goal
+  data Rule goal
 
-    simplify
-        :: MonadSimplify m
-        => goal
-        -> Strategy.TransitionT (Rule goal) m goal
+  -- | Remove the destination of the goal.
+  removeDestination
+    :: MonadSimplify m
+    => goal
+    -> Strategy.TransitionT (Rule goal) m goal
 
-    isTriviallyValid :: goal -> Bool
+  simplify
+    :: MonadSimplify m
+    => goal
+    -> Strategy.TransitionT (Rule goal) m goal
 
-    isTrusted :: goal -> Bool
+  isTriviallyValid :: goal -> Bool
 
-    -- | Apply 'Rule's in to the goal in parallel.
-    derivePar
-        :: MonadSimplify m
-        => [Rule goal]
-        -> goal
-        -> Strategy.TransitionT (Rule goal) m (ProofState goal)
+  isTrusted :: goal -> Bool
 
-    -- | Apply 'Rule's in to the goal in sequence.
-    deriveSeq
-        :: MonadSimplify m
-        => [Rule goal]
-        -> goal
-        -> Strategy.TransitionT (Rule goal) m (ProofState goal)
+  -- | Apply 'Rule's in to the goal in parallel.
+  derivePar
+    :: MonadSimplify m
+    => [Rule goal]
+    -> goal
+    -> Strategy.TransitionT (Rule goal) m (ProofState goal)
+
+  -- | Apply 'Rule's in to the goal in sequence.
+  deriveSeq
+    :: MonadSimplify m
+    => [Rule goal]
+    -> goal
+    -> Strategy.TransitionT (Rule goal) m (ProofState goal)
 
 transitionRule
-    :: (MonadSimplify m, Goal goal)
-    => Prim (Rule goal)
-    -> ProofState goal
-    -> Strategy.TransitionT (Rule goal) m (ProofState goal)
+  :: (MonadSimplify m, Goal goal)
+  => Prim (Rule goal)
+  -> ProofState goal
+  -> Strategy.TransitionT (Rule goal) m (ProofState goal)
 transitionRule = transitionRuleWorker
   where
     transitionRuleWorker CheckProven Proven = empty
     transitionRuleWorker CheckGoalRem (GoalRem _) = empty
-
     transitionRuleWorker Simplify (Goal g) =
-        Goal <$> simplify g
+      Goal <$> simplify g
     transitionRuleWorker Simplify (GoalRem g) =
-        GoalRem <$> simplify g
-
+      GoalRem <$> simplify g
     transitionRuleWorker RemoveDestination (Goal g) =
-        GoalRem <$> removeDestination g
-
+      GoalRem <$> removeDestination g
     transitionRuleWorker TriviallyValid (Goal g)
       | isTriviallyValid g = return Proven
     transitionRuleWorker TriviallyValid (GoalRem g)
       | isTriviallyValid g = return Proven
-
     transitionRuleWorker (DerivePar rules) (GoalRem g) =
-        derivePar rules g
-
+      derivePar rules g
     transitionRuleWorker (DeriveSeq rules) (GoalRem g) =
-        deriveSeq rules g
-
+      deriveSeq rules g
     transitionRuleWorker _ state = return state
 
 allPathStrategy
-    :: [rule]
-    -- ^ Claims
-    -> [rule]
-    -- ^ Axioms
-    -> [Strategy (Prim rule)]
+  :: [rule]
+  -- ^ Claims
+  -> [rule]
+  -- ^ Axioms
+  -> [Strategy (Prim rule)]
 allPathStrategy claims axioms =
-    firstStep : repeat nextStep
+  firstStep : repeat nextStep
   where
     firstStep =
-        (Strategy.sequence . map Strategy.apply)
-            [ CheckProven
-            , CheckGoalRem
-            , RemoveDestination
-            , TriviallyValid
-            , DerivePar axioms
-            , TriviallyValid
-            ]
+      (Strategy.sequence . map Strategy.apply)
+        [ CheckProven,
+          CheckGoalRem,
+          RemoveDestination,
+          TriviallyValid,
+          DerivePar axioms,
+          TriviallyValid
+          ]
     nextStep =
-        (Strategy.sequence . map Strategy.apply)
-            [ CheckProven
-            , CheckGoalRem
-            , RemoveDestination
-            , TriviallyValid
-            , DeriveSeq claims
-            , DerivePar axioms
-            , TriviallyValid
-            ]
+      (Strategy.sequence . map Strategy.apply)
+        [ CheckProven,
+          CheckGoalRem,
+          RemoveDestination,
+          TriviallyValid,
+          DeriveSeq claims,
+          DerivePar axioms,
+          TriviallyValid
+          ]
 
 onePathFirstStep :: [rule] -> Strategy (Prim rule)
 onePathFirstStep axioms =
-    (Strategy.sequence . map Strategy.apply)
-        [ CheckProven
-        , CheckGoalRem
-        , Simplify
-        , TriviallyValid
-        , RemoveDestination
-        , Simplify
-        , TriviallyValid
-        , DeriveSeq axioms
-        , Simplify
-        , TriviallyValid
-        ]
+  (Strategy.sequence . map Strategy.apply)
+    [ CheckProven,
+      CheckGoalRem,
+      Simplify,
+      TriviallyValid,
+      RemoveDestination,
+      Simplify,
+      TriviallyValid,
+      DeriveSeq axioms,
+      Simplify,
+      TriviallyValid
+      ]
 
 onePathFollowupStep :: [rule] -> [rule] -> Strategy (Prim rule)
 onePathFollowupStep claims axioms =
-    (Strategy.sequence . map Strategy.apply)
-        [ CheckProven
-        , CheckGoalRem
-        , Simplify
-        , TriviallyValid
-        , RemoveDestination
-        , Simplify
-        , TriviallyValid
-        , DeriveSeq claims
-        , DeriveSeq axioms
-        , Simplify
-        , TriviallyValid
-        ]
+  (Strategy.sequence . map Strategy.apply)
+    [ CheckProven,
+      CheckGoalRem,
+      Simplify,
+      TriviallyValid,
+      RemoveDestination,
+      Simplify,
+      TriviallyValid,
+      DeriveSeq claims,
+      DeriveSeq axioms,
+      Simplify,
+      TriviallyValid
+      ]
 
 {- | The predicate to remove the destination from the present configuration.
  -}
 removalPredicate
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Pattern variable
-    -- ^ Destination
-    -> Pattern variable
-    -- ^ Current configuration
-    -> Predicate variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Pattern variable
+  -- ^ Destination
+  -> Pattern variable
+  -- ^ Current configuration
+  -> Predicate variable
 removalPredicate destination config =
-    let
-        -- The variables of the destination that are missing from the
-        -- configuration. These are the variables which should be existentially
-        -- quantified in the removal predicate.
-        configVariables =
-            FreeVariables.getFreeVariables $ Pattern.freeVariables config
-        destinationVariables =
-            FreeVariables.getFreeVariables $ Pattern.freeVariables destination
-        extraVariables = Set.toList
-            $ Set.difference destinationVariables configVariables
-        extraElementVariables = [v | ElemVar v <- extraVariables]
-        extraNonElemVariables = filter (not . isElemVar) extraVariables
-        quantifyPredicate = Predicate.makeMultipleExists extraElementVariables
-    in
-        if not (null extraNonElemVariables)
-        then error
-            ("Cannot quantify non-element variables: "
-                ++ show (unparse <$> extraNonElemVariables))
-        else Predicate.makeNotPredicate
+  let -- The variables of the destination that are missing from the
+      -- configuration. These are the variables which should be existentially
+      -- quantified in the removal predicate.
+      configVariables =
+        FreeVariables.getFreeVariables $ Pattern.freeVariables config
+      destinationVariables =
+        FreeVariables.getFreeVariables $ Pattern.freeVariables destination
+      extraVariables =
+        Set.toList
+          $ Set.difference destinationVariables configVariables
+      extraElementVariables = [v | ElemVar v <- extraVariables]
+      extraNonElemVariables = filter (not . isElemVar) extraVariables
+      quantifyPredicate = Predicate.makeMultipleExists extraElementVariables
+   in if not (null extraNonElemVariables)
+        then
+          error
+            ( "Cannot quantify non-element variables: "
+                ++ show (unparse <$> extraNonElemVariables)
+              )
+        else
+          Predicate.makeNotPredicate
             $ quantifyPredicate
             $ Predicate.makeCeilPredicate
             $ mkAnd
@@ -297,129 +310,130 @@ removalPredicate destination config =
                 (Pattern.toTermLike config)
 
 instance
-    ( SortedVariable variable
-    , Debug variable
-    , Unparse variable
-    , Show variable
-    , FreshVariable variable
-    ) => Goal (OnePathRule variable) where
+  ( SortedVariable variable,
+    Debug variable,
+    Unparse variable,
+    Show variable,
+    FreshVariable variable
+    )
+  => Goal (OnePathRule variable)
+  where
 
-    newtype Rule (OnePathRule variable) =
-        Rule { unRule :: RewriteRule variable }
-        deriving (GHC.Generic, Show, Unparse)
+  newtype Rule (OnePathRule variable)
+    = Rule {unRule :: RewriteRule variable}
+    deriving (GHC.Generic, Show, Unparse)
 
-    isTrusted =
-        Trusted.isTrusted
-        . Attribute.trusted
-        . attributes
-        . coerce
+  isTrusted =
+    Trusted.isTrusted
+      . Attribute.trusted
+      . attributes
+      . coerce
 
-    removeDestination goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            removal = removalPredicate destination configuration
-            result = Conditional.andPredicate configuration removal
-        pure $ makeRuleFromPatterns result destination
+  removeDestination goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+        removal = removalPredicate destination configuration
+        result = Conditional.andPredicate configuration removal
+    pure $ makeRuleFromPatterns result destination
 
-    simplify goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-        configs <-
-            Monad.Trans.lift
-            $ simplifyAndRemoveTopExists configuration
-        filteredConfigs <- SMT.Evaluator.filterMultiOr configs
-        if null filteredConfigs
-           then pure $ makeRuleFromPatterns Pattern.bottom destination
-           else do
-               let simplifiedRules =
-                       fmap (flip makeRuleFromPatterns destination) filteredConfigs
-               Foldable.asum (pure <$> simplifiedRules)
+  simplify goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+    configs <-
+      Monad.Trans.lift
+        $ simplifyAndRemoveTopExists configuration
+    filteredConfigs <- SMT.Evaluator.filterMultiOr configs
+    if null filteredConfigs
+      then pure $ makeRuleFromPatterns Pattern.bottom destination
+      else do
+        let simplifiedRules =
+              fmap (flip makeRuleFromPatterns destination) filteredConfigs
+        Foldable.asum (pure <$> simplifiedRules)
 
+  isTriviallyValid =
+    isBottom . left . coerce
 
-    isTriviallyValid =
-        isBottom . left . coerce
-
-    derivePar rules goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            rewrites = unRule <$> rules
-        eitherResults <-
-            Monad.Trans.lift
-            . Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesParallel
-                (Step.UnificationProcedure Unification.unificationProcedure)
-                rewrites
-                configuration
-        case eitherResults of
-            Left err ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , Pretty.indent 4 (Pretty.pretty err)
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse configuration)
-                ,   "We decided to end the execution because we don't \
+  derivePar rules goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+        rewrites = unRule <$> rules
+    eitherResults <-
+      Monad.Trans.lift
+        . Monad.Unify.runUnifierT
+        $ Step.applyRewriteRulesParallel
+            (Step.UnificationProcedure Unification.unificationProcedure)
+            rewrites
+            configuration
+    case eitherResults of
+      Left err ->
+        (error . show . Pretty.vsep)
+          [ "Not implemented error:",
+            Pretty.indent 4 (Pretty.pretty err),
+            "while applying a \\rewrite axiom to the pattern:",
+            Pretty.indent 4 (unparse configuration),
+            "We decided to end the execution because we don't \
                     \understand this case well enough at the moment."
-                ]
-            Right results -> do
-                let mapRules =
-                        Result.mapRules
-                        $ Rule
-                        . RewriteRule
-                        . Step.unwrapRule
-                        . Step.withoutUnification
-                    traverseConfigs =
-                        Result.traverseConfigs
-                            (pure . Goal)
-                            removeDestSimplifyRemainder
-                let onePathResults =
-                        Result.mapConfigs
-                            (flip makeRuleFromPatterns $ destination)
-                            (flip makeRuleFromPatterns $ destination)
-                            (Result.mergeResults results)
-                results' <-
-                    traverseConfigs (mapRules onePathResults)
-                Result.transitionResults results'
+            ]
+      Right results -> do
+        let mapRules =
+              Result.mapRules
+                $ Rule
+                . RewriteRule
+                . Step.unwrapRule
+                . Step.withoutUnification
+            traverseConfigs =
+              Result.traverseConfigs
+                (pure . Goal)
+                removeDestSimplifyRemainder
+        let onePathResults =
+              Result.mapConfigs
+                (flip makeRuleFromPatterns $ destination)
+                (flip makeRuleFromPatterns $ destination)
+                (Result.mergeResults results)
+        results' <-
+          traverseConfigs (mapRules onePathResults)
+        Result.transitionResults results'
 
-    deriveSeq rules goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            rewrites = unRule <$> rules
-        eitherResults <-
-            Monad.Trans.lift
-            . Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesSequence
-                (Step.UnificationProcedure Unification.unificationProcedure)
-                configuration
-                rewrites
-        case eitherResults of
-            Left err ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , Pretty.indent 4 (Pretty.pretty err)
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse configuration)
-                ,   "We decided to end the execution because we don't \
+  deriveSeq rules goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+        rewrites = unRule <$> rules
+    eitherResults <-
+      Monad.Trans.lift
+        . Monad.Unify.runUnifierT
+        $ Step.applyRewriteRulesSequence
+            (Step.UnificationProcedure Unification.unificationProcedure)
+            configuration
+            rewrites
+    case eitherResults of
+      Left err ->
+        (error . show . Pretty.vsep)
+          [ "Not implemented error:",
+            Pretty.indent 4 (Pretty.pretty err),
+            "while applying a \\rewrite axiom to the pattern:",
+            Pretty.indent 4 (unparse configuration),
+            "We decided to end the execution because we don't \
                     \understand this case well enough at the moment."
-                ]
-            Right results -> do
-                let mapRules =
-                        Result.mapRules
-                        $ Rule
-                        . RewriteRule
-                        . Step.unwrapRule
-                        . Step.withoutUnification
-                    traverseConfigs =
-                        Result.traverseConfigs
-                            (pure . Goal)
-                            removeDestSimplifyRemainder
-                let onePathResults =
-                        Result.mapConfigs
-                            (flip makeRuleFromPatterns $ destination)
-                            (flip makeRuleFromPatterns $ destination)
-                            (Result.mergeResults results)
-                results' <-
-                    traverseConfigs (mapRules onePathResults)
-                Result.transitionResults results'
+            ]
+      Right results -> do
+        let mapRules =
+              Result.mapRules
+                $ Rule
+                . RewriteRule
+                . Step.unwrapRule
+                . Step.withoutUnification
+            traverseConfigs =
+              Result.traverseConfigs
+                (pure . Goal)
+                removeDestSimplifyRemainder
+        let onePathResults =
+              Result.mapConfigs
+                (flip makeRuleFromPatterns $ destination)
+                (flip makeRuleFromPatterns $ destination)
+                (Result.mergeResults results)
+        results' <-
+          traverseConfigs (mapRules onePathResults)
+        Result.transitionResults results'
 
 instance SOP.Generic (Rule (OnePathRule variable))
 
@@ -428,50 +442,46 @@ instance SOP.HasDatatypeInfo (Rule (OnePathRule variable))
 instance Debug variable => Debug (Rule (OnePathRule variable))
 
 removeDestSimplifyRemainder
-    :: forall variable m
-    .  MonadSimplify m
-    => SortedVariable variable
-    => Debug variable
-    => Unparse variable
-    => Show variable
-    => FreshVariable variable
-    => OnePathRule variable
-    -> Strategy.TransitionT (Rule (OnePathRule variable)) m (ProofState (OnePathRule variable))
+  :: forall variable m. MonadSimplify m
+  => SortedVariable variable
+  => Debug variable
+  => Unparse variable
+  => Show variable
+  => FreshVariable variable
+  => OnePathRule variable
+  -> Strategy.TransitionT (Rule (OnePathRule variable)) m (ProofState (OnePathRule variable))
 removeDestSimplifyRemainder remainder = do
-    result <- removeDestination remainder >>= simplify
-    if isTriviallyValid result
-       then pure Proven
-       else pure . GoalRem $ result
+  result <- removeDestination remainder >>= simplify
+  if isTriviallyValid result
+    then pure Proven
+    else pure . GoalRem $ result
 
 getConfiguration
-    :: forall rule variable
-    .  Ord variable
-    => Coercible rule (RulePattern variable)
-    => rule
-    -> Pattern variable
-getConfiguration (coerce -> RulePattern { left, requires }) =
-    Pattern.withCondition left (Conditional.fromPredicate requires)
+  :: forall rule variable. Ord variable
+  => Coercible rule (RulePattern variable)
+  => rule
+  -> Pattern variable
+getConfiguration (coerce -> RulePattern {left, requires}) =
+  Pattern.withCondition left (Conditional.fromPredicate requires)
 
 getDestination
-    :: forall rule variable
-    .  Ord variable
-    => Coercible rule (RulePattern variable)
-    => rule
-    -> Pattern variable
-getDestination (coerce -> RulePattern { right, ensures }) =
-    Pattern.withCondition right (Conditional.fromPredicate ensures)
+  :: forall rule variable. Ord variable
+  => Coercible rule (RulePattern variable)
+  => rule
+  -> Pattern variable
+getDestination (coerce -> RulePattern {right, ensures}) =
+  Pattern.withCondition right (Conditional.fromPredicate ensures)
 
 makeRuleFromPatterns
-    :: forall rule variable
-    .  Ord variable
-    => SortedVariable variable
-    => Unparse variable
-    => Show variable
-    => Coercible (RulePattern variable) rule
-    => Pattern variable
-    -> Pattern variable
-    -> rule
+  :: forall rule variable. Ord variable
+  => SortedVariable variable
+  => Unparse variable
+  => Show variable
+  => Coercible (RulePattern variable) rule
+  => Pattern variable
+  -> Pattern variable
+  -> rule
 makeRuleFromPatterns configuration destination =
-    let (left, Conditional.toPredicate -> requires) = Pattern.splitTerm configuration
-        (right, Conditional.toPredicate -> ensures) = Pattern.splitTerm destination
-    in coerce RulePattern { left, right, requires, ensures, attributes = Default.def }
+  let (left, Conditional.toPredicate -> requires) = Pattern.splitTerm configuration
+      (right, Conditional.toPredicate -> ensures) = Pattern.splitTerm destination
+   in coerce RulePattern {left, right, requires, ensures, attributes = Default.def}

--- a/kore/src/Kore/IndexedModule/Error.hs
+++ b/kore/src/Kore/IndexedModule/Error.hs
@@ -2,27 +2,27 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-
 module Kore.IndexedModule.Error
-    ( noSort
-    , noSortText
-    , noHead
-    , noAlias
-    , noAliasText
-    , noSymbol
-    , noSymbolText
-    ) where
+  ( noSort,
+    noSortText,
+    noHead,
+    noAlias,
+    noAliasText,
+    noSymbol,
+    noSymbolText
+    )
+where
 
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-
 import Kore.Syntax
 
 -- | A message declaring that a Sort is undefined
 noSort :: Id -> String
 noSort sortId =
-    notDefined "Sort" $ getIdForError sortId
+  notDefined "Sort" $ getIdForError sortId
 
 -- | A message declaring that a Sort is undefined
 noSortText :: Id -> Text
@@ -31,12 +31,12 @@ noSortText sortId = Text.pack (noSort sortId)
 -- | A message declaring that a Head is undefined
 noHead :: SymbolOrAlias -> String
 noHead patternHead =
-    notDefined "Head" . getIdForError . symbolOrAliasConstructor $ patternHead
+  notDefined "Head" . getIdForError . symbolOrAliasConstructor $ patternHead
 
 -- | A message declaring that a Alias is undefined
 noAlias :: Id -> String
 noAlias identifier =
-    notDefined "Alias" $ getIdForError identifier
+  notDefined "Alias" $ getIdForError identifier
 
 -- | A message declaring that a Alias is undefined
 noAliasText :: Id -> Text
@@ -45,7 +45,7 @@ noAliasText identifier = Text.pack (noAlias identifier)
 -- | A message declaring that a Symbol is undefined
 noSymbol :: Id -> String
 noSymbol identifier =
-    notDefined "Symbol" $ getIdForError identifier
+  notDefined "Symbol" $ getIdForError identifier
 
 -- | A message declaring that a Symbol is undefined
 noSymbolText :: Id -> Text
@@ -54,4 +54,4 @@ noSymbolText identifier = Text.pack (noSymbol identifier)
 -- | A message declaring that some `tag` is undefined.
 notDefined :: String -> String -> String
 notDefined tag identifier =
-    tag ++ " '" ++ identifier ++ "' not defined."
+  tag ++ " '" ++ identifier ++ "' not defined."

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -7,89 +7,104 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : POSIX
 -}
-
 module Kore.IndexedModule.IndexedModule
-    ( ImplicitIndexedModule (ImplicitIndexedModule)
-    , IndexedModule
-        -- the IndexedModule data constructor not included in the list on
+  ( ImplicitIndexedModule (ImplicitIndexedModule),
+    IndexedModule
+      ( -- the IndexedModule data constructor not included in the list on
         -- purpose.
-        ( indexedModuleName, indexedModuleAliasSentences
-        , indexedModuleSymbolSentences
-        , indexedModuleSortDescriptions
-        , indexedModuleAxioms, indexedModuleClaims
-        , indexedModuleAttributes, indexedModuleImports
-        , indexedModuleHooks
-        )
-    , IndexModuleError
-    , KoreImplicitIndexedModule
-    , KoreIndexedModule
-    , VerifiedModule
-    , eraseAttributes
-    , eraseAxiomAttributes
-    , erasePatterns
-    , mapPatterns
-    , indexedModuleRawSentences
-    , indexModuleIfNeeded
-    , SortDescription
-    , getIndexedSentence
-    , hookedObjectSymbolSentences
-    , indexedModuleSubsorts
-    , indexedModulesInScope
-    , toVerifiedModule
-    , toVerifiedDefinition
-    , recursiveIndexedModuleAxioms
-    , recursiveIndexedModuleSortDescriptions
-    , recursiveIndexedModuleSymbolSentences
+        indexedModuleName,
+        indexedModuleAliasSentences,
+        indexedModuleSymbolSentences,
+        indexedModuleSortDescriptions,
+        indexedModuleAxioms,
+        indexedModuleClaims,
+        indexedModuleAttributes,
+        indexedModuleImports,
+        indexedModuleHooks
+        ),
+    IndexModuleError,
+    KoreImplicitIndexedModule,
+    KoreIndexedModule,
+    VerifiedModule,
+    eraseAttributes,
+    eraseAxiomAttributes,
+    erasePatterns,
+    mapPatterns,
+    indexedModuleRawSentences,
+    indexModuleIfNeeded,
+    SortDescription,
+    getIndexedSentence,
+    hookedObjectSymbolSentences,
+    indexedModuleSubsorts,
+    indexedModulesInScope,
+    toVerifiedModule,
+    toVerifiedDefinition,
+    recursiveIndexedModuleAxioms,
+    recursiveIndexedModuleSortDescriptions,
+    recursiveIndexedModuleSymbolSentences,
     -- * Implicit Kore
-    , implicitModuleName
-    , implicitNames
-    , implicitSortNames
-    , implicitIndexedModule
-    , implicitModules
-    ) where
+    implicitModuleName,
+    implicitNames,
+    implicitSortNames,
+    implicitIndexedModule,
+    implicitModules
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
-import           Control.Monad
-                 ( foldM )
-import           Control.Monad.Extra
-                 ( unlessM )
-import           Control.Monad.State.Strict
-                 ( execState )
+  ( makeLenses
+    )
+import Control.Monad
+  ( foldM
+    )
+import Control.Monad.Extra
+  ( unlessM
+    )
+import Control.Monad.State.Strict
+  ( execState
+    )
 import qualified Control.Monad.State.Strict as Monad.State
-import           Data.Default as Default
+import Data.Default as Default
 import qualified Data.Foldable as Foldable
-import           Data.Function
+import Data.Function
 import qualified Data.List as List
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
-import           GHC.Generics
-                 ( Generic )
-
-import           Kore.AST.Error
-import           Kore.Attribute.Hook
+import Data.Text
+  ( Text
+    )
+import GHC.Generics
+  ( Generic
+    )
+import Kore.AST.Error
+import Kore.Attribute.Hook
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Attribute.Parser
-                 ( ParseAttributes )
+import Kore.Attribute.Parser
+  ( ParseAttributes
+    )
 import qualified Kore.Attribute.Parser as Attribute.Parser
 import qualified Kore.Attribute.Sort as Attribute
-                 ( Sort )
-import           Kore.Attribute.Subsort
+  ( Sort
+    )
+import Kore.Attribute.Subsort
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
-import           Kore.Error
-import           Kore.Parser
-                 ( ParsedPattern )
-import           Kore.Syntax
-import           Kore.Syntax.Definition
+  ( Symbol
+    )
+import Kore.Error
+import Kore.Parser
+  ( ParsedPattern
+    )
+import Kore.Syntax
+import Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
 
 type SortDescription = SentenceSort (Pattern Variable Attribute.Null)
@@ -112,142 +127,135 @@ All 'IndexedModule' instances should either be returned by
 -}
 -- TODO (thomas.tuegel): Consider splitting IndexedModule into separate sort,
 -- symbol, and axiom indices.
-data IndexedModule pat declAtts axiomAtts =
-    IndexedModule
-    { indexedModuleName          :: !ModuleName
-    , indexedModuleAliasSentences
-        :: !(Map.Map Id (declAtts, SentenceAlias pat))
-    , indexedModuleSymbolSentences
-        :: !(Map.Map Id (declAtts, SentenceSymbol pat))
-    , indexedModuleSortDescriptions
-        :: !(Map.Map Id (Attribute.Sort, SentenceSort pat))
-    , indexedModuleAxioms :: ![(axiomAtts, SentenceAxiom pat)]
-    , indexedModuleClaims :: ![(axiomAtts, SentenceClaim pat)]
-    , indexedModuleAttributes :: !(declAtts, Attributes)
-    , indexedModuleImports
-        :: ![( declAtts
-             , Attributes
-             , IndexedModule pat declAtts axiomAtts
-             )
-            ]
-    , indexedModuleHookedIdentifiers
-        :: !(Set.Set Id)
+data IndexedModule pat declAtts axiomAtts
+  = IndexedModule
+      { indexedModuleName :: !ModuleName,
+        indexedModuleAliasSentences
+          :: !(Map.Map Id (declAtts, SentenceAlias pat)),
+        indexedModuleSymbolSentences
+          :: !(Map.Map Id (declAtts, SentenceSymbol pat)),
+        indexedModuleSortDescriptions
+          :: !(Map.Map Id (Attribute.Sort, SentenceSort pat)),
+        indexedModuleAxioms :: ![(axiomAtts, SentenceAxiom pat)],
+        indexedModuleClaims :: ![(axiomAtts, SentenceClaim pat)],
+        indexedModuleAttributes :: !(declAtts, Attributes),
+        indexedModuleImports
+          :: ![ ( declAtts,
+                  Attributes,
+                  IndexedModule pat declAtts axiomAtts
+                  )
+                ],
+        indexedModuleHookedIdentifiers
+          :: !(Set.Set Id),
         -- ^ set of hooked identifiers
-
-    -- TODO (thomas.tuegel): Having multiple identifiers hooked to the same
-    -- builtin is not actually valid, but the index must admit invalid data
-    -- because verification only happens after.
-    , indexedModuleHooks
-        :: !(Map.Map Text [Id])
+        -- TODO (thomas.tuegel): Having multiple identifiers hooked to the same
+        -- builtin is not actually valid, but the index must admit invalid data
+        -- because verification only happens after.
+        indexedModuleHooks
+          :: !(Map.Map Text [Id])
         -- ^ map from builtin domain (symbol and sort) identifiers to the hooked
         -- identifiers
-    }
-    deriving (Generic, Show)
+        }
+  deriving (Generic, Show)
 
 recursiveIndexedModuleSortDescriptions
-    :: forall pat declAtts axiomAtts
-    .  IndexedModule pat declAtts axiomAtts
-    -> Map.Map Id (Attribute.Sort, SentenceSort pat)
+  :: forall pat declAtts axiomAtts. IndexedModule pat declAtts axiomAtts
+  -> Map.Map Id (Attribute.Sort, SentenceSort pat)
 recursiveIndexedModuleSortDescriptions =
-    recursiveIndexedModuleStuff indexedModuleSortDescriptions
+  recursiveIndexedModuleStuff indexedModuleSortDescriptions
 
 recursiveIndexedModuleSymbolSentences
-    :: forall pat axiomAtts
-    .  IndexedModule pat Attribute.Symbol axiomAtts
-    -> Map.Map Id (Attribute.Symbol, SentenceSymbol pat)
+  :: forall pat axiomAtts. IndexedModule pat Attribute.Symbol axiomAtts
+  -> Map.Map Id (Attribute.Symbol, SentenceSymbol pat)
 recursiveIndexedModuleSymbolSentences =
-    recursiveIndexedModuleStuff indexedModuleSymbolSentences
+  recursiveIndexedModuleStuff indexedModuleSymbolSentences
 
 recursiveIndexedModuleAxioms
-    :: forall pat declAtts axiomAtts
-    .  IndexedModule pat declAtts axiomAtts
-    -> [(axiomAtts, SentenceAxiom pat)]
+  :: forall pat declAtts axiomAtts. IndexedModule pat declAtts axiomAtts
+  -> [(axiomAtts, SentenceAxiom pat)]
 recursiveIndexedModuleAxioms = recursiveIndexedModuleStuff indexedModuleAxioms
 
 recursiveIndexedModuleStuff
-    :: forall pat declAtts axiomAtts stuff
-    .  (Monoid stuff)
-    => (IndexedModule pat declAtts axiomAtts -> stuff)
-    -> IndexedModule pat declAtts axiomAtts
-    -> stuff
+  :: forall pat declAtts axiomAtts stuff. (Monoid stuff)
+  => (IndexedModule pat declAtts axiomAtts -> stuff)
+  -> IndexedModule pat declAtts axiomAtts
+  -> stuff
 recursiveIndexedModuleStuff stuffExtractor m =
-    Foldable.fold
-        (stuffExtractor m : subModuleStuffs)
+  Foldable.fold
+    (stuffExtractor m : subModuleStuffs)
   where
     subModuleStuffs :: [stuff]
     subModuleStuffs =
-        map subModuleStuff (indexedModuleImports m)
+      map subModuleStuff (indexedModuleImports m)
     subModuleStuff
-        ::  ( declAtts
-            , Attributes
-            , IndexedModule pat declAtts axiomAtts
-            )
-        -> stuff
+      :: ( declAtts,
+           Attributes,
+           IndexedModule pat declAtts axiomAtts
+           )
+      -> stuff
     subModuleStuff (_, _, subMod) =
-        recursiveIndexedModuleStuff stuffExtractor subMod
+      recursiveIndexedModuleStuff stuffExtractor subMod
 
 -- | Strip module of its parsed attributes, replacing them with 'Attribute.Null'
 eraseAxiomAttributes
-    :: IndexedModule patternType1 declAttributes axiomAttributes
-    -> IndexedModule patternType1 declAttributes Attribute.Null
+  :: IndexedModule patternType1 declAttributes axiomAttributes
+  -> IndexedModule patternType1 declAttributes Attribute.Null
 eraseAxiomAttributes
-    indexedModule@IndexedModule
-        { indexedModuleAxioms
-        , indexedModuleClaims
-        , indexedModuleImports
-        }
-  =
+  indexedModule@IndexedModule
+    { indexedModuleAxioms,
+      indexedModuleClaims,
+      indexedModuleImports
+      } =
     indexedModule
-        { indexedModuleAxioms =
-            indexedModuleAxioms
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleClaims =
-            indexedModuleClaims
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleImports =
-            indexedModuleImports
+      { indexedModuleAxioms =
+          indexedModuleAxioms
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleClaims =
+          indexedModuleClaims
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleImports =
+          indexedModuleImports
             & Lens.over (Lens.mapped . Lens._3) eraseAxiomAttributes
         }
 
 -- | Strip module of its parsed attributes, replacing them with 'Attribute.Null'
 eraseAttributes
-    :: IndexedModule patternType1 declAttributes axiomAttributes
-    -> IndexedModule patternType1 Attribute.Null Attribute.Null
+  :: IndexedModule patternType1 declAttributes axiomAttributes
+  -> IndexedModule patternType1 Attribute.Null Attribute.Null
 eraseAttributes
-    indexedModule@IndexedModule
-        { indexedModuleAliasSentences
-        , indexedModuleSymbolSentences
-        , indexedModuleAxioms
-        , indexedModuleClaims
-        , indexedModuleAttributes
-        , indexedModuleImports
-        }
-  =
+  indexedModule@IndexedModule
+    { indexedModuleAliasSentences,
+      indexedModuleSymbolSentences,
+      indexedModuleAxioms,
+      indexedModuleClaims,
+      indexedModuleAttributes,
+      indexedModuleImports
+      } =
     indexedModule
-        { indexedModuleAliasSentences =
-            indexedModuleAliasSentences
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleSymbolSentences =
-            indexedModuleSymbolSentences
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleAxioms =
-            indexedModuleAxioms
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleClaims =
-            indexedModuleClaims
-            & Lens.set (Lens.mapped . Lens._1) Attribute.Null
-        , indexedModuleAttributes =
-            indexedModuleAttributes
-            & Lens.set Lens._1 Attribute.Null
-        , indexedModuleImports =
-            indexedModuleImports
+      { indexedModuleAliasSentences =
+          indexedModuleAliasSentences
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleSymbolSentences =
+          indexedModuleSymbolSentences
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleAxioms =
+          indexedModuleAxioms
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleClaims =
+          indexedModuleClaims
+            & Lens.set (Lens.mapped . Lens._1) Attribute.Null,
+        indexedModuleAttributes =
+          indexedModuleAttributes
+            & Lens.set Lens._1 Attribute.Null,
+        indexedModuleImports =
+          indexedModuleImports
             & Lens.set (Lens.mapped . Lens._1) Attribute.Null
             & Lens.over (Lens.mapped . Lens._3) eraseAttributes
         }
 
 instance
-    ( NFData patternType , NFData declAttributes , NFData axiomAttributes ) =>
-    NFData (IndexedModule patternType declAttributes axiomAttributes)
+  (NFData patternType, NFData declAttributes, NFData axiomAttributes)
+  => NFData (IndexedModule patternType declAttributes axiomAttributes)
 
 -- |Convenient notation for retrieving a sentence from a
 -- @(attributes,sentence)@ pair format.
@@ -264,53 +272,53 @@ symbols, and aliases, but it does not need to know anything about patterns.
 
  -}
 erasePatterns
-    :: IndexedModule patternType1 declAttributes axiomAttributes
-    -> IndexedModule ()           declAttributes axiomAttributes
+  :: IndexedModule patternType1 declAttributes axiomAttributes
+  -> IndexedModule () declAttributes axiomAttributes
 erasePatterns indexedModule =
-    indexedModule
-        { indexedModuleAliasSentences =
-            Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
-            $ indexedModuleAliasSentences indexedModule
-        , indexedModuleSymbolSentences =
-            Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
-            $ indexedModuleSymbolSentences indexedModule
-        , indexedModuleSortDescriptions =
-            Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
-            $ indexedModuleSortDescriptions indexedModule
-        , indexedModuleAxioms = []
-        , indexedModuleClaims = []
-        , indexedModuleImports =
-            Lens.over (Lens.mapped . Lens._3) erasePatterns
-            $ indexedModuleImports indexedModule
-        }
+  indexedModule
+    { indexedModuleAliasSentences =
+        Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
+          $ indexedModuleAliasSentences indexedModule,
+      indexedModuleSymbolSentences =
+        Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
+          $ indexedModuleSymbolSentences indexedModule,
+      indexedModuleSortDescriptions =
+        Lens.set (Lens.mapped . Lens._2 . Lens.mapped) ()
+          $ indexedModuleSortDescriptions indexedModule,
+      indexedModuleAxioms = [],
+      indexedModuleClaims = [],
+      indexedModuleImports =
+        Lens.over (Lens.mapped . Lens._3) erasePatterns
+          $ indexedModuleImports indexedModule
+      }
 
 mapPatterns
-    :: (patternType1 -> patternType2)
-    -> IndexedModule patternType1 declAttributes axiomAttributes
-    -> IndexedModule patternType2 declAttributes axiomAttributes
+  :: (patternType1 -> patternType2)
+  -> IndexedModule patternType1 declAttributes axiomAttributes
+  -> IndexedModule patternType2 declAttributes axiomAttributes
 mapPatterns mapping indexedModule =
-    indexedModule
-        { indexedModuleAliasSentences =
-            (fmap . fmap . fmap) mapping indexedModuleAliasSentences
-        , indexedModuleSymbolSentences =
-            (fmap . fmap . fmap) mapping indexedModuleSymbolSentences
-        , indexedModuleSortDescriptions =
-            (fmap . fmap . fmap) mapping indexedModuleSortDescriptions
-        , indexedModuleAxioms =
-            (fmap . fmap . fmap) mapping indexedModuleAxioms
-        , indexedModuleClaims =
-            (fmap . fmap . fmap) mapping indexedModuleClaims
-        , indexedModuleImports =
-            indexedModuleImports
-            & Lens.over (Lens.mapped . Lens._3) (mapPatterns mapping)
-        }
+  indexedModule
+    { indexedModuleAliasSentences =
+        (fmap . fmap . fmap) mapping indexedModuleAliasSentences,
+      indexedModuleSymbolSentences =
+        (fmap . fmap . fmap) mapping indexedModuleSymbolSentences,
+      indexedModuleSortDescriptions =
+        (fmap . fmap . fmap) mapping indexedModuleSortDescriptions,
+      indexedModuleAxioms =
+        (fmap . fmap . fmap) mapping indexedModuleAxioms,
+      indexedModuleClaims =
+        (fmap . fmap . fmap) mapping indexedModuleClaims,
+      indexedModuleImports =
+        indexedModuleImports
+          & Lens.over (Lens.mapped . Lens._3) (mapPatterns mapping)
+      }
   where
-    IndexedModule { indexedModuleAliasSentences } = indexedModule
-    IndexedModule { indexedModuleSymbolSentences } = indexedModule
-    IndexedModule { indexedModuleSortDescriptions } = indexedModule
-    IndexedModule { indexedModuleAxioms } = indexedModule
-    IndexedModule { indexedModuleClaims } = indexedModule
-    IndexedModule { indexedModuleImports } = indexedModule
+    IndexedModule {indexedModuleAliasSentences} = indexedModule
+    IndexedModule {indexedModuleSymbolSentences} = indexedModule
+    IndexedModule {indexedModuleSortDescriptions} = indexedModule
+    IndexedModule {indexedModuleAxioms} = indexedModule
+    IndexedModule {indexedModuleClaims} = indexedModule
+    IndexedModule {indexedModuleImports} = indexedModule
 
 type KoreIndexedModule = IndexedModule ParsedPattern
 
@@ -322,14 +330,14 @@ The original module attributes /are/ preserved.
 
  -}
 toVerifiedModule
-    :: VerifiedModule declAtts axiomAtts
-    -> Module Verified.Sentence
+  :: VerifiedModule declAtts axiomAtts
+  -> Module Verified.Sentence
 toVerifiedModule module' =
-    Module
-        { moduleName = indexedModuleName module'
-        , moduleSentences = indexedModuleRawSentences module'
-        , moduleAttributes = snd (indexedModuleAttributes module')
-        }
+  Module
+    { moduleName = indexedModuleName module',
+      moduleSentences = indexedModuleRawSentences module',
+      moduleAttributes = snd (indexedModuleAttributes module')
+      }
 
 {- | Convert any collection of 'VerifiedModule's back into a 'Definition'.
 
@@ -343,425 +351,411 @@ See also: 'toVerifiedPureModule'
 
  -}
 toVerifiedDefinition
-    :: Foldable t
-    => t (VerifiedModule declAtts axiomAtts)
-    -> Definition Verified.Sentence
+  :: Foldable t
+  => t (VerifiedModule declAtts axiomAtts)
+  -> Definition Verified.Sentence
 toVerifiedDefinition idx =
-    Definition
-        { definitionAttributes = Default.def
-        , definitionModules =
-            toVerifiedModule
-            <$> filter notImplicitKoreModule (Foldable.toList idx)
-        }
+  Definition
+    { definitionAttributes = Default.def,
+      definitionModules =
+        toVerifiedModule
+          <$> filter notImplicitKoreModule (Foldable.toList idx)
+      }
   where
     notImplicitKoreModule verifiedModule =
-        indexedModuleName verifiedModule /= "kore"
+      indexedModuleName verifiedModule /= "kore"
 
 indexedModuleRawSentences
-    :: IndexedModule pat atts atts' -> [Sentence pat]
+  :: IndexedModule pat atts atts' -> [Sentence pat]
 indexedModuleRawSentences im =
-    map (SentenceAliasSentence . getIndexedSentence)
-        (Map.elems (indexedModuleAliasSentences im))
-    ++
-    map hookSymbolIfNeeded
-        (Map.toList (indexedModuleSymbolSentences im))
-    ++
-    map hookSortIfNeeded
-        (Map.toList (indexedModuleSortDescriptions im))
-    ++
-    map
-        (SentenceAxiomSentence . getIndexedSentence)
-        (indexedModuleAxioms im)
-    ++
-    map
-        (SentenceClaimSentence . getIndexedSentence)
-        (indexedModuleClaims im)
-    ++
-    [ SentenceImportSentence
-      (SentenceImport (indexedModuleName m) attributes)
-    | (_, attributes, m) <- indexedModuleImports im
-    ]
+  map (SentenceAliasSentence . getIndexedSentence)
+    (Map.elems (indexedModuleAliasSentences im))
+    ++ map hookSymbolIfNeeded
+         (Map.toList (indexedModuleSymbolSentences im))
+    ++ map hookSortIfNeeded
+         (Map.toList (indexedModuleSortDescriptions im))
+    ++ map
+         (SentenceAxiomSentence . getIndexedSentence)
+         (indexedModuleAxioms im)
+    ++ map
+         (SentenceClaimSentence . getIndexedSentence)
+         (indexedModuleClaims im)
+    ++ [ SentenceImportSentence
+           (SentenceImport (indexedModuleName m) attributes)
+         | (_, attributes, m) <- indexedModuleImports im
+         ]
   where
     hookedIds :: Set.Set Id
     hookedIds = indexedModuleHookedIdentifiers im
     hookSortIfNeeded (x, (_, sortDescription))
-        | x `Set.member` hookedIds =
-            SentenceHookSentence (SentenceHookedSort sortDescription)
-        | otherwise =
-            SentenceSortSentence sortDescription
+      | x `Set.member` hookedIds =
+        SentenceHookSentence (SentenceHookedSort sortDescription)
+      | otherwise =
+        SentenceSortSentence sortDescription
     hookSymbolIfNeeded (x, (_, symbolSentence))
-        | x `Set.member` hookedIds =
-            SentenceHookSentence (SentenceHookedSymbol symbolSentence)
-        | otherwise =
-            SentenceSymbolSentence symbolSentence
+      | x `Set.member` hookedIds =
+        SentenceHookSentence (SentenceHookedSymbol symbolSentence)
+      | otherwise =
+        SentenceSymbolSentence symbolSentence
 
 {-|'ImplicitIndexedModule' is the type for the 'IndexedModule' containing
 things that are implicitly defined.
 -}
-newtype ImplicitIndexedModule pat declAtts axiomAtts =
-    ImplicitIndexedModule (IndexedModule pat declAtts axiomAtts)
-    deriving (Show)
+newtype ImplicitIndexedModule pat declAtts axiomAtts
+  = ImplicitIndexedModule (IndexedModule pat declAtts axiomAtts)
+  deriving (Show)
 
 type KoreImplicitIndexedModule = ImplicitIndexedModule ParsedPattern
 
 emptyIndexedModule
-    ::  ( Default parsedDeclAttributes
-        , Default parsedAxiomAttributes
-        )
-    => ModuleName
-    -> IndexedModule pat parsedDeclAttributes parsedAxiomAttributes
+  :: ( Default parsedDeclAttributes,
+       Default parsedAxiomAttributes
+       )
+  => ModuleName
+  -> IndexedModule pat parsedDeclAttributes parsedAxiomAttributes
 emptyIndexedModule name =
-    IndexedModule
-    { indexedModuleName = name
-    , indexedModuleAliasSentences = Map.empty
-    , indexedModuleSymbolSentences = Map.empty
-    , indexedModuleSortDescriptions = Map.empty
-    , indexedModuleAxioms = []
-    , indexedModuleClaims = []
-    , indexedModuleAttributes = (def, Attributes [])
-    , indexedModuleImports = []
-    , indexedModuleHookedIdentifiers = Set.empty
-    , indexedModuleHooks = Map.empty
-    }
+  IndexedModule
+    { indexedModuleName = name,
+      indexedModuleAliasSentences = Map.empty,
+      indexedModuleSymbolSentences = Map.empty,
+      indexedModuleSortDescriptions = Map.empty,
+      indexedModuleAxioms = [],
+      indexedModuleClaims = [],
+      indexedModuleAttributes = (def, Attributes []),
+      indexedModuleImports = [],
+      indexedModuleHookedIdentifiers = Set.empty,
+      indexedModuleHooks = Map.empty
+      }
 
 {-|'indexedModuleWithDefaultImports' provides an 'IndexedModule' with the given
 name and containing the implicit definitions module.
 -}
 indexedModuleWithDefaultImports
-    ::  ( Default declAttrs
-        , Default axiomAttrs
-        )
-    => ModuleName
-    -> Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> IndexedModule patternType declAttrs axiomAttrs
+  :: ( Default declAttrs,
+       Default axiomAttrs
+       )
+  => ModuleName
+  -> Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
+  -> IndexedModule patternType declAttrs axiomAttrs
 indexedModuleWithDefaultImports name defaultImport =
-    (emptyIndexedModule name)
-        { indexedModuleImports =
-            case defaultImport of
-                Just (ImplicitIndexedModule implicitModule) ->
-                    [(def, Attributes [], implicitModule)]
-                Nothing ->
-                    []
-        }
-
+  (emptyIndexedModule name)
+    { indexedModuleImports = case defaultImport of
+        Just (ImplicitIndexedModule implicitModule) ->
+          [(def, Attributes [], implicitModule)]
+        Nothing ->
+          []
+      }
 
 {-|'indexModuleIfNeeded' transforms a 'Module' into an 'IndexedModule', unless
 the module is already in the 'IndexedModule' map.
 -}
 indexModuleIfNeeded
-    ::  ( ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -- ^ Module containing the implicit Kore definitions
-    -> Map.Map ModuleName (Module sentence)
-    -- ^ Map containing all defined modules, used for resolving imports.
-    -> Map.Map ModuleName indexed
-    -- ^ Map containing all modules that were already indexed.
-    -> Module sentence
-    -- ^ Module to be indexed
-    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed)
-    -- ^ If the module was indexed succesfully, the map returned on 'Right'
-    -- contains everything that the provided 'IndexedModule' map contained,
-    -- plus the current module, plus all the modules that were indexed when
-    -- resolving imports.
+  :: ( ParseAttributes declAttrs,
+       ParseAttributes axiomAttrs,
+       Ord sentence,
+       sentence ~ Sentence patternType,
+       indexed ~ IndexedModule patternType declAttrs axiomAttrs
+       )
+  => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
+  -- ^ Module containing the implicit Kore definitions
+  -> Map.Map ModuleName (Module sentence)
+  -- ^ Map containing all defined modules, used for resolving imports.
+  -> Map.Map ModuleName indexed
+  -- ^ Map containing all modules that were already indexed.
+  -> Module sentence
+  -- ^ Module to be indexed
+  -> Either (Error IndexModuleError) (Map.Map ModuleName indexed)
+  -- ^ If the module was indexed succesfully, the map returned on 'Right'
+  -- contains everything that the provided 'IndexedModule' map contained,
+  -- plus the current module, plus all the modules that were indexed when
+  -- resolving imports.
 indexModuleIfNeeded implicitModule nameToModule indexedModules koreModule =
-    fst <$>
-        internalIndexModuleIfNeeded
-            implicitModule Set.empty nameToModule indexedModules koreModule
+  fst
+    <$> internalIndexModuleIfNeeded
+          implicitModule
+          Set.empty
+          nameToModule
+          indexedModules
+          koreModule
 
 internalIndexModuleIfNeeded
-    ::  ( ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> Map.Map ModuleName indexed
-    -> Module sentence
-    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
-internalIndexModuleIfNeeded
-    implicitModule importingModules nameToModule indexedModules koreModule
-  =
-    withContext
-        ("module '" ++ getModuleNameForError koreModuleName ++ "'")
-        (do
-            koreFailWhen
-                (koreModuleName `Set.member` importingModules)
-                "Circular module import dependency."
-            case Map.lookup koreModuleName indexedModules of
-                Just indexedModule -> return (indexedModules, indexedModule)
-                Nothing -> do
-                    parsedModuleAtts <- parseAttributes moduleAtts
-                    let
-                        indexedModulesAndStartingIndexedModule =
-                            ( indexedModules
-                            , (indexedModuleWithDefaultImports
-                                    (moduleName koreModule) implicitModule)
-                                { indexedModuleAttributes =
-                                    (parsedModuleAtts, moduleAtts)
-                                }
-                            )
-                    (newIndex, newModule) <-
-                        foldM
-                            (indexModuleSentence
-                                implicitModule
-                                importingModulesWithCurrentOne
-                                nameToModule
-                            )
-                            indexedModulesAndStartingIndexedModule
-                            (List.sort $ moduleSentences koreModule)
-                    -- Parse subsorts to fail now if subsort attributes are
-                    -- malformed, so indexedModuleSubsorts can appear total
-                    -- TODO: consider making subsorts an IndexedModule field
-                    _ <- internalIndexedModuleSubsorts newModule
-                    return
-                        ( Map.insert koreModuleName newModule newIndex
-                        , newModule
-                        )
-        )
+  :: ( ParseAttributes declAttrs,
+       ParseAttributes axiomAttrs,
+       Ord sentence,
+       sentence ~ Sentence patternType,
+       indexed ~ IndexedModule patternType declAttrs axiomAttrs
+       )
+  => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
+  -> Set.Set ModuleName
+  -> Map.Map ModuleName (Module sentence)
+  -> Map.Map ModuleName indexed
+  -> Module sentence
+  -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
+internalIndexModuleIfNeeded implicitModule importingModules nameToModule indexedModules koreModule =
+  withContext
+    ("module '" ++ getModuleNameForError koreModuleName ++ "'")
+    ( do
+        koreFailWhen
+          (koreModuleName `Set.member` importingModules)
+          "Circular module import dependency."
+        case Map.lookup koreModuleName indexedModules of
+          Just indexedModule -> return (indexedModules, indexedModule)
+          Nothing -> do
+            parsedModuleAtts <- parseAttributes moduleAtts
+            let indexedModulesAndStartingIndexedModule =
+                  ( indexedModules,
+                    ( indexedModuleWithDefaultImports
+                        (moduleName koreModule)
+                        implicitModule
+                      )
+                      { indexedModuleAttributes =
+                          (parsedModuleAtts, moduleAtts)
+                        }
+                    )
+            (newIndex, newModule) <-
+              foldM
+                ( indexModuleSentence
+                    implicitModule
+                    importingModulesWithCurrentOne
+                    nameToModule
+                  )
+                indexedModulesAndStartingIndexedModule
+                (List.sort $ moduleSentences koreModule)
+            -- Parse subsorts to fail now if subsort attributes are
+            -- malformed, so indexedModuleSubsorts can appear total
+            -- TODO: consider making subsorts an IndexedModule field
+            _ <- internalIndexedModuleSubsorts newModule
+            return
+              ( Map.insert koreModuleName newModule newIndex,
+                newModule
+                )
+      )
   where
     moduleAtts = moduleAttributes koreModule
     koreModuleName = moduleName koreModule
     importingModulesWithCurrentOne = Set.insert koreModuleName importingModules
 
 indexModuleSentence
-    ::  ( ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> (Map.Map ModuleName indexed, indexed)
-    -> Sentence patternType
-    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
+  :: ( ParseAttributes declAttrs,
+       ParseAttributes axiomAttrs,
+       Ord sentence,
+       sentence ~ Sentence patternType,
+       indexed ~ IndexedModule patternType declAttrs axiomAttrs
+       )
+  => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
+  -> Set.Set ModuleName
+  -> Map.Map ModuleName (Module sentence)
+  -> (Map.Map ModuleName indexed, indexed)
+  -> Sentence patternType
+  -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
 indexModuleSentence
-    implicitModule
-    importingModules
-    nameToModule
-    ( indexedModules
-    , indexedModule@IndexedModule
-        { indexedModuleAliasSentences
-        , indexedModuleSymbolSentences
-        , indexedModuleAxioms
-        , indexedModuleClaims
-        , indexedModuleImports
-        , indexedModuleSortDescriptions
-        , indexedModuleHookedIdentifiers
-        , indexedModuleHooks
+  implicitModule
+  importingModules
+  nameToModule
+  ( indexedModules,
+    indexedModule@IndexedModule
+      { indexedModuleAliasSentences,
+        indexedModuleSymbolSentences,
+        indexedModuleAxioms,
+        indexedModuleClaims,
+        indexedModuleImports,
+        indexedModuleSortDescriptions,
+        indexedModuleHookedIdentifiers,
+        indexedModuleHooks
         }
     )
-    sentence
-  =
+  sentence =
     withSentenceContext sentence indexModuleMetaSentence0
-  where
-    indexModuleMetaSentence0 =
+    where
+      indexModuleMetaSentence0 =
         case sentence of
-            SentenceAliasSentence s  -> indexSentenceAlias s
-            SentenceSymbolSentence s -> indexSentenceSymbol s
-            SentenceAxiomSentence s  -> indexSentenceAxiom s
-            SentenceClaimSentence s  -> indexSentenceClaim s
-            SentenceImportSentence s -> indexSentenceImport s
-            SentenceSortSentence s   -> indexSentenceSort s
-            SentenceHookSentence s   -> indexSentenceHook s
-
-    indexSentenceAlias
+          SentenceAliasSentence s -> indexSentenceAlias s
+          SentenceSymbolSentence s -> indexSentenceSymbol s
+          SentenceAxiomSentence s -> indexSentenceAxiom s
+          SentenceClaimSentence s -> indexSentenceClaim s
+          SentenceImportSentence s -> indexSentenceImport s
+          SentenceSortSentence s -> indexSentenceSort s
+          SentenceHookSentence s -> indexSentenceHook s
+      indexSentenceAlias
         _sentence@SentenceAlias
-            { sentenceAliasAlias = Alias { aliasConstructor }
-            , sentenceAliasAttributes
-            }
-      = do
-        atts <- parseAttributes sentenceAliasAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleAliasSentences =
-                    Map.insert aliasConstructor (atts, _sentence)
+          { sentenceAliasAlias = Alias {aliasConstructor},
+            sentenceAliasAttributes
+            } =
+          do
+            atts <- parseAttributes sentenceAliasAttributes
+            return
+              ( indexedModules,
+                indexedModule
+                  { indexedModuleAliasSentences =
+                      Map.insert aliasConstructor (atts, _sentence)
                         indexedModuleAliasSentences
-                }
-            )
-
-    indexSentenceSymbol
+                    }
+                )
+      indexSentenceSymbol
         _sentence@SentenceSymbol
-            { sentenceSymbolSymbol = Symbol { symbolConstructor }
-            , sentenceSymbolAttributes
-            }
-      = do
-        atts <- parseAttributes sentenceSymbolAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSymbolSentences =
-                    Map.insert
+          { sentenceSymbolSymbol = Symbol {symbolConstructor},
+            sentenceSymbolAttributes
+            } =
+          do
+            atts <- parseAttributes sentenceSymbolAttributes
+            return
+              ( indexedModules,
+                indexedModule
+                  { indexedModuleSymbolSentences =
+                      Map.insert
                         symbolConstructor
                         (atts, _sentence)
                         indexedModuleSymbolSentences
-                }
-            )
-
-    indexSentenceAxiom
-        _sentence@SentenceAxiom { sentenceAxiomAttributes }
-      = do
-        atts <- parseAttributes sentenceAxiomAttributes
-        return
-            ( indexedModules
-            , indexedModule
+                    }
+                )
+      indexSentenceAxiom _sentence@SentenceAxiom {sentenceAxiomAttributes} =
+        do
+          atts <- parseAttributes sentenceAxiomAttributes
+          return
+            ( indexedModules,
+              indexedModule
                 { indexedModuleAxioms =
                     (atts, _sentence) : indexedModuleAxioms
-                }
-            )
-
-    indexSentenceClaim
-        _sentence@(SentenceClaim SentenceAxiom { sentenceAxiomAttributes })
-      = do
-        atts <- parseAttributes sentenceAxiomAttributes
-        return
-            ( indexedModules
-            , indexedModule
+                  }
+              )
+      indexSentenceClaim _sentence@(SentenceClaim SentenceAxiom {sentenceAxiomAttributes}) =
+        do
+          atts <- parseAttributes sentenceAxiomAttributes
+          return
+            ( indexedModules,
+              indexedModule
                 { indexedModuleClaims =
                     (atts, _sentence) : indexedModuleClaims
-                }
-            )
-
-    indexSentenceImport
+                  }
+              )
+      indexSentenceImport
         SentenceImport
-            { sentenceImportModuleName = importedModuleName
-            , sentenceImportAttributes = attributes
-            }
-      = do
-        (newIndexedModules, importedModule) <-
-            indexImportedModule
+          { sentenceImportModuleName = importedModuleName,
+            sentenceImportAttributes = attributes
+            } =
+          do
+            (newIndexedModules, importedModule) <-
+              indexImportedModule
                 implicitModule
                 importingModules
                 nameToModule
                 indexedModules
                 importedModuleName
-        atts <- parseAttributes attributes
-        return
-            ( newIndexedModules
-            , indexedModule
-                { indexedModuleImports =
-                    (:) (atts, attributes, importedModule)
+            atts <- parseAttributes attributes
+            return
+              ( newIndexedModules,
+                indexedModule
+                  { indexedModuleImports =
+                      (:) (atts, attributes, importedModule)
                         indexedModuleImports
-                }
-            )
-
-    indexSentenceSort
+                    }
+                )
+      indexSentenceSort
         _sentence@SentenceSort
-            { sentenceSortAttributes
-            , sentenceSortName
-            }
-      = do
-        atts <- parseAttributes sentenceSortAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSortDescriptions =
-                    Map.insert sentenceSortName (atts, _sentence)
+          { sentenceSortAttributes,
+            sentenceSortName
+            } =
+          do
+            atts <- parseAttributes sentenceSortAttributes
+            return
+              ( indexedModules,
+                indexedModule
+                  { indexedModuleSortDescriptions =
+                      Map.insert sentenceSortName (atts, _sentence)
                         indexedModuleSortDescriptions
+                    }
+                )
+      indexSentenceHook
+        ( SentenceHookedSort
+            _sentence@SentenceSort
+              { sentenceSortName,
+                sentenceSortAttributes
                 }
-            )
-
-    indexSentenceHook
-        (SentenceHookedSort _sentence@SentenceSort
-            { sentenceSortName
-            , sentenceSortAttributes
-            }
-        )
-      = do
-        (indexedModules', indexedModule') <-
-            indexModuleSentence
+          ) =
+          do
+            (indexedModules', indexedModule') <-
+              indexModuleSentence
                 implicitModule
                 importingModules
                 nameToModule
                 (indexedModules, indexedModule)
                 (SentenceSortSentence _sentence)
-        hook <- getHookAttribute sentenceSortAttributes
-        return
-            ( indexedModules'
-            , indexedModule'
-                { indexedModuleHookedIdentifiers =
-                    Set.insert sentenceSortName indexedModuleHookedIdentifiers
-                , indexedModuleHooks =
-                    Map.alter
+            hook <- getHookAttribute sentenceSortAttributes
+            return
+              ( indexedModules',
+                indexedModule'
+                  { indexedModuleHookedIdentifiers =
+                      Set.insert sentenceSortName indexedModuleHookedIdentifiers,
+                    indexedModuleHooks =
+                      Map.alter
                         (Just . maybe [sentenceSortName] (sentenceSortName :))
                         hook
                         indexedModuleHooks
+                    }
+                )
+      indexSentenceHook
+        ( SentenceHookedSymbol
+            _sentence@SentenceSymbol
+              { sentenceSymbolAttributes,
+                sentenceSymbolSymbol = Symbol {symbolConstructor}
                 }
-            )
-
-    indexSentenceHook
-        (SentenceHookedSymbol _sentence@SentenceSymbol
-            { sentenceSymbolAttributes
-            , sentenceSymbolSymbol = Symbol { symbolConstructor }
-            }
-        )
-      = do
-        atts <- parseAttributes sentenceSymbolAttributes
-        hook <- getHookAttribute sentenceSymbolAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSymbolSentences =
-                    Map.insert symbolConstructor (atts, _sentence)
-                        indexedModuleSymbolSentences
-                , indexedModuleHookedIdentifiers =
-                    Set.insert symbolConstructor indexedModuleHookedIdentifiers
-                , indexedModuleHooks =
-                    Map.alter
+          ) =
+          do
+            atts <- parseAttributes sentenceSymbolAttributes
+            hook <- getHookAttribute sentenceSymbolAttributes
+            return
+              ( indexedModules,
+                indexedModule
+                  { indexedModuleSymbolSentences =
+                      Map.insert symbolConstructor (atts, _sentence)
+                        indexedModuleSymbolSentences,
+                    indexedModuleHookedIdentifiers =
+                      Set.insert symbolConstructor indexedModuleHookedIdentifiers,
+                    indexedModuleHooks =
+                      Map.alter
                         (Just . maybe [symbolConstructor] (symbolConstructor :))
                         hook
                         indexedModuleHooks
-                }
-            )
+                    }
+                )
 
 indexImportedModule
-    ::  ( ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> Map.Map ModuleName indexed
-    -> ModuleName
-    -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
+  :: ( ParseAttributes declAttrs,
+       ParseAttributes axiomAttrs,
+       Ord sentence,
+       sentence ~ Sentence patternType,
+       indexed ~ IndexedModule patternType declAttrs axiomAttrs
+       )
+  => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
+  -> Set.Set ModuleName
+  -> Map.Map ModuleName (Module sentence)
+  -> Map.Map ModuleName indexed
+  -> ModuleName
+  -> Either (Error IndexModuleError) (Map.Map ModuleName indexed, indexed)
 indexImportedModule
-    implicitModule
-    importingModules
-    nameToModule
-    indexedModules
-    importedModuleName
-  =
+  implicitModule
+  importingModules
+  nameToModule
+  indexedModules
+  importedModuleName =
     case Map.lookup importedModuleName indexedModules of
-        Just indexedModule -> return (indexedModules, indexedModule)
-        Nothing -> do
-            koreModule <-
-                case Map.lookup importedModuleName nameToModule of
-                    Nothing ->
-                        koreFail
-                            (  "Module '"
-                            ++ getModuleNameForError importedModuleName
-                            ++ "' imported but not found."
-                            )
-                    Just m -> return m
-            internalIndexModuleIfNeeded
-                implicitModule
-                importingModules
-                nameToModule
-                indexedModules
-                koreModule
+      Just indexedModule -> return (indexedModules, indexedModule)
+      Nothing -> do
+        koreModule <-
+          case Map.lookup importedModuleName nameToModule of
+            Nothing ->
+              koreFail
+                ( "Module '"
+                    ++ getModuleNameForError importedModuleName
+                    ++ "' imported but not found."
+                  )
+            Just m -> return m
+        internalIndexModuleIfNeeded
+          implicitModule
+          importingModules
+          nameToModule
+          indexedModules
+          koreModule
 
 {- | Parse attributes in the context of indexing a module.
 
@@ -770,49 +764,48 @@ indexImportedModule
 See also: 'parseAttributes'
 -}
 parseAttributes
-    :: ParseAttributes a
-    => Attributes
-    -> Either (Error IndexModuleError) a
+  :: ParseAttributes a
+  => Attributes
+  -> Either (Error IndexModuleError) a
 parseAttributes = Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
 
 {- | Retrieve those object-level symbol sentences that are hooked.
 
  -}
 hookedObjectSymbolSentences
-    :: IndexedModule pat declAtts axiomAtts
-    -> Map.Map Id (declAtts, SentenceSymbol pat)
+  :: IndexedModule pat declAtts axiomAtts
+  -> Map.Map Id (declAtts, SentenceSymbol pat)
 hookedObjectSymbolSentences
-    IndexedModule
-        { indexedModuleSymbolSentences
-        , indexedModuleHookedIdentifiers
-        }
-  =
+  IndexedModule
+    { indexedModuleSymbolSentences,
+      indexedModuleHookedIdentifiers
+      } =
     Map.restrictKeys
-        indexedModuleSymbolSentences
-        indexedModuleHookedIdentifiers
+      indexedModuleSymbolSentences
+      indexedModuleHookedIdentifiers
 
 indexedModuleSubsorts :: IndexedModule pat declAtts axiomAtts -> [Subsort]
 indexedModuleSubsorts imod =
-    case internalIndexedModuleSubsorts imod of
-        Right subsorts -> subsorts
-        Left err -> error $ "IndexedModule should already have checked"
-            ++ " form of subsort attributes, but parsing failed\n:"
-            ++ show err
+  case internalIndexedModuleSubsorts imod of
+    Right subsorts -> subsorts
+    Left err ->
+      error $ "IndexedModule should already have checked"
+        ++ " form of subsort attributes, but parsing failed\n:"
+        ++ show err
 
 internalIndexedModuleSubsorts
-    :: IndexedModule pat declAtts axiomAtts
-    -> Either (Error IndexModuleError) [Subsort]
+  :: IndexedModule pat declAtts axiomAtts
+  -> Either (Error IndexModuleError) [Subsort]
 internalIndexedModuleSubsorts imod = do
-    let
-        attributes =
-            [ sentenceAxiomAttributes
-            | (_, SentenceAxiom { sentenceAxiomAttributes })
-                <- indexedModuleAxioms imod
-            ]
-    Subsorts subsorts <-
-        Attribute.Parser.liftParser
-        $ Foldable.foldrM Attribute.Parser.parseAttributesWith def attributes
-    return subsorts
+  let attributes =
+        [ sentenceAxiomAttributes
+          | (_, SentenceAxiom {sentenceAxiomAttributes}) <-
+              indexedModuleAxioms imod
+          ]
+  Subsorts subsorts <-
+    Attribute.Parser.liftParser
+      $ Foldable.foldrM Attribute.Parser.parseAttributesWith def attributes
+  return subsorts
 
 {- | Determine all indexed modules in scope from the given module.
 
@@ -822,34 +815,32 @@ modules once.
 
  -}
 indexedModulesInScope
-    :: IndexedModule pat declAtts axiomAtts
-    -> Map ModuleName (IndexedModule pat declAtts axiomAtts)
+  :: IndexedModule pat declAtts axiomAtts
+  -> Map ModuleName (IndexedModule pat declAtts axiomAtts)
 indexedModulesInScope =
-    \imod -> execState (resolveModule imod) Map.empty
+  \imod -> execState (resolveModule imod) Map.empty
   where
     alreadyResolved name =
-        Monad.State.gets (Map.member name)
-
+      Monad.State.gets (Map.member name)
     {- | Resolve one indexed module
-
+    
     If the module is not already part of the result, insert it and resolve its
     imports. If the module is already part of the result, skip it.
-
+    
      -}
     resolveModule imod =
-        unlessM (alreadyResolved name) $ do
-            -- resolve the module: insert it into the map
-            Monad.State.modify' (Map.insert name imod)
-            -- resolve this modules imports
-            mapM_ resolveImport (indexedModuleImports imod)
+      unlessM (alreadyResolved name) $ do
+        -- resolve the module: insert it into the map
+        Monad.State.modify' (Map.insert name imod)
+        -- resolve this modules imports
+        mapM_ resolveImport (indexedModuleImports imod)
       where
         name = indexedModuleName imod
-
     resolveImport (_, _, imod) = resolveModule imod
 
 implicitModules
-    :: (Default declAttrs, Default axiomAttrs)
-    => Map ModuleName (IndexedModule patternType declAttrs axiomAttrs)
+  :: (Default declAttrs, Default axiomAttrs)
+  => Map ModuleName (IndexedModule patternType declAttrs axiomAttrs)
 implicitModules = Map.singleton implicitModuleName implicitIndexedModule
 
 -- | The name of the module containing the implicit Kore declarations.
@@ -858,25 +849,25 @@ implicitModuleName = ModuleName "kore"
 
 -- | The 'IndexedModule' that indexes the implicit Kore declarations.
 implicitIndexedModule
-    :: (Default declAttrs, Default axiomAttrs)
-    => IndexedModule patternType declAttrs axiomAttrs
+  :: (Default declAttrs, Default axiomAttrs)
+  => IndexedModule patternType declAttrs axiomAttrs
 implicitIndexedModule =
-    (emptyIndexedModule implicitModuleName)
-        { indexedModuleSortDescriptions =
-            Map.fromSet makeSortIndex implicitSortNames
-        }
+  (emptyIndexedModule implicitModuleName)
+    { indexedModuleSortDescriptions =
+        Map.fromSet makeSortIndex implicitSortNames
+      }
   where
     makeSortIndex sortId = (Default.def, declareSort sortId)
     declareSort sortId =
-        SentenceSort
-            { sentenceSortName = sortId
-            , sentenceSortParameters = []
-            , sentenceSortAttributes = Attributes []
-            }
+      SentenceSort
+        { sentenceSortName = sortId,
+          sentenceSortParameters = [],
+          sentenceSortAttributes = Attributes []
+          }
 
 implicitNames :: Map Text AstLocation
 implicitNames =
-    Map.mapKeys getId
+  Map.mapKeys getId
     $ Map.fromSet idLocation
     $ Set.insert predicateSortId implicitSortNames
 

--- a/kore/src/Kore/IndexedModule/MetadataTools.hs
+++ b/kore/src/Kore/IndexedModule/MetadataTools.hs
@@ -9,63 +9,71 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.IndexedModule.MetadataTools
-    ( MetadataTools (..)
-    , SmtMetadataTools
-    , extractMetadataTools
-    ) where
+  ( MetadataTools (..),
+    SmtMetadataTools,
+    extractMetadataTools
+    )
+where
 
-import           Data.Function
-                 ( on )
-import           Data.Graph
-import           Data.Map.Strict
-                 ( Map )
+import Data.Function
+  ( on
+    )
+import Data.Graph
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-                 ( mapMaybe )
-import           Data.Set
-                 ( Set )
+import Data.Maybe
+  ( mapMaybe
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Sort as Attribute
-import           Kore.Attribute.Subsort
-import           Kore.IndexedModule.IndexedModule
-import           Kore.IndexedModule.Resolvers
-import           Kore.Internal.ApplicationSorts
-import           Kore.Internal.Symbol
-                 ( Symbol )
+import Kore.Attribute.Subsort
+import Kore.IndexedModule.IndexedModule
+import Kore.IndexedModule.Resolvers
+import Kore.Internal.ApplicationSorts
+import Kore.Internal.Symbol
+  ( Symbol
+    )
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Sort
+import Kore.Sort
 import qualified Kore.Step.SMT.AST as SMT.AST
-                 ( SmtDeclarations )
-import           Kore.Syntax.Application
-                 ( SymbolOrAlias (..) )
+  ( SmtDeclarations
+    )
+import Kore.Syntax.Application
+  ( SymbolOrAlias (..)
+    )
 
 -- |'MetadataTools' defines a dictionary of functions which can be used to
 -- access the metadata needed during the unification process.
-data MetadataTools smt attributes = MetadataTools
-    { sortAttributes :: Sort -> Attribute.Sort
-    -- ^ get the attributes of a sort
-    , isSubsortOf :: Sort -> Sort -> Bool
-    {- ^ @isSubsortOf a b@ is true if sort @a@ is a subsort of sort @b@,
-       including when @a@ equals @b@. -}
-    , subsorts :: Sort -> Set Sort
-    -- ^ get the subsorts for a sort
-    , applicationSorts :: SymbolOrAlias -> ApplicationSorts
-    -- ^ Sorts for a specific symbol application.
-    , symbolAttributes :: Id -> attributes
-    -- ^ get the attributes of a symbol
-    , isOverloading :: Symbol -> Symbol -> Bool
-    -- ^ whether the first argument is overloading the second
-    , isOverloaded :: Symbol -> Bool
-    -- ^ Whether the symbol is overloaded
-    , smtData :: smt
-    -- ^ The SMT data for the given module.
-    }
-  deriving Functor
+data MetadataTools smt attributes
+  = MetadataTools
+      { sortAttributes :: Sort -> Attribute.Sort,
+        -- ^ get the attributes of a sort
+        isSubsortOf :: Sort -> Sort -> Bool,
+        {- ^ @isSubsortOf a b@ is true if sort @a@ is a subsort of sort @b@,
+           including when @a@ equals @b@. -}
+        subsorts :: Sort -> Set Sort,
+        -- ^ get the subsorts for a sort
+        applicationSorts :: SymbolOrAlias -> ApplicationSorts,
+        -- ^ Sorts for a specific symbol application.
+        symbolAttributes :: Id -> attributes,
+        -- ^ get the attributes of a symbol
+        isOverloading :: Symbol -> Symbol -> Bool,
+        -- ^ whether the first argument is overloading the second
+        isOverloaded :: Symbol -> Bool,
+        -- ^ Whether the symbol is overloaded
+        smtData :: smt
+        -- ^ The SMT data for the given module.
+        }
+  deriving (Functor)
 
-type SmtMetadataTools attributes =
-    MetadataTools SMT.AST.SmtDeclarations attributes
+type SmtMetadataTools attributes
+  = MetadataTools SMT.AST.SmtDeclarations attributes
 
 -- |'extractMetadataTools' extracts a set of 'MetadataTools' from a
 -- 'KoreIndexedModule'.  The metadata tools are functions yielding information
@@ -73,66 +81,59 @@ type SmtMetadataTools attributes =
 -- its argument and result sorts.
 --
 extractMetadataTools
-    ::  forall declAtts smt.
-        VerifiedModule declAtts Attribute.Axiom
-    ->  (  VerifiedModule declAtts Attribute.Axiom
-        -> smt
-        )
-    -> MetadataTools smt declAtts
+  :: forall declAtts smt. VerifiedModule declAtts Attribute.Axiom
+  -> ( VerifiedModule declAtts Attribute.Axiom
+       -> smt
+       )
+  -> MetadataTools smt declAtts
 extractMetadataTools m smtExtractor =
-    MetadataTools
-        { sortAttributes = getSortAttributes m
-        , isSubsortOf = checkSubsort
-        , subsorts = Set.fromList . fmap getSortFromId . getSubsorts
-        , applicationSorts = getHeadApplicationSorts m
-        , symbolAttributes = getSymbolAttributes m
-        , isOverloading = checkOverloading `on` Symbol.toSymbolOrAlias
-        , isOverloaded = checkOverloaded . Symbol.toSymbolOrAlias
-        , smtData = smtExtractor m
-        }
+  MetadataTools
+    { sortAttributes = getSortAttributes m,
+      isSubsortOf = checkSubsort,
+      subsorts = Set.fromList . fmap getSortFromId . getSubsorts,
+      applicationSorts = getHeadApplicationSorts m,
+      symbolAttributes = getSymbolAttributes m,
+      isOverloading = checkOverloading `on` Symbol.toSymbolOrAlias,
+      isOverloaded = checkOverloaded . Symbol.toSymbolOrAlias,
+      smtData = smtExtractor m
+      }
   where
     subsortTable :: Map Sort [Sort]
-    subsortTable = Map.unionsWith (++)
+    subsortTable =
+      Map.unionsWith (++)
         [ Map.insert subsort [] $ Map.singleton supersort [subsort]
-        | Subsort subsort supersort <- indexedModuleSubsorts m]
-
+          | Subsort subsort supersort <- indexedModuleSubsorts m
+          ]
     -- In `sortGraph`, an edge (a, b) represents a subsort relationship between
     -- b and a.
     (sortGraph, vertexToSort, sortToVertex) =
-        graphFromEdges [ ((),supersort,subsorts)
-                        | (supersort,subsorts)
-                            <- Map.toList subsortTable]
+      graphFromEdges
+        [ ((), supersort, subsorts)
+          | (supersort, subsorts) <-
+              Map.toList subsortTable
+          ]
     getSortFromId :: Vertex -> Sort
     getSortFromId sortId =
-        let (_, sort, _) = vertexToSort sortId
-        in sort
-
+      let (_, sort, _) = vertexToSort sortId
+       in sort
     getSubsorts :: Sort -> [Vertex]
     getSubsorts = maybe [] (reachable sortGraph) . sortToVertex
-
     checkSubsort :: Sort -> Sort -> Bool
     checkSubsort =
-        let
-            realCheckSubsort subsort supersort
-              | Just subId <- sortToVertex subsort
-              , Just supId <- sortToVertex supersort =
-                path sortGraph supId subId
-            realCheckSubsort _ _ = False
-        in realCheckSubsort
-
+      let realCheckSubsort subsort supersort
+            | Just subId <- sortToVertex subsort,
+              Just supId <- sortToVertex supersort =
+              path sortGraph supId subId
+          realCheckSubsort _ _ = False
+       in realCheckSubsort
     overloadPairsSet = Set.fromList overloadPairsList
-
     overloadPairsList =
-        mapMaybe
-            (Attribute.getOverload . Attribute.overload . fst)
-            (recursiveIndexedModuleAxioms m)
-
-    allOverloadsList = concatMap (\(o1, o2) -> [o1,o2]) overloadPairsList
-
+      mapMaybe
+        (Attribute.getOverload . Attribute.overload . fst)
+        (recursiveIndexedModuleAxioms m)
+    allOverloadsList = concatMap (\(o1, o2) -> [o1, o2]) overloadPairsList
     allOverloadsSet = Set.fromList allOverloadsList
-
     checkOverloaded :: SymbolOrAlias -> Bool
     checkOverloaded = (`Set.member` allOverloadsSet)
-
     checkOverloading :: SymbolOrAlias -> SymbolOrAlias -> Bool
     checkOverloading head1 head2 = (head1, head2) `Set.member` overloadPairsSet

--- a/kore/src/Kore/IndexedModule/MetadataToolsBuilder.hs
+++ b/kore/src/Kore/IndexedModule/MetadataToolsBuilder.hs
@@ -8,20 +8,26 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.IndexedModule.MetadataToolsBuilder
-    ( build
-    ) where
+  ( build
+    )
+where
 
 import qualified Kore.Attribute.Axiom as Attribute
-                 ( Axiom )
-import           Kore.Attribute.Symbol
-                 ( StepperAttributes )
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools, extractMetadataTools )
+  ( Axiom
+    )
+import Kore.Attribute.Symbol
+  ( StepperAttributes
+    )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools,
+    extractMetadataTools
+    )
 import qualified Kore.Step.SMT.Representation.All as SMT.Representation
-                 ( build )
-
+  ( build
+    )
 
 -- |Creates a set of 'MetadataTools' from a 'KoreIndexedModule'.
 --
@@ -30,6 +36,6 @@ import qualified Kore.Step.SMT.Representation.All as SMT.Representation
 -- its argument and result sorts.
 --
 build
-    :: VerifiedModule StepperAttributes Attribute.Axiom
-    -> SmtMetadataTools StepperAttributes
+  :: VerifiedModule StepperAttributes Attribute.Axiom
+  -> SmtMetadataTools StepperAttributes
 build m = extractMetadataTools m SMT.Representation.build

--- a/kore/src/Kore/IndexedModule/Resolvers.hs
+++ b/kore/src/Kore/IndexedModule/Resolvers.hs
@@ -8,86 +8,99 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.IndexedModule.Resolvers
-    ( getSortAttributes
-    , getSymbolAttributes
-    , resolveSort
-    , resolveAlias
-    , resolveSymbol
-    , resolveHook
-    , findIndexedSort
-
+  ( getSortAttributes,
+    getSymbolAttributes,
+    resolveSort,
+    resolveAlias,
+    resolveSymbol,
+    resolveHook,
+    findIndexedSort,
     -- TODO: This symbol is used by `resolveHook`.
     -- `resolveHook` doesn't have tests, but
     -- `getHeadApplicationSorts does. So this is
     -- exported until `resolveHook` has its own
     -- tests.
-    , getHeadApplicationSorts
-
-    ) where
+    getHeadApplicationSorts
+    )
+where
 
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           GHC.Stack
-                 ( HasCallStack )
-
-import           Kore.AST.Error
-                 ( koreFailWithLocations )
+import GHC.Stack
+  ( HasCallStack
+    )
+import Kore.AST.Error
+  ( koreFailWithLocations
+    )
 import qualified Kore.Attribute.Sort as Attribute
-import           Kore.Error
-import           Kore.IndexedModule.Error
-                 ( noAliasText, noHead, noSort, noSortText, noSymbol,
-                 noSymbolText )
-import           Kore.IndexedModule.IndexedModule
-                 ( IndexedModule (..), getIndexedSentence,
-                 indexedModulesInScope )
-import           Kore.Internal.ApplicationSorts
-import           Kore.Syntax
-import           Kore.Syntax.Definition hiding
-                 ( Alias (..), Symbol (..) )
+import Kore.Error
+import Kore.IndexedModule.Error
+  ( noAliasText,
+    noHead,
+    noSort,
+    noSortText,
+    noSymbol,
+    noSymbolText
+    )
+import Kore.IndexedModule.IndexedModule
+  ( IndexedModule (..),
+    getIndexedSentence,
+    indexedModulesInScope
+    )
+import Kore.Internal.ApplicationSorts
+import Kore.Syntax
+import Kore.Syntax.Definition hiding
+  ( Alias (..),
+    Symbol (..)
+    )
 
 symbolSentencesMap
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Map.Map Id (declAtts, SentenceSymbol patternType)
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Map.Map Id (declAtts, SentenceSymbol patternType)
 symbolSentencesMap = indexedModuleSymbolSentences
 
 aliasSentencesMap
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Map.Map Id (declAtts, SentenceAlias patternType)
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Map.Map Id (declAtts, SentenceAlias patternType)
 aliasSentencesMap = indexedModuleAliasSentences
 
 sortSentencesMap
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Map.Map Id (Attribute.Sort, SentenceSort patternType)
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Map.Map Id (Attribute.Sort, SentenceSort patternType)
 sortSentencesMap = indexedModuleSortDescriptions
 
 -- |Given a KoreIndexedModule and a head, it looks up the 'SentenceSymbol' or
 -- 'SentenceAlias', and instantiates sort parameters with the arguments
 -- specified by the head to obtain the corresponding 'ApplicationSorts'.
 getHeadApplicationSorts
-    :: IndexedModule patternType declAtts axiomAtts
-    -- ^ Module representing an indexed definition
-    -> SymbolOrAlias     -- ^the head we want to find sorts for
-    -> ApplicationSorts
+  :: IndexedModule patternType declAtts axiomAtts
+  -- ^ Module representing an indexed definition
+  -> SymbolOrAlias -- ^the head we want to find sorts for
+  -> ApplicationSorts
 getHeadApplicationSorts m patternHead =
-    applyToHeadSentence sentenceSorts m patternHead
+  applyToHeadSentence sentenceSorts m patternHead
   where
     sentenceSorts
-        :: SentenceSymbolOrAlias sentence
-        => [Sort] -> sentence pat -> ApplicationSorts
+      :: SentenceSymbolOrAlias sentence
+      => [Sort]
+      -> sentence pat
+      -> ApplicationSorts
     sentenceSorts sortParameters sentence =
-        assertRight $ symbolOrAliasSorts sortParameters sentence
+      assertRight $ symbolOrAliasSorts sortParameters sentence
 
 getSortAttributes
-    :: HasCallStack
-    => IndexedModule patternType declAtts axiomAtts
-    -> Sort
-    -> Attribute.Sort
+  :: HasCallStack
+  => IndexedModule patternType declAtts axiomAtts
+  -> Sort
+  -> Attribute.Sort
 getSortAttributes m (SortActualSort (SortActual sortId _)) =
   case resolveSort m sortId of
     Right (atts, _) -> atts
@@ -95,10 +108,10 @@ getSortAttributes m (SortActualSort (SortActual sortId _)) =
 getSortAttributes _ _ = error "Can't lookup attributes for sort variables"
 
 getSymbolAttributes
-    :: HasCallStack
-    => IndexedModule patternType declAtts axiomAtts
-    -> Id
-    -> declAtts
+  :: HasCallStack
+  => IndexedModule patternType declAtts axiomAtts
+  -> Id
+  -> declAtts
 getSymbolAttributes m symbolId =
   case resolveSymbol m symbolId of
     Right (atts, _) -> atts
@@ -108,157 +121,157 @@ getSymbolAttributes m symbolId =
 imported modules.
 -}
 resolveThing
-    ::  (  IndexedModule patternType declAtts axiomAtts
-        -> Map.Map Id result
-        )
-    -- ^ extracts the map into which to look up the id
-    -> IndexedModule patternType declAtts axiomAtts
-    -> Id
-    -> Maybe result
+  :: ( IndexedModule patternType declAtts axiomAtts
+       -> Map.Map Id result
+       -- ^ extracts the map into which to look up the id
+       )
+  -> IndexedModule patternType declAtts axiomAtts
+  -> Id
+  -> Maybe result
 resolveThing
-    mapExtractor
-    indexedModule
-    thingId
-  =
+  mapExtractor
+  indexedModule
+  thingId =
     fst
-        ( resolveThingInternal
-            (Nothing, Set.empty) mapExtractor indexedModule thingId
+      ( resolveThingInternal
+          (Nothing, Set.empty)
+          mapExtractor
+          indexedModule
+          thingId
         )
 
 resolveThingInternal
-    :: (Maybe result, Set.Set ModuleName)
-    ->  (  IndexedModule patternType declAtts axiomAtts
-        -> Map.Map Id result
-        )
-    -> IndexedModule patternType declAtts axiomAtts
-    -> Id
-    -> (Maybe result, Set.Set ModuleName)
+  :: (Maybe result, Set.Set ModuleName)
+  -> ( IndexedModule patternType declAtts axiomAtts
+       -> Map.Map Id result
+       )
+  -> IndexedModule patternType declAtts axiomAtts
+  -> Id
+  -> (Maybe result, Set.Set ModuleName)
 resolveThingInternal x@(Just _, _) _ _ _ = x
 resolveThingInternal x@(Nothing, searchedModules) _ indexedModule _
-    | indexedModuleName indexedModule `Set.member` searchedModules = x
+  | indexedModuleName indexedModule `Set.member` searchedModules = x
 resolveThingInternal
-    (Nothing, searchedModules)
-    mapExtractor
-    indexedModule
-    thingId
-  =
+  (Nothing, searchedModules)
+  mapExtractor
+  indexedModule
+  thingId =
     case Map.lookup thingId things of
-        Just thing -> (Just thing, undefined {- this should never evaluate -})
-        Nothing ->
-            foldr
-                (\(_, _, m) partialResult -> resolveThingInternal
-                    partialResult
-                    mapExtractor
-                    m
-                    thingId
-                )
-                ( Nothing
-                , Set.insert (indexedModuleName indexedModule) searchedModules
-                )
-                (indexedModuleImports indexedModule)
-  where
-    things = mapExtractor indexedModule
+      Just thing -> (Just thing, undefined) {- this should never evaluate -}
+      Nothing ->
+        foldr
+          ( \(_, _, m) partialResult ->
+              resolveThingInternal
+                partialResult
+                mapExtractor
+                m
+                thingId
+            )
+          ( Nothing,
+            Set.insert (indexedModuleName indexedModule) searchedModules
+            )
+          (indexedModuleImports indexedModule)
+    where
+      things = mapExtractor indexedModule
 
 {-|'resolveSymbol' looks up a symbol id in an 'IndexedModule',
 also searching in the imported modules.
 -}
 resolveSymbol
-    :: MonadError (Error e) m
-    => IndexedModule patternType declAtts axiomAtts
-    -> Id
-    -> m (declAtts, SentenceSymbol patternType)
+  :: MonadError (Error e) m
+  => IndexedModule patternType declAtts axiomAtts
+  -> Id
+  -> m (declAtts, SentenceSymbol patternType)
 resolveSymbol m headId =
-    case resolveThing symbolSentencesMap m headId of
-        Nothing ->
-            koreFailWithLocations [headId] (noSymbolText headId)
-        Just result ->
-            return result
+  case resolveThing symbolSentencesMap m headId of
+    Nothing ->
+      koreFailWithLocations [headId] (noSymbolText headId)
+    Just result ->
+      return result
 
 {-|'resolveAlias' looks up a symbol id in an 'IndexedModule',
 also searching in the imported modules.
 -}
 resolveAlias
-    :: MonadError (Error e) m
-    => IndexedModule pat declAtts axiomAtts
-    -> Id
-    -> m (declAtts, SentenceAlias pat)
+  :: MonadError (Error e) m
+  => IndexedModule pat declAtts axiomAtts
+  -> Id
+  -> m (declAtts, SentenceAlias pat)
 resolveAlias m headId =
-    case resolveThing aliasSentencesMap m headId of
-        Nothing ->
-            koreFailWithLocations [headId] (noAliasText headId)
-        Just result ->
-            return result
-
-
+  case resolveThing aliasSentencesMap m headId of
+    Nothing ->
+      koreFailWithLocations [headId] (noAliasText headId)
+    Just result ->
+      return result
 
 {-|'resolveSort' looks up a sort id in an 'IndexedModule',
 also searching in the imported modules.
 -}
 resolveSort
-    :: MonadError (Error e) m
-    => IndexedModule patternType declAtts axiomAtts
-    -> Id
-    -> m (Attribute.Sort, SentenceSort patternType)
+  :: MonadError (Error e) m
+  => IndexedModule patternType declAtts axiomAtts
+  -> Id
+  -> m (Attribute.Sort, SentenceSort patternType)
 resolveSort m sortId =
-    case resolveThing sortSentencesMap m sortId of
-        Nothing ->
-            koreFailWithLocations [sortId] $ noSortText sortId
-        Just sortDescription ->
-            return sortDescription
+  case resolveThing sortSentencesMap m sortId of
+    Nothing ->
+      koreFailWithLocations [sortId] $ noSortText sortId
+    Just sortDescription ->
+      return sortDescription
 
 resolveHook
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Text
-    -> Sort
-    -> Either (Error e) Id
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Text
+  -> Sort
+  -> Either (Error e) Id
 resolveHook indexedModule builtinName builtinSort =
-    resolveHookHandler builtinName
+  resolveHookHandler builtinName
     $ Set.filter relevant
     $ resolveHooks indexedModule builtinName
   where
     relevant name =
-        involvesSort indexedModule builtinSort (SymbolOrAlias name [])
+      involvesSort indexedModule builtinSort (SymbolOrAlias name [])
 
 involvesSort
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Sort
-    -> SymbolOrAlias
-    -> Bool
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Sort
+  -> SymbolOrAlias
+  -> Bool
 involvesSort indexedModule builtinSort sym =
-    elem builtinSort $
-    (\s -> applicationSortsResult s : applicationSortsOperands s) $
-    getHeadApplicationSorts indexedModule sym
+  elem builtinSort
+    $ (\s -> applicationSortsResult s : applicationSortsOperands s)
+    $ getHeadApplicationSorts indexedModule sym
 
 resolveHookHandler
-    :: Text
-    -> Set Id
-    -> Either (Error e) Id
+  :: Text
+  -> Set Id
+  -> Either (Error e) Id
 resolveHookHandler builtinName results =
-    case Set.toList results of
-        [hookId] -> return hookId
-        [] ->
-            koreFail
-                ("Builtin '" ++ Text.unpack builtinName ++ "' is not hooked.")
-        hookIds ->
-            koreFail
-                ("Builtin '" ++ Text.unpack builtinName
-                    ++ "' is hooked to multiple identifiers: "
-                    ++ List.intercalate ", "
-                        (squotes . getIdForError <$> hookIds)
-                )
-      where
-        squotes str = "'" ++ str ++ "'"
+  case Set.toList results of
+    [hookId] -> return hookId
+    [] ->
+      koreFail
+        ("Builtin '" ++ Text.unpack builtinName ++ "' is not hooked.")
+    hookIds ->
+      koreFail
+        ( "Builtin '" ++ Text.unpack builtinName
+            ++ "' is hooked to multiple identifiers: "
+            ++ List.intercalate ", "
+                 (squotes . getIdForError <$> hookIds)
+          )
+  where
+    squotes str = "'" ++ str ++ "'"
 
 resolveHooks
-    :: IndexedModule patternType declAtts axiomAtts
-    -> Text
-    -> Set Id
+  :: IndexedModule patternType declAtts axiomAtts
+  -> Text
+  -> Set Id
 resolveHooks indexedModule builtinName =
-    foldMap resolveHooks1 allHooks
+  foldMap resolveHooks1 allHooks
   where
     allHooks = indexedModuleHooks <$> indexedModulesInScope indexedModule
     resolveHooks1 hooks =
-        maybe Set.empty Set.fromList (Map.lookup builtinName hooks)
+      maybe Set.empty Set.fromList (Map.lookup builtinName hooks)
 
 {- | Find a sort by name in an indexed module and its imports.
 
@@ -266,14 +279,13 @@ resolveHooks indexedModule builtinName =
 
  -}
 findIndexedSort
-    :: IndexedModule patternType declAtts axiomAtts
-    -- ^ indexed module
-    -> Id
-    -- ^ sort identifier
-    -> Either (Error e) (SentenceSort patternType)
+  :: IndexedModule patternType declAtts axiomAtts
+  -- ^ indexed module
+  -> Id
+  -- ^ sort identifier
+  -> Either (Error e) (SentenceSort patternType)
 findIndexedSort indexedModule sort =
-    fmap getIndexedSentence (resolveSort indexedModule sort)
-
+  fmap getIndexedSentence (resolveSort indexedModule sort)
 
 {- Utilities -}
 
@@ -281,29 +293,31 @@ findIndexedSort indexedModule sort =
 -- the fully type annotation is required even there, and that makes
 -- for too much clutter.
 applyToHeadSentence
-    :: (forall sentence.  SentenceSymbolOrAlias sentence
+  :: ( forall sentence. SentenceSymbolOrAlias sentence
        => [Sort]
        -> sentence pat
-       -> result)
-    -> IndexedModule pat declAtts axiomAtts
-    -> SymbolOrAlias
-    -> result
+       -> result
+       )
+  -> IndexedModule pat declAtts axiomAtts
+  -> SymbolOrAlias
+  -> result
 applyToHeadSentence f =
-     applyToResolution (\ params (_, sentence) -> f params sentence)
+  applyToResolution (\params (_, sentence) -> f params sentence)
 
 applyToResolution
-    :: HasCallStack
-    => (forall sentence.  SentenceSymbolOrAlias sentence
-        => [Sort]
-        -> (declAtts, sentence pat)
-        -> result)
-    -> IndexedModule pat declAtts axiomAtts
-    -> SymbolOrAlias
-    -> result
+  :: HasCallStack
+  => ( forall sentence. SentenceSymbolOrAlias sentence
+       => [Sort]
+       -> (declAtts, sentence pat)
+       -> result
+       )
+  -> IndexedModule pat declAtts axiomAtts
+  -> SymbolOrAlias
+  -> result
 applyToResolution f m patternHead =
-    case symbolResult <> aliasResult of
-        Right result -> result
-        Left _ -> error $ noHead patternHead
+  case symbolResult <> aliasResult of
+    Right result -> result
+    Left _ -> error $ noHead patternHead
   where
     headName = symbolOrAliasConstructor patternHead
     headParams = symbolOrAliasParams patternHead

--- a/kore/src/Kore/Internal/Alias.hs
+++ b/kore/src/Kore/Internal/Alias.hs
@@ -3,23 +3,23 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Internal.Alias
-    ( Alias (..)
-    , toSymbolOrAlias
+  ( Alias (..),
+    toSymbolOrAlias,
     -- * Re-exports
-    , module Kore.Internal.ApplicationSorts
-    ) where
+    module Kore.Internal.ApplicationSorts
+    )
+where
 
-import           Control.DeepSeq
+import Control.DeepSeq
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
-       ( FreeVariables )
+  ( FreeVariables
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Internal.ApplicationSorts
@@ -27,28 +27,28 @@ import Kore.Sort
 import Kore.Syntax.Application
 import Kore.Unparser
 
-data Alias =
-    Alias
-        { aliasConstructor :: !Id
-        , aliasParams      :: ![Sort]
-        , aliasSorts       :: !ApplicationSorts
+data Alias
+  = Alias
+      { aliasConstructor :: !Id,
+        aliasParams :: ![Sort],
+        aliasSorts :: !ApplicationSorts
         }
-    deriving (GHC.Generic, Show)
+  deriving (GHC.Generic, Show)
 
 instance Eq Alias where
-    (==) a b =
-            Function.on (==) aliasConstructor a b
-        &&  Function.on (==) aliasParams a b
-    {-# INLINE (==) #-}
+  (==) a b =
+    Function.on (==) aliasConstructor a b
+      && Function.on (==) aliasParams a b
+  {-# INLINE (==) #-}
 
 instance Ord Alias where
-    compare a b =
-            Function.on compare aliasConstructor a b
-        <>  Function.on compare aliasParams a b
+  compare a b =
+    Function.on compare aliasConstructor a b
+      <> Function.on compare aliasParams a b
 
 instance Hashable Alias where
-    hashWithSalt salt Alias { aliasConstructor, aliasParams } =
-        salt `hashWithSalt` aliasConstructor `hashWithSalt` aliasParams
+  hashWithSalt salt Alias {aliasConstructor, aliasParams} =
+    salt `hashWithSalt` aliasConstructor `hashWithSalt` aliasParams
 
 instance NFData Alias
 
@@ -59,34 +59,35 @@ instance SOP.HasDatatypeInfo Alias
 instance Debug Alias
 
 instance Unparse Alias where
-    unparse Alias { aliasConstructor, aliasParams } =
-        unparse aliasConstructor
-        <> parameters aliasParams
 
-    unparse2 Alias { aliasConstructor } =
-        unparse2 aliasConstructor
+  unparse Alias {aliasConstructor, aliasParams} =
+    unparse aliasConstructor
+      <> parameters aliasParams
+
+  unparse2 Alias {aliasConstructor} =
+    unparse2 aliasConstructor
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Application Alias)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Application Alias)
   where
-    -- TODO (thomas.tuegel): Consider that there could be bound variables here.
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  -- TODO (thomas.tuegel): Consider that there could be bound variables here.
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Application Alias) where
-    synthetic application =
-        resultSort Function.& deepseq (matchSorts operandSorts children)
-      where
-        Application { applicationSymbolOrAlias = alias } = application
-        Application { applicationChildren = children } = application
-        Alias { aliasSorts } = alias
-        resultSort = applicationSortsResult aliasSorts
-        operandSorts = applicationSortsOperands aliasSorts
+  synthetic application =
+    resultSort Function.& deepseq (matchSorts operandSorts children)
+    where
+      Application {applicationSymbolOrAlias = alias} = application
+      Application {applicationChildren = children} = application
+      Alias {aliasSorts} = alias
+      resultSort = applicationSortsResult aliasSorts
+      operandSorts = applicationSortsOperands aliasSorts
 
 toSymbolOrAlias :: Alias -> SymbolOrAlias
 toSymbolOrAlias alias =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = aliasConstructor alias
-        , symbolOrAliasParams = aliasParams alias
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = aliasConstructor alias,
+      symbolOrAliasParams = aliasParams alias
+      }

--- a/kore/src/Kore/Internal/ApplicationSorts.hs
+++ b/kore/src/Kore/Internal/ApplicationSorts.hs
@@ -3,35 +3,39 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Internal.ApplicationSorts
-    ( ApplicationSorts (..)
-    , applicationSorts
-    , symbolOrAliasSorts
-    ) where
+  ( ApplicationSorts (..),
+    applicationSorts,
+    symbolOrAliasSorts
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Function
-import           Data.Hashable
-                 ( Hashable )
-import           Data.Map
-                 ( Map )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Function
+import Data.Hashable
+  ( Hashable
+    )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Error
 import Kore.Sort hiding
-       ( substituteSortVariables )
+  ( substituteSortVariables
+    )
 import Kore.Syntax.Sentence
 
-data ApplicationSorts = ApplicationSorts
-    { applicationSortsOperands :: ![Sort]
-    , applicationSortsResult   :: !Sort
-    }
-    deriving (Eq, GHC.Generic, Ord, Show)
+data ApplicationSorts
+  = ApplicationSorts
+      { applicationSortsOperands :: ![Sort],
+        applicationSortsResult :: !Sort
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance NFData ApplicationSorts
 
@@ -50,65 +54,65 @@ applicationSorts = ApplicationSorts
 pattern from the given sort parameters.
 -}
 symbolOrAliasSorts
-    :: (SentenceSymbolOrAlias sentence, MonadError (Error e) m)
-    => [Sort]
-    -> sentence pat
-    -> m ApplicationSorts
+  :: (SentenceSymbolOrAlias sentence, MonadError (Error e) m)
+  => [Sort]
+  -> sentence pat
+  -> m ApplicationSorts
 symbolOrAliasSorts params sentence = do
-    variableToSort <-
-        pairVariablesToSorts
-            paramVariables
-            params
-    fullReturnSort <-
-        substituteSortVariables
-            (Map.fromList variableToSort)
-            parametrizedReturnSort
-    operandSorts <-
-        mapM
-            (substituteSortVariables (Map.fromList variableToSort))
-            parametrizedArgumentSorts
-    return ApplicationSorts
-        { applicationSortsOperands = operandSorts
-        , applicationSortsResult = fullReturnSort
-        }
+  variableToSort <-
+    pairVariablesToSorts
+      paramVariables
+      params
+  fullReturnSort <-
+    substituteSortVariables
+      (Map.fromList variableToSort)
+      parametrizedReturnSort
+  operandSorts <-
+    mapM
+      (substituteSortVariables (Map.fromList variableToSort))
+      parametrizedArgumentSorts
+  return ApplicationSorts
+    { applicationSortsOperands = operandSorts,
+      applicationSortsResult = fullReturnSort
+      }
   where
     paramVariables = getSentenceSymbolOrAliasSortParams sentence
     parametrizedArgumentSorts = getSentenceSymbolOrAliasArgumentSorts sentence
     parametrizedReturnSort = getSentenceSymbolOrAliasResultSort sentence
 
 substituteSortVariables
-    :: MonadError (Error e) m
-    => Map SortVariable Sort
-    -> Sort
-    -> m Sort
+  :: MonadError (Error e) m
+  => Map SortVariable Sort
+  -> Sort
+  -> m Sort
 substituteSortVariables variableToSort (SortVariableSort variable) =
-    Map.lookup variable variableToSort
+  Map.lookup variable variableToSort
     & maybe missingSortVariable return
   where
     missingSortVariable =
-        koreFail
-            (  "Sort variable not found: '"
+      koreFail
+        ( "Sort variable not found: '"
             ++ getIdForError (getSortVariable variable)
             ++ "'."
-            )
+          )
 substituteSortVariables
-    variableToSort
-    (SortActualSort sort@SortActual { sortActualSorts = sortList })
-  = do
-    substituted <- mapM (substituteSortVariables variableToSort) sortList
-    return (SortActualSort sort { sortActualSorts = substituted })
+  variableToSort
+  (SortActualSort sort@SortActual {sortActualSorts = sortList}) =
+    do
+      substituted <- mapM (substituteSortVariables variableToSort) sortList
+      return (SortActualSort sort {sortActualSorts = substituted})
 
 pairVariablesToSorts
-    :: MonadError (Error e) m
-    => [SortVariable]
-    -> [Sort]
-    -> m [(SortVariable, Sort)]
+  :: MonadError (Error e) m
+  => [SortVariable]
+  -> [Sort]
+  -> m [(SortVariable, Sort)]
 pairVariablesToSorts variables sorts
-    | variablesLength < sortsLength =
-        koreFail "Application uses more sorts than the declaration."
-    | variablesLength > sortsLength =
-        koreFail "Application uses less sorts than the declaration."
-    | otherwise = return (zip variables sorts)
+  | variablesLength < sortsLength =
+    koreFail "Application uses more sorts than the declaration."
+  | variablesLength > sortsLength =
+    koreFail "Application uses less sorts than the declaration."
+  | otherwise = return (zip variables sorts)
   where
     variablesLength = length variables
     sortsLength = length sorts

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -5,46 +5,55 @@ License     : NCSA
 Representation of conditional terms.
 -}
 module Kore.Internal.Conditional
-    ( Conditional (..)
-    , withoutTerm
-    , withCondition
-    , andCondition
-    , fromPredicate
-    , fromSubstitution
-    , fromSingleSubstitution
-    , andPredicate
-    , Kore.Internal.Conditional.freeVariables
-    , splitTerm
-    , toPredicate
-    , Kore.Internal.Conditional.mapVariables
-    ) where
+  ( Conditional (..),
+    withoutTerm,
+    withCondition,
+    andCondition,
+    fromPredicate,
+    fromSubstitution,
+    fromSingleSubstitution,
+    andPredicate,
+    Kore.Internal.Conditional.freeVariables,
+    splitTerm,
+    toPredicate,
+    Kore.Internal.Conditional.mapVariables
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Hashable
-import           Data.Monoid
-                 ( (<>) )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Hashable
+import Data.Monoid
+  ( (<>)
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables )
-import           Kore.Debug
-import           Kore.Internal.TermLike
-                 ( TermLike, termLikeSort )
-import           Kore.Predicate.Predicate
-                 ( Predicate )
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables
+    )
+import Kore.Debug
+import Kore.Internal.TermLike
+  ( TermLike,
+    termLikeSort
+    )
+import Kore.Predicate.Predicate
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Predicate
-import           Kore.Syntax
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unification.Substitution
-                 ( Substitution )
+import Kore.Syntax
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unification.Substitution
+  ( Substitution
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable )
+import Kore.Unparser
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable
+    )
 
 {- | @Conditional@ represents a value conditioned on a predicate.
 
@@ -59,25 +68,25 @@ There is intentionally no 'Monad' instance; such an instance would have
 quadratic complexity.
 
  -}
-data Conditional variable child =
-    Conditional
-        { term :: child
-        , predicate :: !(Predicate variable)
-        , substitution :: !(Substitution variable)
+data Conditional variable child
+  = Conditional
+      { term :: child,
+        predicate :: !(Predicate variable),
+        substitution :: !(Substitution variable)
         }
-    deriving (Foldable, Functor, GHC.Generic, Traversable)
+  deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 deriving instance
-    (Eq child, Ord variable) =>
-    Eq (Conditional variable child)
+  (Eq child, Ord variable)
+  => Eq (Conditional variable child)
 
 deriving instance
-    (Ord child, Ord variable) =>
-    Ord (Conditional variable child)
+  (Ord child, Ord variable)
+  => Ord (Conditional variable child)
 
 deriving instance
-    (Show child, Show variable) =>
-    Show (Conditional variable child)
+  (Show child, Show variable)
+  => Show (Conditional variable child)
 
 instance SOP.Generic (Conditional variable child)
 
@@ -86,155 +95,164 @@ instance SOP.HasDatatypeInfo (Conditional variable child)
 instance (Debug variable, Debug child) => Debug (Conditional variable child)
 
 instance
-    (Hashable child, Hashable variable) =>
-    Hashable (Conditional variable child)
+  (Hashable child, Hashable variable)
+  => Hashable (Conditional variable child)
 
 instance
-    (NFData child, NFData variable) =>
-    NFData (Conditional variable child)
+  (NFData child, NFData variable)
+  => NFData (Conditional variable child)
 
 instance
-    ( Ord variable
-    , Unparse variable
-    , SortedVariable variable
-    , Semigroup term
-    ) =>
-    Semigroup (Conditional variable term)
+  ( Ord variable,
+    Unparse variable,
+    SortedVariable variable,
+    Semigroup term
+    )
+  => Semigroup (Conditional variable term)
   where
-    (<>) predicated1 predicated2 = (<>) <$> predicated1 <*> predicated2
-    {-# INLINE (<>) #-}
+  (<>) predicated1 predicated2 = (<>) <$> predicated1 <*> predicated2
+  {-# INLINE (<>) #-}
 
 instance
-    ( Ord variable
-    , Unparse variable
-    , SortedVariable variable
-    , Monoid term
-    ) =>
-    Monoid (Conditional variable term)
+  ( Ord variable,
+    Unparse variable,
+    SortedVariable variable,
+    Monoid term
+    )
+  => Monoid (Conditional variable term)
   where
-    mempty =
-        Conditional
-            { term = mempty
-            , predicate = Predicate.makeTruePredicate
-            , substitution = mempty
-            }
-    {-# INLINE mempty #-}
 
-    mappend = (<>)
-    {-# INLINE mappend #-}
+  mempty =
+    Conditional
+      { term = mempty,
+        predicate = Predicate.makeTruePredicate,
+        substitution = mempty
+        }
+  {-# INLINE mempty #-}
+
+  mappend = (<>)
+  {-# INLINE mappend #-}
 
 instance
-    ( SortedVariable variable
-    , Ord variable
-    , Unparse variable
-    ) =>
-    Applicative (Conditional variable)
+  ( SortedVariable variable,
+    Ord variable,
+    Unparse variable
+    )
+  => Applicative (Conditional variable)
   where
-    pure term =
-        Conditional
-            { term
-            , predicate = Predicate.makeTruePredicate
-            , substitution = mempty
-            }
 
-    (<*>) predicated1 predicated2 =
-        Conditional
-            { term = f a
-            , predicate = Predicate.makeAndPredicate predicate1 predicate2
-            , substitution = substitution1 <> substitution2
-            }
-      where
-        Conditional f predicate1 substitution1 = predicated1
-        Conditional a predicate2 substitution2 = predicated2
+  pure term =
+    Conditional
+      { term,
+        predicate = Predicate.makeTruePredicate,
+        substitution = mempty
+        }
 
-instance TopBottom term
-    => TopBottom (Conditional variable term)
+  (<*>) predicated1 predicated2 =
+    Conditional
+      { term = f a,
+        predicate = Predicate.makeAndPredicate predicate1 predicate2,
+        substitution = substitution1 <> substitution2
+        }
+    where
+      Conditional f predicate1 substitution1 = predicated1
+      Conditional a predicate2 substitution2 = predicated2
+
+instance
+  TopBottom term
+  => TopBottom (Conditional variable term)
   where
-    isTop Conditional {term, predicate, substitution} =
-        isTop term && isTop predicate && isTop substitution
-    isBottom Conditional {term, predicate, substitution} =
-        isBottom term || isBottom predicate || isBottom substitution
 
-instance ( SortedVariable variable
-         , Ord variable
-         , Show variable
-         , Unparse variable
-         ) => Unparse (Conditional variable (TermLike variable)) where
-    unparse Conditional { term, predicate, substitution } =
-        unparseAnd
-            (below "/* term: */" (unparse term))
-            (unparseAnd
-                (below
-                    "/* predicate: */"
-                    (unparse termLikePredicate)
-                )
-                (below
-                    "/* substitution: */"
-                    (unparse termLikeSubstitution)
-                )
+  isTop Conditional {term, predicate, substitution} =
+    isTop term && isTop predicate && isTop substitution
+
+  isBottom Conditional {term, predicate, substitution} =
+    isBottom term || isBottom predicate || isBottom substitution
+
+instance
+  ( SortedVariable variable,
+    Ord variable,
+    Show variable,
+    Unparse variable
+    )
+  => Unparse (Conditional variable (TermLike variable))
+  where
+
+  unparse Conditional {term, predicate, substitution} =
+    unparseAnd
+      (below "/* term: */" (unparse term))
+      ( unparseAnd
+          ( below
+              "/* predicate: */"
+              (unparse termLikePredicate)
             )
-      where
-        unparseAnd first second =
-            "\\and" <> parameters' [unparse sort] <> arguments' [first, second]
-        below first second =
-            (Pretty.align . Pretty.vsep) [first, second]
-        sort = termLikeSort term
-        termLikePredicate = Predicate.fromPredicate sort predicate
-        termLikeSubstitution =
-            Predicate.fromPredicate
-                sort
-                $ Predicate.fromSubstitution substitution
-
-    unparse2 Conditional { term, predicate, substitution } =
-        unparseAnd2
-            (below "/* term: */" (unparse2 term))
-            (unparseAnd2
-                (below
-                    "/* predicate: */"
-                    (unparse2 termLikePredicate)
-                )
-                (below
-                    "/* substitution: */"
-                    (unparse2 termLikeSubstitution)
-                )
+          ( below
+              "/* substitution: */"
+              (unparse termLikeSubstitution)
             )
-      where
-        unparseAnd2 first second =
-            "\\and2" <> parameters' [unparse sort] <> arguments' [first, second]
-        below first second =
-            (Pretty.align . Pretty.vsep) [first, second]
-        sort = termLikeSort term
-        termLikePredicate = Predicate.fromPredicate sort predicate
-        termLikeSubstitution =
-            Predicate.fromPredicate
-                sort
-                $ Predicate.fromSubstitution substitution
+        )
+    where
+      unparseAnd first second =
+        "\\and" <> parameters' [unparse sort] <> arguments' [first, second]
+      below first second =
+        (Pretty.align . Pretty.vsep) [first, second]
+      sort = termLikeSort term
+      termLikePredicate = Predicate.fromPredicate sort predicate
+      termLikeSubstitution =
+        Predicate.fromPredicate
+          sort
+          $ Predicate.fromSubstitution substitution
+
+  unparse2 Conditional {term, predicate, substitution} =
+    unparseAnd2
+      (below "/* term: */" (unparse2 term))
+      ( unparseAnd2
+          ( below
+              "/* predicate: */"
+              (unparse2 termLikePredicate)
+            )
+          ( below
+              "/* substitution: */"
+              (unparse2 termLikeSubstitution)
+            )
+        )
+    where
+      unparseAnd2 first second =
+        "\\and2" <> parameters' [unparse sort] <> arguments' [first, second]
+      below first second =
+        (Pretty.align . Pretty.vsep) [first, second]
+      sort = termLikeSort term
+      termLikePredicate = Predicate.fromPredicate sort predicate
+      termLikeSubstitution =
+        Predicate.fromPredicate
+          sort
+          $ Predicate.fromSubstitution substitution
 
 {- | Forget the 'term', keeping only the attached conditions.
  -}
 withoutTerm :: Conditional variable term -> Conditional variable ()
-withoutTerm predicated = predicated { term = () }
+withoutTerm predicated = predicated {term = ()}
 
 {- | Attach the condition to the given 'term'.
  -}
 withCondition
-    :: term
-    -> Conditional variable ()
-    -- ^ Condition
-    -> Conditional variable term
-withCondition term predicated = predicated { term }
+  :: term
+  -> Conditional variable ()
+  -- ^ Condition
+  -> Conditional variable term
+withCondition term predicated = predicated {term}
 
 {- | Combine the conditions of both arguments, taking the 'term' of the first.
  -}
 andCondition
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Conditional variable term
-    -> Conditional variable ()
-    -> Conditional variable term
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Conditional variable term
+  -> Conditional variable ()
+  -> Conditional variable term
 andCondition = (<*)
 
 {- | Construct a 'Conditional' holding the given 'Predicate'.
@@ -243,11 +261,11 @@ The result has an empty 'Substitution'.
 
  -}
 fromPredicate
-    :: Ord variable
-    => Predicate variable
-    -> Conditional variable ()
+  :: Ord variable
+  => Predicate variable
+  -> Conditional variable ()
 fromPredicate predicate =
-    Conditional { term = (), predicate, substitution = mempty }
+  Conditional {term = (), predicate, substitution = mempty}
 
 {- | Construct a 'Conditional' holding the given 'Substitution'.
 
@@ -255,15 +273,15 @@ The result has a true 'Predicate'.
 
  -}
 fromSubstitution
-    :: (Ord variable, SortedVariable variable)
-    => Substitution variable
-    -> Conditional variable ()
+  :: (Ord variable, SortedVariable variable)
+  => Substitution variable
+  -> Conditional variable ()
 fromSubstitution substitution =
-    Conditional
-        { term = ()
-        , predicate = Predicate.makeTruePredicate
-        , substitution
-        }
+  Conditional
+    { term = (),
+      predicate = Predicate.makeTruePredicate,
+      substitution
+      }
 
 {- | Construct a 'Conditional' holding a single substitution.
 
@@ -271,27 +289,27 @@ The result has a true 'Predicate'.
 
  -}
 fromSingleSubstitution
-    :: (Ord variable, SortedVariable variable)
-    => (UnifiedVariable variable, TermLike variable)
-    -> Conditional variable ()
+  :: (Ord variable, SortedVariable variable)
+  => (UnifiedVariable variable, TermLike variable)
+  -> Conditional variable ()
 fromSingleSubstitution pair =
-    Conditional
-        { term = ()
-        , predicate = Predicate.makeTruePredicate
-        , substitution = Substitution.wrap [pair]
-        }
+  Conditional
+    { term = (),
+      predicate = Predicate.makeTruePredicate,
+      substitution = Substitution.wrap [pair]
+      }
 
 {- | Combine the predicate with the conditions of the first argument.
  -}
 andPredicate
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Conditional variable term
-    -> Predicate variable
-    -> Conditional variable term
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Conditional variable term
+  -> Predicate variable
+  -> Conditional variable term
 andPredicate config predicate = config `andCondition` fromPredicate predicate
 
 {- | Extract the set of free variables from a 'Conditional' term.
@@ -299,13 +317,13 @@ andPredicate config predicate = config `andCondition` fromPredicate predicate
 See also: 'Predicate.freeVariables'.
 -}
 freeVariables
-    :: Ord variable
-    => (term -> FreeVariables variable)
-    -- ^ Extract the free variables of @term@.
-    -> Conditional variable term
-    -> FreeVariables variable
-freeVariables getFreeVariables Conditional { term, predicate, substitution } =
-    getFreeVariables term
+  :: Ord variable
+  => (term -> FreeVariables variable)
+  -- ^ Extract the free variables of @term@.
+  -> Conditional variable term
+  -> FreeVariables variable
+freeVariables getFreeVariables Conditional {term, predicate, substitution} =
+  getFreeVariables term
     <> Predicate.freeVariables predicate
     <> Substitution.freeVariables substitution
 
@@ -323,37 +341,36 @@ See also: 'substitutionToPredicate'.
 
 -}
 toPredicate
-    :: ( SortedVariable variable
-       , Ord variable
-       , Show variable
-       , Unparse variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
        )
-    => Conditional variable term
-    -> Predicate variable
-toPredicate Conditional { predicate, substitution } =
-    Predicate.makeAndPredicate
-        predicate
-        (Predicate.fromSubstitution substitution)
+  => Conditional variable term
+  -> Predicate variable
+toPredicate Conditional {predicate, substitution} =
+  Predicate.makeAndPredicate
+    predicate
+    (Predicate.fromSubstitution substitution)
 
 {- | Transform all variables (free and quantified) in a 'Conditional' term.
 
 -}
 mapVariables
-    :: (Ord variableFrom, Ord variableTo)
-    => ((variableFrom -> variableTo) -> termFrom -> termTo)
-    -> (variableFrom -> variableTo)
-    -> Conditional variableFrom termFrom
-    -> Conditional variableTo   termTo
+  :: (Ord variableFrom, Ord variableTo)
+  => ((variableFrom -> variableTo) -> termFrom -> termTo)
+  -> (variableFrom -> variableTo)
+  -> Conditional variableFrom termFrom
+  -> Conditional variableTo termTo
 mapVariables
-    mapTermVariables
-    mapVariable
-    Conditional { term, predicate, substitution }
-  =
+  mapTermVariables
+  mapVariable
+  Conditional {term, predicate, substitution} =
     Conditional
-        { term = mapTermVariables mapVariable term
-        , predicate = Predicate.mapVariables mapVariable predicate
-        , substitution = Substitution.mapVariables mapVariable substitution
+      { term = mapTermVariables mapVariable term,
+        predicate = Predicate.mapVariables mapVariable predicate,
+        substitution = Substitution.mapVariables mapVariable substitution
         }
 
 splitTerm :: Conditional variable term -> (term, Conditional variable ())
-splitTerm patt@Conditional { term } = (term, withoutTerm patt)
+splitTerm patt@Conditional {term} = (term, withoutTerm patt)

--- a/kore/src/Kore/Internal/MultiOr.hs
+++ b/kore/src/Kore/Internal/MultiOr.hs
@@ -9,37 +9,42 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Internal.MultiOr
-    ( MultiOr (..)
-    , crossProductGeneric
-    , crossProductGenericF
-    , extractPatterns
-    , filterOr
-    , flatten
-    , flattenGeneric
-    , fullCrossProduct
-    , make
-    , merge
-    , mergeAll
-    , singleton
+  ( MultiOr (..),
+    crossProductGeneric,
+    crossProductGenericF,
+    extractPatterns,
+    filterOr,
+    flatten,
+    flattenGeneric,
+    fullCrossProduct,
+    make,
+    merge,
+    mergeAll,
+    singleton,
     -- * Re-exports
-    , Alternative (..)
-    ) where
+    Alternative (..)
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.List
-                 ( foldl' )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.List
+  ( foldl'
+    )
 import qualified Data.Set as Set
-import qualified Generics.SOP as SOP
-import           GHC.Exts
-                 ( IsList )
+import GHC.Exts
+  ( IsList
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.TopBottom
-       ( TopBottom (..) )
+  ( TopBottom (..)
+    )
 
 {-| 'MultiOr' is a Matching logic or of its children
 
@@ -54,20 +59,20 @@ A non-empty 'MultiOr' would also have a nice symmetry between 'Top' and 'Bottom'
 patterns.
 
 -}
-newtype MultiOr child = MultiOr { getMultiOr :: [child] }
-    deriving
-        ( Alternative
-        , Applicative
-        , Eq
-        , Foldable
-        , Functor
-        , GHC.Generic
-        , IsList
-        , Monad
-        , Ord
-        , Show
-        , Traversable
-        )
+newtype MultiOr child = MultiOr {getMultiOr :: [child]}
+  deriving
+    ( Alternative,
+      Applicative,
+      Eq,
+      Foldable,
+      Functor,
+      GHC.Generic,
+      IsList,
+      Monad,
+      Ord,
+      Show,
+      Traversable
+      )
 
 instance SOP.Generic (MultiOr child)
 
@@ -76,20 +81,22 @@ instance SOP.HasDatatypeInfo (MultiOr child)
 instance Debug child => Debug (MultiOr child)
 
 instance (Ord child, TopBottom child) => Semigroup (MultiOr child) where
-    (MultiOr []) <> b = b
-    a <> (MultiOr []) = a
-    (MultiOr a) <> (MultiOr b) = make (a <> b)
+  (MultiOr []) <> b = b
+  a <> (MultiOr []) = a
+  (MultiOr a) <> (MultiOr b) = make (a <> b)
 
 instance (Ord child, TopBottom child) => Monoid (MultiOr child) where
-    mempty = make []
+  mempty = make []
 
 instance NFData child => NFData (MultiOr child)
 
 instance TopBottom child => TopBottom (MultiOr child) where
-    isTop (MultiOr [child]) = isTop child
-    isTop _ = False
-    isBottom (MultiOr []) = True
-    isBottom _ = False
+
+  isTop (MultiOr [child]) = isTop child
+  isTop _ = False
+
+  isBottom (MultiOr []) = True
+  isBottom _ = False
 
 {-| 'OrBool' is an some sort of Bool data type used when evaluating things
 inside a 'MultiOr'.
@@ -106,9 +113,9 @@ See also: 'filterUnique'
 
 -}
 filterOr
-    :: (Ord term, TopBottom term)
-    => MultiOr term
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => MultiOr term
+  -> MultiOr term
 filterOr = filterGeneric patternToOrBool . filterUnique
 
 {- | Simplify the disjunction by eliminating duplicate elements.
@@ -129,17 +136,17 @@ filterUnique = MultiOr . Set.toList . Set.fromList . getMultiOr
 {-| 'make' constructs a normalized 'MultiOr'.
 -}
 make
-    :: (Ord term, TopBottom term)
-    => [term]
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => [term]
+  -> MultiOr term
 make patts = filterOr (MultiOr patts)
 
 {- | Construct a normalized 'MultiOr' from a single pattern.
 -}
 singleton
-    :: (Ord term, TopBottom term)
-    => term
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => term
+  -> MultiOr term
 singleton patt = make [patt]
 
 {-| 'extractPatterns' instantiates 'getMultiOr' at 'Pattern'.
@@ -147,8 +154,8 @@ singleton patt = make [patt]
 It returns the patterns inside an @\or@.
 -}
 extractPatterns
-    :: MultiOr term
-    -> [term]
+  :: MultiOr term
+  -> [term]
 extractPatterns = getMultiOr
 
 {-| 'fullCrossProduct' distributes all the elements in a list of or, making
@@ -183,11 +190,11 @@ makeGeneric
 
 -}
 fullCrossProduct
-    :: [MultiOr term]
-    -> MultiOr [term]
+  :: [MultiOr term]
+  -> MultiOr [term]
 fullCrossProduct [] = MultiOr [[]]
 fullCrossProduct ors =
-    foldr (crossProductGeneric (:)) lastOrsWithLists (init ors)
+  foldr (crossProductGeneric (:)) lastOrsWithLists (init ors)
   where
     lastOrsWithLists = fmap (: []) (last ors)
 
@@ -195,18 +202,19 @@ fullCrossProduct ors =
 into a (MultiOr term) by or-ing all the inner elements.
 -}
 flatten
-    :: (Ord term, TopBottom term)
-    => MultiOr (MultiOr term)
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => MultiOr (MultiOr term)
+  -> MultiOr term
 flatten ors =
-    filterOr (flattenGeneric ors)
+  filterOr (flattenGeneric ors)
 
 {-| 'patternToOrBool' does a very simple attempt to check whether a pattern
 is top or bottom.
 -}
 patternToOrBool
-    :: TopBottom term
-    => term -> OrBool
+  :: TopBottom term
+  => term
+  -> OrBool
 patternToOrBool patt
   | isTop patt = OrTrue
   | isBottom patt = OrFalse
@@ -216,22 +224,23 @@ patternToOrBool patt
 evaluates its children to true/false/unknown.
 -}
 filterGeneric
-    :: (child -> OrBool)
-    -> MultiOr child
-    -> MultiOr child
+  :: (child -> OrBool)
+  -> MultiOr child
+  -> MultiOr child
 filterGeneric orFilter (MultiOr patts) =
-    go orFilter [] patts
+  go orFilter [] patts
   where
-    go  :: (child -> OrBool)
-        -> [child]
-        -> [child]
-        -> MultiOr child
+    go
+      :: (child -> OrBool)
+      -> [child]
+      -> [child]
+      -> MultiOr child
     go _ filtered [] = MultiOr (reverse filtered)
-    go filterOr' filtered (element:unfiltered) =
-        case filterOr' element of
-            OrTrue -> MultiOr [element]
-            OrFalse -> go filterOr' filtered unfiltered
-            OrUnknown -> go filterOr' (element:filtered) unfiltered
+    go filterOr' filtered (element : unfiltered) =
+      case filterOr' element of
+        OrTrue -> MultiOr [element]
+        OrFalse -> go filterOr' filtered unfiltered
+        OrUnknown -> go filterOr' (element : filtered) unfiltered
 
 {- | Merge two disjunctions of items.
 
@@ -239,12 +248,12 @@ The result is simplified with the 'filterOr' function.
 
 -}
 merge
-    :: (Ord term, TopBottom term)
-    => MultiOr term
-    -> MultiOr term
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => MultiOr term
+  -> MultiOr term
+  -> MultiOr term
 merge patts1 patts2 =
-    filterOr (mergeGeneric patts1 patts2)
+  filterOr (mergeGeneric patts1 patts2)
 
 {- | Merge any number of disjunctions of items.
 
@@ -252,29 +261,29 @@ The result is simplified with the 'filterOr' function.
 
 -}
 mergeAll
-    :: (Ord term, TopBottom term)
-    => [MultiOr term]
-    -> MultiOr term
+  :: (Ord term, TopBottom term)
+  => [MultiOr term]
+  -> MultiOr term
 mergeAll ors =
-    filterOr (foldl' mergeGeneric (make []) ors)
+  filterOr (foldl' mergeGeneric (make []) ors)
 
 {-| 'merge' merges two 'MultiOr'.
 -}
 mergeGeneric
-    :: MultiOr child
-    -> MultiOr child
-    -> MultiOr child
+  :: MultiOr child
+  -> MultiOr child
+  -> MultiOr child
 -- TODO(virgil): All *Generic functions should also receive a filter,
 -- otherwise we could have unexpected results when a caller uses the generic
 -- version but produces a result with Patterns.
 mergeGeneric (MultiOr patts1) (MultiOr patts2) =
-    MultiOr (patts1 ++ patts2)
+  MultiOr (patts1 ++ patts2)
 
 {-| 'flattenGeneric' merges all 'MultiOr's inside a 'MultiOr'.
 -}
 flattenGeneric
-    :: MultiOr (MultiOr child)
-    -> MultiOr child
+  :: MultiOr (MultiOr child)
+  -> MultiOr child
 flattenGeneric (MultiOr []) = MultiOr []
 flattenGeneric (MultiOr ors) = foldr1 mergeGeneric ors
 
@@ -282,13 +291,13 @@ flattenGeneric (MultiOr ors) = foldr1 mergeGeneric ors
 applicative thing.
 -}
 crossProductGenericF
-    :: Applicative f
-    => (child1 -> child2 -> f child3)
-    -> MultiOr child1
-    -> MultiOr child2
-    -> f (MultiOr child3)
+  :: Applicative f
+  => (child1 -> child2 -> f child3)
+  -> MultiOr child1
+  -> MultiOr child2
+  -> f (MultiOr child3)
 crossProductGenericF joiner (MultiOr first) (MultiOr second) =
-    MultiOr <$> sequenceA (joiner <$> first <*> second)
+  MultiOr <$> sequenceA (joiner <$> first <*> second)
 
 {-| 'crossProductGeneric' makes all pairs between the elements of two ors,
 then applies the given function to the result.
@@ -316,9 +325,9 @@ makeGeneric
 
 -}
 crossProductGeneric
-    :: (child1 -> child2 -> child3)
-    -> MultiOr child1
-    -> MultiOr child2
-    -> MultiOr child3
+  :: (child1 -> child2 -> child3)
+  -> MultiOr child1
+  -> MultiOr child2
+  -> MultiOr child3
 crossProductGeneric joiner (MultiOr first) (MultiOr second) =
-    MultiOr $ joiner <$> first <*> second
+  MultiOr $ joiner <$> first <*> second

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -4,35 +4,38 @@ License     : NCSA
 
 -}
 module Kore.Internal.OrPattern
-    ( OrPattern
-    , fromPatterns
-    , toPatterns
-    , fromPattern
-    , fromTermLike
-    , bottom
-    , isFalse
-    , top
-    , isTrue
-    , toPattern
-    , toTermLike
-    , MultiOr.flatten
-    , MultiOr.filterOr
-    ) where
+  ( OrPattern,
+    fromPatterns,
+    toPatterns,
+    fromPattern,
+    fromTermLike,
+    bottom,
+    isFalse,
+    top,
+    isTrue,
+    toPattern,
+    toTermLike,
+    MultiOr.flatten,
+    MultiOr.filterOr
+    )
+where
 
 import qualified Data.Foldable as Foldable
-
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unparser
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unparser
 
 {-| The disjunction of 'Pattern'.
 -}
@@ -41,17 +44,17 @@ type OrPattern variable = MultiOr (Pattern variable)
 {- | A "disjunction" of one 'Pattern.Pattern'.
  -}
 fromPattern
-    :: Ord variable
-    => Pattern variable
-    -> OrPattern variable
+  :: Ord variable
+  => Pattern variable
+  -> OrPattern variable
 fromPattern = MultiOr.singleton
 
 {- | Disjoin a collection of patterns.
  -}
 fromPatterns
-    :: (Foldable f, Ord variable)
-    => f (Pattern variable)
-    -> OrPattern variable
+  :: (Foldable f, Ord variable)
+  => f (Pattern variable)
+  -> OrPattern variable
 fromPatterns = MultiOr.make . Foldable.toList
 
 {- | Examine a disjunction of 'Pattern.Pattern's.
@@ -65,9 +68,9 @@ See also: 'fromPattern'
 
  -}
 fromTermLike
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> OrPattern variable
 fromTermLike = fromPattern . Pattern.fromTermLike
 
 {- | @\\bottom@
@@ -104,34 +107,36 @@ isTrue = isTop
 an 'Pattern.Pattern'.
 -}
 toPattern
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => OrPattern variable -> Pattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> Pattern variable
 toPattern multiOr =
-    case MultiOr.extractPatterns multiOr of
-        [] -> Pattern.bottom
-        [patt] -> patt
-        patts ->
-            Conditional.Conditional
-                { term = Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts)
-                , predicate = Syntax.Predicate.makeTruePredicate
-                , substitution = mempty
-                }
+  case MultiOr.extractPatterns multiOr of
+    [] -> Pattern.bottom
+    [patt] -> patt
+    patts ->
+      Conditional.Conditional
+        { term = Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts),
+          predicate = Syntax.Predicate.makeTruePredicate,
+          substitution = mempty
+          }
 
 {-| Transforms a 'Pattern' into a 'TermLike'.
 -}
 toTermLike
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => OrPattern variable -> TermLike variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> TermLike variable
 toTermLike multiOr =
-    case MultiOr.extractPatterns multiOr of
-        [] -> mkBottom_
-        [patt] -> Pattern.toTermLike patt
-        patts -> Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts)
+  case MultiOr.extractPatterns multiOr of
+    [] -> mkBottom_
+    [patt] -> Pattern.toTermLike patt
+    patts -> Foldable.foldr1 mkOr (Pattern.toTermLike <$> patts)

--- a/kore/src/Kore/Internal/OrPredicate.hs
+++ b/kore/src/Kore/Internal/OrPredicate.hs
@@ -4,32 +4,35 @@ License     : NCSA
 
 -}
 module Kore.Internal.OrPredicate
-    ( OrPredicate
-    , fromPredicates
-    , fromPredicate
-    , bottom
-    , top
-    , isFalse
-    , isTrue
-    , toPredicate
-    ) where
+  ( OrPredicate,
+    fromPredicates,
+    fromPredicate,
+    bottom,
+    top,
+    isFalse,
+    isTrue,
+    toPredicate
+    )
+where
 
 import qualified Data.Foldable as Foldable
-
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unparser
-
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unparser
 
 {-| The disjunction of 'Predicate'.
 -}
@@ -38,17 +41,17 @@ type OrPredicate variable = MultiOr (Predicate variable)
 {- | A "disjunction" of one 'Predicate'.
  -}
 fromPredicate
-    :: Ord variable
-    => Predicate variable
-    -> OrPredicate variable
+  :: Ord variable
+  => Predicate variable
+  -> OrPredicate variable
 fromPredicate = MultiOr.singleton
 
 {- | Disjoin a collection of predicates.
  -}
 fromPredicates
-    :: (Foldable f, Ord variable)
-    => f (Predicate variable)
-    -> OrPredicate variable
+  :: (Foldable f, Ord variable)
+  => f (Predicate variable)
+  -> OrPredicate variable
 fromPredicates = MultiOr.make . Foldable.toList
 
 {- | @\\bottom@
@@ -83,11 +86,12 @@ isTrue = isTop
 
 {-| Transforms an 'Predicate' into a 'Predicate.Predicate'. -}
 toPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => MultiOr (Syntax.Predicate variable) -> Syntax.Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => MultiOr (Syntax.Predicate variable)
+  -> Syntax.Predicate variable
 toPredicate multiOr =
-    Syntax.Predicate.makeMultipleOrPredicate (MultiOr.extractPatterns multiOr)
+  Syntax.Predicate.makeMultipleOrPredicate (MultiOr.extractPatterns multiOr)

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -5,47 +5,54 @@ License     : NCSA
 Representation of program configurations as conditional patterns.
 -}
 module Kore.Internal.Pattern
-    ( Pattern
-    , fromPredicate
-    , fromPredicateSorted
-    , toPredicate
-    , bottom
-    , bottomOf
-    , isBottom
-    , isTop
-    , Kore.Internal.Pattern.mapVariables
-    , splitTerm
-    , toTermLike
-    , top
-    , topOf
-    , fromTermLike
-    , Kore.Internal.Pattern.freeVariables
-    , Kore.Internal.Pattern.freeElementVariables
+  ( Pattern,
+    fromPredicate,
+    fromPredicateSorted,
+    toPredicate,
+    bottom,
+    bottomOf,
+    isBottom,
+    isTop,
+    Kore.Internal.Pattern.mapVariables,
+    splitTerm,
+    toTermLike,
+    top,
+    topOf,
+    fromTermLike,
+    Kore.Internal.Pattern.freeVariables,
+    Kore.Internal.Pattern.freeElementVariables,
     -- * Re-exports
-    , Conditional (..)
-    , Conditional.withCondition
-    , Conditional.withoutTerm
-    , Predicate
-    ) where
+    Conditional (..),
+    Conditional.withCondition,
+    Conditional.withoutTerm,
+    Predicate
+    )
+where
 
 import GHC.Stack
-       ( HasCallStack )
-
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables, getFreeElementVariables )
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
+  ( HasCallStack
+    )
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables,
+    getFreeElementVariables
+    )
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.Predicate
-                 ( Predicate )
-import           Kore.Internal.TermLike as TermLike
+import Kore.Internal.Predicate
+  ( Predicate
+    )
+import Kore.Internal.TermLike as TermLike
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.TopBottom
-                 ( TopBottom (..) )
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
+import Kore.Unparser
 
 {- | The conjunction of a pattern, predicate, and substitution.
 
@@ -56,48 +63,47 @@ program configuration for Kore execution.
 type Pattern variable = Conditional variable (TermLike variable)
 
 fromPredicate
-    :: (Ord variable, SortedVariable variable)
-    => Predicate variable
-    -> Pattern variable
+  :: (Ord variable, SortedVariable variable)
+  => Predicate variable
+  -> Pattern variable
 fromPredicate = (<$) mkTop_
 
 fromPredicateSorted
-    :: (Ord variable, SortedVariable variable)
-    => Sort
-    -> Predicate variable
-    -> Pattern variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort
+  -> Predicate variable
+  -> Pattern variable
 fromPredicateSorted sort = (<$) (mkTop sort)
 
 freeVariables
-    :: Ord variable
-    => Pattern variable
-    -> FreeVariables variable
+  :: Ord variable
+  => Pattern variable
+  -> FreeVariables variable
 freeVariables = Conditional.freeVariables TermLike.freeVariables
 
 freeElementVariables
-    :: Ord variable
-    => Pattern variable
-    -> [ElementVariable variable]
+  :: Ord variable
+  => Pattern variable
+  -> [ElementVariable variable]
 freeElementVariables =
-    getFreeElementVariables . Kore.Internal.Pattern.freeVariables
+  getFreeElementVariables . Kore.Internal.Pattern.freeVariables
 
 {-|'mapVariables' transforms all variables, including the quantified ones,
 in an Pattern.
 -}
 mapVariables
-    :: (Ord variableFrom, Ord variableTo)
-    => (variableFrom -> variableTo)
-    -> Pattern variableFrom
-    -> Pattern variableTo
+  :: (Ord variableFrom, Ord variableTo)
+  => (variableFrom -> variableTo)
+  -> Pattern variableFrom
+  -> Pattern variableTo
 mapVariables
-    variableMapper
-    Conditional { term, predicate, substitution }
-  =
+  variableMapper
+  Conditional {term, predicate, substitution} =
     Conditional
-        { term = TermLike.mapVariables variableMapper term
-        , predicate = Syntax.Predicate.mapVariables variableMapper predicate
-        , substitution =
-            Substitution.mapVariables variableMapper substitution
+      { term = TermLike.mapVariables variableMapper term,
+        predicate = Syntax.Predicate.mapVariables variableMapper predicate,
+        substitution =
+          Substitution.mapVariables variableMapper substitution
         }
 
 {- | Convert an 'Pattern' to an ordinary 'TermLike'.
@@ -109,30 +115,30 @@ important.
 
  -}
 toTermLike
-    ::  forall variable.
-        ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , HasCallStack
-        )
-    => Pattern variable -> TermLike variable
-toTermLike Conditional { term, predicate, substitution } =
-    simpleAnd
-        (simpleAnd term predicate)
-        (Syntax.Predicate.fromSubstitution substitution)
+  :: forall variable. ( SortedVariable variable,
+                        Ord variable,
+                        Show variable,
+                        Unparse variable,
+                        HasCallStack
+                        )
+  => Pattern variable
+  -> TermLike variable
+toTermLike Conditional {term, predicate, substitution} =
+  simpleAnd
+    (simpleAnd term predicate)
+    (Syntax.Predicate.fromSubstitution substitution)
   where
     -- TODO: Most likely I defined this somewhere.
     simpleAnd
-        :: TermLike variable
-        -> Syntax.Predicate variable
-        -> TermLike variable
+      :: TermLike variable
+      -> Syntax.Predicate variable
+      -> TermLike variable
     simpleAnd pattern' predicate'
-      | isTop predicate'    = pattern'
+      | isTop predicate' = pattern'
       | isBottom predicate' = mkBottom sort
-      | isTop pattern'      = predicateTermLike
-      | isBottom pattern'   = pattern'
-      | otherwise           = mkAnd pattern' predicateTermLike
+      | isTop pattern' = predicateTermLike
+      | isBottom pattern' = pattern'
+      | otherwise = mkAnd pattern' predicateTermLike
       where
         predicateTermLike = Syntax.Predicate.fromPredicate sort predicate'
         sort = termLikeSort pattern'
@@ -142,11 +148,11 @@ should become Bottom when transformed to a ML pattern.
 -}
 bottom :: (Ord variable, SortedVariable variable) => Pattern variable
 bottom =
-    Conditional
-        { term      = mkBottom_
-        , predicate = Syntax.Predicate.makeFalsePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = mkBottom_,
+      predicate = Syntax.Predicate.makeFalsePredicate,
+      substitution = mempty
+      }
 
 {- | An 'Pattern' where the 'term' is 'Bottom' of the given 'Sort'.
 
@@ -155,32 +161,32 @@ The 'predicate' is set to 'makeFalsePredicate'.
  -}
 bottomOf :: (Ord variable, SortedVariable variable) => Sort -> Pattern variable
 bottomOf resultSort =
-    Conditional
-        { term      = mkBottom resultSort
-        , predicate = Syntax.Predicate.makeFalsePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = mkBottom resultSort,
+      predicate = Syntax.Predicate.makeFalsePredicate,
+      substitution = mempty
+      }
 
 {-|'top' is an expanded pattern that has a top condition and that
 should become Top when transformed to a ML pattern.
 -}
 top :: (Ord variable, SortedVariable variable) => Pattern variable
 top =
-    Conditional
-        { term      = mkTop_
-        , predicate = Syntax.Predicate.makeTruePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = mkTop_,
+      predicate = Syntax.Predicate.makeTruePredicate,
+      substitution = mempty
+      }
 
 {- | An 'Pattern' where the 'term' is 'Top' of the given 'Sort'.
  -}
 topOf :: (Ord variable, SortedVariable variable) => Sort -> Pattern variable
 topOf resultSort =
-    Conditional
-        { term      = mkTop resultSort
-        , predicate = Syntax.Predicate.makeTruePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = mkTop resultSort,
+      predicate = Syntax.Predicate.makeTruePredicate,
+      substitution = mempty
+      }
 
 {- | Construct an 'Pattern' from a 'TermLike'.
 
@@ -191,26 +197,26 @@ See also: 'makeTruePredicate', 'pure'
 
  -}
 fromTermLike
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> Pattern variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> Pattern variable
 fromTermLike term
   | isBottom term = bottom
   | otherwise =
     Conditional
-        { term
-        , predicate = Syntax.Predicate.makeTruePredicate
-        , substitution = mempty
+      { term,
+        predicate = Syntax.Predicate.makeTruePredicate,
+        substitution = mempty
         }
 
 toPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Pattern variable
-    -> Syntax.Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Pattern variable
+  -> Syntax.Predicate variable
 toPredicate = Conditional.toPredicate
 
 splitTerm :: Pattern variable -> (TermLike variable, Predicate variable)

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -4,52 +4,55 @@ License     : NCSA
 
 -}
 module Kore.Internal.Predicate
-    ( Predicate
-    , eraseConditionalTerm
-    , top
-    , topTODO
-    , bottom
-    , topPredicate
-    , bottomPredicate
-    , fromPattern
-    , Conditional.fromPredicate
-    , Conditional.fromSingleSubstitution
-    , Conditional.fromSubstitution
-    , toPredicate
-    , freeVariables
-    , Kore.Internal.Predicate.mapVariables
+  ( Predicate,
+    eraseConditionalTerm,
+    top,
+    topTODO,
+    bottom,
+    topPredicate,
+    bottomPredicate,
+    fromPattern,
+    Conditional.fromPredicate,
+    Conditional.fromSingleSubstitution,
+    Conditional.fromSubstitution,
+    toPredicate,
+    freeVariables,
+    Kore.Internal.Predicate.mapVariables,
     -- * Re-exports
-    , Conditional (..)
-    ) where
+    Conditional (..)
+    )
+where
 
-
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables )
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables
+    )
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.Syntax
-import           Kore.Unparser
+import Kore.Syntax
+import Kore.Unparser
 
 -- | A predicate and substitution without an accompanying term.
 type Predicate variable = Conditional variable ()
 
 -- | Erase the @Conditional@ 'term' to yield a 'Predicate'.
 eraseConditionalTerm
-    :: Conditional variable child
-    -> Predicate variable
+  :: Conditional variable child
+  -> Predicate variable
 eraseConditionalTerm = Conditional.withoutTerm
 
 top :: (Ord variable, SortedVariable variable) => Predicate variable
 top =
-    Conditional
-        { term = ()
-        , predicate = Syntax.Predicate.makeTruePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = (),
+      predicate = Syntax.Predicate.makeTruePredicate,
+      substitution = mempty
+      }
 
 -- | A 'top' 'Predicate' for refactoring which should eventually be removed.
 topTODO :: (Ord variable, SortedVariable variable) => Predicate variable
@@ -57,33 +60,32 @@ topTODO = top
 
 bottom :: (Ord variable, SortedVariable variable) => Predicate variable
 bottom =
-    Conditional
-        { term = ()
-        , predicate = Syntax.Predicate.makeFalsePredicate
-        , substitution = mempty
-        }
+  Conditional
+    { term = (),
+      predicate = Syntax.Predicate.makeFalsePredicate,
+      substitution = mempty
+      }
 
 topPredicate :: (Ord variable, SortedVariable variable) => Predicate variable
 topPredicate = top
 
 bottomPredicate
-    :: (Ord variable, SortedVariable variable)
-    => Predicate variable
+  :: (Ord variable, SortedVariable variable)
+  => Predicate variable
 bottomPredicate = bottom
 
 {- | Extract the set of free variables from a predicate and substitution.
 
     See also: 'Predicate.freeVariables'.
 -}
-
 freeVariables
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => Predicate variable
-    -> FreeVariables variable
+  => Predicate variable
+  -> FreeVariables variable
 freeVariables = Conditional.freeVariables (const mempty)
 
 {- | Extract the set of free set variables from a predicate and substitution.
@@ -100,18 +102,18 @@ See also: 'substitutionToPredicate'.
 
 -}
 toPredicate
-    :: ( SortedVariable variable
-       , Ord variable
-       , Show variable
-       , Unparse variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
        )
-    => Predicate variable
-    -> Syntax.Predicate variable
+  => Predicate variable
+  -> Syntax.Predicate variable
 toPredicate = Conditional.toPredicate
 
 mapVariables
-    :: (Ord variable1, Ord variable2)
-    => (variable1 -> variable2)
-    -> Predicate variable1
-    -> Predicate variable2
+  :: (Ord variable1, Ord variable2)
+  => (variable1 -> variable2)
+  -> Predicate variable1
+  -> Predicate variable2
 mapVariables = Conditional.mapVariables (\_ () -> ())

--- a/kore/src/Kore/Internal/Symbol.hs
+++ b/kore/src/Kore/Internal/Symbol.hs
@@ -3,76 +3,78 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Internal.Symbol
-    ( Symbol (..)
-    , toSymbolOrAlias
-    , isNonSimplifiable
-    , isConstructor
-    , isSortInjection
-    , isFunctional
-    , isFunction
-    , isTotal
-    , isInjective
-    , symbolHook
-    , constructor
-    , functional
-    , function
-    , injective
-    , sortInjection
-    , smthook
-    , hook
-    , coerceSortInjection
+  ( Symbol (..),
+    toSymbolOrAlias,
+    isNonSimplifiable,
+    isConstructor,
+    isSortInjection,
+    isFunctional,
+    isFunction,
+    isTotal,
+    isInjective,
+    symbolHook,
+    constructor,
+    functional,
+    function,
+    injective,
+    sortInjection,
+    smthook,
+    hook,
+    coerceSortInjection,
     -- * Re-exports
-    , module Kore.Internal.ApplicationSorts
-    ) where
+    module Kore.Internal.ApplicationSorts
+    )
+where
 
-import           Control.DeepSeq
+import Control.DeepSeq
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
+  ( makeLenses
+    )
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
-import           Data.Generics.Product
-import           Data.Hashable
-import           Data.Text
-                 ( Text )
-import qualified Generics.SOP as SOP
+import Data.Generics.Product
+import Data.Hashable
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Pattern.FreeVariables
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Pattern.FreeVariables
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
-import           Kore.Internal.ApplicationSorts
-import           Kore.Sort
-import           Kore.Syntax.Application
-import           Kore.Unparser
-import           SMT.AST
-                 ( SExpr )
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Internal.ApplicationSorts
+import Kore.Sort
+import Kore.Syntax.Application
+import Kore.Unparser
+import SMT.AST
+  ( SExpr
+    )
 
-data Symbol =
-    Symbol
-        { symbolConstructor :: !Id
-        , symbolParams      :: ![Sort]
-        , symbolSorts       :: !ApplicationSorts
-        , symbolAttributes  :: !Attribute.Symbol
+data Symbol
+  = Symbol
+      { symbolConstructor :: !Id,
+        symbolParams :: ![Sort],
+        symbolSorts :: !ApplicationSorts,
+        symbolAttributes :: !Attribute.Symbol
         }
-    deriving (GHC.Generic, Show)
+  deriving (GHC.Generic, Show)
 
 instance Eq Symbol where
-    (==) a b =
-            Function.on (==) symbolConstructor a b
-        &&  Function.on (==) symbolParams a b
-    {-# INLINE (==) #-}
+  (==) a b =
+    Function.on (==) symbolConstructor a b
+      && Function.on (==) symbolParams a b
+  {-# INLINE (==) #-}
 
 instance Ord Symbol where
-    compare a b =
-            Function.on compare symbolConstructor a b
-        <>  Function.on compare symbolParams a b
+  compare a b =
+    Function.on compare symbolConstructor a b
+      <> Function.on compare symbolParams a b
 
 instance Hashable Symbol where
-    hashWithSalt salt Symbol { symbolConstructor, symbolParams } =
-        salt `hashWithSalt` symbolConstructor `hashWithSalt` symbolParams
+  hashWithSalt salt Symbol {symbolConstructor, symbolParams} =
+    salt `hashWithSalt` symbolConstructor `hashWithSalt` symbolParams
 
 instance NFData Symbol
 
@@ -83,35 +85,36 @@ instance SOP.HasDatatypeInfo Symbol
 instance Debug Symbol
 
 instance Unparse Symbol where
-    unparse Symbol { symbolConstructor, symbolParams } =
-        unparse symbolConstructor <> parameters symbolParams
 
-    unparse2 Symbol { symbolConstructor } =
-        unparse2 symbolConstructor
+  unparse Symbol {symbolConstructor, symbolParams} =
+    unparse symbolConstructor <> parameters symbolParams
+
+  unparse2 Symbol {symbolConstructor} =
+    unparse2 symbolConstructor
 
 instance
-    Ord variable
-    => Synthetic (FreeVariables variable) (Application Symbol)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Application Symbol)
   where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Application Symbol) where
-    synthetic application =
-        resultSort Function.& deepseq (matchSorts operandSorts children)
-      where
-        Application { applicationSymbolOrAlias = symbol } = application
-        Application { applicationChildren = children } = application
-        Symbol { symbolSorts } = symbol
-        resultSort = applicationSortsResult symbolSorts
-        operandSorts = applicationSortsOperands symbolSorts
+  synthetic application =
+    resultSort Function.& deepseq (matchSorts operandSorts children)
+    where
+      Application {applicationSymbolOrAlias = symbol} = application
+      Application {applicationChildren = children} = application
+      Symbol {symbolSorts} = symbol
+      resultSort = applicationSortsResult symbolSorts
+      operandSorts = applicationSortsOperands symbolSorts
 
 toSymbolOrAlias :: Symbol -> SymbolOrAlias
 toSymbolOrAlias symbol =
-    SymbolOrAlias
-        { symbolOrAliasConstructor = symbolConstructor symbol
-        , symbolOrAliasParams = symbolParams symbol
-        }
+  SymbolOrAlias
+    { symbolOrAliasConstructor = symbolConstructor symbol,
+      symbolOrAliasParams = symbolParams symbol
+      }
 
 -- | Is a symbol not simplifiable?
 --
@@ -132,11 +135,11 @@ isNonSimplifiable = Attribute.isNonSimplifiable . symbolAttributes
 
 isConstructor :: Symbol -> Bool
 isConstructor =
-    Attribute.isConstructor . Attribute.constructor . symbolAttributes
+  Attribute.isConstructor . Attribute.constructor . symbolAttributes
 
 isSortInjection :: Symbol -> Bool
 isSortInjection =
-    Attribute.isSortInjection . Attribute.sortInjection . symbolAttributes
+  Attribute.isSortInjection . Attribute.sortInjection . symbolAttributes
 
 isInjective :: Symbol -> Bool
 isInjective = Attribute.isInjective . symbolAttributes
@@ -155,45 +158,38 @@ symbolHook = Attribute.hook . symbolAttributes
 
 constructor :: Symbol -> Symbol
 constructor =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Constructor)
-        Attribute.Constructor { isConstructor = True }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Constructor) Attribute.Constructor {isConstructor = True}
 
 functional :: Symbol -> Symbol
 functional =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Functional)
-        Attribute.Functional { isDeclaredFunctional = True }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Functional) Attribute.Functional {isDeclaredFunctional = True}
 
 function :: Symbol -> Symbol
 function =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Function)
-        Attribute.Function { isDeclaredFunction = True }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Function) Attribute.Function {isDeclaredFunction = True}
 
 injective :: Symbol -> Symbol
 injective =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Injective)
-        Attribute.Injective { isDeclaredInjective = True }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Injective) Attribute.Injective {isDeclaredInjective = True}
 
 sortInjection :: Symbol -> Symbol
 sortInjection =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.SortInjection)
-        Attribute.SortInjection { isSortInjection = True }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.SortInjection) Attribute.SortInjection {isSortInjection = True}
 
 smthook :: SExpr -> Symbol -> Symbol
 smthook sExpr =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Smthook)
-        Attribute.Smthook { getSmthook = Just sExpr }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Smthook) Attribute.Smthook {getSmthook = Just sExpr}
 
 hook :: Text -> Symbol -> Symbol
 hook name =
-    Lens.set
-        (typed @Attribute.Symbol . typed @Attribute.Hook)
-        Attribute.Hook { getHook = Just name }
+  Lens.set
+    (typed @Attribute.Symbol . typed @Attribute.Hook) Attribute.Hook {getHook = Just name}
 
 {- | Coerce a sort injection symbol's source and target sorts.
 
@@ -202,15 +198,15 @@ injection 'Symbol' when evaluating or simplifying sort injections.
 
  -}
 coerceSortInjection
-    :: Symbol
-    -- ^ Original sort injection symbol
-    -> Sort
-    -- ^ New source sort
-    -> Sort
-    -- ^ New target sort
-    -> Symbol
+  :: Symbol
+  -- ^ Original sort injection symbol
+  -> Sort
+  -- ^ New source sort
+  -> Sort
+  -- ^ New target sort
+  -> Symbol
 coerceSortInjection injectionSymbol sourceSort targetSort =
-    injectionSymbol
-        { symbolParams = [sourceSort, targetSort]
-        , symbolSorts = applicationSorts [sourceSort] targetSort
-        }
+  injectionSymbol
+    { symbolParams = [sourceSort, targetSort],
+      symbolSorts = applicationSorts [sourceSort] targetSort
+      }

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -3,243 +3,258 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 
 -}
-
 module Kore.Internal.TermLike
-    ( TermLikeF (..)
-    , TermLike (..)
-    , Evaluated (..)
-    , Builtin
-    , extractAttributes
-    , isFunctionPattern
-    , isFunctionalPattern
-    , isDefinedPattern
-    , freeVariables
-    , termLikeSort
-    , hasFreeVariable
-    , withoutFreeVariable
-    , mapVariables
-    , traverseVariables
-    , asConcrete
-    , isConcrete
-    , fromConcrete
-    , substitute
-    , externalizeFreshVariables
+  ( TermLikeF (..),
+    TermLike (..),
+    Evaluated (..),
+    Builtin,
+    extractAttributes,
+    isFunctionPattern,
+    isFunctionalPattern,
+    isDefinedPattern,
+    freeVariables,
+    termLikeSort,
+    hasFreeVariable,
+    withoutFreeVariable,
+    mapVariables,
+    traverseVariables,
+    asConcrete,
+    isConcrete,
+    fromConcrete,
+    substitute,
+    externalizeFreshVariables,
     -- * Utility functions for dealing with sorts
-    , forceSort
+    forceSort,
     -- * Pure Kore pattern constructors
-    , mkAnd
-    , mkApplyAlias
-    , mkApplySymbol
-    , mkBottom
-    , mkBuiltin
-    , mkBuiltinList
-    , mkBuiltinMap
-    , mkBuiltinSet
-    , mkCeil
-    , mkDomainValue
-    , mkEquals
-    , mkExists
-    , mkExistsN
-    , mkFloor
-    , mkForall
-    , mkForallN
-    , mkIff
-    , mkImplies
-    , mkIn
-    , mkMu
-    , mkNext
-    , mkNot
-    , mkNu
-    , mkOr
-    , mkRewrites
-    , mkTop
-    , mkVar
-    , mkSetVar
-    , mkElemVar
-    , mkStringLiteral
-    , mkCharLiteral
-    , mkSort
-    , mkSortVariable
-    , mkInhabitant
-    , mkEvaluated
-    , elemVarS
-    , setVarS
+    mkAnd,
+    mkApplyAlias,
+    mkApplySymbol,
+    mkBottom,
+    mkBuiltin,
+    mkBuiltinList,
+    mkBuiltinMap,
+    mkBuiltinSet,
+    mkCeil,
+    mkDomainValue,
+    mkEquals,
+    mkExists,
+    mkExistsN,
+    mkFloor,
+    mkForall,
+    mkForallN,
+    mkIff,
+    mkImplies,
+    mkIn,
+    mkMu,
+    mkNext,
+    mkNot,
+    mkNu,
+    mkOr,
+    mkRewrites,
+    mkTop,
+    mkVar,
+    mkSetVar,
+    mkElemVar,
+    mkStringLiteral,
+    mkCharLiteral,
+    mkSort,
+    mkSortVariable,
+    mkInhabitant,
+    mkEvaluated,
+    elemVarS,
+    setVarS,
     -- * Predicate constructors
-    , mkBottom_
-    , mkCeil_
-    , mkEquals_
-    , mkFloor_
-    , mkIn_
-    , mkTop_
+    mkBottom_,
+    mkCeil_,
+    mkEquals_,
+    mkFloor_,
+    mkIn_,
+    mkTop_,
     -- * Sentence constructors
-    , mkAlias
-    , mkAlias_
-    , mkAxiom
-    , mkAxiom_
-    , mkSymbol
-    , mkSymbol_
+    mkAlias,
+    mkAlias_,
+    mkAxiom,
+    mkAxiom_,
+    mkSymbol,
+    mkSymbol_,
     -- * Application constructors
-    , applyAlias
-    , applyAlias_
-    , applySymbol
-    , applySymbol_
+    applyAlias,
+    applyAlias_,
+    applySymbol,
+    applySymbol_,
     -- * Pattern synonyms
-    , pattern And_
-    , pattern ApplyAlias_
-    , pattern App_
-    , pattern Bottom_
-    , pattern Builtin_
-    , pattern BuiltinBool_
-    , pattern BuiltinInt_
-    , pattern BuiltinList_
-    , pattern BuiltinMap_
-    , pattern BuiltinSet_
-    , pattern BuiltinString_
-    , pattern Ceil_
-    , pattern DV_
-    , pattern Equals_
-    , pattern Exists_
-    , pattern Floor_
-    , pattern Forall_
-    , pattern Iff_
-    , pattern Implies_
-    , pattern In_
-    , pattern Mu_
-    , pattern Next_
-    , pattern Not_
-    , pattern Nu_
-    , pattern Or_
-    , pattern Rewrites_
-    , pattern Top_
-    , pattern Var_
-    , pattern ElemVar_
-    , pattern SetVar_
-    , pattern StringLiteral_
-    , pattern CharLiteral_
-    , pattern Evaluated_
+    pattern And_,
+    pattern ApplyAlias_,
+    pattern App_,
+    pattern Bottom_,
+    pattern Builtin_,
+    pattern BuiltinBool_,
+    pattern BuiltinInt_,
+    pattern BuiltinList_,
+    pattern BuiltinMap_,
+    pattern BuiltinSet_,
+    pattern BuiltinString_,
+    pattern Ceil_,
+    pattern DV_,
+    pattern Equals_,
+    pattern Exists_,
+    pattern Floor_,
+    pattern Forall_,
+    pattern Iff_,
+    pattern Implies_,
+    pattern In_,
+    pattern Mu_,
+    pattern Next_,
+    pattern Not_,
+    pattern Nu_,
+    pattern Or_,
+    pattern Rewrites_,
+    pattern Top_,
+    pattern Var_,
+    pattern ElemVar_,
+    pattern SetVar_,
+    pattern StringLiteral_,
+    pattern CharLiteral_,
+    pattern Evaluated_,
     -- * Re-exports
-    , Symbol (..)
-    , Alias (..)
-    , SortedVariable (..)
-    , module Kore.Syntax.Id
-    , CofreeF (..), Comonad (..)
-    , Sort (..), SortActual (..), SortVariable (..)
-    , charMetaSort, stringMetaSort
-    , module Kore.Syntax.And
-    , module Kore.Syntax.Application
-    , module Kore.Syntax.Bottom
-    , module Kore.Syntax.Ceil
-    , module Kore.Syntax.CharLiteral
-    , module Kore.Syntax.DomainValue
-    , module Kore.Syntax.Equals
-    , module Kore.Syntax.Exists
-    , module Kore.Syntax.Floor
-    , module Kore.Syntax.Forall
-    , module Kore.Syntax.Iff
-    , module Kore.Syntax.Implies
-    , module Kore.Syntax.In
-    , module Kore.Syntax.Inhabitant
-    , module Kore.Syntax.Mu
-    , module Kore.Syntax.Next
-    , module Kore.Syntax.Not
-    , module Kore.Syntax.Nu
-    , module Kore.Syntax.Or
-    , module Kore.Syntax.Rewrites
-    , module Kore.Syntax.ElementVariable
-    , module Kore.Syntax.SetVariable
-    , module Kore.Syntax.StringLiteral
-    , module Kore.Syntax.Top
-    , module Variable
-    ) where
+    Symbol (..),
+    Alias (..),
+    SortedVariable (..),
+    module Kore.Syntax.Id,
+    CofreeF (..),
+    Comonad (..),
+    Sort (..),
+    SortActual (..),
+    SortVariable (..),
+    charMetaSort,
+    stringMetaSort,
+    module Kore.Syntax.And,
+    module Kore.Syntax.Application,
+    module Kore.Syntax.Bottom,
+    module Kore.Syntax.Ceil,
+    module Kore.Syntax.CharLiteral,
+    module Kore.Syntax.DomainValue,
+    module Kore.Syntax.Equals,
+    module Kore.Syntax.Exists,
+    module Kore.Syntax.Floor,
+    module Kore.Syntax.Forall,
+    module Kore.Syntax.Iff,
+    module Kore.Syntax.Implies,
+    module Kore.Syntax.In,
+    module Kore.Syntax.Inhabitant,
+    module Kore.Syntax.Mu,
+    module Kore.Syntax.Next,
+    module Kore.Syntax.Not,
+    module Kore.Syntax.Nu,
+    module Kore.Syntax.Or,
+    module Kore.Syntax.Rewrites,
+    module Kore.Syntax.ElementVariable,
+    module Kore.Syntax.SetVariable,
+    module Kore.Syntax.StringLiteral,
+    module Kore.Syntax.Top,
+    module Variable
+    )
+where
 
-
-import           Control.Applicative
-import           Control.Comonad
-import           Control.Comonad.Trans.Cofree
+import Control.Applicative
+import Control.Comonad
+import Control.Comonad.Trans.Cofree
 import qualified Control.Comonad.Trans.Env as Env
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Control.Monad.Reader
-                 ( Reader )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Control.Monad.Reader
+  ( Reader
+    )
 import qualified Control.Monad.Reader as Reader
-import           Data.Align
+import Data.Align
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Functor.Compose
-                 ( Compose (..) )
-import           Data.Functor.Foldable
-                 ( Base, Corecursive, Recursive )
+import Data.Function
+import Data.Functor.Compose
+  ( Compose (..)
+    )
+import Data.Functor.Foldable
+  ( Base,
+    Corecursive,
+    Recursive
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Functor.Identity
-                 ( Identity (..) )
-import           Data.Hashable
-import           Data.Map.Strict
-                 ( Map )
+import Data.Functor.Identity
+  ( Identity (..)
+    )
+import Data.Hashable
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Monoid
-                 ( Endo (..) )
+import Data.Maybe
+import Data.Monoid
+  ( Endo (..)
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           Data.These
-import qualified Generics.SOP as SOP
+import Data.These
 import qualified GHC.Generics as GHC
 import qualified GHC.Stack as GHC
-
-import           Generically
+import Generically
+import qualified Generics.SOP as SOP
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Pattern.Defined as Pattern
-import           Kore.Attribute.Pattern.FreeVariables
+import Kore.Attribute.Pattern.FreeVariables
 import qualified Kore.Attribute.Pattern.Function as Pattern
 import qualified Kore.Attribute.Pattern.Functional as Pattern
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
+import Kore.Attribute.Synthetic
+import Kore.Debug
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.Error
-import           Kore.Internal.Alias
-import           Kore.Internal.Symbol
-import           Kore.Sort
+import Kore.Error
+import Kore.Internal.Alias
+import Kore.Internal.Symbol
+import Kore.Sort
 import qualified Kore.Substitute as Substitute
-import           Kore.Syntax.And
-import           Kore.Syntax.Application
-import           Kore.Syntax.Bottom
-import           Kore.Syntax.Ceil
-import           Kore.Syntax.CharLiteral
-import           Kore.Syntax.Definition hiding
-                 ( Alias, Symbol )
+import Kore.Syntax.And
+import Kore.Syntax.Application
+import Kore.Syntax.Bottom
+import Kore.Syntax.Ceil
+import Kore.Syntax.CharLiteral
+import Kore.Syntax.Definition hiding
+  ( Alias,
+    Symbol
+    )
 import qualified Kore.Syntax.Definition as Syntax
-import           Kore.Syntax.DomainValue
-import           Kore.Syntax.ElementVariable
-import           Kore.Syntax.Equals
-import           Kore.Syntax.Exists
-import           Kore.Syntax.Floor
-import           Kore.Syntax.Forall
-import           Kore.Syntax.Id
-import           Kore.Syntax.Iff
-import           Kore.Syntax.Implies
-import           Kore.Syntax.In
-import           Kore.Syntax.Inhabitant
-import           Kore.Syntax.Mu
-import           Kore.Syntax.Next
-import           Kore.Syntax.Not
-import           Kore.Syntax.Nu
-import           Kore.Syntax.Or
-import           Kore.Syntax.Rewrites
-import           Kore.Syntax.SetVariable
-import           Kore.Syntax.StringLiteral
-import           Kore.Syntax.Top
-import           Kore.Syntax.Variable as Variable
-import           Kore.TopBottom
-import           Kore.Unparser
-                 ( Unparse (..) )
+import Kore.Syntax.DomainValue
+import Kore.Syntax.ElementVariable
+import Kore.Syntax.Equals
+import Kore.Syntax.Exists
+import Kore.Syntax.Floor
+import Kore.Syntax.Forall
+import Kore.Syntax.Id
+import Kore.Syntax.Iff
+import Kore.Syntax.Implies
+import Kore.Syntax.In
+import Kore.Syntax.Inhabitant
+import Kore.Syntax.Mu
+import Kore.Syntax.Next
+import Kore.Syntax.Not
+import Kore.Syntax.Nu
+import Kore.Syntax.Or
+import Kore.Syntax.Rewrites
+import Kore.Syntax.SetVariable
+import Kore.Syntax.StringLiteral
+import Kore.Syntax.Top
+import Kore.Syntax.Variable as Variable
+import Kore.TopBottom
+import Kore.Unparser
+  ( Unparse (..)
+    )
 import qualified Kore.Unparser as Unparser
-import           Kore.Variables.Binding
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
+import Kore.Variables.Binding
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
 
 {- | @Evaluated@ wraps patterns which are fully evaluated.
 
@@ -247,8 +262,8 @@ Fully-evaluated patterns will not be simplified further because no progress
 could be made.
 
  -}
-newtype Evaluated child = Evaluated { getEvaluated :: child }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+newtype Evaluated child = Evaluated {getEvaluated :: child}
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (Evaluated child)
 
@@ -261,14 +276,16 @@ instance Hashable child => Hashable (Evaluated child)
 instance NFData child => NFData (Evaluated child)
 
 instance Unparse child => Unparse (Evaluated child) where
-    unparse evaluated =
-        Pretty.vsep ["/* evaluated: */", Unparser.unparseGeneric evaluated]
-    unparse2 evaluated =
-        Pretty.vsep ["/* evaluated: */", Unparser.unparse2Generic evaluated]
+
+  unparse evaluated =
+    Pretty.vsep ["/* evaluated: */", Unparser.unparseGeneric evaluated]
+
+  unparse2 evaluated =
+    Pretty.vsep ["/* evaluated: */", Unparser.unparse2Generic evaluated]
 
 instance Synthetic syn Evaluated where
-    synthetic = getEvaluated
-    {-# INLINE synthetic #-}
+  synthetic = getEvaluated
+  {-# INLINE synthetic #-}
 
 -- | The type of internal domain values.
 type Builtin = Domain.Builtin (TermLike Concrete)
@@ -277,40 +294,43 @@ type Builtin = Domain.Builtin (TermLike Concrete)
 
 -}
 data TermLikeF variable child
-    = AndF           !(And Sort child)
-    | ApplySymbolF   !(Application Symbol child)
-    | ApplyAliasF    !(Application Alias child)
-    | BottomF        !(Bottom Sort child)
-    | CeilF          !(Ceil Sort child)
-    | DomainValueF   !(DomainValue Sort child)
-    | EqualsF        !(Equals Sort child)
-    | ExistsF        !(Exists Sort variable child)
-    | FloorF         !(Floor Sort child)
-    | ForallF        !(Forall Sort variable child)
-    | IffF           !(Iff Sort child)
-    | ImpliesF       !(Implies Sort child)
-    | InF            !(In Sort child)
-    | MuF            !(Mu variable child)
-    | NextF          !(Next Sort child)
-    | NotF           !(Not Sort child)
-    | NuF            !(Nu variable child)
-    | OrF            !(Or Sort child)
-    | RewritesF      !(Rewrites Sort child)
-    | TopF           !(Top Sort child)
-    | InhabitantF    !(Inhabitant child)
-    | BuiltinF       !(Builtin child)
-    | EvaluatedF     !(Evaluated child)
-    | StringLiteralF !(Const StringLiteral child)
-    | CharLiteralF   !(Const CharLiteral child)
-    | VariableF      !(Const (UnifiedVariable variable) child)
-    deriving (Eq, Ord, Show)
-    deriving (Functor, Foldable, Traversable)
-    deriving (GHC.Generic, GHC.Generic1)
-    deriving
-        ( Synthetic (FreeVariables variable), Synthetic Sort
-        , Synthetic Pattern.Functional, Synthetic Pattern.Function
-        , Synthetic Pattern.Defined
-        ) via (Generically1 (TermLikeF variable))
+  = AndF !(And Sort child)
+  | ApplySymbolF !(Application Symbol child)
+  | ApplyAliasF !(Application Alias child)
+  | BottomF !(Bottom Sort child)
+  | CeilF !(Ceil Sort child)
+  | DomainValueF !(DomainValue Sort child)
+  | EqualsF !(Equals Sort child)
+  | ExistsF !(Exists Sort variable child)
+  | FloorF !(Floor Sort child)
+  | ForallF !(Forall Sort variable child)
+  | IffF !(Iff Sort child)
+  | ImpliesF !(Implies Sort child)
+  | InF !(In Sort child)
+  | MuF !(Mu variable child)
+  | NextF !(Next Sort child)
+  | NotF !(Not Sort child)
+  | NuF !(Nu variable child)
+  | OrF !(Or Sort child)
+  | RewritesF !(Rewrites Sort child)
+  | TopF !(Top Sort child)
+  | InhabitantF !(Inhabitant child)
+  | BuiltinF !(Builtin child)
+  | EvaluatedF !(Evaluated child)
+  | StringLiteralF !(Const StringLiteral child)
+  | CharLiteralF !(Const CharLiteral child)
+  | VariableF !(Const (UnifiedVariable variable) child)
+  deriving (Eq, Ord, Show)
+  deriving (Functor, Foldable, Traversable)
+  deriving (GHC.Generic, GHC.Generic1)
+  deriving
+    ( Synthetic (FreeVariables variable),
+      Synthetic Sort,
+      Synthetic Pattern.Functional,
+      Synthetic Pattern.Function,
+      Synthetic Pattern.Defined
+      )
+    via (Generically1 (TermLikeF variable))
 
 instance SOP.Generic (TermLikeF variable child)
 
@@ -319,19 +339,22 @@ instance SOP.HasDatatypeInfo (TermLikeF variable child)
 instance (Debug child, Debug variable) => Debug (TermLikeF variable child)
 
 instance
-    (Hashable child, Hashable variable) =>
-    Hashable (TermLikeF variable child)
+  (Hashable child, Hashable variable)
+  => Hashable (TermLikeF variable child)
 
 instance (NFData child, NFData variable) => NFData (TermLikeF variable child)
 
 instance
-    ( SortedVariable variable, Unparse variable
-    , Unparse child
-    ) =>
-    Unparse (TermLikeF variable child)
+  ( SortedVariable variable,
+    Unparse variable,
+    Unparse child
+    )
+  => Unparse (TermLikeF variable child)
   where
-    unparse = Unparser.unparseGeneric
-    unparse2 = Unparser.unparse2Generic
+
+  unparse = Unparser.unparseGeneric
+
+  unparse2 = Unparser.unparse2Generic
 
 {- | Use the provided mapping to replace all variables in a 'TermLikeF' head.
 
@@ -340,9 +363,9 @@ not injective!
 
 -}
 mapVariablesF
-    :: (variable1 -> variable2)
-    -> TermLikeF variable1 child
-    -> TermLikeF variable2 child
+  :: (variable1 -> variable2)
+  -> TermLikeF variable1 child
+  -> TermLikeF variable2 child
 mapVariablesF mapping = runIdentity . traverseVariablesF (Identity . mapping)
 
 {- | Use the provided traversal to replace all variables in a 'TermLikeF' head.
@@ -352,62 +375,63 @@ traversal is not injective!
 
 -}
 traverseVariablesF
-    :: Applicative f
-    => (variable1 -> f variable2)
-    ->    TermLikeF variable1 child
-    -> f (TermLikeF variable2 child)
+  :: Applicative f
+  => (variable1 -> f variable2)
+  -> TermLikeF variable1 child
+  -> f (TermLikeF variable2 child)
 traverseVariablesF traversing =
-    \case
-        -- Non-trivial cases
-        ExistsF any0 -> ExistsF <$> traverseVariablesExists any0
-        ForallF all0 -> ForallF <$> traverseVariablesForall all0
-        MuF any0 -> MuF <$> traverseVariablesMu any0
-        NuF any0 -> NuF <$> traverseVariablesNu any0
-        VariableF variable -> VariableF <$> traverseConstVariable variable
-        -- Trivial cases
-        AndF andP -> pure (AndF andP)
-        ApplySymbolF applySymbolF -> pure (ApplySymbolF applySymbolF)
-        ApplyAliasF applyAliasF -> pure (ApplyAliasF applyAliasF)
-        BottomF botP -> pure (BottomF botP)
-        BuiltinF builtinP -> pure (BuiltinF builtinP)
-        CeilF ceilP -> pure (CeilF ceilP)
-        DomainValueF dvP -> pure (DomainValueF dvP)
-        EqualsF eqP -> pure (EqualsF eqP)
-        FloorF flrP -> pure (FloorF flrP)
-        IffF iffP -> pure (IffF iffP)
-        ImpliesF impP -> pure (ImpliesF impP)
-        InF inP -> pure (InF inP)
-        NextF nxtP -> pure (NextF nxtP)
-        NotF notP -> pure (NotF notP)
-        OrF orP -> pure (OrF orP)
-        RewritesF rewP -> pure (RewritesF rewP)
-        StringLiteralF strP -> pure (StringLiteralF strP)
-        CharLiteralF charP -> pure (CharLiteralF charP)
-        TopF topP -> pure (TopF topP)
-        InhabitantF s -> pure (InhabitantF s)
-        EvaluatedF childP -> pure (EvaluatedF childP)
+  \case
+    -- Non-trivial cases
+    ExistsF any0 -> ExistsF <$> traverseVariablesExists any0
+    ForallF all0 -> ForallF <$> traverseVariablesForall all0
+    MuF any0 -> MuF <$> traverseVariablesMu any0
+    NuF any0 -> NuF <$> traverseVariablesNu any0
+    VariableF variable -> VariableF <$> traverseConstVariable variable
+    -- Trivial cases
+    AndF andP -> pure (AndF andP)
+    ApplySymbolF applySymbolF -> pure (ApplySymbolF applySymbolF)
+    ApplyAliasF applyAliasF -> pure (ApplyAliasF applyAliasF)
+    BottomF botP -> pure (BottomF botP)
+    BuiltinF builtinP -> pure (BuiltinF builtinP)
+    CeilF ceilP -> pure (CeilF ceilP)
+    DomainValueF dvP -> pure (DomainValueF dvP)
+    EqualsF eqP -> pure (EqualsF eqP)
+    FloorF flrP -> pure (FloorF flrP)
+    IffF iffP -> pure (IffF iffP)
+    ImpliesF impP -> pure (ImpliesF impP)
+    InF inP -> pure (InF inP)
+    NextF nxtP -> pure (NextF nxtP)
+    NotF notP -> pure (NotF notP)
+    OrF orP -> pure (OrF orP)
+    RewritesF rewP -> pure (RewritesF rewP)
+    StringLiteralF strP -> pure (StringLiteralF strP)
+    CharLiteralF charP -> pure (CharLiteralF charP)
+    TopF topP -> pure (TopF topP)
+    InhabitantF s -> pure (InhabitantF s)
+    EvaluatedF childP -> pure (EvaluatedF childP)
   where
     traverseConstVariable (Const variable) =
-        Const <$> traverse traversing variable
-    traverseVariablesExists Exists { existsSort, existsVariable, existsChild } =
-        Exists existsSort
+      Const <$> traverse traversing variable
+    traverseVariablesExists Exists {existsSort, existsVariable, existsChild} =
+      Exists existsSort
         <$> traverse traversing existsVariable
         <*> pure existsChild
-    traverseVariablesForall Forall { forallSort, forallVariable, forallChild } =
-        Forall forallSort
+    traverseVariablesForall Forall {forallSort, forallVariable, forallChild} =
+      Forall forallSort
         <$> traverse traversing forallVariable
         <*> pure forallChild
-    traverseVariablesMu Mu { muVariable, muChild } =
-        Mu <$> traverse traversing muVariable <*> pure muChild
-    traverseVariablesNu Nu { nuVariable, nuChild } =
-        Nu <$> traverse traversing nuVariable <*> pure nuChild
+    traverseVariablesMu Mu {muVariable, muChild} =
+      Mu <$> traverse traversing muVariable <*> pure muChild
+    traverseVariablesNu Nu {nuVariable, nuChild} =
+      Nu <$> traverse traversing nuVariable <*> pure nuChild
 
-newtype TermLike variable =
-    TermLike
-        { getTermLike
-            :: Cofree (TermLikeF variable) (Attribute.Pattern variable)
+newtype TermLike variable
+  = TermLike
+      { getTermLike
+          :: Cofree (TermLikeF variable)
+               (Attribute.Pattern variable)
         }
-    deriving (GHC.Generic, Show)
+  deriving (GHC.Generic, Show)
 
 instance SOP.Generic (TermLike variable)
 
@@ -416,198 +440,205 @@ instance SOP.HasDatatypeInfo (TermLike variable)
 instance Debug variable => Debug (TermLike variable)
 
 instance
-    (Eq variable, Eq (TermLikeF variable (TermLike variable))) =>
-    Eq (TermLike variable)
+  (Eq variable, Eq (TermLikeF variable (TermLike variable)))
+  => Eq (TermLike variable)
   where
-    (==)
-        (Recursive.project -> _ :< pat1)
-        (Recursive.project -> _ :< pat2)
-      = pat1 == pat2
+  (==)
+    (Recursive.project -> _ :< pat1)
+    (Recursive.project -> _ :< pat2) =
+      pat1 == pat2
 
 instance
-    (Ord variable, Ord (TermLikeF variable (TermLike variable))) =>
-    Ord (TermLike variable)
+  (Ord variable, Ord (TermLikeF variable (TermLike variable)))
+  => Ord (TermLike variable)
   where
-    compare
-        (Recursive.project -> _ :< pat1)
-        (Recursive.project -> _ :< pat2)
-      = compare pat1 pat2
+  compare
+    (Recursive.project -> _ :< pat1)
+    (Recursive.project -> _ :< pat2) =
+      compare pat1 pat2
 
 instance Hashable variable => Hashable (TermLike variable) where
-    hashWithSalt salt (Recursive.project -> _ :< pat) = hashWithSalt salt pat
-    {-# INLINE hashWithSalt #-}
+  hashWithSalt salt (Recursive.project -> _ :< pat) = hashWithSalt salt pat
+  {-# INLINE hashWithSalt #-}
 
 instance NFData variable => NFData (TermLike variable) where
-    rnf (Recursive.project -> annotation :< pat) =
-        rnf annotation `seq` rnf pat
+  rnf (Recursive.project -> annotation :< pat) =
+    rnf annotation `seq` rnf pat
 
 instance SortedVariable variable => Unparse (TermLike variable) where
-    unparse term =
-        case Recursive.project freshVarTerm of
-          (_ :< pat) -> unparse pat
-      where
-        freshVarTerm =
-            externalizeFreshVariables
-            $ mapVariables toVariable term
 
-    unparse2 term =
-        case Recursive.project freshVarTerm of
-          (_ :< pat) -> unparse2 pat
-      where
-        freshVarTerm =
-            externalizeFreshVariables
-            $ mapVariables toVariable term
+  unparse term =
+    case Recursive.project freshVarTerm of
+      (_ :< pat) -> unparse pat
+    where
+      freshVarTerm =
+        externalizeFreshVariables
+          $ mapVariables toVariable term
 
-type instance Base (TermLike variable) =
+  unparse2 term =
+    case Recursive.project freshVarTerm of
+      (_ :< pat) -> unparse2 pat
+    where
+      freshVarTerm =
+        externalizeFreshVariables
+          $ mapVariables toVariable term
+
+type instance
+  Base (TermLike variable) =
     CofreeF (TermLikeF variable) (Attribute.Pattern variable)
 
 -- This instance implements all class functions for the TermLike newtype
 -- because the their implementations for the inner type may be specialized.
 instance Recursive (TermLike variable) where
-    project = \(TermLike embedded) ->
-        case Recursive.project embedded of
-            Compose (Identity projected) -> TermLike <$> projected
-    {-# INLINE project #-}
 
-    -- This specialization is particularly important: The default implementation
-    -- of 'cata' in terms of 'project' would involve an extra call to 'fmap' at
-    -- every level of the tree due to the implementation of 'project' above.
-    cata alg = \(TermLike fixed) ->
-        Recursive.cata
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE cata #-}
+  project = \(TermLike embedded) ->
+    case Recursive.project embedded of
+      Compose (Identity projected) -> TermLike <$> projected
+  {-# INLINE project #-}
 
-    para alg = \(TermLike fixed) ->
-        Recursive.para
-            (\(Compose (Identity base)) ->
-                 alg (Bifunctor.first TermLike <$> base)
-            )
-            fixed
-    {-# INLINE para #-}
+  -- This specialization is particularly important: The default implementation
+  -- of 'cata' in terms of 'project' would involve an extra call to 'fmap' at
+  -- every level of the tree due to the implementation of 'project' above.
+  cata alg = \(TermLike fixed) ->
+    Recursive.cata
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE cata #-}
 
-    gpara dist alg = \(TermLike fixed) ->
-        Recursive.gpara
-            (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
-            (\(Compose (Identity base)) -> alg (Env.local TermLike <$> base))
-            fixed
-    {-# INLINE gpara #-}
+  para alg = \(TermLike fixed) ->
+    Recursive.para
+      ( \(Compose (Identity base)) ->
+          alg (Bifunctor.first TermLike <$> base)
+        )
+      fixed
+  {-# INLINE para #-}
 
-    prepro pre alg = \(TermLike fixed) ->
-        Recursive.prepro
-            (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE prepro #-}
+  gpara dist alg = \(TermLike fixed) ->
+    Recursive.gpara
+      (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
+      (\(Compose (Identity base)) -> alg (Env.local TermLike <$> base))
+      fixed
+  {-# INLINE gpara #-}
 
-    gprepro dist pre alg = \(TermLike fixed) ->
-        Recursive.gprepro
-            (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
-            (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE gprepro #-}
+  prepro pre alg = \(TermLike fixed) ->
+    Recursive.prepro
+      (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE prepro #-}
+
+  gprepro dist pre alg = \(TermLike fixed) ->
+    Recursive.gprepro
+      (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
+      (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE gprepro #-}
 
 -- This instance implements all class functions for the TermLike newtype
 -- because the their implementations for the inner type may be specialized.
 instance Corecursive (TermLike variable) where
-    embed = \projected ->
-        (TermLike . Recursive.embed . Compose . Identity)
-            (getTermLike <$> projected)
-    {-# INLINE embed #-}
 
-    ana coalg = TermLike . ana0
-      where
-        ana0 =
-            Recursive.ana (Compose . Identity . coalg)
-    {-# INLINE ana #-}
+  embed = \projected ->
+    (TermLike . Recursive.embed . Compose . Identity)
+      (getTermLike <$> projected)
+  {-# INLINE embed #-}
 
-    apo coalg = TermLike . apo0
-      where
-        apo0 =
-            Recursive.apo
-                (\a ->
-                     (Compose . Identity)
-                        (Bifunctor.first getTermLike <$> coalg a)
-                )
-    {-# INLINE apo #-}
+  ana coalg = TermLike . ana0
+    where
+      ana0 =
+        Recursive.ana (Compose . Identity . coalg)
+  {-# INLINE ana #-}
 
-    postpro post coalg = TermLike . postpro0
-      where
-        postpro0 =
-            Recursive.postpro
-                (\(Compose (Identity base)) -> (Compose . Identity) (post base))
-                (Compose . Identity . coalg)
-    {-# INLINE postpro #-}
+  apo coalg = TermLike . apo0
+    where
+      apo0 =
+        Recursive.apo
+          ( \a ->
+              (Compose . Identity)
+                (Bifunctor.first getTermLike <$> coalg a)
+            )
+  {-# INLINE apo #-}
 
-    gpostpro dist post coalg = TermLike . gpostpro0
-      where
-        gpostpro0 =
-            Recursive.gpostpro
-                (Compose . Identity . dist . (<$>) (runIdentity . getCompose))
-                (\(Compose (Identity base)) -> (Compose . Identity) (post base))
-                (Compose . Identity . coalg)
-    {-# INLINE gpostpro #-}
+  postpro post coalg = TermLike . postpro0
+    where
+      postpro0 =
+        Recursive.postpro
+          (\(Compose (Identity base)) -> (Compose . Identity) (post base))
+          (Compose . Identity . coalg)
+  {-# INLINE postpro #-}
+
+  gpostpro dist post coalg = TermLike . gpostpro0
+    where
+      gpostpro0 =
+        Recursive.gpostpro
+          (Compose . Identity . dist . (<$>) (runIdentity . getCompose))
+          (\(Compose (Identity base)) -> (Compose . Identity) (post base))
+          (Compose . Identity . coalg)
+  {-# INLINE gpostpro #-}
 
 instance TopBottom (TermLike variable) where
-    isTop (Recursive.project -> _ :< TopF Top {}) = True
-    isTop _ = False
-    isBottom (Recursive.project -> _ :< BottomF Bottom {}) = True
-    isBottom _ = False
+
+  isTop (Recursive.project -> _ :< TopF Top {}) = True
+  isTop _ = False
+
+  isBottom (Recursive.project -> _ :< BottomF Bottom {}) = True
+  isBottom _ = False
 
 extractAttributes :: TermLike variable -> Attribute.Pattern variable
 extractAttributes = extract . getTermLike
 
 instance
-    (Ord variable, SortedVariable variable, Show variable) =>
-    Binding (TermLike variable)
+  (Ord variable, SortedVariable variable, Show variable)
+  => Binding (TermLike variable)
   where
-    type VariableType (TermLike variable) = UnifiedVariable variable
 
-    traverseVariable match termLike =
-        case termLikeF of
-            VariableF (Const variable) -> mkVar <$> match variable
-            _ -> pure termLike
-      where
-        _ :< termLikeF = Recursive.project termLike
+  type VariableType (TermLike variable) = UnifiedVariable variable
 
-    traverseBinder match termLike =
-        case termLikeF of
-            ExistsF exists -> synthesize . ExistsF <$> existsBinder match exists
-            ForallF forall -> synthesize . ForallF <$> forallBinder match forall
-            MuF mu -> synthesize . MuF <$> muBinder match mu
-            NuF nu -> synthesize . NuF <$> nuBinder match nu
-            _ -> pure termLike
-      where
-        _ :< termLikeF = Recursive.project termLike
+  traverseVariable match termLike =
+    case termLikeF of
+      VariableF (Const variable) -> mkVar <$> match variable
+      _ -> pure termLike
+    where
+      _ :< termLikeF = Recursive.project termLike
+
+  traverseBinder match termLike =
+    case termLikeF of
+      ExistsF exists -> synthesize . ExistsF <$> existsBinder match exists
+      ForallF forall -> synthesize . ForallF <$> forallBinder match forall
+      MuF mu -> synthesize . MuF <$> muBinder match mu
+      NuF nu -> synthesize . NuF <$> nuBinder match nu
+      _ -> pure termLike
+    where
+      _ :< termLikeF = Recursive.project termLike
 
 freeVariables :: TermLike variable -> FreeVariables variable
 freeVariables = Attribute.freeVariables . extractAttributes
 
 hasFreeVariable
-    :: Ord variable
-    => UnifiedVariable variable
-    -> TermLike variable
-    -> Bool
+  :: Ord variable
+  => UnifiedVariable variable
+  -> TermLike variable
+  -> Bool
 hasFreeVariable variable = isFreeVariable variable . freeVariables
 
 {- | Is the 'TermLike' a function pattern?
  -}
 isFunctionPattern :: TermLike variable -> Bool
 isFunctionPattern =
-    Pattern.isFunction . Attribute.function . extractAttributes
+  Pattern.isFunction . Attribute.function . extractAttributes
 
 {- | Is the 'TermLike' functional?
  -}
 isFunctionalPattern :: TermLike variable -> Bool
 isFunctionalPattern =
-    Pattern.isFunctional . Attribute.functional . extractAttributes
+  Pattern.isFunctional . Attribute.functional . extractAttributes
 
 {- | Is the 'TermLike' defined, i.e. known not to be 'Bottom'?
  -}
 isDefinedPattern :: TermLike variable -> Bool
 isDefinedPattern =
-    Pattern.isDefined . Attribute.defined . extractAttributes
+  Pattern.isDefined . Attribute.defined . extractAttributes
 
 {- | Throw an error if the variable occurs free in the pattern.
 
@@ -615,20 +646,20 @@ Otherwise, the argument is returned.
 
  -}
 withoutFreeVariable
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => UnifiedVariable variable  -- ^ variable
-    -> TermLike variable
-    -> a  -- ^ result, if the variable does not occur free in the pattern
-    -> a
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => UnifiedVariable variable -- ^ variable
+  -> TermLike variable
+  -> a -- ^ result, if the variable does not occur free in the pattern
+  -> a
 withoutFreeVariable variable termLike result
   | hasFreeVariable variable termLike =
     (error . show . Pretty.vsep)
-        [ Pretty.hsep
-            [ "Unexpected free variable"
-            , unparse variable
-            , "in pattern:"
-            ]
-        , Pretty.indent 4 (unparse termLike)
+      [ Pretty.hsep
+          [ "Unexpected free variable",
+            unparse variable,
+            "in pattern:"
+            ],
+        Pretty.indent 4 (unparse termLike)
         ]
   | otherwise = result
 
@@ -645,15 +676,15 @@ See also: 'traverseVariables'
 
  -}
 mapVariables
-    :: Ord variable2
-    => (variable1 -> variable2)
-    -> TermLike variable1
-    -> TermLike variable2
+  :: Ord variable2
+  => (variable1 -> variable2)
+  -> TermLike variable1
+  -> TermLike variable2
 mapVariables mapping =
-    Recursive.unfold (mapVariablesWorker . Recursive.project)
+  Recursive.unfold (mapVariablesWorker . Recursive.project)
   where
     mapVariablesWorker (attrs :< pat) =
-        Attribute.mapVariables mapping attrs :< mapVariablesF mapping pat
+      Attribute.mapVariables mapping attrs :< mapVariablesF mapping pat
 
 {- | Use the provided traversal to replace all variables in a 'TermLike'.
 
@@ -669,21 +700,20 @@ See also: 'mapVariables'
 
  -}
 traverseVariables
-    ::  forall m variable1 variable2.
-        (Monad m, Ord variable2)
-    => (variable1 -> m variable2)
-    -> TermLike variable1
-    -> m (TermLike variable2)
+  :: forall m variable1 variable2. (Monad m, Ord variable2)
+  => (variable1 -> m variable2)
+  -> TermLike variable1
+  -> m (TermLike variable2)
 traverseVariables traversing =
-    Recursive.fold traverseVariablesWorker
+  Recursive.fold traverseVariablesWorker
   where
     traverseVariablesWorker (attrs :< pat) =
-        Recursive.embed <$> projected
+      Recursive.embed <$> projected
       where
         projected =
-            (:<)
-                <$> Attribute.traverseVariables traversing attrs
-                <*> (traverseVariablesF traversing =<< sequence pat)
+          (:<)
+            <$> Attribute.traverseVariables traversing attrs
+            <*> (traverseVariablesF traversing =<< sequence pat)
 
 {- | Construct a @'TermLike' 'Concrete'@ from any 'TermLike'.
 
@@ -697,9 +727,10 @@ deciding if the result is @Nothing@ or @Just _@.
 
  -}
 asConcrete
-    :: TermLike variable
-    -> Maybe (TermLike Concrete)
-asConcrete = traverseVariables (\case { _ -> Nothing })
+  :: TermLike variable
+  -> Maybe (TermLike Concrete)
+asConcrete = traverseVariables (\case
+      _ -> Nothing)
 
 isConcrete :: TermLike variable -> Bool
 isConcrete = isJust . asConcrete
@@ -714,10 +745,11 @@ composes with other tree transformations without allocating intermediates.
 
  -}
 fromConcrete
-    :: Ord variable
-    => TermLike Concrete
-    -> TermLike variable
-fromConcrete = mapVariables (\case {})
+  :: Ord variable
+  => TermLike Concrete
+  -> TermLike variable
+fromConcrete = mapVariables (\case
+    )
 
 {- | Traverse the pattern from the top down and apply substitutions.
 
@@ -730,14 +762,14 @@ may appear in the right-hand side of any substitution, but this is not checked.
  -}
 -- TODO (thomas.tuegel): This should normalize internal representations.
 substitute
-    ::  ( FreshVariable variable
-        , Ord variable
-        , SortedVariable variable
-        , Show variable
-        )
-    =>  Map (UnifiedVariable variable) (TermLike variable)
-    ->  TermLike variable
-    ->  TermLike variable
+  :: ( FreshVariable variable,
+       Ord variable,
+       SortedVariable variable,
+       Show variable
+       )
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> TermLike variable
+  -> TermLike variable
 substitute = Substitute.substitute freeVariables
 
 {- | Reset the 'variableCounter' of all 'Variables'.
@@ -748,149 +780,149 @@ ensuring that no 'Variable' in the result is accidentally captured.
  -}
 externalizeFreshVariables :: TermLike Variable -> TermLike Variable
 externalizeFreshVariables termLike =
-    Reader.runReader
-        (Recursive.fold externalizeFreshVariablesWorker termLike)
-        renamedFreeVariables
+  Reader.runReader
+    (Recursive.fold externalizeFreshVariablesWorker termLike)
+    renamedFreeVariables
   where
     -- | 'originalFreeVariables' are present in the original pattern; they do
     -- not have a generated counter. 'generatedFreeVariables' have a generated
     -- counter, usually because they were introduced by applying some axiom.
-    originalFreeVariables, generatedFreeVariables
+    originalFreeVariables,
+      generatedFreeVariables
         :: Set.Set (UnifiedVariable Variable)
     (originalFreeVariables, generatedFreeVariables) =
-        Set.partition (foldMapVariable Variable.isOriginalVariable)
-        $ getFreeVariables $ freeVariables termLike
-
+      Set.partition (foldMapVariable Variable.isOriginalVariable)
+        $ getFreeVariables
+        $ freeVariables termLike
     -- | The map of generated free variables, renamed to be unique from the
     -- original free variables.
     renamedFreeVariables :: Map Variable Variable
     (renamedFreeVariables, _) =
-        Foldable.foldl' rename initial generatedFreeVariables
+      Foldable.foldl' rename initial generatedFreeVariables
       where
         initial = (Map.empty, FreeVariables originalFreeVariables)
         rename (renaming, avoiding) variable =
-            let
-                variable' = safeVariable avoiding variable
-                renaming' =
-                    Map.insert
-                        (asVariable variable)
-                        (asVariable variable')
-                        renaming
-                avoiding' = freeVariable variable' <> avoiding
-            in
-                (renaming', avoiding')
-
+          let variable' = safeVariable avoiding variable
+              renaming' =
+                Map.insert
+                  (asVariable variable)
+                  (asVariable variable')
+                  renaming
+              avoiding' = freeVariable variable' <> avoiding
+           in (renaming', avoiding')
     {- | Look up a variable renaming.
-
+    
     The original (not generated) variables of the pattern are never renamed, so
     these variables are not present in the Map of renamed variables.
-
+    
      -}
-    lookupVariable :: Variable ->  Reader (Map Variable Variable) Variable
+    lookupVariable :: Variable -> Reader (Map Variable Variable) Variable
     lookupVariable variable =
-        Reader.asks (Map.lookup variable) >>= \case
-            Nothing -> return variable
-            Just variable' -> return variable'
-
+      Reader.asks (Map.lookup variable) >>= \case
+        Nothing -> return variable
+        Just variable' -> return variable'
     {- | Externalize a variable safely.
-
+    
     The variable's counter is incremented until its externalized form is unique
     among the set of avoided variables. The externalized form is returned.
-
+    
      -}
     safeVariable
-        :: FreeVariables Variable
-        -> UnifiedVariable Variable
-        -> UnifiedVariable Variable
+      :: FreeVariables Variable
+      -> UnifiedVariable Variable
+      -> UnifiedVariable Variable
     safeVariable avoiding variable =
-        head  -- 'head' is safe because 'iterate' creates an infinite list
+      head -- 'head' is safe because 'iterate' creates an infinite list
         $ dropWhile wouldCapture
         $ fmap Variable.externalizeFreshVariable
         <$> iterate (fmap nextVariable) variable
       where
         wouldCapture var = isFreeVariable var avoiding
-
     underBinder freeVariables' variable child = do
-        let variable' = safeVariable freeVariables' variable
-        child' <- Reader.local
-            (Map.insert (asVariable variable) (asVariable variable'))
-            child
-        return (variable', child')
-
+      let variable' = safeVariable freeVariables' variable
+      child' <-
+        Reader.local
+          (Map.insert (asVariable variable) (asVariable variable'))
+          child
+      return (variable', child')
     externalizeFreshVariablesWorker
-        ::  Base
-                (TermLike Variable)
-                (Reader
-                    (Map Variable Variable)
-                    (TermLike Variable)
-                )
-        ->  Reader
-                (Map Variable Variable)
-                (TermLike Variable)
+      :: Base
+           (TermLike Variable)
+           ( Reader
+               (Map Variable Variable)
+               (TermLike Variable)
+             )
+      -> Reader
+           (Map Variable Variable)
+           (TermLike Variable)
     externalizeFreshVariablesWorker (attrs :< patt) = do
-        attrs' <- Attribute.traverseVariables lookupVariable attrs
-        let freeVariables' = Attribute.freeVariables attrs'
-        patt' <-
-            case patt of
-                ExistsF exists -> do
-                    let Exists { existsVariable, existsChild } = exists
-                    (existsVariable', existsChild') <-
-                        underBinder
-                            freeVariables'
-                            (ElemVar existsVariable)
-                            existsChild
-                    let exists' =
-                            exists
-                                { existsVariable = ElementVariable
-                                    (asVariable existsVariable')
-                                , existsChild = existsChild'
-                                }
-                    return (ExistsF exists')
-                ForallF forall -> do
-                    let Forall { forallVariable, forallChild } = forall
-                    (forallVariable', forallChild') <-
-                        underBinder
-                            freeVariables'
-                            (ElemVar forallVariable)
-                            forallChild
-                    let forall' =
-                            forall
-                                { forallVariable = ElementVariable
-                                    (asVariable forallVariable')
-                                , forallChild = forallChild'
-                                }
-                    return (ForallF forall')
-                MuF mu -> do
-                    let Mu { muVariable, muChild } = mu
-                    (muVariable', muChild') <-
-                        underBinder
-                            freeVariables'
-                            (SetVar muVariable)
-                            muChild
-                    let mu' =
-                            mu
-                                { muVariable = SetVariable
-                                    (asVariable muVariable')
-                                , muChild = muChild'
-                                }
-                    return (MuF mu')
-                NuF nu -> do
-                    let Nu { nuVariable, nuChild } = nu
-                    (nuVariable', nuChild') <-
-                        underBinder
-                            freeVariables'
-                            (SetVar nuVariable)
-                            nuChild
-                    let nu' =
-                            nu
-                                { nuVariable = SetVariable
-                                    (asVariable nuVariable')
-                                , nuChild = nuChild'
-                                }
-                    return (NuF nu')
-                _ ->
-                    traverseVariablesF lookupVariable patt >>= sequence
-        (return . Recursive.embed) (attrs' :< patt')
+      attrs' <- Attribute.traverseVariables lookupVariable attrs
+      let freeVariables' = Attribute.freeVariables attrs'
+      patt' <-
+        case patt of
+          ExistsF exists -> do
+            let Exists {existsVariable, existsChild} = exists
+            (existsVariable', existsChild') <-
+              underBinder
+                freeVariables'
+                (ElemVar existsVariable)
+                existsChild
+            let exists' =
+                  exists
+                    { existsVariable =
+                        ElementVariable
+                          (asVariable existsVariable'),
+                      existsChild = existsChild'
+                      }
+            return (ExistsF exists')
+          ForallF forall -> do
+            let Forall {forallVariable, forallChild} = forall
+            (forallVariable', forallChild') <-
+              underBinder
+                freeVariables'
+                (ElemVar forallVariable)
+                forallChild
+            let forall' =
+                  forall
+                    { forallVariable =
+                        ElementVariable
+                          (asVariable forallVariable'),
+                      forallChild = forallChild'
+                      }
+            return (ForallF forall')
+          MuF mu -> do
+            let Mu {muVariable, muChild} = mu
+            (muVariable', muChild') <-
+              underBinder
+                freeVariables'
+                (SetVar muVariable)
+                muChild
+            let mu' =
+                  mu
+                    { muVariable =
+                        SetVariable
+                          (asVariable muVariable'),
+                      muChild = muChild'
+                      }
+            return (MuF mu')
+          NuF nu -> do
+            let Nu {nuVariable, nuChild} = nu
+            (nuVariable', nuChild') <-
+              underBinder
+                freeVariables'
+                (SetVar nuVariable)
+                nuChild
+            let nu' =
+                  nu
+                    { nuVariable =
+                        SetVariable
+                          (asVariable nuVariable'),
+                      nuChild = nuChild'
+                      }
+            return (NuF nu')
+          _ ->
+            traverseVariablesF lookupVariable patt >>= sequence
+      (return . Recursive.embed) (attrs' :< patt')
     --TODO(traiansf): consider removing this usage of asVariable
     asVariable :: UnifiedVariable variable -> variable
     asVariable = foldMapVariable id
@@ -901,91 +933,91 @@ termLikeSort = Attribute.patternSort . extractAttributes
 
 -- | Attempts to modify p to have sort s.
 forceSort
-    :: (SortedVariable variable, Unparse variable, GHC.HasCallStack)
-    => Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: (SortedVariable variable, Unparse variable, GHC.HasCallStack)
+  => Sort
+  -> TermLike variable
+  -> TermLike variable
 forceSort forcedSort = Recursive.apo forceSortWorker
   where
     forceSortWorker original@(Recursive.project -> attrs :< pattern') =
-        (:<)
-            (attrs { Attribute.patternSort = forcedSort })
-            (case attrs of
-                Attribute.Pattern { patternSort = sort }
-                  | sort == forcedSort    -> Left <$> pattern'
-                  | sort == predicateSort -> forceSortWorkerPredicate
-                  | otherwise             -> illSorted
-            )
+      (:<)
+        (attrs {Attribute.patternSort = forcedSort})
+        ( case attrs of
+            Attribute.Pattern {patternSort = sort}
+              | sort == forcedSort -> Left <$> pattern'
+              | sort == predicateSort -> forceSortWorkerPredicate
+              | otherwise -> illSorted
+          )
       where
         illSorted =
-            (error . show . Pretty.vsep)
+          (error . show . Pretty.vsep)
             [ Pretty.cat
-                [ "Could not force pattern to sort "
-                , Pretty.squotes (unparse forcedSort)
-                , ", instead it has sort "
-                , Pretty.squotes (unparse (termLikeSort original))
-                , ":"
-                ]
-            , Pretty.indent 4 (unparse original)
-            ]
+                [ "Could not force pattern to sort ",
+                  Pretty.squotes (unparse forcedSort),
+                  ", instead it has sort ",
+                  Pretty.squotes (unparse (termLikeSort original)),
+                  ":"
+                  ],
+              Pretty.indent 4 (unparse original)
+              ]
         forceSortWorkerPredicate =
-            case pattern' of
-                -- Recurse
-                EvaluatedF evaluated -> EvaluatedF (Right <$> evaluated)
-                -- Predicates: Force sort and stop.
-                BottomF bottom' -> BottomF bottom' { bottomSort = forcedSort }
-                TopF top' -> TopF top' { topSort = forcedSort }
-                CeilF ceil' -> CeilF (Left <$> ceil'')
-                  where
-                    ceil'' = ceil' { ceilResultSort = forcedSort }
-                FloorF floor' -> FloorF (Left <$> floor'')
-                  where
-                    floor'' = floor' { floorResultSort = forcedSort }
-                EqualsF equals' -> EqualsF (Left <$> equals'')
-                  where
-                    equals'' = equals' { equalsResultSort = forcedSort }
-                InF in' -> InF (Left <$> in'')
-                  where
-                    in'' = in' { inResultSort = forcedSort }
-                -- Connectives: Force sort and recurse.
-                AndF and' -> AndF (Right <$> and'')
-                  where
-                    and'' = and' { andSort = forcedSort }
-                OrF or' -> OrF (Right <$> or'')
-                  where
-                    or'' = or' { orSort = forcedSort }
-                IffF iff' -> IffF (Right <$> iff'')
-                  where
-                    iff'' = iff' { iffSort = forcedSort }
-                ImpliesF implies' -> ImpliesF (Right <$> implies'')
-                  where
-                    implies'' = implies' { impliesSort = forcedSort }
-                NotF not' -> NotF (Right <$> not'')
-                  where
-                    not'' = not' { notSort = forcedSort }
-                NextF next' -> NextF (Right <$> next'')
-                  where
-                    next'' = next' { nextSort = forcedSort }
-                RewritesF rewrites' -> RewritesF (Right <$> rewrites'')
-                  where
-                    rewrites'' = rewrites' { rewritesSort = forcedSort }
-                ExistsF exists' -> ExistsF (Right <$> exists'')
-                  where
-                    exists'' = exists' { existsSort = forcedSort }
-                ForallF forall' -> ForallF (Right <$> forall'')
-                  where
-                    forall'' = forall' { forallSort = forcedSort }
-                -- Rigid: These patterns should never have sort _PREDICATE{}.
-                MuF _ -> illSorted
-                NuF _ -> illSorted
-                ApplySymbolF _ -> illSorted
-                ApplyAliasF _ -> illSorted
-                BuiltinF _ -> illSorted
-                DomainValueF _ -> illSorted
-                CharLiteralF _ -> illSorted
-                StringLiteralF _ -> illSorted
-                VariableF _ -> illSorted
-                InhabitantF _ -> illSorted
+          case pattern' of
+            -- Recurse
+            EvaluatedF evaluated -> EvaluatedF (Right <$> evaluated)
+            -- Predicates: Force sort and stop.
+            BottomF bottom' -> BottomF bottom' {bottomSort = forcedSort}
+            TopF top' -> TopF top' {topSort = forcedSort}
+            CeilF ceil' -> CeilF (Left <$> ceil'')
+              where
+                ceil'' = ceil' {ceilResultSort = forcedSort}
+            FloorF floor' -> FloorF (Left <$> floor'')
+              where
+                floor'' = floor' {floorResultSort = forcedSort}
+            EqualsF equals' -> EqualsF (Left <$> equals'')
+              where
+                equals'' = equals' {equalsResultSort = forcedSort}
+            InF in' -> InF (Left <$> in'')
+              where
+                in'' = in' {inResultSort = forcedSort}
+            -- Connectives: Force sort and recurse.
+            AndF and' -> AndF (Right <$> and'')
+              where
+                and'' = and' {andSort = forcedSort}
+            OrF or' -> OrF (Right <$> or'')
+              where
+                or'' = or' {orSort = forcedSort}
+            IffF iff' -> IffF (Right <$> iff'')
+              where
+                iff'' = iff' {iffSort = forcedSort}
+            ImpliesF implies' -> ImpliesF (Right <$> implies'')
+              where
+                implies'' = implies' {impliesSort = forcedSort}
+            NotF not' -> NotF (Right <$> not'')
+              where
+                not'' = not' {notSort = forcedSort}
+            NextF next' -> NextF (Right <$> next'')
+              where
+                next'' = next' {nextSort = forcedSort}
+            RewritesF rewrites' -> RewritesF (Right <$> rewrites'')
+              where
+                rewrites'' = rewrites' {rewritesSort = forcedSort}
+            ExistsF exists' -> ExistsF (Right <$> exists'')
+              where
+                exists'' = exists' {existsSort = forcedSort}
+            ForallF forall' -> ForallF (Right <$> forall'')
+              where
+                forall'' = forall' {forallSort = forcedSort}
+            -- Rigid: These patterns should never have sort _PREDICATE{}.
+            MuF _ -> illSorted
+            NuF _ -> illSorted
+            ApplySymbolF _ -> illSorted
+            ApplyAliasF _ -> illSorted
+            BuiltinF _ -> illSorted
+            DomainValueF _ -> illSorted
+            CharLiteralF _ -> illSorted
+            StringLiteralF _ -> illSorted
+            VariableF _ -> illSorted
+            InhabitantF _ -> illSorted
 
 {- | Call the argument function with two patterns whose sorts agree.
 
@@ -997,44 +1029,42 @@ same sort.
 
  -}
 makeSortsAgree
-    :: (SortedVariable variable, Unparse variable, GHC.HasCallStack)
-    => (TermLike variable -> TermLike variable -> Sort -> a)
-    -> TermLike variable
-    -> TermLike variable
-    -> a
+  :: (SortedVariable variable, Unparse variable, GHC.HasCallStack)
+  => (TermLike variable -> TermLike variable -> Sort -> a)
+  -> TermLike variable
+  -> TermLike variable
+  -> a
 makeSortsAgree withPatterns = \pattern1 pattern2 ->
-    let
-        sort1 = getRigidSort pattern1
-        sort2 = getRigidSort pattern2
-        sort = fromMaybe predicateSort (sort1 <|> sort2)
-        !pattern1' = forceSort sort pattern1
-        !pattern2' = forceSort sort pattern2
-    in
-        withPatterns pattern1' pattern2' sort
+  let sort1 = getRigidSort pattern1
+      sort2 = getRigidSort pattern2
+      sort = fromMaybe predicateSort (sort1 <|> sort2)
+      !pattern1' = forceSort sort pattern1
+      !pattern2' = forceSort sort pattern2
+   in withPatterns pattern1' pattern2' sort
 {-# INLINE makeSortsAgree #-}
 
 getRigidSort :: TermLike variable -> Maybe Sort
 getRigidSort pattern' =
-    case termLikeSort pattern' of
-        sort
-          | sort == predicateSort -> Nothing
-          | otherwise -> Just sort
+  case termLikeSort pattern' of
+    sort
+      | sort == predicateSort -> Nothing
+      | otherwise -> Just sort
 
 {- | Construct an 'And' pattern.
  -}
 mkAnd
-    ::  ( Ord variable
-        , SortedVariable variable
-        , Unparse variable
-        , GHC.HasCallStack
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Unparse variable,
+       GHC.HasCallStack
+       )
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkAnd = makeSortsAgree mkAndWorker
   where
     mkAndWorker andFirst andSecond andSort =
-        synthesize (AndF And { andSort, andFirst, andSecond })
+      synthesize (AndF And {andSort, andFirst, andSecond})
 
 {- | Force the 'TermLike's to conform to their 'Sort's.
 
@@ -1045,24 +1075,24 @@ See also: 'forceSort'
 
  -}
 forceSorts
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => [Sort]
-    -> [TermLike variable]
-    -> [TermLike variable]
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => [Sort]
+  -> [TermLike variable]
+  -> [TermLike variable]
 forceSorts operandSorts children =
-    alignWith forceTheseSorts operandSorts children
+  alignWith forceTheseSorts operandSorts children
   where
     forceTheseSorts (This _) =
-        (error . show . Pretty.vsep) ("Too few arguments:" : expected)
+      (error . show . Pretty.vsep) ("Too few arguments:" : expected)
     forceTheseSorts (That _) =
-        (error . show . Pretty.vsep) ("Too many arguments:" : expected)
+      (error . show . Pretty.vsep) ("Too many arguments:" : expected)
     forceTheseSorts (These sort termLike) = forceSort sort termLike
     expected =
-        [ "Expected:"
-        , Pretty.indent 4 (Unparser.arguments operandSorts)
-        , "but found:"
-        , Pretty.indent 4 (Unparser.arguments children)
+      [ "Expected:",
+        Pretty.indent 4 (Unparser.arguments operandSorts),
+        "but found:",
+        Pretty.indent 4 (Unparser.arguments children)
         ]
 
 {- | Construct an 'Application' pattern.
@@ -1075,21 +1105,21 @@ See also: 'applyAlias', 'applySymbol'
 
  -}
 mkApplyAlias
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => Alias
-    -- ^ Application symbol or alias
-    -> [TermLike variable]
-    -- ^ Application arguments
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => Alias
+  -- ^ Application symbol or alias
+  -> [TermLike variable]
+  -- ^ Application arguments
+  -> TermLike variable
 mkApplyAlias alias children =
-    synthesize (ApplyAliasF application)
+  synthesize (ApplyAliasF application)
   where
     application =
-        Application
-            { applicationSymbolOrAlias = alias
-            , applicationChildren = forceSorts operandSorts children
-            }
+      Application
+        { applicationSymbolOrAlias = alias,
+          applicationChildren = forceSorts operandSorts children
+          }
     operandSorts = applicationSortsOperands (aliasSorts alias)
 
 {- | Construct an 'Application' pattern.
@@ -1102,21 +1132,21 @@ See also: 'applyAlias', 'applySymbol'
 
  -}
 mkApplySymbol
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => Symbol
-    -- ^ Application symbol or alias
-    -> [TermLike variable]
-    -- ^ Application arguments
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => Symbol
+  -- ^ Application symbol or alias
+  -> [TermLike variable]
+  -- ^ Application arguments
+  -> TermLike variable
 mkApplySymbol symbol children =
-    synthesize (ApplySymbolF application)
+  synthesize (ApplySymbolF application)
   where
     application =
-        Application
-            { applicationSymbolOrAlias = symbol
-            , applicationChildren = forceSorts operandSorts children
-            }
+      Application
+        { applicationSymbolOrAlias = symbol,
+          applicationChildren = forceSorts operandSorts children
+          }
     operandSorts = applicationSortsOperands (symbolSorts symbol)
 
 {- | Construct an 'Application' pattern from a 'Alias' declaration.
@@ -1127,49 +1157,49 @@ See also: 'mkApplyAlias', 'applyAlias_', 'applySymbol', 'mkAlias'
 
  -}
 applyAlias
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => SentenceAlias (TermLike variable)
-    -- ^ 'Alias' declaration
-    -> [Sort]
-    -- ^ 'Alias' sort parameters
-    -> [TermLike variable]
-    -- ^ 'Application' arguments
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => SentenceAlias (TermLike variable)
+  -- ^ 'Alias' declaration
+  -> [Sort]
+  -- ^ 'Alias' sort parameters
+  -> [TermLike variable]
+  -- ^ 'Application' arguments
+  -> TermLike variable
 applyAlias sentence params children =
-    mkApplyAlias internal children'
+  mkApplyAlias internal children'
   where
-    SentenceAlias { sentenceAliasAlias = external } = sentence
-    Syntax.Alias { aliasConstructor } = external
-    Syntax.Alias { aliasParams } = external
+    SentenceAlias {sentenceAliasAlias = external} = sentence
+    Syntax.Alias {aliasConstructor} = external
+    Syntax.Alias {aliasParams} = external
     internal =
-        Alias
-            { aliasConstructor
-            , aliasParams = params
-            , aliasSorts =
-                symbolOrAliasSorts params sentence
-                & assertRight
-            }
+      Alias
+        { aliasConstructor,
+          aliasParams = params,
+          aliasSorts =
+            symbolOrAliasSorts params sentence
+              & assertRight
+          }
     substitution = sortSubstitution aliasParams params
     childSorts = substituteSortVariables substitution <$> sentenceAliasSorts
       where
-        SentenceAlias { sentenceAliasSorts } = sentence
+        SentenceAlias {sentenceAliasSorts} = sentence
     children' = alignWith forceChildSort childSorts children
       where
         forceChildSort =
-            \case
-                These sort pattern' -> forceSort sort pattern'
-                This _ ->
-                    (error . show . Pretty.vsep)
-                        ("Too few parameters:" : expected)
-                That _ ->
-                    (error . show . Pretty.vsep)
-                        ("Too many parameters:" : expected)
+          \case
+            These sort pattern' -> forceSort sort pattern'
+            This _ ->
+              (error . show . Pretty.vsep)
+                ("Too few parameters:" : expected)
+            That _ ->
+              (error . show . Pretty.vsep)
+                ("Too many parameters:" : expected)
         expected =
-            [ "Expected:"
-            , Pretty.indent 4 (Unparser.arguments childSorts)
-            , "but found:"
-            , Pretty.indent 4 (Unparser.arguments children)
+          [ "Expected:",
+            Pretty.indent 4 (Unparser.arguments childSorts),
+            "but found:",
+            Pretty.indent 4 (Unparser.arguments children)
             ]
 
 {- | Construct an 'Application' pattern from a 'Alias' declaration.
@@ -1180,14 +1210,14 @@ See also: 'mkApp', 'applyAlias'
 
  -}
 applyAlias_
-    ::  ( Ord variable
-        , SortedVariable variable
-        , Unparse variable
-        , GHC.HasCallStack
-        )
-    => SentenceAlias (TermLike variable)
-    -> [TermLike variable]
-    -> TermLike variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Unparse variable,
+       GHC.HasCallStack
+       )
+  => SentenceAlias (TermLike variable)
+  -> [TermLike variable]
+  -> TermLike variable
 applyAlias_ sentence = applyAlias sentence []
 
 {- | Construct an 'Application' pattern from a 'Symbol' declaration.
@@ -1198,29 +1228,29 @@ See also: 'mkApp', 'applySymbol_', 'mkSymbol'
 
  -}
 applySymbol
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => SentenceSymbol pattern''
-    -- ^ 'Symbol' declaration
-    -> [Sort]
-    -- ^ 'Symbol' sort parameters
-    -> [TermLike variable]
-    -- ^ 'Application' arguments
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => SentenceSymbol pattern''
+  -- ^ 'Symbol' declaration
+  -> [Sort]
+  -- ^ 'Symbol' sort parameters
+  -> [TermLike variable]
+  -- ^ 'Application' arguments
+  -> TermLike variable
 applySymbol sentence params children =
-    mkApplySymbol internal children
+  mkApplySymbol internal children
   where
-    SentenceSymbol { sentenceSymbolSymbol = external } = sentence
-    Syntax.Symbol { symbolConstructor } = external
+    SentenceSymbol {sentenceSymbolSymbol = external} = sentence
+    Syntax.Symbol {symbolConstructor} = external
     internal =
-        Symbol
-            { symbolConstructor
-            , symbolParams = params
-            , symbolAttributes = Default.def
-            , symbolSorts =
-                symbolOrAliasSorts params sentence
-                & assertRight
-            }
+      Symbol
+        { symbolConstructor,
+          symbolParams = params,
+          symbolAttributes = Default.def,
+          symbolSorts =
+            symbolOrAliasSorts params sentence
+              & assertRight
+          }
 
 {- | Construct an 'Application' pattern from a 'Symbol' declaration.
 
@@ -1230,11 +1260,11 @@ See also: 'mkApplySymbol', 'applySymbol'
 
  -}
 applySymbol_
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => SentenceSymbol pattern''
-    -> [TermLike variable]
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => SentenceSymbol pattern''
+  -> [TermLike variable]
+  -> TermLike variable
 applySymbol_ sentence = applySymbol sentence []
 
 {- | Construct a 'Bottom' pattern in the given sort.
@@ -1243,7 +1273,7 @@ See also: 'mkBottom_'
 
  -}
 mkBottom :: (Ord variable, SortedVariable variable) => Sort -> TermLike variable
-mkBottom bottomSort = synthesize (BottomF Bottom { bottomSort })
+mkBottom bottomSort = synthesize (BottomF Bottom {bottomSort})
 
 {- | Construct a 'Bottom' pattern in 'predicateSort'.
 
@@ -1262,12 +1292,12 @@ See also: 'mkCeil_'
 
  -}
 mkCeil
-    :: (Ord variable, SortedVariable variable)
-    => Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort
+  -> TermLike variable
+  -> TermLike variable
 mkCeil ceilResultSort ceilChild =
-    synthesize (CeilF Ceil { ceilOperandSort, ceilResultSort, ceilChild })
+  synthesize (CeilF Ceil {ceilOperandSort, ceilResultSort, ceilChild})
   where
     ceilOperandSort = termLikeSort ceilChild
 
@@ -1280,49 +1310,49 @@ See also: 'mkCeil'
 
  -}
 mkCeil_
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
 mkCeil_ = mkCeil predicateSort
 
 {- | Construct a builtin pattern.
  -}
 mkBuiltin
-    :: (Ord variable, SortedVariable variable)
-    => Domain.Builtin (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Domain.Builtin (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 mkBuiltin = synthesize . BuiltinF
 
 {- | Construct a builtin list pattern.
  -}
 mkBuiltinList
-    :: (Ord variable, SortedVariable variable)
-    => Domain.InternalList (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Domain.InternalList (TermLike variable)
+  -> TermLike variable
 mkBuiltinList = synthesize . BuiltinF . Domain.BuiltinList
 
 {- | Construct a builtin map pattern.
  -}
 mkBuiltinMap
-    :: (Ord variable, SortedVariable variable)
-    => Domain.InternalMap (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Domain.InternalMap (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 mkBuiltinMap = synthesize . BuiltinF . Domain.BuiltinMap
 
 {- | Construct a builtin set pattern.
  -}
 mkBuiltinSet
-    :: (Ord variable, SortedVariable variable)
-    => Domain.InternalSet (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Domain.InternalSet (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 mkBuiltinSet = synthesize . BuiltinF . Domain.BuiltinSet
 
 {- | Construct a 'DomainValue' pattern.
  -}
 mkDomainValue
-    :: (Ord variable, SortedVariable variable)
-    => DomainValue Sort (TermLike variable)
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => DomainValue Sort (TermLike variable)
+  -> TermLike variable
 mkDomainValue = synthesize . DomainValueF
 
 {- | Construct an 'Equals' pattern in the given sort.
@@ -1331,25 +1361,25 @@ See also: 'mkEquals_'
 
  -}
 mkEquals
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkEquals equalsResultSort =
-    makeSortsAgree mkEqualsWorker
+  makeSortsAgree mkEqualsWorker
   where
     mkEqualsWorker equalsFirst equalsSecond equalsOperandSort =
-        synthesize (EqualsF equals)
+      synthesize (EqualsF equals)
       where
         equals =
-            Equals
-                { equalsOperandSort
-                , equalsResultSort
-                , equalsFirst
-                , equalsSecond
-                }
+          Equals
+            { equalsOperandSort,
+              equalsResultSort,
+              equalsFirst,
+              equalsSecond
+              }
 
 {- | Construct a 'Equals' pattern in 'predicateSort'.
 
@@ -1360,36 +1390,36 @@ See also: 'mkEquals'
 
  -}
 mkEquals_
-    ::  ( Ord variable
-        , SortedVariable variable
-        , Unparse variable
-        , GHC.HasCallStack
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Unparse variable,
+       GHC.HasCallStack
+       )
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkEquals_ = mkEquals predicateSort
 
 {- | Construct an 'Exists' pattern.
  -}
 mkExists
-    :: (Ord variable, SortedVariable variable)
-    => ElementVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => ElementVariable variable
+  -> TermLike variable
+  -> TermLike variable
 mkExists existsVariable existsChild =
-    synthesize (ExistsF Exists { existsSort, existsVariable, existsChild })
+  synthesize (ExistsF Exists {existsSort, existsVariable, existsChild})
   where
     existsSort = termLikeSort existsChild
 
 {- | Construct a sequence of 'Exists' patterns over several variables.
  -}
 mkExistsN
-    :: (Ord variable, SortedVariable variable)
-    => Foldable foldable
-    => foldable (ElementVariable variable)
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Foldable foldable
+  => foldable (ElementVariable variable)
+  -> TermLike variable
+  -> TermLike variable
 mkExistsN = appEndo . foldMap (Endo . mkExists)
 
 {- | Construct a 'Floor' pattern in the given sort.
@@ -1398,12 +1428,12 @@ See also: 'mkFloor_'
 
  -}
 mkFloor
-    :: (Ord variable, SortedVariable variable)
-    => Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort
+  -> TermLike variable
+  -> TermLike variable
 mkFloor floorResultSort floorChild =
-    synthesize (FloorF Floor { floorOperandSort, floorResultSort, floorChild })
+  synthesize (FloorF Floor {floorOperandSort, floorResultSort, floorChild})
   where
     floorOperandSort = termLikeSort floorChild
 
@@ -1416,59 +1446,60 @@ See also: 'mkFloor'
 
  -}
 mkFloor_
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
 mkFloor_ = mkFloor predicateSort
 
 {- | Construct a 'Forall' pattern.
  -}
 mkForall
-    :: (Ord variable, SortedVariable variable)
-    => ElementVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => ElementVariable variable
+  -> TermLike variable
+  -> TermLike variable
 mkForall forallVariable forallChild =
-    synthesize (ForallF Forall { forallSort, forallVariable, forallChild })
+  synthesize (ForallF Forall {forallSort, forallVariable, forallChild})
   where
     forallSort = termLikeSort forallChild
 
 {- | Construct a sequence of 'Forall' patterns over several variables.
  -}
 mkForallN
-    :: (Ord variable, SortedVariable variable)
-    => Foldable foldable
-    => foldable (ElementVariable variable)
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Foldable foldable
+  => foldable (ElementVariable variable)
+  -> TermLike variable
+  -> TermLike variable
 mkForallN = appEndo . foldMap (Endo . mkForall)
 
 {- | Construct an 'Iff' pattern.
  -}
 mkIff
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkIff = makeSortsAgree mkIffWorker
   where
     mkIffWorker iffFirst iffSecond iffSort =
-        synthesize (IffF Iff { iffSort, iffFirst, iffSecond })
+      synthesize (IffF Iff {iffSort, iffFirst, iffSecond})
 
 {- | Construct an 'Implies' pattern.
  -}
 mkImplies
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkImplies = makeSortsAgree mkImpliesWorker
   where
     mkImpliesWorker impliesFirst impliesSecond impliesSort =
-        synthesize (ImpliesF implies')
+      synthesize (ImpliesF implies')
       where
-        implies' = Implies { impliesSort, impliesFirst, impliesSecond }
+        implies' = Implies {impliesSort, impliesFirst, impliesSecond}
 
 {- | Construct a 'In' pattern in the given sort.
 
@@ -1476,24 +1507,24 @@ See also: 'mkIn_'
 
  -}
 mkIn
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkIn inResultSort = makeSortsAgree mkInWorker
   where
     mkInWorker inContainedChild inContainingChild inOperandSort =
-        synthesize (InF in')
+      synthesize (InF in')
       where
         in' =
-            In
-                { inOperandSort
-                , inResultSort
-                , inContainedChild
-                , inContainingChild
-                }
+          In
+            { inOperandSort,
+              inResultSort,
+              inContainedChild,
+              inContainingChild
+              }
 
 {- | Construct a 'In' pattern in 'predicateSort'.
 
@@ -1504,92 +1535,92 @@ See also: 'mkIn'
 
  -}
 mkIn_
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkIn_ = mkIn predicateSort
 
 {- | Construct a 'Mu' pattern.
  -}
 mkMu
-    :: Ord variable
-    => SortedVariable variable
-    => Unparse variable
-    => SetVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => Unparse variable
+  => SetVariable variable
+  -> TermLike variable
+  -> TermLike variable
 mkMu muVar = makeSortsAgree mkMuWorker (mkSetVar muVar)
   where
     mkMuWorker (SetVar_ muVar') muChild _ =
-        synthesize (MuF Mu { muVariable = muVar', muChild })
+      synthesize (MuF Mu {muVariable = muVar', muChild})
     mkMuWorker _ _ _ = error "Unreachable code"
 
 {- | Construct a 'Next' pattern.
  -}
 mkNext
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
 mkNext nextChild =
-    synthesize (NextF Next { nextSort, nextChild })
+  synthesize (NextF Next {nextSort, nextChild})
   where
     nextSort = termLikeSort nextChild
 
 {- | Construct a 'Not' pattern.
  -}
 mkNot
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
 mkNot notChild =
-    synthesize (NotF Not { notSort, notChild })
+  synthesize (NotF Not {notSort, notChild})
   where
     notSort = termLikeSort notChild
 
 {- | Construct a 'Nu' pattern.
  -}
 mkNu
-    :: Ord variable
-    => SortedVariable variable
-    => Unparse variable
-    => SetVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => Unparse variable
+  => SetVariable variable
+  -> TermLike variable
+  -> TermLike variable
 mkNu nuVar = makeSortsAgree mkNuWorker (mkSetVar nuVar)
   where
     mkNuWorker (SetVar_ nuVar') nuChild _ =
-        synthesize (NuF Nu { nuVariable = nuVar', nuChild })
+      synthesize (NuF Nu {nuVariable = nuVar', nuChild})
     mkNuWorker _ _ _ = error "Unreachable code"
 
 {- | Construct an 'Or' pattern.
  -}
 mkOr
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkOr = makeSortsAgree mkOrWorker
   where
     mkOrWorker orFirst orSecond orSort =
-        synthesize (OrF Or { orSort, orFirst, orSecond })
+      synthesize (OrF Or {orSort, orFirst, orSecond})
 
 {- | Construct a 'Rewrites' pattern.
  -}
 mkRewrites
-    :: (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 mkRewrites = makeSortsAgree mkRewritesWorker
   where
     mkRewritesWorker rewritesFirst rewritesSecond rewritesSort =
-        synthesize (RewritesF rewrites')
+      synthesize (RewritesF rewrites')
       where
-        rewrites' = Rewrites { rewritesSort, rewritesFirst, rewritesSecond }
+        rewrites' = Rewrites {rewritesSort, rewritesFirst, rewritesSecond}
 
 {- | Construct a 'Top' pattern in the given sort.
 
@@ -1597,7 +1628,7 @@ See also: 'mkTop_'
 
  -}
 mkTop :: (Ord variable, SortedVariable variable) => Sort -> TermLike variable
-mkTop topSort = synthesize (TopF Top { topSort })
+mkTop topSort = synthesize (TopF Top {topSort})
 
 {- | Construct a 'Top' pattern in 'predicateSort'.
 
@@ -1613,53 +1644,56 @@ mkTop_ = mkTop predicateSort
 {- | Construct a variable pattern.
  -}
 mkVar
-    :: Ord variable
-    => SortedVariable variable
-    => UnifiedVariable variable -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => UnifiedVariable variable
+  -> TermLike variable
 mkVar = synthesize . VariableF . Const
 
 {- | Construct an element variable pattern.
  -}
 mkElemVar
-    :: Ord variable
-    => SortedVariable variable
-    => ElementVariable variable -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => ElementVariable variable
+  -> TermLike variable
 mkElemVar = mkVar . ElemVar
 
 {- | Construct a set variable pattern.
  -}
 mkSetVar
-    :: Ord variable
-    => SortedVariable variable
-    => SetVariable variable -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => SetVariable variable
+  -> TermLike variable
 mkSetVar = mkVar . SetVar
 
 {- | Construct a 'StringLiteral' pattern.
  -}
 mkStringLiteral
-    :: (Ord variable, SortedVariable variable)
-    => Text
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Text
+  -> TermLike variable
 mkStringLiteral = synthesize . StringLiteralF . Const . StringLiteral
 
 {- | Construct a 'CharLiteral' pattern.
  -}
 mkCharLiteral
-    :: (Ord variable, SortedVariable variable)
-    => Char
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Char
+  -> TermLike variable
 mkCharLiteral = synthesize . CharLiteralF . Const . CharLiteral
 
 mkInhabitant
-    :: (Ord variable, SortedVariable variable)
-    => Sort
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => Sort
+  -> TermLike variable
 mkInhabitant = synthesize . InhabitantF . Inhabitant
 
 mkEvaluated
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> TermLike variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
 mkEvaluated = synthesize . EvaluatedF . Evaluated
 
 mkSort :: Id -> Sort
@@ -1676,11 +1710,11 @@ mkSortVariable name = SortVariableSort $ SortVariable name
  -}
 varS :: Id -> Sort -> Variable
 varS variableName variableSort =
-    Variable
-        { variableName
-        , variableSort
-        , variableCounter = mempty
-        }
+  Variable
+    { variableName,
+      variableSort,
+      variableCounter = mempty
+      }
 
 {- | Construct an element variable with a given name and sort.
 
@@ -1692,7 +1726,7 @@ varS variableName variableSort =
  -}
 elemVarS :: Id -> Sort -> ElementVariable Variable
 elemVarS variableName variableSort =
-    ElementVariable (varS variableName variableSort)
+  ElementVariable (varS variableName variableSort)
 
 {- | Construct a set variable with a given name and sort.
 
@@ -1704,20 +1738,20 @@ elemVarS variableName variableSort =
  -}
 setVarS :: Id -> Sort -> SetVariable Variable
 setVarS variableName variableSort =
-    SetVariable (varS variableName variableSort)
+  SetVariable (varS variableName variableSort)
 
 {- | Construct an axiom declaration with the given parameters and pattern.
  -}
 mkAxiom
-    :: [SortVariable]
-    -> TermLike variable
-    -> SentenceAxiom (TermLike variable)
+  :: [SortVariable]
+  -> TermLike variable
+  -> SentenceAxiom (TermLike variable)
 mkAxiom sentenceAxiomParameters sentenceAxiomPattern =
-    SentenceAxiom
-        { sentenceAxiomParameters
-        , sentenceAxiomPattern
-        , sentenceAxiomAttributes = Attributes []
-        }
+  SentenceAxiom
+    { sentenceAxiomParameters,
+      sentenceAxiomPattern,
+      sentenceAxiomAttributes = Attributes []
+      }
 
 {- | Construct an axiom declaration with no parameters.
 
@@ -1730,22 +1764,21 @@ mkAxiom_ = mkAxiom []
 {- | Construct a symbol declaration with the given parameters and sorts.
  -}
 mkSymbol
-    :: Id
-    -> [SortVariable]
-    -> [Sort]
-    -> Sort
-    -> SentenceSymbol (TermLike variable)
+  :: Id
+  -> [SortVariable]
+  -> [Sort]
+  -> Sort
+  -> SentenceSymbol (TermLike variable)
 mkSymbol symbolConstructor symbolParams argumentSorts resultSort' =
-    SentenceSymbol
-        { sentenceSymbolSymbol =
-            Syntax.Symbol
-                { symbolConstructor
-                , symbolParams
-                }
-        , sentenceSymbolSorts = argumentSorts
-        , sentenceSymbolResultSort = resultSort'
-        , sentenceSymbolAttributes = Attributes []
-        }
+  SentenceSymbol
+    { sentenceSymbolSymbol = Syntax.Symbol
+        { symbolConstructor,
+          symbolParams
+          },
+      sentenceSymbolSorts = argumentSorts,
+      sentenceSymbolResultSort = resultSort',
+      sentenceSymbolAttributes = Attributes []
+      }
 
 {- | Construct a symbol declaration with no parameters.
 
@@ -1753,43 +1786,40 @@ See also: 'mkSymbol'
 
  -}
 mkSymbol_
-    :: Id
-    -> [Sort]
-    -> Sort
-    -> SentenceSymbol (TermLike variable)
+  :: Id
+  -> [Sort]
+  -> Sort
+  -> SentenceSymbol (TermLike variable)
 mkSymbol_ symbolConstructor = mkSymbol symbolConstructor []
 
 {- | Construct an alias declaration with the given parameters and sorts.
  -}
 mkAlias
-    :: Id
-    -> [SortVariable]
-    -> Sort
-    -> [ElementVariable Variable]
-    -> TermLike Variable
-    -> SentenceAlias (TermLike Variable)
+  :: Id
+  -> [SortVariable]
+  -> Sort
+  -> [ElementVariable Variable]
+  -> TermLike Variable
+  -> SentenceAlias (TermLike Variable)
 mkAlias aliasConstructor aliasParams resultSort' arguments right =
-    SentenceAlias
-        { sentenceAliasAlias =
-            Syntax.Alias
-                { aliasConstructor
-                , aliasParams
-                }
-        , sentenceAliasSorts = argumentSorts
-        , sentenceAliasResultSort = resultSort'
-        , sentenceAliasLeftPattern =
-            Application
-                { applicationSymbolOrAlias =
-                    SymbolOrAlias
-                        { symbolOrAliasConstructor = aliasConstructor
-                        , symbolOrAliasParams =
-                            SortVariableSort <$> aliasParams
-                        }
-                , applicationChildren = arguments
-                }
-        , sentenceAliasRightPattern = right
-        , sentenceAliasAttributes = Attributes []
-        }
+  SentenceAlias
+    { sentenceAliasAlias = Syntax.Alias
+        { aliasConstructor,
+          aliasParams
+          },
+      sentenceAliasSorts = argumentSorts,
+      sentenceAliasResultSort = resultSort',
+      sentenceAliasLeftPattern = Application
+        { applicationSymbolOrAlias = SymbolOrAlias
+            { symbolOrAliasConstructor = aliasConstructor,
+              symbolOrAliasParams =
+                SortVariableSort <$> aliasParams
+              },
+          applicationChildren = arguments
+          },
+      sentenceAliasRightPattern = right,
+      sentenceAliasAttributes = Attributes []
+      }
   where
     argumentSorts = variableSort . getElementVariable <$> arguments
 
@@ -1799,141 +1829,141 @@ See also: 'mkAlias'
 
  -}
 mkAlias_
-    :: Id
-    -> Sort
-    -> [ElementVariable Variable]
-    -> TermLike Variable
-    -> SentenceAlias (TermLike Variable)
+  :: Id
+  -> Sort
+  -> [ElementVariable Variable]
+  -> TermLike Variable
+  -> SentenceAlias (TermLike Variable)
 mkAlias_ aliasConstructor = mkAlias aliasConstructor []
 
 pattern And_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern App_
-    :: Symbol
-    -> [TermLike variable]
-    -> TermLike variable
+  :: Symbol
+  -> [TermLike variable]
+  -> TermLike variable
 
 pattern ApplyAlias_
-    :: Alias
-    -> [TermLike variable]
-    -> TermLike variable
+  :: Alias
+  -> [TermLike variable]
+  -> TermLike variable
 
 pattern Bottom_
-    :: Sort
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
 
 pattern Ceil_
-    :: Sort
-    -> Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> Sort
+  -> TermLike variable
+  -> TermLike variable
 
 pattern DV_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Builtin_
-    :: Domain.Builtin (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: Domain.Builtin (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 
 pattern BuiltinBool_
-    :: Domain.InternalBool
-    -> TermLike variable
+  :: Domain.InternalBool
+  -> TermLike variable
 
 pattern BuiltinInt_
-    :: Domain.InternalInt
-    -> TermLike variable
+  :: Domain.InternalInt
+  -> TermLike variable
 
 pattern BuiltinList_
-    :: Domain.InternalList (TermLike variable)
-    -> TermLike variable
+  :: Domain.InternalList (TermLike variable)
+  -> TermLike variable
 
 pattern BuiltinMap_
-    :: Domain.InternalMap (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: Domain.InternalMap (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 
 pattern BuiltinSet_
-    :: Domain.InternalSet (TermLike Concrete) (TermLike variable)
-    -> TermLike variable
+  :: Domain.InternalSet (TermLike Concrete) (TermLike variable)
+  -> TermLike variable
 
 pattern BuiltinString_
-    :: Domain.InternalString
-    -> TermLike variable
+  :: Domain.InternalString
+  -> TermLike variable
 
 pattern Equals_
-    :: Sort
-    -> Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Exists_
-    :: Sort
-    -> ElementVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> ElementVariable variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Floor_
-    :: Sort
-    -> Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> Sort
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Forall_
-    :: Sort
-    -> ElementVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> ElementVariable variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Iff_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Implies_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern In_
-    :: Sort
-    -> Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Mu_
-    :: SetVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: SetVariable variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Next_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Not_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Nu_
-    :: SetVariable variable
-    -> TermLike variable
-    -> TermLike variable
+  :: SetVariable variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Or_
-    :: Sort
-    -> TermLike variable
-    -> TermLike variable
-    -> TermLike variable
+  :: Sort
+  -> TermLike variable
+  -> TermLike variable
+  -> TermLike variable
 
 pattern Rewrites_
   :: Sort
@@ -1956,35 +1986,39 @@ pattern CharLiteral_ :: Char -> TermLike variable
 pattern Evaluated_ :: TermLike variable -> TermLike variable
 
 pattern And_ andSort andFirst andSecond <-
-    (Recursive.project -> _ :< AndF And { andSort, andFirst, andSecond })
+  (Recursive.project -> _ :< AndF And {andSort, andFirst, andSecond})
 
 pattern ApplyAlias_ applicationSymbolOrAlias applicationChildren <-
-    (Recursive.project ->
-        _ :< ApplyAliasF Application
-            { applicationSymbolOrAlias
-            , applicationChildren
-            }
+  ( Recursive.project ->
+      _ :<
+        ApplyAliasF
+          Application
+            { applicationSymbolOrAlias,
+              applicationChildren
+              }
     )
 
 pattern App_ applicationSymbolOrAlias applicationChildren <-
-    (Recursive.project ->
-        _ :< ApplySymbolF Application
-            { applicationSymbolOrAlias
-            , applicationChildren
-            }
+  ( Recursive.project ->
+      _ :<
+        ApplySymbolF
+          Application
+            { applicationSymbolOrAlias,
+              applicationChildren
+              }
     )
 
 pattern Bottom_ bottomSort <-
-    (Recursive.project -> _ :< BottomF Bottom { bottomSort })
+  (Recursive.project -> _ :< BottomF Bottom {bottomSort})
 
 pattern Ceil_ ceilOperandSort ceilResultSort ceilChild <-
-    (Recursive.project ->
-        _ :< CeilF Ceil { ceilOperandSort, ceilResultSort, ceilChild }
+  ( Recursive.project ->
+      _ :< CeilF Ceil {ceilOperandSort, ceilResultSort, ceilChild}
     )
 
 pattern DV_ domainValueSort domainValueChild <-
-    (Recursive.project ->
-        _ :< DomainValueF DomainValue { domainValueSort, domainValueChild }
+  ( Recursive.project ->
+      _ :< DomainValueF DomainValue {domainValueSort, domainValueChild}
     )
 
 pattern Builtin_ builtin <- (Recursive.project -> _ :< BuiltinF builtin)
@@ -1999,103 +2033,113 @@ pattern BuiltinMap_ internalMap <- Builtin_ (Domain.BuiltinMap internalMap)
 
 pattern BuiltinSet_ internalSet <- Builtin_ (Domain.BuiltinSet internalSet)
 
-pattern BuiltinString_ internalString
-    <- Builtin_ (Domain.BuiltinString internalString)
+pattern BuiltinString_ internalString <-
+  Builtin_ (Domain.BuiltinString internalString)
 
 pattern Equals_ equalsOperandSort equalsResultSort equalsFirst equalsSecond <-
-    (Recursive.project ->
-        _ :< EqualsF Equals
-            { equalsOperandSort
-            , equalsResultSort
-            , equalsFirst
-            , equalsSecond
-            }
+  ( Recursive.project ->
+      _ :<
+        EqualsF
+          Equals
+            { equalsOperandSort,
+              equalsResultSort,
+              equalsFirst,
+              equalsSecond
+              }
     )
 
 pattern Exists_ existsSort existsVariable existsChild <-
-    (Recursive.project ->
-        _ :< ExistsF Exists { existsSort, existsVariable, existsChild }
+  ( Recursive.project ->
+      _ :< ExistsF Exists {existsSort, existsVariable, existsChild}
     )
 
 pattern Floor_ floorOperandSort floorResultSort floorChild <-
-    (Recursive.project ->
-        _ :< FloorF Floor
-            { floorOperandSort
-            , floorResultSort
-            , floorChild
-            }
+  ( Recursive.project ->
+      _ :<
+        FloorF
+          Floor
+            { floorOperandSort,
+              floorResultSort,
+              floorChild
+              }
     )
 
 pattern Forall_ forallSort forallVariable forallChild <-
-    (Recursive.project ->
-        _ :< ForallF Forall { forallSort, forallVariable, forallChild }
+  ( Recursive.project ->
+      _ :< ForallF Forall {forallSort, forallVariable, forallChild}
     )
 
 pattern Iff_ iffSort iffFirst iffSecond <-
-    (Recursive.project ->
-        _ :< IffF Iff { iffSort, iffFirst, iffSecond }
+  ( Recursive.project ->
+      _ :< IffF Iff {iffSort, iffFirst, iffSecond}
     )
 
 pattern Implies_ impliesSort impliesFirst impliesSecond <-
-    (Recursive.project ->
-        _ :< ImpliesF Implies { impliesSort, impliesFirst, impliesSecond }
+  ( Recursive.project ->
+      _ :< ImpliesF Implies {impliesSort, impliesFirst, impliesSecond}
     )
 
 pattern In_ inOperandSort inResultSort inFirst inSecond <-
-    (Recursive.project ->
-        _ :< InF In
-            { inOperandSort
-            , inResultSort
-            , inContainedChild = inFirst
-            , inContainingChild = inSecond
-            }
+  ( Recursive.project ->
+      _ :<
+        InF
+          In
+            { inOperandSort,
+              inResultSort,
+              inContainedChild = inFirst,
+              inContainingChild = inSecond
+              }
     )
 
 pattern Mu_ muVariable muChild <-
-    (Recursive.project ->
-        _ :< MuF Mu { muVariable, muChild }
+  ( Recursive.project ->
+      _ :< MuF Mu {muVariable, muChild}
     )
 
 pattern Next_ nextSort nextChild <-
-    (Recursive.project ->
-        _ :< NextF Next { nextSort, nextChild })
+  ( Recursive.project ->
+      _ :< NextF Next {nextSort, nextChild}
+    )
 
 pattern Not_ notSort notChild <-
-    (Recursive.project ->
-        _ :< NotF Not { notSort, notChild })
+  ( Recursive.project ->
+      _ :< NotF Not {notSort, notChild}
+    )
 
 pattern Nu_ nuVariable nuChild <-
-    (Recursive.project ->
-        _ :< NuF Nu { nuVariable, nuChild }
+  ( Recursive.project ->
+      _ :< NuF Nu {nuVariable, nuChild}
     )
 
 pattern Or_ orSort orFirst orSecond <-
-    (Recursive.project -> _ :< OrF Or { orSort, orFirst, orSecond })
+  (Recursive.project -> _ :< OrF Or {orSort, orFirst, orSecond})
 
 pattern Rewrites_ rewritesSort rewritesFirst rewritesSecond <-
-    (Recursive.project ->
-        _ :< RewritesF Rewrites
-            { rewritesSort
-            , rewritesFirst
-            , rewritesSecond
-            }
+  ( Recursive.project ->
+      _ :<
+        RewritesF
+          Rewrites
+            { rewritesSort,
+              rewritesFirst,
+              rewritesSecond
+              }
     )
 
 pattern Top_ topSort <-
-    (Recursive.project -> _ :< TopF Top { topSort })
+  (Recursive.project -> _ :< TopF Top {topSort})
 
 pattern Var_ variable <-
-    (Recursive.project -> _ :< VariableF (Const variable))
+  (Recursive.project -> _ :< VariableF (Const variable))
 
 pattern SetVar_ setVariable <- Var_ (SetVar setVariable)
 
 pattern ElemVar_ elemVariable <- Var_ (ElemVar elemVariable)
 
 pattern StringLiteral_ str <-
-    (Recursive.project -> _ :< StringLiteralF (Const (StringLiteral str)))
+  (Recursive.project -> _ :< StringLiteralF (Const (StringLiteral str)))
 
 pattern CharLiteral_ char <-
-    (Recursive.project -> _ :< CharLiteralF (Const (CharLiteral char)))
+  (Recursive.project -> _ :< CharLiteralF (Const (CharLiteral char)))
 
 pattern Evaluated_ child <-
-    (Recursive.project -> _ :< EvaluatedF (Evaluated child))
+  (Recursive.project -> _ :< EvaluatedF (Evaluated child))

--- a/kore/src/Kore/Logger/Output.hs
+++ b/kore/src/Kore/Logger/Output.hs
@@ -5,92 +5,123 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 -}
-
 module Kore.Logger.Output
-    ( KoreLogType (..)
-    , KoreLogOptions (..)
-    , withLogger
-    , parseKoreLogOptions
-    , emptyLogger
-    , stderrLogger
-    , swappableLogger
-    , makeKoreLogger
-    , Colog.logTextStderr
-    , Colog.logTextHandle
-    , module Kore.Logger
-    , runLoggerT
-    ) where
+  ( KoreLogType (..),
+    KoreLogOptions (..),
+    withLogger,
+    parseKoreLogOptions,
+    emptyLogger,
+    stderrLogger,
+    swappableLogger,
+    makeKoreLogger,
+    Colog.logTextStderr,
+    Colog.logTextHandle,
+    module Kore.Logger,
+    runLoggerT
+    )
+where
 
-import           Colog
-                 ( LogAction (..) )
+import Colog
+  ( LogAction (..)
+    )
 import qualified Colog
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Concurrent.MVar
-import           Control.Monad.Catch
-                 ( MonadMask, bracket )
-import           Control.Monad.IO.Class
-                 ( MonadIO, liftIO )
-import           Control.Monad.Reader
-                 ( runReaderT )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Concurrent.MVar
+import Control.Monad.Catch
+  ( MonadMask,
+    bracket
+    )
+import Control.Monad.IO.Class
+  ( MonadIO,
+    liftIO
+    )
+import Control.Monad.Reader
+  ( runReaderT
+    )
 import qualified Control.Monad.Trans as Trans
-import           Data.Foldable
-                 ( fold )
+import Data.Foldable
+  ( fold
+    )
 import qualified Data.Foldable as Fold
-import           Data.Functor
-                 ( void )
-import           Data.Functor.Contravariant
-                 ( contramap )
-import           Data.List
-                 ( intersperse )
-import           Data.Set
-                 ( Set )
+import Data.Functor
+  ( void
+    )
+import Data.Functor.Contravariant
+  ( contramap
+    )
+import Data.List
+  ( intersperse
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.String
-                 ( IsString, fromString )
-import           Data.Text
-                 ( Text )
+import Data.String
+  ( IsString,
+    fromString
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
-import           Data.Text.Lazy.Builder
-                 ( Builder )
+import Data.Text.Lazy.Builder
+  ( Builder
+    )
 import qualified Data.Text.Lazy.Builder as Builder
-import           Data.Time.Clock
-                 ( getCurrentTime )
-import           Data.Time.Format
-                 ( defaultTimeLocale, formatTime )
-import           Data.Time.LocalTime
-                 ( LocalTime, getCurrentTimeZone, utcToLocalTime )
-import           GHC.Stack
-                 ( CallStack, getCallStack, popCallStack, prettyCallStack )
-import           Options.Applicative
-                 ( Parser, help, long, maybeReader, option )
+import Data.Time.Clock
+  ( getCurrentTime
+    )
+import Data.Time.Format
+  ( defaultTimeLocale,
+    formatTime
+    )
+import Data.Time.LocalTime
+  ( LocalTime,
+    getCurrentTimeZone,
+    utcToLocalTime
+    )
+import GHC.Stack
+  ( CallStack,
+    getCallStack,
+    popCallStack,
+    prettyCallStack
+    )
+import Kore.Logger
+import Options.Applicative
+  ( Parser,
+    help,
+    long,
+    maybeReader,
+    option
+    )
 import qualified Text.Megaparsec as Parser
 import qualified Text.Megaparsec.Char as Parser
-
-import Kore.Logger
 
 -- | 'KoreLogType' is passed via command line arguments and decides if and how
 -- the logger will operate.
 data KoreLogType
-    = LogNone
+  = LogNone
     -- ^ do not log when no '--log' is passed
-    | LogStdErr
+  | LogStdErr
     -- ^ log to StdOut when '--log StdOut' is passed
-    | LogFileText
+  | LogFileText
     -- ^ log to "./kore-(date).log" when '--log FileText' is passed
-    deriving (Read)
+  deriving (Read)
 
 -- | 'KoreLogOptions' is the top-level options type for logging, containing the
 -- desired output method and the minimum 'Severity'.
-data KoreLogOptions = KoreLogOptions
-    { logType   :: KoreLogType
-    -- ^ desired output method, see 'KoreLogType'
-    , logLevel  :: Severity
-    -- ^ minimal log level, passed via "--log-level"
-    , logScopes :: Set Scope
-    -- ^ scopes to show, empty means show all
-    }
+data KoreLogOptions
+  = KoreLogOptions
+      { logType :: KoreLogType,
+        -- ^ desired output method, see 'KoreLogType'
+        logLevel :: Severity,
+        -- ^ minimal log level, passed via "--log-level"
+        logScopes :: Set Scope
+        -- ^ scopes to show, empty means show all
+        }
 
 -- | Internal type used to add timestamps to a 'LogMessage'.
 data LogMessageWithTimestamp = LogMessageWithTimestamp LogMessage LocalTime
@@ -98,28 +129,29 @@ data LogMessageWithTimestamp = LogMessageWithTimestamp LogMessage LocalTime
 -- | Generates an appropriate logger for the given 'KoreLogOptions'. It uses
 -- the CPS style because some outputters require cleanup (e.g. files).
 withLogger
-    :: Trans.MonadIO m
-    => KoreLogOptions
-    -> (LogAction m LogMessage -> IO a)
-    -> IO a
-withLogger KoreLogOptions { logType, logLevel, logScopes } cont =
-    case logType of
-        LogNone     ->
-            cont mempty
-        LogStdErr   ->
-            cont (stderrLogger logLevel logScopes)
-        LogFileText -> do
-            fileName <- getKoreLogFileName
-            Colog.withLogTextFile fileName
-                $ cont . makeKoreLogger logLevel logScopes
+  :: Trans.MonadIO m
+  => KoreLogOptions
+  -> (LogAction m LogMessage -> IO a)
+  -> IO a
+withLogger KoreLogOptions {logType, logLevel, logScopes} cont =
+  case logType of
+    LogNone ->
+      cont mempty
+    LogStdErr ->
+      cont (stderrLogger logLevel logScopes)
+    LogFileText -> do
+      fileName <- getKoreLogFileName
+      Colog.withLogTextFile fileName
+        $ cont
+        . makeKoreLogger logLevel logScopes
   where
     getKoreLogFileName :: IO String
     getKoreLogFileName = do
-        currentTimeDate <- getLocalTime
-        pure
-            $ "kore-"
-            <> formatLocalTime "%Y-%m-%d-%H-%M-%S" currentTimeDate
-            <> ".log"
+      currentTimeDate <- getLocalTime
+      pure
+        $ "kore-"
+        <> formatLocalTime "%Y-%m-%d-%H-%M-%S" currentTimeDate
+        <> ".log"
 
 -- | Run a 'LoggerT' with the given options.
 runLoggerT :: KoreLogOptions -> LoggerT IO a -> IO a
@@ -128,115 +160,107 @@ runLoggerT options = withLogger options . runReaderT . getLoggerT
 -- Parser for command line log options.
 parseKoreLogOptions :: Parser KoreLogOptions
 parseKoreLogOptions =
-    KoreLogOptions
+  KoreLogOptions
     <$> (parseType <|> pure LogNone)
     <*> (parseLevel <|> pure Warning)
     <*> (parseScope <|> pure mempty)
   where
     parseType =
-        option
-            (maybeReader parseTypeString)
-            $ long "log"
-            <> help "Log type: None, StdOut, FileText"
+      option
+        (maybeReader parseTypeString)
+        $ long "log"
+        <> help "Log type: None, StdOut, FileText"
     parseTypeString =
-        \case
-            "none"     -> pure LogNone
-            "stdout"   -> pure LogStdErr
-            "filetext" -> pure LogFileText
-            _          -> Nothing
-
+      \case
+        "none" -> pure LogNone
+        "stdout" -> pure LogStdErr
+        "filetext" -> pure LogFileText
+        _ -> Nothing
     parseLevel =
-        option
-            (maybeReader parseSeverity)
-            $ long "log-level"
-            <> help "Log level: Debug, Info, Warning, Error, or Critical"
+      option
+        (maybeReader parseSeverity)
+        $ long "log-level"
+        <> help "Log level: Debug, Info, Warning, Error, or Critical"
     parseSeverity =
-        \case
-            "debug"    -> pure Debug
-            "info"     -> pure Info
-            "warning"  -> pure Warning
-            "error"    -> pure Error
-            "critical" -> pure Critical
-            _          -> Nothing
-
+      \case
+        "debug" -> pure Debug
+        "info" -> pure Info
+        "warning" -> pure Warning
+        "error" -> pure Error
+        "critical" -> pure Critical
+        _ -> Nothing
     parseScope =
-        option
-            parseCommaSeparatedScopes
-            $ long "log-scope"
-            <> help "Log scope"
+      option
+        parseCommaSeparatedScopes
+        $ long "log-scope"
+        <> help "Log scope"
     parseCommaSeparatedScopes = maybeReader $ Parser.parseMaybe scopeParser
     scopeParser :: Parser.Parsec String String (Set Scope)
     scopeParser = do
-        args <- many itemParser
-        pure . Set.fromList $ args
+      args <- many itemParser
+      pure . Set.fromList $ args
     itemParser :: Parser.Parsec String String Scope
     itemParser = do
-        argument <- some (Parser.noneOf [','])
-        _ <- void (Parser.char ',') <|> Parser.eof
-        pure . Scope . Text.pack $ argument
+      argument <- some (Parser.noneOf [','])
+      _ <- void (Parser.char ',') <|> Parser.eof
+      pure . Scope . Text.pack $ argument
 
 -- Creates a kore logger which:
 --     * filters messages that have lower severity than the provided severity
 --     * adds timestamps
 --     * formats messages: "[<severity>][<localTime>][<scope>]: <message>"
 makeKoreLogger
-    :: forall m
-    .  MonadIO m
-    => Severity
-    -> Set Scope
-    -> LogAction m Text
-    -> LogAction m LogMessage
+  :: forall m. MonadIO m
+  => Severity
+  -> Set Scope
+  -> LogAction m Text
+  -> LogAction m LogMessage
 makeKoreLogger severity scopeSet logToText =
-    Colog.cfilter (\(LogMessage _ logSeverity logScope _) -> logSeverity >= severity && logScope `member` scopeSet)
-        . Colog.cmapM addTimeStamp
-        $ contramap messageToText logToText
+  Colog.cfilter (\(LogMessage _ logSeverity logScope _) -> logSeverity >= severity && logScope `member` scopeSet)
+    . Colog.cmapM addTimeStamp
+    $ contramap messageToText logToText
   where
     addTimeStamp :: LogMessage -> m LogMessageWithTimestamp
     addTimeStamp msg =
-        LogMessageWithTimestamp msg <$> getLocalTime
-
+      LogMessageWithTimestamp msg <$> getLocalTime
     messageToText :: LogMessageWithTimestamp -> Text
     messageToText
-        (LogMessageWithTimestamp
-                (LogMessage message severity' scope callstack)
-            localTime
-        )
-            = Text.Lazy.toStrict . Builder.toLazyText
-                $ "["
-                <> Builder.fromString (show severity')
-                <> "] ["
-                <> formatLocalTime "%Y-%m-%d %H:%M:%S%Q" localTime
-                <> "] ["
-                <> scopeToBuilder scope
-                <> "]: "
-                <> Builder.fromText message
-                <> " ["
-                <> formatCallStack callstack
-                <> "]"
-
+      ( LogMessageWithTimestamp
+          (LogMessage message severity' scope callstack)
+          localTime
+        ) =
+        Text.Lazy.toStrict . Builder.toLazyText
+          $ "["
+          <> Builder.fromString (show severity')
+          <> "] ["
+          <> formatLocalTime "%Y-%m-%d %H:%M:%S%Q" localTime
+          <> "] ["
+          <> scopeToBuilder scope
+          <> "]: "
+          <> Builder.fromText message
+          <> " ["
+          <> formatCallStack callstack
+          <> "]"
     scopeToBuilder :: [Scope] -> Builder
     scopeToBuilder =
-        fold
-            . intersperse "."
-            . fmap (Builder.fromText . unScope)
-
+      fold
+        . intersperse "."
+        . fmap (Builder.fromText . unScope)
     formatCallStack :: CallStack -> Builder
     formatCallStack cs
-        | length (getCallStack cs) <= 1 = mempty
-        | otherwise                    = callStackToBuilder cs
-
+      | length (getCallStack cs) <= 1 = mempty
+      | otherwise = callStackToBuilder cs
     callStackToBuilder :: CallStack -> Builder
     callStackToBuilder = Builder.fromString . prettyCallStack . popCallStack
-
     member :: [Scope] -> Set Scope -> Bool
     member s set
       | Set.null set = True
-      | otherwise    = Fold.any (`Set.member` set) s
+      | otherwise = Fold.any (`Set.member` set) s
 
 -- Helper to get the local time in 'MonadIO'.
 getLocalTime :: MonadIO m => m LocalTime
 getLocalTime =
-    liftIO $ utcToLocalTime <$> getCurrentTimeZone <*> getCurrentTime
+  liftIO $ utcToLocalTime <$> getCurrentTimeZone <*> getCurrentTime
 
 -- Formats the local time using the provided format string.
 formatLocalTime :: IsString s => String -> LocalTime -> s
@@ -255,11 +279,11 @@ makes the logger thread-safe.)
 
  -}
 swappableLogger
-    :: (MonadIO m, MonadMask m)
-    => MVar (LogAction m a)
-    -> LogAction m a
+  :: (MonadIO m, MonadMask m)
+  => MVar (LogAction m a)
+  -> LogAction m a
 swappableLogger mvar =
-    Colog.LogAction $ bracket acquire release . worker
+  Colog.LogAction $ bracket acquire release . worker
   where
     acquire = liftIO $ takeMVar mvar
     release = liftIO . putMVar mvar

--- a/kore/src/Kore/ModelChecker/Bounded.hs
+++ b/kore/src/Kore/ModelChecker/Bounded.hs
@@ -2,144 +2,158 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-
 module Kore.ModelChecker.Bounded
-    ( CheckResult (..)
-    , Axiom (..)
-    , bmcStrategy
-    , checkClaim
-    ) where
+  ( CheckResult (..),
+    Axiom (..),
+    bmcStrategy,
+    checkClaim
+    )
+where
 
 import qualified Control.Monad.State.Strict as State
 import qualified Data.Foldable as Foldable
 import qualified Data.Graph.Inductive.Graph as Graph
-import           Data.Limit
-                 ( Limit )
+import Data.Limit
+  ( Limit
+    )
 import qualified Data.Limit as Limit
 import qualified Data.Text as Text
-
-import           Kore.Internal.Pattern
-                 ( Conditional (Conditional) )
-import           Kore.Internal.Pattern as Conditional
-                 ( Conditional (..) )
+import Kore.Internal.Pattern
+  ( Conditional (Conditional)
+    )
+import Kore.Internal.Pattern as Conditional
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Logger as Logger
-import           Kore.ModelChecker.Step
-                 ( CommonModalPattern, CommonProofState, ModalPattern (..),
-                 Prim (..), defaultOneStepStrategy )
+import Kore.ModelChecker.Step
+  ( CommonModalPattern,
+    CommonProofState,
+    ModalPattern (..),
+    Prim (..),
+    defaultOneStepStrategy
+    )
 import qualified Kore.ModelChecker.Step as ProofState
-                 ( ProofState (..) )
+  ( ProofState (..)
+    )
 import qualified Kore.ModelChecker.Step as ModelChecker
-                 ( Transition, transitionRule )
+  ( Transition,
+    transitionRule
+    )
 import qualified Kore.Predicate.Predicate as Predicate
-import           Kore.Step.Rule
-                 ( ImplicationRule (ImplicationRule), RewriteRule,
-                 RulePattern (..) )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
-import           Kore.Step.Strategy
-                 ( ExecutionGraph (..), GraphSearchOrder, Strategy, pickFinal,
-                 runStrategyWithSearchOrder )
-import           Kore.Syntax.Id
-                 ( Id (..) )
-import           Kore.Syntax.Variable
-                 ( Variable )
-import           Numeric.Natural
-                 ( Natural )
+import Kore.Step.Rule
+  ( ImplicationRule (ImplicationRule),
+    RewriteRule,
+    RulePattern (..)
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
+import Kore.Step.Strategy
+  ( ExecutionGraph (..),
+    GraphSearchOrder,
+    Strategy,
+    pickFinal,
+    runStrategyWithSearchOrder
+    )
+import Kore.Syntax.Id
+  ( Id (..)
+    )
+import Kore.Syntax.Variable
+  ( Variable
+    )
+import Numeric.Natural
+  ( Natural
+    )
 
 data CheckResult patt
-    = Proved
+  = Proved
     -- ^ Property is proved within the bound.
-    | Failed !patt
+  | Failed !patt
     -- ^ Counter example is found within the bound.
-    | Unknown
+  | Unknown
     -- ^ Result is unknown within the bound.
-    deriving (Show)
+  deriving (Show)
 
-newtype Axiom = Axiom { unAxiom :: RewriteRule Variable }
+newtype Axiom = Axiom {unAxiom :: RewriteRule Variable}
 
 bmcStrategy
-    :: [Axiom]
-    -> CommonModalPattern
-    -> [Strategy (Prim CommonModalPattern (RewriteRule Variable))]
+  :: [Axiom]
+  -> CommonModalPattern
+  -> [Strategy (Prim CommonModalPattern (RewriteRule Variable))]
 bmcStrategy
-    axioms
-    goal
-  =  repeat (defaultOneStepStrategy goal rewrites)
-  where
-    rewrites :: [RewriteRule Variable]
-    rewrites = map unwrap axioms
-      where
-        unwrap (Axiom a) = a
+  axioms
+  goal =
+    repeat (defaultOneStepStrategy goal rewrites)
+    where
+      rewrites :: [RewriteRule Variable]
+      rewrites = map unwrap axioms
+        where
+          unwrap (Axiom a) = a
 
 checkClaim
-    :: forall m
-    .  MonadSimplify m
-    =>  (  CommonModalPattern
-        -> [Strategy (Prim CommonModalPattern (RewriteRule Variable))]
-        )
-    -- ^ Creates a one-step strategy from a target pattern. See
-    -- 'defaultStrategy'.
-    -> GraphSearchOrder
-    -> (ImplicationRule Variable, Limit Natural)
-    -- a claim to check, together with a maximum number of verification steps
-    -- for each.
-    -> m (CheckResult (TermLike Variable))
+  :: forall m. MonadSimplify m
+  => ( CommonModalPattern
+       -> [Strategy (Prim CommonModalPattern (RewriteRule Variable))]
+       -- ^ Creates a one-step strategy from a target pattern. See
+       -- 'defaultStrategy'.
+       )
+  -> GraphSearchOrder
+  -> (ImplicationRule Variable, Limit Natural)
+  -> -- a claim to check, together with a maximum number of verification steps
+  -- for each.
+  m (CheckResult (TermLike Variable))
 checkClaim
-    strategyBuilder
-    searchOrder
-    (ImplicationRule RulePattern { left, right }, stepLimit)
-  = do
-        let
-            ApplyAlias_ Alias { aliasConstructor = alias } [prop] = right
-            goalPattern = ModalPattern { modalOp = getId alias, term = prop }
-            strategy =
-                Limit.takeWithin
-                    stepLimit
-                    (strategyBuilder goalPattern)
-            startState :: CommonProofState
-            startState =
-                ProofState.GoalLHS
-                    Conditional
-                        { term = left
-                        , predicate = Predicate.makeTruePredicate
-                        , substitution = mempty
-                        }
-        executionGraph <- State.evalStateT
-                            (runStrategyWithSearchOrder
-                                transitionRule'
-                                strategy
-                                searchOrder
-                                startState)
-                            Nothing
-
-        Logger.withLogScope (Logger.Scope "BMCStats")
-            . Logger.logInfo
-            . Text.pack
-            $ ("searched states: " ++ (show . Graph.order . graph $ executionGraph))
-
-        let
-            finalResult = (checkFinalNodes . pickFinal) executionGraph
-        return finalResult
-  where
-    transitionRule'
+  strategyBuilder
+  searchOrder
+  (ImplicationRule RulePattern {left, right}, stepLimit) =
+    do
+      let ApplyAlias_ Alias {aliasConstructor = alias} [prop] = right
+          goalPattern = ModalPattern {modalOp = getId alias, term = prop}
+          strategy =
+            Limit.takeWithin
+              stepLimit
+              (strategyBuilder goalPattern)
+          startState :: CommonProofState
+          startState =
+            ProofState.GoalLHS Conditional
+              { term = left,
+                predicate = Predicate.makeTruePredicate,
+                substitution = mempty
+                }
+      executionGraph <-
+        State.evalStateT
+          ( runStrategyWithSearchOrder
+              transitionRule'
+              strategy
+              searchOrder
+              startState
+            )
+          Nothing
+      Logger.withLogScope (Logger.Scope "BMCStats")
+        . Logger.logInfo
+        . Text.pack
+        $ ("searched states: " ++ (show . Graph.order . graph $ executionGraph))
+      let finalResult = (checkFinalNodes . pickFinal) executionGraph
+      return finalResult
+    where
+      transitionRule'
         :: Prim CommonModalPattern (RewriteRule Variable)
         -> CommonProofState
         -> ModelChecker.Transition m CommonProofState
-    transitionRule' = ModelChecker.transitionRule
-
-    checkFinalNodes
+      transitionRule' = ModelChecker.transitionRule
+      checkFinalNodes
         :: [CommonProofState]
         -> CheckResult (TermLike Variable)
-    checkFinalNodes nodes
-      = Foldable.foldl' checkFinalNodesHelper Proved nodes
-      where
-        checkFinalNodesHelper Proved  ProofState.Proven = Proved
-        checkFinalNodesHelper Proved  (ProofState.Unprovable config) =
+      checkFinalNodes nodes =
+        Foldable.foldl' checkFinalNodesHelper Proved nodes
+        where
+          checkFinalNodesHelper Proved ProofState.Proven = Proved
+          checkFinalNodesHelper Proved (ProofState.Unprovable config) =
             Failed (Pattern.toTermLike config)
-        checkFinalNodesHelper Proved  _ = Unknown
-        checkFinalNodesHelper Unknown (ProofState.Unprovable config) =
+          checkFinalNodesHelper Proved _ = Unknown
+          checkFinalNodesHelper Unknown (ProofState.Unprovable config) =
             Failed (Pattern.toTermLike config)
-        checkFinalNodesHelper Unknown _ = Unknown
-        checkFinalNodesHelper (Failed config) _ = Failed config
+          checkFinalNodesHelper Unknown _ = Unknown
+          checkFinalNodesHelper (Failed config) _ = Failed config

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -2,77 +2,82 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-
 module Kore.ModelChecker.Simplification
-    ( checkImplicationIsTop
-    ) where
+  ( checkImplicationIsTop
+    )
+where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike as TermLike
+import Kore.Internal.TermLike as TermLike
 import qualified Kore.Predicate.Predicate as Predicate
-import           Kore.Step.Simplification.Data
-import qualified Kore.Step.Simplification.Pattern as Pattern
-                 ( simplifyAndRemoveTopExists )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
-                 ( filterMultiOr )
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+  ( filterMultiOr
+    )
+import Kore.Step.Simplification.Data
+import qualified Kore.Step.Simplification.Pattern as Pattern
+  ( simplifyAndRemoveTopExists
+    )
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 checkImplicationIsTop
-    :: MonadSimplify m
-    => Pattern Variable
-    -> TermLike Variable
-    -> m Bool
+  :: MonadSimplify m
+  => Pattern Variable
+  -> TermLike Variable
+  -> m Bool
 checkImplicationIsTop lhs rhs =
-    case stripForallQuantifiers rhs of
-        ( forallQuantifiers, Implies_ _ implicationLHS implicationRHS ) -> do
-            let rename = refreshVariables lhsFreeVariables forallQuantifiers
-                subst = mkElemVar <$> Map.mapKeys ElemVar rename
-                implicationLHS' = TermLike.substitute subst implicationLHS
-                implicationRHS' = TermLike.substitute subst implicationRHS
-                resultTerm =
-                    mkCeil_
-                        (mkAnd
-                            (mkAnd lhsMLPatt implicationLHS')
-                            (mkNot implicationRHS')
-                        )
-                result = Conditional
-                    { term = resultTerm
-                    , predicate = Predicate.makeTruePredicate
-                    , substitution = mempty
-                    }
-            orResult <- Pattern.simplifyAndRemoveTopExists result
-            orFinalResult <- SMT.Evaluator.filterMultiOr orResult
-            return (isBottom orFinalResult)
-        _ -> (error . show . Pretty.vsep)
-             [ "Not implemented error:"
-             , "We don't know how to simplify the implication whose rhs is:"
-             , Pretty.indent 4 (unparse rhs)
-             ]
-      where
-        lhsFreeVariables = Set.fromList $
-            FreeVariables.getFreeElementVariables (Pattern.freeVariables lhs)
-        lhsMLPatt = Pattern.toTermLike lhs
+  case stripForallQuantifiers rhs of
+    (forallQuantifiers, Implies_ _ implicationLHS implicationRHS) -> do
+      let rename = refreshVariables lhsFreeVariables forallQuantifiers
+          subst = mkElemVar <$> Map.mapKeys ElemVar rename
+          implicationLHS' = TermLike.substitute subst implicationLHS
+          implicationRHS' = TermLike.substitute subst implicationRHS
+          resultTerm =
+            mkCeil_
+              ( mkAnd
+                  (mkAnd lhsMLPatt implicationLHS')
+                  (mkNot implicationRHS')
+                )
+          result = Conditional
+            { term = resultTerm,
+              predicate = Predicate.makeTruePredicate,
+              substitution = mempty
+              }
+      orResult <- Pattern.simplifyAndRemoveTopExists result
+      orFinalResult <- SMT.Evaluator.filterMultiOr orResult
+      return (isBottom orFinalResult)
+    _ ->
+      (error . show . Pretty.vsep)
+        [ "Not implemented error:",
+          "We don't know how to simplify the implication whose rhs is:",
+          Pretty.indent 4 (unparse rhs)
+          ]
+  where
+    lhsFreeVariables =
+      Set.fromList
+        $ FreeVariables.getFreeElementVariables (Pattern.freeVariables lhs)
+    lhsMLPatt = Pattern.toTermLike lhs
 
 stripForallQuantifiers
-    :: TermLike Variable
-    -> (Set.Set (ElementVariable Variable), TermLike Variable)
-stripForallQuantifiers patt
-  = case patt of
-        Forall_ _ forallVar child ->
-            let
-                ( childVars, strippedChild ) = stripForallQuantifiers child
-            in
-                ( Set.insert forallVar childVars, strippedChild)
-        _ -> ( Set.empty , patt )
+  :: TermLike Variable
+  -> (Set.Set (ElementVariable Variable), TermLike Variable)
+stripForallQuantifiers patt =
+  case patt of
+    Forall_ _ forallVar child ->
+      let (childVars, strippedChild) = stripForallQuantifiers child
+       in (Set.insert forallVar childVars, strippedChild)
+    _ -> (Set.empty, patt)

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -2,90 +2,107 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-
 module Kore.ModelChecker.Step
-    ( -- * Primitive strategies
-      Prim (..)
-    , ModalPattern (..)
-    , CommonModalPattern
-    , ProofState (..)
-    , CommonProofState
-    , Transition
-    , transitionRule
-    , defaultOneStepStrategy
-    ) where
+  ( -- * Primitive strategies
+    Prim (..),
+    ModalPattern (..),
+    CommonModalPattern,
+    ProofState (..),
+    CommonProofState,
+    Transition,
+    transitionRule,
+    defaultOneStepStrategy
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Monad
-                 ( when )
-import           Control.Monad.State.Strict
-                 ( StateT )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Monad
+  ( when
+    )
+import Control.Monad.State.Strict
+  ( StateT
+    )
 import qualified Control.Monad.State.Strict as State
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Foldable as Foldable
-import           Data.Hashable
-import           Data.Maybe
-                 ( isJust )
-import           Data.Text
-                 ( Text )
+import Data.Hashable
+import Data.Maybe
+  ( isJust
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           GHC.Generics
-
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import GHC.Generics
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-                 ( TermLike )
-import           Kore.ModelChecker.Simplification
-                 ( checkImplicationIsTop )
+import Kore.Internal.TermLike
+  ( TermLike
+    )
+import Kore.ModelChecker.Simplification
+  ( checkImplicationIsTop
+    )
 import qualified Kore.Step.Result as StepResult
-import           Kore.Step.Rule
-                 ( RewriteRule (RewriteRule), allPathGlobally )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
-import qualified Kore.Step.Simplification.Pattern as Pattern
-                 ( simplifyAndRemoveTopExists )
+import Kore.Step.Rule
+  ( RewriteRule (RewriteRule),
+    allPathGlobally
+    )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
-                 ( filterMultiOr )
+  ( filterMultiOr
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
+import qualified Kore.Step.Simplification.Pattern as Pattern
+  ( simplifyAndRemoveTopExists
+    )
 import qualified Kore.Step.Step as Step
-import           Kore.Step.Strategy
-                 ( Strategy, TransitionT )
+import Kore.Step.Strategy
+  ( Strategy,
+    TransitionT
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.Syntax.Variable
-                 ( Variable )
+import Kore.Syntax.Variable
+  ( Variable
+    )
 import qualified Kore.Unification.Procedure as Unification
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
+import Kore.Unparser
 
-data Prim patt rewrite =
-      CheckProofState
+data Prim patt rewrite
+  = CheckProofState
     -- ^ Check the proof state and decide whether to terminate the computation
-    | Simplify
+  | Simplify
     -- ^ Builtin and function symbol simplification step
-    | Unroll !patt
+  | Unroll !patt
     -- ^ Unroll the proof goal
-    | ComputeWeakNext ![rewrite]
+  | ComputeWeakNext ![rewrite]
     -- ^ Compute next states
-    deriving (Show)
+  deriving (Show)
 
-data ModalPattern variable = ModalPattern
-    { modalOp :: !Text
-    , term  :: !(TermLike variable)
-    }
+data ModalPattern variable
+  = ModalPattern
+      { modalOp :: !Text,
+        term :: !(TermLike variable)
+        }
 
 deriving instance Eq variable => Eq (ModalPattern variable)
+
 deriving instance Show variable => Show (ModalPattern variable)
 
 type CommonModalPattern = ModalPattern Variable
 
 data ProofState patt
-    = Proven
-    | Unprovable !patt
-    | GoalLHS !patt
+  = Proven
+  | Unprovable !patt
+  | GoalLHS !patt
     -- ^ State on which a normal 'Rewrite' can be applied. Also used
     -- for the start patterns.
-    | GoalRemLHS !patt
+  | GoalRemLHS !patt
     -- ^ State which can't be rewritten anymore.
   deriving (Show, Eq, Ord, Generic)
 
@@ -106,145 +123,139 @@ unroll = Unroll
 computeWeakNext :: [rewrite] -> Prim patt rewrite
 computeWeakNext = ComputeWeakNext
 
-type Transition m =
-    TransitionT (RewriteRule Variable) (StateT (Maybe ()) m)
+type Transition m
+  = TransitionT (RewriteRule Variable) (StateT (Maybe ()) m)
 
 transitionRule
-    :: forall m
-    .  MonadSimplify m
-    => Prim CommonModalPattern (RewriteRule Variable)
-    -> CommonProofState
-    -> Transition m CommonProofState
+  :: forall m. MonadSimplify m
+  => Prim CommonModalPattern (RewriteRule Variable)
+  -> CommonProofState
+  -> Transition m CommonProofState
 transitionRule
-    strategyPrim
-    proofState
-  = case strategyPrim of
-        CheckProofState -> transitionCheckProofState proofState
-        Simplify -> transitionSimplify proofState
-        Unroll goalrhs -> transitionUnroll goalrhs proofState
-        ComputeWeakNext rewrites ->
-            transitionComputeWeakNext rewrites proofState
-  where
-    transitionCheckProofState
+  strategyPrim
+  proofState =
+    case strategyPrim of
+      CheckProofState -> transitionCheckProofState proofState
+      Simplify -> transitionSimplify proofState
+      Unroll goalrhs -> transitionUnroll goalrhs proofState
+      ComputeWeakNext rewrites ->
+        transitionComputeWeakNext rewrites proofState
+    where
+      transitionCheckProofState
         :: CommonProofState
         -> Transition m CommonProofState
-    transitionCheckProofState proofState0 = do
+      transitionCheckProofState proofState0 = do
         execState <- Monad.Trans.lift State.get
         -- End early if any unprovable state was reached
         when (isJust execState) empty
         case proofState0 of
-            Proven -> empty
-            Unprovable _ -> empty
-            ps -> return ps
-
-    transitionSimplify
+          Proven -> empty
+          Unprovable _ -> empty
+          ps -> return ps
+      transitionSimplify
         :: CommonProofState
         -> Transition m CommonProofState
-    transitionSimplify Proven = return Proven
-    transitionSimplify (Unprovable config) = return (Unprovable config)
-    transitionSimplify (GoalLHS config) =
+      transitionSimplify Proven = return Proven
+      transitionSimplify (Unprovable config) = return (Unprovable config)
+      transitionSimplify (GoalLHS config) =
         applySimplify GoalLHS config
-    transitionSimplify (GoalRemLHS config) =
+      transitionSimplify (GoalRemLHS config) =
         applySimplify GoalRemLHS config
-
-    applySimplify wrapper config =
+      applySimplify wrapper config =
         do
-            configs <-
-                Monad.Trans.lift . Monad.Trans.lift
-                $ Pattern.simplifyAndRemoveTopExists config
-            filteredConfigs <- SMT.Evaluator.filterMultiOr configs
-            if null filteredConfigs
-                then return Proven
-                else Foldable.asum (pure . wrapper <$> filteredConfigs)
-
-    transitionUnroll
+          configs <-
+            Monad.Trans.lift . Monad.Trans.lift
+              $ Pattern.simplifyAndRemoveTopExists config
+          filteredConfigs <- SMT.Evaluator.filterMultiOr configs
+          if null filteredConfigs
+            then return Proven
+            else Foldable.asum (pure . wrapper <$> filteredConfigs)
+      transitionUnroll
         :: CommonModalPattern
         -> CommonProofState
         -> Transition m CommonProofState
-    transitionUnroll _ Proven = empty
-    transitionUnroll _ (Unprovable _) = empty
-    transitionUnroll goalrhs (GoalLHS config)
+      transitionUnroll _ Proven = empty
+      transitionUnroll _ (Unprovable _) = empty
+      transitionUnroll goalrhs (GoalLHS config)
         | Pattern.isBottom config = return Proven
         | otherwise = applyUnroll goalrhs GoalLHS config
-    transitionUnroll goalrhs (GoalRemLHS config)
+      transitionUnroll goalrhs (GoalRemLHS config)
         | Pattern.isBottom config = return Proven
         | otherwise = applyUnroll goalrhs GoalRemLHS config
-
-    applyUnroll ModalPattern { modalOp, term } wrapper config
-        | modalOp == allPathGlobally = do
+      applyUnroll ModalPattern {modalOp, term} wrapper config
+        | modalOp == allPathGlobally =
+          do
             result <-
-                Monad.Trans.lift . Monad.Trans.lift
+              Monad.Trans.lift . Monad.Trans.lift
                 $ checkImplicationIsTop config term
             if result
-                then return (wrapper config)
-                else do
-                    (Monad.Trans.lift . State.put) (Just ())
-                    return (Unprovable config)
-        | otherwise = (error . show . Pretty.vsep)
-                      [ "Not implemented error:"
-                      , "We don't know how to unroll the modalOp:"
-                      , Pretty.pretty modalOp
-                      ]
-
-    transitionComputeWeakNext
+              then return (wrapper config)
+              else do
+                (Monad.Trans.lift . State.put) (Just ())
+                return (Unprovable config)
+        | otherwise =
+          (error . show . Pretty.vsep)
+            [ "Not implemented error:",
+              "We don't know how to unroll the modalOp:",
+              Pretty.pretty modalOp
+              ]
+      transitionComputeWeakNext
         :: [RewriteRule Variable]
         -> CommonProofState
         -> Transition m CommonProofState
-    transitionComputeWeakNext _ Proven = return Proven
-    transitionComputeWeakNext _ (Unprovable config) = return (Unprovable config)
-    transitionComputeWeakNext rules (GoalLHS config)
-      = transitionComputeWeakNextHelper rules config
-    transitionComputeWeakNext _ (GoalRemLHS _)
-      = return (GoalLHS Pattern.bottom)
-
-    transitionComputeWeakNextHelper
+      transitionComputeWeakNext _ Proven = return Proven
+      transitionComputeWeakNext _ (Unprovable config) = return (Unprovable config)
+      transitionComputeWeakNext rules (GoalLHS config) =
+        transitionComputeWeakNextHelper rules config
+      transitionComputeWeakNext _ (GoalRemLHS _) =
+        return (GoalLHS Pattern.bottom)
+      transitionComputeWeakNextHelper
         :: [RewriteRule Variable]
         -> Pattern Variable
         -> Transition m CommonProofState
-    transitionComputeWeakNextHelper _ config
+      transitionComputeWeakNextHelper _ config
         | Pattern.isBottom config = return Proven
-    transitionComputeWeakNextHelper rules config = do
+      transitionComputeWeakNextHelper rules config = do
         eitherResults <-
-            Monad.Trans.lift . Monad.Trans.lift
+          Monad.Trans.lift . Monad.Trans.lift
             $ Monad.Unify.runUnifierT
             $ Step.applyRewriteRulesParallel
                 (Step.UnificationProcedure Unification.unificationProcedure)
                 rules
                 config
         case eitherResults of
-            Left _ ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse config)
-                ,   "We decided to end the execution because we don't \
+          Left _ ->
+            (error . show . Pretty.vsep)
+              [ "Not implemented error:",
+                "while applying a \\rewrite axiom to the pattern:",
+                Pretty.indent 4 (unparse config),
+                "We decided to end the execution because we don't \
                     \understand this case well enough at the moment."
                 ]
-            Right results -> do
-                let
-                    mapRules =
-                        StepResult.mapRules
-                        $ RewriteRule
-                        . Step.unwrapRule
-                        . Step.withoutUnification
-                    mapConfigs =
-                        StepResult.mapConfigs
-                            GoalLHS
-                            GoalRemLHS
-                StepResult.transitionResults
-                    (mapConfigs $ mapRules (StepResult.mergeResults results))
+          Right results -> do
+            let mapRules =
+                  StepResult.mapRules
+                    $ RewriteRule
+                    . Step.unwrapRule
+                    . Step.withoutUnification
+                mapConfigs =
+                  StepResult.mapConfigs
+                    GoalLHS
+                    GoalRemLHS
+            StepResult.transitionResults
+              (mapConfigs $ mapRules (StepResult.mergeResults results))
 
 defaultOneStepStrategy
-    :: patt
-    -- ^ The modal pattern.
-    -> [rewrite]
-    -- ^ normal rewrites
-    -> Strategy (Prim patt rewrite)
+  :: patt
+  -- ^ The modal pattern.
+  -> [rewrite]
+  -- ^ normal rewrites
+  -> Strategy (Prim patt rewrite)
 defaultOneStepStrategy goalrhs rewrites =
-    Strategy.sequence
-        [ Strategy.apply checkProofState
-        , Strategy.apply simplify
-        , Strategy.apply (unroll goalrhs)
-        , Strategy.apply (computeWeakNext rewrites)
-        , Strategy.apply simplify
-        ]
+  Strategy.sequence
+    [ Strategy.apply checkProofState,
+      Strategy.apply simplify,
+      Strategy.apply (unroll goalrhs),
+      Strategy.apply (computeWeakNext rewrites),
+      Strategy.apply simplify
+      ]

--- a/kore/src/Kore/OnePath/Verification.hs
+++ b/kore/src/Kore/OnePath/Verification.hs
@@ -7,45 +7,53 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 
 This should be imported qualified.
 -}
-
 module Kore.OnePath.Verification
-    ( Claim
-    , CommonProofState
-    , defaultStrategy
-    , verify
-    , verifyClaimStep
-    , toRulePattern
-    , toRule
-    ) where
+  ( Claim,
+    CommonProofState,
+    defaultStrategy,
+    verify,
+    verifyClaimStep,
+    toRulePattern,
+    toRule
+    )
+where
 
-import           Control.Monad.Except
-                 ( ExceptT )
+import Control.Monad.Except
+  ( ExceptT
+    )
 import qualified Control.Monad.Except as Monad.Except
 import qualified Control.Monad.Trans as Monad.Trans
-import           Data.Coerce
-                 ( Coercible, coerce )
+import Data.Coerce
+  ( Coercible,
+    coerce
+    )
 import qualified Data.Foldable as Foldable
 import qualified Data.Graph.Inductive.Graph as Graph
-import           Data.Limit
-                 ( Limit )
+import Data.Limit
+  ( Limit
+    )
 import qualified Data.Limit as Limit
-
-import           Kore.Debug
-import           Kore.Goal
-import           Kore.Internal.Pattern
-                 ( Pattern )
-import           Kore.Step.Rule as RulePattern
-                 ( RulePattern (..) )
-import           Kore.Step.Simplification.Data
-import           Kore.Step.Strategy
-import           Kore.Step.Transition
-                 ( runTransitionT )
+import Kore.Debug
+import Kore.Goal
+import Kore.Internal.Pattern
+  ( Pattern
+    )
+import Kore.Step.Rule as RulePattern
+  ( RulePattern (..)
+    )
+import Kore.Step.Simplification.Data
+import Kore.Step.Strategy
+import Kore.Step.Transition
+  ( runTransitionT
+    )
 import qualified Kore.Step.Transition as Transition
-import           Kore.Syntax.Variable
-                 ( Variable )
-import           Kore.Unparser
-import           Numeric.Natural
-                 ( Natural )
+import Kore.Syntax.Variable
+  ( Variable
+    )
+import Kore.Unparser
+import Numeric.Natural
+  ( Natural
+    )
 
 {- NOTE: Non-deterministic semantics
 
@@ -80,20 +88,19 @@ feature of the algorithm. You should not rely on this assumption elsewhere. This
 decision is subject to change without notice.
 
  -}
-
 type CommonProofState = ProofState (Pattern Variable)
 
 {- | Class type for claim-like rules
 -}
-type Claim claim =
-    ( Coercible (RulePattern Variable) claim
-    , Coercible (Rule claim) (RulePattern Variable)
-    , Coercible (RulePattern Variable) (Rule claim)
-    , Coercible claim (RulePattern Variable)
-    , Unparse claim
-    , Unparse (Rule claim)
-    , Goal claim
-    )
+type Claim claim
+  = ( Coercible (RulePattern Variable) claim,
+      Coercible (Rule claim) (RulePattern Variable),
+      Coercible (RulePattern Variable) (Rule claim),
+      Coercible claim (RulePattern Variable),
+      Unparse claim,
+      Unparse (Rule claim),
+      Goal claim
+      )
 
 {- | @Verifer a@ is a 'Simplifier'-based action which returns an @a@.
 
@@ -112,22 +119,20 @@ didn't manage to verify a claim within the its maximum number of steps.
 
 If the verification succeeds, it returns ().
 -}
-
 verify
-    :: forall claim m
-    .  Claim claim
-    => Show claim
-    => Show (Rule claim)
-    => MonadSimplify m
-    => [Strategy (Prim (Rule claim))]
-    -- ^ Creates a one-step strategy from a target pattern. See
-    -- 'defaultStrategy'.
-    -> [(claim, Limit Natural)]
-    -- ^ List of claims, together with a maximum number of verification steps
-    -- for each.
-    -> ExceptT (Pattern Variable) m ()
+  :: forall claim m. Claim claim
+  => Show claim
+  => Show (Rule claim)
+  => MonadSimplify m
+  => [Strategy (Prim (Rule claim))]
+  -- ^ Creates a one-step strategy from a target pattern. See
+  -- 'defaultStrategy'.
+  -> [(claim, Limit Natural)]
+  -- ^ List of claims, together with a maximum number of verification steps
+  -- for each.
+  -> ExceptT (Pattern Variable) m ()
 verify strategy =
-    mapM_ (verifyClaim strategy)
+  mapM_ (verifyClaim strategy)
 
 {- | Default implementation for a one-path strategy. You can apply it to the
 first two arguments and pass the resulting function to 'verify'.
@@ -138,63 +143,58 @@ Things to note when implementing your own:
 
 2. You can return an infinite list.
 -}
-
 defaultStrategy
-    :: forall claim
-    .  Claim claim
-    => [claim]
-    -- The claims that we want to prove
-    -> [Rule claim]
-    -> [Strategy (Prim (Rule claim))]
+  :: forall claim. Claim claim
+  => [claim]
+  -> -- The claims that we want to prove
+  [Rule claim]
+  -> [Strategy (Prim (Rule claim))]
 defaultStrategy
-    claims
-    axioms
-  =
+  claims
+  axioms =
     onePathFirstStep rewrites
-    : repeat
-        (onePathFollowupStep
-            coinductiveRewrites
-            rewrites
-        )
-  where
-    rewrites :: [Rule claim]
-    rewrites = axioms
-    coinductiveRewrites :: [Rule claim]
-    coinductiveRewrites = map (toRule . toRulePattern) claims
+      : repeat
+          ( onePathFollowupStep
+              coinductiveRewrites
+              rewrites
+            )
+    where
+      rewrites :: [Rule claim]
+      rewrites = axioms
+      coinductiveRewrites :: [Rule claim]
+      coinductiveRewrites = map (toRule . toRulePattern) claims
 
 verifyClaim
-    :: forall claim m
-    .  MonadSimplify m
-    => Claim claim
-    => Show claim
-    => Show (Rule claim)
-    => [Strategy (Prim (Rule claim))]
-    -> (claim, Limit Natural)
-    -> ExceptT (Pattern Variable) m ()
+  :: forall claim m. MonadSimplify m
+  => Claim claim
+  => Show claim
+  => Show (Rule claim)
+  => [Strategy (Prim (Rule claim))]
+  -> (claim, Limit Natural)
+  -> ExceptT (Pattern Variable) m ()
 verifyClaim
-    strategy
-    (goal, stepLimit)
-  = traceExceptT D_OnePath_verifyClaim [debugArg "rule" goal] $ do
-    let
-        startPattern = Goal $ getConfiguration goal
-        destination = getDestination goal
-        limitedStrategy =
+  strategy
+  (goal, stepLimit) =
+    traceExceptT D_OnePath_verifyClaim [debugArg "rule" goal] $ do
+      let startPattern = Goal $ getConfiguration goal
+          destination = getDestination goal
+          limitedStrategy =
             Limit.takeWithin
-                stepLimit
-                strategy
-    executionGraph <-
+              stepLimit
+              strategy
+      executionGraph <-
         runStrategy (modifiedTransitionRule destination) limitedStrategy startPattern
-    -- Throw the first unproven configuration as an error.
-    Foldable.traverse_ Monad.Except.throwError (unprovenNodes executionGraph)
-  where
-    modifiedTransitionRule
+      -- Throw the first unproven configuration as an error.
+      Foldable.traverse_ Monad.Except.throwError (unprovenNodes executionGraph)
+    where
+      modifiedTransitionRule
         :: Pattern Variable
         -> Prim (Rule claim)
         -> CommonProofState
         -> TransitionT (Rule claim) (Verifier m) CommonProofState
-    modifiedTransitionRule destination prim proofState' = do
+      modifiedTransitionRule destination prim proofState' = do
         transitions <-
-            Monad.Trans.lift . Monad.Trans.lift . runTransitionT
+          Monad.Trans.lift . Monad.Trans.lift . runTransitionT
             $ transitionRule' destination prim proofState'
         Transition.scatter transitions
 
@@ -202,70 +202,66 @@ verifyClaim
 -- in the execution graph designated by the provided node. Re-constructs the
 -- execution graph by inserting this step.
 verifyClaimStep
-    :: forall claim m
-    .  MonadSimplify m
-    => Claim claim
-    => claim
-    -- ^ claim that is being proven
-    -> [claim]
-    -- ^ list of claims in the spec module
-    -> [Rule claim]
-    -- ^ list of axioms in the main module
-    -> ExecutionGraph CommonProofState (Rule claim)
-    -- ^ current execution graph
-    -> Graph.Node
-    -- ^ selected node in the graph
-    -> m (ExecutionGraph CommonProofState (Rule claim))
+  :: forall claim m. MonadSimplify m
+  => Claim claim
+  => claim
+  -- ^ claim that is being proven
+  -> [claim]
+  -- ^ list of claims in the spec module
+  -> [Rule claim]
+  -- ^ list of axioms in the main module
+  -> ExecutionGraph CommonProofState (Rule claim)
+  -- ^ current execution graph
+  -> Graph.Node
+  -- ^ selected node in the graph
+  -> m (ExecutionGraph CommonProofState (Rule claim))
 verifyClaimStep
-    target
-    claims
-    axioms
-    eg@ExecutionGraph { root }
-    node
-  = do
+  target
+  claims
+  axioms
+  eg@ExecutionGraph {root}
+  node =
+    do
       let destination = getDestination target
       executionHistoryStep
         (transitionRule' destination)
         strategy'
         eg
         node
-  where
-    strategy' :: Strategy (Prim (Rule claim))
-    strategy'
+    where
+      strategy' :: Strategy (Prim (Rule claim))
+      strategy'
         | isRoot =
-            onePathFirstStep rewrites
+          onePathFirstStep rewrites
         | otherwise =
-            onePathFollowupStep
-                (coerce . toRulePattern <$> claims)
-                rewrites
-
-    rewrites :: [Rule claim]
-    rewrites = axioms
-
-    isRoot :: Bool
-    isRoot = node == root
+          onePathFollowupStep
+            (coerce . toRulePattern <$> claims)
+            rewrites
+      rewrites :: [Rule claim]
+      rewrites = axioms
+      isRoot :: Bool
+      isRoot = node == root
 
 transitionRule'
-    :: forall claim m
-    .  MonadSimplify m
-    => Claim claim
-    => Pattern Variable
-    -> Prim (Rule claim)
-    -> CommonProofState
-    -> TransitionT (Rule claim) m CommonProofState
+  :: forall claim m. MonadSimplify m
+  => Claim claim
+  => Pattern Variable
+  -> Prim (Rule claim)
+  -> CommonProofState
+  -> TransitionT (Rule claim) m CommonProofState
 transitionRule' destination prim state = do
-    let goal = (flip makeRuleFromPatterns) destination <$> state
-    next <- transitionRule prim goal
-    pure $ fmap getConfiguration next
+  let goal = (flip makeRuleFromPatterns) destination <$> state
+  next <- transitionRule prim goal
+  pure $ fmap getConfiguration next
 
 toRulePattern
-    :: forall claim
-    .  Claim claim
-    => claim -> RulePattern Variable
+  :: forall claim. Claim claim
+  => claim
+  -> RulePattern Variable
 toRulePattern = coerce
 
 toRule
-    :: forall claim
-    .  Claim claim
-    => RulePattern Variable -> Rule claim
+  :: forall claim. Claim claim
+  => RulePattern Variable
+  -> Rule claim
 toRule = coerce

--- a/kore/src/Kore/Parser.hs
+++ b/kore/src/Kore/Parser.hs
@@ -23,20 +23,22 @@ main = do
 
 -}
 module Kore.Parser
-    ( parseKoreDefinition
-    , parseKorePattern
-    , koreParser
-    , korePatternParser
-    , ParsedPattern
-    , Parser.asParsedPattern
-    , ParsedDefinition
-    ) where
+  ( parseKoreDefinition,
+    parseKorePattern,
+    koreParser,
+    korePatternParser,
+    ParsedPattern,
+    Parser.asParsedPattern,
+    ParsedDefinition
+    )
+where
 
-import           Kore.Parser.Lexeme
-                 ( skipWhitespace )
+import Kore.Parser.Lexeme
+  ( skipWhitespace
+    )
 import qualified Kore.Parser.Parser as Parser
-import           Kore.Parser.ParserUtils
-import           Kore.Syntax.Definition
+import Kore.Parser.ParserUtils
+import Kore.Syntax.Definition
 
 {-|'koreParser' is a parser for Kore.
 The input must contain a full valid Kore defininition and nothing else.
@@ -59,9 +61,9 @@ else.
 
  -}
 parseKoreDefinition
-    :: FilePath  -- ^ Filename used for error messages
-    -> String  -- ^ The concrete syntax of a valid Kore definition
-    -> Either String ParsedDefinition
+  :: FilePath -- ^ Filename used for error messages
+  -> String -- ^ The concrete syntax of a valid Kore definition
+  -> Either String ParsedDefinition
 parseKoreDefinition = parseOnly (skipWhitespace *> koreParser)
 
 {- | Parse a string representing a Kore pattern.
@@ -71,7 +73,7 @@ message otherwise. The input must contain a valid Kore pattern and nothing else.
 
  -}
 parseKorePattern
-    :: FilePath  -- ^ Filename used for error messages
-    -> String  -- ^ The concrete syntax of a valid Kore pattern
-    -> Either String ParsedPattern
+  :: FilePath -- ^ Filename used for error messages
+  -> String -- ^ The concrete syntax of a valid Kore pattern
+  -> Either String ParsedPattern
 parseKorePattern = parseOnly (skipWhitespace *> korePatternParser)

--- a/kore/src/Kore/Parser/CString.hs
+++ b/kore/src/Kore/Parser/CString.hs
@@ -8,22 +8,31 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.Parser.CString
-       ( unescapeCString
-       , escapeCString
-       , escapeCStringT
-       , oneCharEscapes
-       , oneCharEscapeDict
-       ) where
+  ( unescapeCString,
+    escapeCString,
+    escapeCStringT,
+    oneCharEscapes,
+    oneCharEscapeDict
+    )
+where
 
-import           Data.Char
-                 ( chr, digitToInt, isHexDigit, isOctDigit, ord, toUpper )
-import           Data.Text
-                 ( Text )
+import Data.Char
+  ( chr,
+    digitToInt,
+    isHexDigit,
+    isOctDigit,
+    ord,
+    toUpper
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           Numeric
-                 ( showHex, showOct )
-
 import Kore.Parser.CharSet as CharSet
+import Numeric
+  ( showHex,
+    showOct
+    )
 
 oneCharEscapes :: [Char]
 oneCharEscapes = "'\"?\\abfnrtv"
@@ -39,13 +48,13 @@ escapeCStringT = Text.concatMap escapeAndAddCharT
 
 padLeftWithCharToLength :: Char -> Int -> ShowS -> ShowS
 padLeftWithCharToLength c i ss =
-    showString (replicate (i - length (ss "")) c) . ss
+  showString (replicate (i - length (ss "")) c) . ss
 
 escapeAndAddChar :: Char -> ShowS
-escapeAndAddChar '"'  = showString "\\\""
+escapeAndAddChar '"' = showString "\\\""
 escapeAndAddChar '\'' = showString "\\'"
 escapeAndAddChar '\\' = showString "\\\\"
-escapeAndAddChar '?'  = showString "\\?"
+escapeAndAddChar '?' = showString "\\?"
 escapeAndAddChar '\a' = showString "\\a"
 escapeAndAddChar '\b' = showString "\\b"
 escapeAndAddChar '\f' = showString "\\f"
@@ -54,20 +63,20 @@ escapeAndAddChar '\r' = showString "\\r"
 escapeAndAddChar '\t' = showString "\\t"
 escapeAndAddChar '\v' = showString "\\v"
 escapeAndAddChar c
-    | code >= 32 && code < 127 = showChar c    -- printable 7-bit ASCII
-    | code <= 255 =
-        showString "\\" . zeroPad 3 (showOct code)
-    | code <= 65535 = showString "\\u" . zeroPad 4 (showHex code)
-    | otherwise =  showString "\\U" . zeroPad 8 (showHex code)
+  | code >= 32 && code < 127 = showChar c -- printable 7-bit ASCII
+  | code <= 255 =
+    showString "\\" . zeroPad 3 (showOct code)
+  | code <= 65535 = showString "\\u" . zeroPad 4 (showHex code)
+  | otherwise = showString "\\U" . zeroPad 8 (showHex code)
   where
     code = ord c
     zeroPad = padLeftWithCharToLength '0'
 
 escapeAndAddCharT :: Char -> Text
-escapeAndAddCharT '"'  = "\\\""
+escapeAndAddCharT '"' = "\\\""
 escapeAndAddCharT '\'' = "\\'"
 escapeAndAddCharT '\\' = "\\\\"
-escapeAndAddCharT '?'  = "\\?"
+escapeAndAddCharT '?' = "\\?"
 escapeAndAddCharT '\a' = "\\a"
 escapeAndAddCharT '\b' = "\\b"
 escapeAndAddCharT '\f' = "\\f"
@@ -76,11 +85,11 @@ escapeAndAddCharT '\r' = "\\r"
 escapeAndAddCharT '\t' = "\\t"
 escapeAndAddCharT '\v' = "\\v"
 escapeAndAddCharT c
-    | code >= 32 && code < 127 = Text.singleton c    -- printable 7-bit ASCII
-    | code <= 255 =
-        "\\" <> zeroPad 3 (Text.pack $ showOct code "")
-    | code <= 65535 = "\\u" <> zeroPad 4 (Text.pack $ showHex code "")
-    | otherwise = "\\U" <> zeroPad 8 (Text.pack $ showHex code "")
+  | code >= 32 && code < 127 = Text.singleton c -- printable 7-bit ASCII
+  | code <= 255 =
+    "\\" <> zeroPad 3 (Text.pack $ showOct code "")
+  | code <= 65535 = "\\u" <> zeroPad 4 (Text.pack $ showHex code "")
+  | otherwise = "\\U" <> zeroPad 8 (Text.pack $ showHex code "")
   where
     code = ord c
     zeroPad i = Text.justifyRight i '0'
@@ -88,41 +97,44 @@ escapeAndAddCharT c
 {-|Expects input string to be a properly escaped C String.
 -}
 unescapeCString :: String -> Either String String
-unescapeCString ""        = return ""
-unescapeCString ('\\':cs) = unescapePrefixAndContinue cs
-unescapeCString (c:cs)    = (c :) <$> unescapeCString cs
+unescapeCString "" = return ""
+unescapeCString ('\\' : cs) = unescapePrefixAndContinue cs
+unescapeCString (c : cs) = (c :) <$> unescapeCString cs
 
 {-|Transforms a unicode code point into a char, providing an error message
 otherwise.
 -}
 safeChr :: Int -> Either String Char
 safeChr i =
-    if i <= ord(maxBound::Char)
-        then return (chr i)
-        else Left ("Character code " ++ show i ++
-            " outside of the representable codes.")
+  if i <= ord (maxBound :: Char)
+    then return (chr i)
+    else
+      Left
+        ( "Character code " ++ show i
+            ++ " outside of the representable codes."
+          )
 
 {-|Assumes that the previous character was the start of an escape sequence,
 i.e. @\@ and continues the unescape of the string.
 -}
 unescapePrefixAndContinue :: String -> Either String String
-unescapePrefixAndContinue (c:cs)
+unescapePrefixAndContinue (c : cs)
   | c `CharSet.elem` oneCharEscapeDict =
-      (:) <$> unescapeOne c <*> unescapeCString cs
+    (:) <$> unescapeOne c <*> unescapeCString cs
   | isOctDigit c =
-      let (octs,rest) = span isOctDigit cs
-          (digits, octs') = splitAt 2 octs
-          octVal = digitsToNumber 8 (c:digits)
-      in ((chr octVal : octs') ++) <$> unescapeCString rest
+    let (octs, rest) = span isOctDigit cs
+        (digits, octs') = splitAt 2 octs
+        octVal = digitsToNumber 8 (c : digits)
+     in ((chr octVal : octs') ++) <$> unescapeCString rest
   | c == 'x' =
-      let (hexes,rest) = span isHexDigit cs
-          hexVal = digitsToNumber 16 hexes
-      in (:) <$> safeChr hexVal <*> unescapeCString rest
+    let (hexes, rest) = span isHexDigit cs
+        hexVal = digitsToNumber 16 hexes
+     in (:) <$> safeChr hexVal <*> unescapeCString rest
   | toUpper c == 'U' =
-      let digitCount = if c == 'u' then 4 else 8
-          (unis, rest) = splitAt digitCount cs
-          hexVal = digitsToNumber 16 unis
-      in if digitCount == length unis
+    let digitCount = if c == 'u' then 4 else 8
+        (unis, rest) = splitAt digitCount cs
+        hexVal = digitsToNumber 16 unis
+     in if digitCount == length unis
           then (:) <$> safeChr hexVal <*> unescapeCString rest
           else Left "Invalid unicode sequence length."
 unescapePrefixAndContinue cs =
@@ -132,17 +144,17 @@ unescapePrefixAndContinue cs =
 -}
 unescapeOne :: Char -> Either String Char
 unescapeOne '\'' = return '\''
-unescapeOne '"'  = return '"'
+unescapeOne '"' = return '"'
 unescapeOne '\\' = return '\\'
-unescapeOne '?'  = return '?'
-unescapeOne 'a'  = return '\a'
-unescapeOne 'b'  = return '\b'
-unescapeOne 'f'  = return '\f'
-unescapeOne 'n'  = return '\n'
-unescapeOne 'r'  = return '\r'
-unescapeOne 't'  = return '\t'
-unescapeOne 'v'  = return '\v'
-unescapeOne c    = Left ("Unexpected escape sequence '``" ++ show c ++ "'.")
+unescapeOne '?' = return '?'
+unescapeOne 'a' = return '\a'
+unescapeOne 'b' = return '\b'
+unescapeOne 'f' = return '\f'
+unescapeOne 'n' = return '\n'
+unescapeOne 'r' = return '\r'
+unescapeOne 't' = return '\t'
+unescapeOne 'v' = return '\v'
+unescapeOne c = Left ("Unexpected escape sequence '``" ++ show c ++ "'.")
 
 {-|String to number conversion.
 -}

--- a/kore/src/Kore/Parser/CharDict.hs
+++ b/kore/src/Kore/Parser/CharDict.hs
@@ -9,26 +9,29 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.Parser.CharDict
-    ( CharDict
-    , makeCharDict
-    , memoize
-    , (!)
-    ) where
+  ( CharDict,
+    makeCharDict,
+    memoize,
+    (!)
+    )
+where
 
 import qualified Data.Array as Array
-import           Data.Maybe
-                 ( fromMaybe )
+import Data.Maybe
+  ( fromMaybe
+    )
 
-newtype CharDict a = CharDict { getCharDict :: Array.Array Char a }
+newtype CharDict a = CharDict {getCharDict :: Array.Array Char a}
 
 memoize :: (Char -> a) -> CharDict a
 memoize f =
-    CharDict $ Array.array ('\0', '\255') [(c, f c) | c <- ['\0'..'\255']]
+  CharDict $ Array.array ('\0', '\255') [(c, f c) | c <- ['\0' .. '\255']]
 
-makeCharDict :: [(Char,a)] -> a -> CharDict a
+makeCharDict :: [(Char, a)] -> a -> CharDict a
 makeCharDict dict defaultValue =
-  CharDict $ Array.array ('\0', '\255')
-      [(c, fromMaybe defaultValue (lookup c dict))| c <- ['\0'..'\255']]
+  CharDict
+    $ Array.array ('\0', '\255')
+        [(c, fromMaybe defaultValue (lookup c dict)) | c <- ['\0' .. '\255']]
 
 (!) :: CharDict a -> Char -> a
 (!) dict c = getCharDict dict Array.! c

--- a/kore/src/Kore/Parser/CharSet.hs
+++ b/kore/src/Kore/Parser/CharSet.hs
@@ -9,27 +9,28 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.Parser.CharSet
-    ( CharSet
-    , makeCharSet
-    , join
-    , elem
-    ) where
-
-import Prelude hiding
-       ( elem )
+  ( CharSet,
+    makeCharSet,
+    join,
+    elem
+    )
+where
 
 import Kore.Parser.CharDict as CharDict
+import Prelude hiding
+  ( elem
+    )
 
-newtype CharSet = CharSet { getCharSet :: CharDict.CharDict Bool }
+newtype CharSet = CharSet {getCharSet :: CharDict.CharDict Bool}
 
 makeCharSet :: String -> CharSet
-makeCharSet dom = CharSet $ makeCharDict (map (\x -> (x,True)) dom) False
+makeCharSet dom = CharSet $ makeCharDict (map (\x -> (x, True)) dom) False
 
 elem :: Char -> CharSet -> Bool
 c `elem` cs = getCharSet cs ! c
 
 domain :: CharSet -> String
-domain cs = filter (`elem` cs) ['\0'..'\255']
+domain cs = filter (`elem` cs) ['\0' .. '\255']
 
 join :: CharSet -> CharSet -> CharSet
-x `join` y =  makeCharSet (domain x ++ domain y)
+x `join` y = makeCharSet (domain x ++ domain y)

--- a/kore/src/Kore/Predicate/Predicate.hs
+++ b/kore/src/Kore/Predicate/Predicate.hs
@@ -9,80 +9,92 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Predicate.Predicate
-    ( Predicate -- Constructor not exported on purpose
-    , pattern PredicateFalse
-    , pattern PredicateTrue
-    , compactPredicatePredicate
-    , isFalse
-    , makePredicate
-    , makeAndPredicate
-    , makeMultipleAndPredicate
-    , makeCeilPredicate
-    , makeEqualsPredicate
-    , makeExistsPredicate
-    , makeMultipleExists
-    , makeForallPredicate
-    , makeFalsePredicate
-    , makeFloorPredicate
-    , makeIffPredicate
-    , makeImpliesPredicate
-    , makeInPredicate
-    , makeMuPredicate
-    , makeNotPredicate
-    , makeNuPredicate
-    , makeOrPredicate
-    , makeMultipleOrPredicate
-    , makeTruePredicate
-    , Kore.Predicate.Predicate.freeVariables
-    , Kore.Predicate.Predicate.freeElementVariables
-    , Kore.Predicate.Predicate.hasFreeVariable
-    , Kore.Predicate.Predicate.mapVariables
-    , stringFromPredicate
-    , substitutionToPredicate
-    , fromPredicate
-    , fromSubstitution
-    , unwrapPredicate
-    , wrapPredicate
-    , Kore.Predicate.Predicate.substitute
-    ) where
+  ( Predicate, -- Constructor not exported on purpose
+    pattern PredicateFalse,
+    pattern PredicateTrue,
+    compactPredicatePredicate,
+    isFalse,
+    makePredicate,
+    makeAndPredicate,
+    makeMultipleAndPredicate,
+    makeCeilPredicate,
+    makeEqualsPredicate,
+    makeExistsPredicate,
+    makeMultipleExists,
+    makeForallPredicate,
+    makeFalsePredicate,
+    makeFloorPredicate,
+    makeIffPredicate,
+    makeImpliesPredicate,
+    makeInPredicate,
+    makeMuPredicate,
+    makeNotPredicate,
+    makeNuPredicate,
+    makeOrPredicate,
+    makeMultipleOrPredicate,
+    makeTruePredicate,
+    Kore.Predicate.Predicate.freeVariables,
+    Kore.Predicate.Predicate.freeElementVariables,
+    Kore.Predicate.Predicate.hasFreeVariable,
+    Kore.Predicate.Predicate.mapVariables,
+    stringFromPredicate,
+    substitutionToPredicate,
+    fromPredicate,
+    fromSubstitution,
+    unwrapPredicate,
+    wrapPredicate,
+    Kore.Predicate.Predicate.substitute
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Functor.Foldable
-                 ( Base )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Functor.Foldable
+  ( Base
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Hashable
-import           Data.List
-                 ( foldl', nub )
-import           Data.Map.Strict
-                 ( Map )
-import qualified Generics.SOP as SOP
+import Data.Hashable
+import Data.List
+  ( foldl',
+    nub
+    )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified GHC.Generics as GHC
-import           GHC.Stack
-                 ( HasCallStack )
-
-import           Kore.Attribute.Pattern.FreeVariables
-import           Kore.Debug
-import           Kore.Error
-                 ( Error, koreFail )
-import           Kore.Internal.TermLike as TermLike
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unification.Substitution
-                 ( Substitution )
+import GHC.Stack
+  ( HasCallStack
+    )
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Debug
+import Kore.Error
+  ( Error,
+    koreFail
+    )
+import Kore.Internal.TermLike as TermLike
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unification.Substitution
+  ( Substitution
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 {-| 'GenericPredicate' is a wrapper for predicates used for type safety.
 Should not be exported, and should be treated as an opaque entity which
 can be manipulated only by functions in this module.
 -}
 newtype GenericPredicate pat = GenericPredicate pat
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (GenericPredicate pat)
 
@@ -95,13 +107,16 @@ instance Hashable pat => Hashable (GenericPredicate pat)
 instance NFData pat => NFData (GenericPredicate pat)
 
 instance TopBottom patt => TopBottom (GenericPredicate patt) where
-    isTop (GenericPredicate patt) = isTop patt
-    isBottom (GenericPredicate patt) = isBottom patt
+
+  isTop (GenericPredicate patt) = isTop patt
+
+  isBottom (GenericPredicate patt) = isBottom patt
 
 instance Unparse pattern' => Unparse (GenericPredicate pattern') where
-    unparse (GenericPredicate pattern') = unparse pattern'
-    unparse2 (GenericPredicate pattern') = unparse2 pattern'
 
+  unparse (GenericPredicate pattern') = unparse pattern'
+
+  unparse2 (GenericPredicate pattern') = unparse2 pattern'
 
 {-| 'Predicate' is a user-visible representation for predicates.
 -}
@@ -111,7 +126,7 @@ type Predicate variable = GenericPredicate (TermLike variable)
 sometimes occurs when, say, using Predicates as Traversable.
 -}
 compactPredicatePredicate
-    :: GenericPredicate (GenericPredicate a) -> GenericPredicate a
+  :: GenericPredicate (GenericPredicate a) -> GenericPredicate a
 compactPredicatePredicate (GenericPredicate x) = x
 
 {- 'stringFromPredicate' extracts a string from a GenericPredicate,
@@ -146,10 +161,10 @@ the resulting pattern into a particular sort.
 
  -}
 fromPredicate
-    :: (SortedVariable variable, Unparse variable, HasCallStack)
-    => Sort  -- ^ Sort of resulting pattern
-    -> Predicate variable
-    -> TermLike variable
+  :: (SortedVariable variable, Unparse variable, HasCallStack)
+  => Sort -- ^ Sort of resulting pattern
+  -> Predicate variable
+  -> TermLike variable
 fromPredicate sort (GenericPredicate p) = TermLike.forceSort sort p
 
 {-|'PredicateFalse' is a pattern for matching 'bottom' predicates.
@@ -161,7 +176,8 @@ pattern PredicateFalse :: Predicate variable
 pattern PredicateTrue :: Predicate variable
 
 pattern PredicateFalse <- GenericPredicate (Recursive.project -> _ :< BottomF _)
-pattern PredicateTrue  <- GenericPredicate (Recursive.project -> _ :< TopF _)
+
+pattern PredicateTrue <- GenericPredicate (Recursive.project -> _ :< TopF _)
 
 {-|'isFalse' checks whether a predicate is obviously bottom.
 -}
@@ -172,45 +188,47 @@ isFalse = isBottom
 doing some simplification.
 -}
 makeMultipleAndPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => [Predicate variable]
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => [Predicate variable]
+  -> Predicate variable
 makeMultipleAndPredicate =
-    foldl' makeAndPredicate makeTruePredicate . nub
-    -- 'and' is idempotent so we eliminate duplicates
-    -- TODO: This is O(n^2), consider doing something better.
+  foldl' makeAndPredicate makeTruePredicate . nub
+
+-- 'and' is idempotent so we eliminate duplicates
+-- TODO: This is O(n^2), consider doing something better.
 
 {-| 'makeMultipleOrPredicate' combines a list of Predicates with 'or',
 doing some simplification.
 -}
 makeMultipleOrPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => [Predicate variable]
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => [Predicate variable]
+  -> Predicate variable
 makeMultipleOrPredicate =
-    foldl' makeOrPredicate makeFalsePredicate . nub
-    -- 'or' is idempotent so we eliminate duplicates
-    -- TODO: This is O(n^2), consider doing something better.
+  foldl' makeOrPredicate makeFalsePredicate . nub
+
+-- 'or' is idempotent so we eliminate duplicates
+-- TODO: This is O(n^2), consider doing something better.
 
 {-| 'makeAndPredicate' combines two Predicates with an 'and', doing some
 simplification.
 -}
 makeAndPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Unparse variable
-        )
-    => Predicate variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Unparse variable
+       )
+  => Predicate variable
+  -> Predicate variable
+  -> Predicate variable
 makeAndPredicate b@PredicateFalse _ = b
 makeAndPredicate _ b@PredicateFalse = b
 makeAndPredicate PredicateTrue second = second
@@ -224,14 +242,14 @@ makeAndPredicate p@(GenericPredicate first) (GenericPredicate second)
 some simplification.
 -}
 makeOrPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Predicate variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Predicate variable
+  -> Predicate variable
+  -> Predicate variable
 makeOrPredicate t@PredicateTrue _ = t
 makeOrPredicate _ t@PredicateTrue = t
 makeOrPredicate PredicateFalse second = second
@@ -245,255 +263,258 @@ makeOrPredicate p@(GenericPredicate first) (GenericPredicate second)
 implication, doing some simplification.
 -}
 makeImpliesPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Predicate variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Predicate variable
+  -> Predicate variable
+  -> Predicate variable
 makeImpliesPredicate PredicateFalse _ = makeTruePredicate
 makeImpliesPredicate _ t@PredicateTrue = t
 makeImpliesPredicate PredicateTrue second = second
 makeImpliesPredicate first PredicateFalse = makeNotPredicate first
 makeImpliesPredicate (GenericPredicate first) (GenericPredicate second) =
-    GenericPredicate $ TermLike.mkImplies first second
+  GenericPredicate $ TermLike.mkImplies first second
 
 {-| 'makeIffPredicate' combines two evaluated with an 'iff', doing
 some simplification.
 -}
 makeIffPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Predicate variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Predicate variable
+  -> Predicate variable
+  -> Predicate variable
 makeIffPredicate PredicateFalse second = makeNotPredicate second
 makeIffPredicate PredicateTrue second = second
 makeIffPredicate first PredicateFalse = makeNotPredicate first
 makeIffPredicate first PredicateTrue = first
 makeIffPredicate (GenericPredicate first) (GenericPredicate second) =
-    GenericPredicate $ TermLike.mkIff first second
+  GenericPredicate $ TermLike.mkIff first second
 
 {-| 'makeNotPredicate' negates an evaluated Predicate, doing some
 simplification.
 -}
 makeNotPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Predicate variable
+  -> Predicate variable
 makeNotPredicate PredicateFalse = makeTruePredicate
-makeNotPredicate PredicateTrue  = makeFalsePredicate
+makeNotPredicate PredicateTrue = makeFalsePredicate
 makeNotPredicate (GenericPredicate predicate) =
-    GenericPredicate $ TermLike.mkNot predicate
+  GenericPredicate $ TermLike.mkNot predicate
 
 {-| 'makeEqualsPredicate' combines two patterns with equals, producing a
 predicate.
 -}
 makeEqualsPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => TermLike variable
+  -> TermLike variable
+  -> Predicate variable
 makeEqualsPredicate first second =
-    GenericPredicate $ TermLike.mkEquals_ first second
+  GenericPredicate $ TermLike.mkEquals_ first second
 
 {-| 'makeInPredicate' combines two patterns with 'in', producing a
 predicate.
 -}
 makeInPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => TermLike variable
+  -> TermLike variable
+  -> Predicate variable
 makeInPredicate first second =
-    GenericPredicate $ TermLike.mkIn_ first second
+  GenericPredicate $ TermLike.mkIn_ first second
 
 {-| 'makeCeilPredicate' takes the 'ceil' of a pattern, producing a
 predicate.
 -}
 makeCeilPredicate
-    ::  ( Ord variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        )
-    => TermLike variable
-    -> Predicate variable
+  :: ( Ord variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable
+       )
+  => TermLike variable
+  -> Predicate variable
 makeCeilPredicate patt =
-    GenericPredicate $ TermLike.mkCeil_ patt
+  GenericPredicate $ TermLike.mkCeil_ patt
 
 {-| 'makeFloorPredicate' takes the 'floor' of a pattern, producing a
 predicate.
 -}
 makeFloorPredicate
-    ::  ( Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => TermLike variable
-    -> Predicate variable
+  :: ( Ord variable,
+       Show variable,
+       SortedVariable variable,
+       Unparse variable
+       )
+  => TermLike variable
+  -> Predicate variable
 makeFloorPredicate patt =
-    GenericPredicate $ TermLike.mkFloor_ patt
+  GenericPredicate $ TermLike.mkFloor_ patt
 
 {-| Existential quantification for the given variable in the given predicate.
 -}
 makeExistsPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => ElementVariable variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => ElementVariable variable
+  -> Predicate variable
+  -> Predicate variable
 makeExistsPredicate _ p@PredicateFalse = p
 makeExistsPredicate _ t@PredicateTrue = t
 makeExistsPredicate v (GenericPredicate p) =
-    GenericPredicate $ TermLike.mkExists v p
+  GenericPredicate $ TermLike.mkExists v p
 
 {- | Existentially-quantify the given variables over the predicate.
  -}
 makeMultipleExists
-    ::  ( Foldable f
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => f (ElementVariable variable)
-    -> Predicate variable
-    -> Predicate variable
+  :: ( Foldable f,
+       SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => f (ElementVariable variable)
+  -> Predicate variable
+  -> Predicate variable
 makeMultipleExists vars phi =
-    foldr makeExistsPredicate phi vars
+  foldr makeExistsPredicate phi vars
 
 {-| Universal quantification for the given variable in the given predicate.
 -}
 makeForallPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => ElementVariable variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => ElementVariable variable
+  -> Predicate variable
+  -> Predicate variable
 makeForallPredicate _ p@PredicateFalse = p
 makeForallPredicate _ t@PredicateTrue = t
 makeForallPredicate v (GenericPredicate p) =
-    GenericPredicate $ TermLike.mkForall v p
+  GenericPredicate $ TermLike.mkForall v p
 
 {-| Mu quantification for the given variable in the given predicate.
 -}
 makeMuPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => SetVariable variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => SetVariable variable
+  -> Predicate variable
+  -> Predicate variable
 makeMuPredicate _ p@PredicateFalse = p
 makeMuPredicate _ t@PredicateTrue = t
 makeMuPredicate v (GenericPredicate p) =
-    GenericPredicate $ TermLike.mkMu v p
+  GenericPredicate $ TermLike.mkMu v p
 
 {-| Nu quantification for the given variable in the given predicate.
 -}
 makeNuPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => SetVariable variable
-    -> Predicate variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => SetVariable variable
+  -> Predicate variable
+  -> Predicate variable
 makeNuPredicate _ p@PredicateFalse = p
 makeNuPredicate _ t@PredicateTrue = t
 makeNuPredicate v (GenericPredicate p) =
-    GenericPredicate $ TermLike.mkNu v p
+  GenericPredicate $ TermLike.mkNu v p
 
 {-| 'makeTruePredicate' produces a predicate wrapping a 'top'.
 -}
 makeTruePredicate
-    :: (Ord variable, SortedVariable variable) => Predicate variable
+  :: (Ord variable, SortedVariable variable) => Predicate variable
 makeTruePredicate = GenericPredicate TermLike.mkTop_
 
 {-| 'makeFalsePredicate' produces a predicate wrapping a 'bottom'.
 -}
 makeFalsePredicate
-    :: (Ord variable, SortedVariable variable) => Predicate variable
+  :: (Ord variable, SortedVariable variable) => Predicate variable
 makeFalsePredicate = GenericPredicate TermLike.mkBottom_
 
 makePredicate
-    :: forall variable e.
-        ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => TermLike variable
-    -> Either (Error e) (Predicate variable)
+  :: forall variable e. ( SortedVariable variable,
+                          Ord variable,
+                          Show variable,
+                          Unparse variable
+                          )
+  => TermLike variable
+  -> Either (Error e) (Predicate variable)
 makePredicate = Recursive.elgot makePredicateBottomUp makePredicateTopDown
   where
     makePredicateBottomUp
-        :: Base
-            (TermLike variable)
-            (Either (Error e) (Predicate variable))
-        -> Either (Error e) (Predicate variable)
+      :: Base
+           (TermLike variable)
+           (Either (Error e) (Predicate variable))
+      -> Either (Error e) (Predicate variable)
     makePredicateBottomUp (_ :< patE) = do
-        pat <- sequence patE
-        case pat of
-            TopF _ -> return makeTruePredicate
-            BottomF _ -> return makeFalsePredicate
-            AndF p -> return $ makeAndPredicate (andFirst p) (andSecond p)
-            OrF p -> return $ makeOrPredicate (orFirst p) (orSecond p)
-            IffF p -> return $ makeIffPredicate (iffFirst p) (iffSecond p)
-            ImpliesF p -> return $
-                makeImpliesPredicate (impliesFirst p) (impliesSecond p)
-            NotF p -> return $ makeNotPredicate (notChild p)
-            ExistsF p -> return $
-                makeExistsPredicate (existsVariable p) (existsChild p)
-            ForallF p -> return $
-                makeForallPredicate (forallVariable p) (forallChild p)
-            p -> koreFail
-                ("Cannot translate to predicate: " ++ show p)
+      pat <- sequence patE
+      case pat of
+        TopF _ -> return makeTruePredicate
+        BottomF _ -> return makeFalsePredicate
+        AndF p -> return $ makeAndPredicate (andFirst p) (andSecond p)
+        OrF p -> return $ makeOrPredicate (orFirst p) (orSecond p)
+        IffF p -> return $ makeIffPredicate (iffFirst p) (iffSecond p)
+        ImpliesF p ->
+          return
+            $ makeImpliesPredicate (impliesFirst p) (impliesSecond p)
+        NotF p -> return $ makeNotPredicate (notChild p)
+        ExistsF p ->
+          return
+            $ makeExistsPredicate (existsVariable p) (existsChild p)
+        ForallF p ->
+          return
+            $ makeForallPredicate (forallVariable p) (forallChild p)
+        p ->
+          koreFail
+            ("Cannot translate to predicate: " ++ show p)
     makePredicateTopDown
-        :: TermLike variable
-        -> Either
-            (Either (Error e) (Predicate variable))
-            (Base (TermLike variable) (TermLike variable))
+      :: TermLike variable
+      -> Either
+           (Either (Error e) (Predicate variable))
+           (Base (TermLike variable) (TermLike variable))
     makePredicateTopDown (Recursive.project -> projected@(_ :< pat)) =
-        case pat of
-            CeilF Ceil { ceilChild } ->
-                (Left . pure) (makeCeilPredicate ceilChild)
-            FloorF Floor { floorChild } ->
-                (Left . pure) (makeFloorPredicate floorChild)
-            EqualsF Equals { equalsFirst, equalsSecond } ->
-                (Left . pure) (makeEqualsPredicate equalsFirst equalsSecond)
-            InF In { inContainedChild, inContainingChild } ->
-                (Left . pure)
-                    (makeInPredicate inContainedChild inContainingChild)
-            _ -> Right projected
+      case pat of
+        CeilF Ceil {ceilChild} ->
+          (Left . pure) (makeCeilPredicate ceilChild)
+        FloorF Floor {floorChild} ->
+          (Left . pure) (makeFloorPredicate floorChild)
+        EqualsF Equals {equalsFirst, equalsSecond} ->
+          (Left . pure) (makeEqualsPredicate equalsFirst equalsSecond)
+        InF In {inContainedChild, inContainingChild} ->
+          (Left . pure)
+            (makeInPredicate inContainedChild inContainingChild)
+        _ -> Right projected
 
 {- | Replace all variables in a @Predicate@ using the provided mapping.
 -}
@@ -503,25 +524,25 @@ mapVariables f = fmap (TermLike.mapVariables f)
 {- | Extract the set of free variables from a @Predicate@.
 -}
 freeVariables
-    :: Ord variable
-    => Predicate variable
-    -> FreeVariables variable
+  :: Ord variable
+  => Predicate variable
+  -> FreeVariables variable
 freeVariables = TermLike.freeVariables . unwrapPredicate
 
 freeElementVariables
-    :: Ord variable
-    => Predicate variable
-    -> [ElementVariable variable]
+  :: Ord variable
+  => Predicate variable
+  -> [ElementVariable variable]
 freeElementVariables =
-    getFreeElementVariables . Kore.Predicate.Predicate.freeVariables
+  getFreeElementVariables . Kore.Predicate.Predicate.freeVariables
 
 hasFreeVariable
-    :: Ord variable
-    => UnifiedVariable variable
-    -> Predicate variable
-    -> Bool
+  :: Ord variable
+  => UnifiedVariable variable
+  -> Predicate variable
+  -> Bool
 hasFreeVariable variable =
-    isFreeVariable variable . Kore.Predicate.Predicate.freeVariables
+  isFreeVariable variable . Kore.Predicate.Predicate.freeVariables
 
 {- | 'substitutionToPredicate' transforms a substitution in a predicate.
 
@@ -530,28 +551,28 @@ returns a conjunction of variable/substitution equalities.
 
 -}
 substitutionToPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Substitution variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Substitution variable
+  -> Predicate variable
 substitutionToPredicate =
-    makeMultipleAndPredicate
+  makeMultipleAndPredicate
     . fmap singleSubstitutionToPredicate
     . Substitution.unwrap
 
 singleSubstitutionToPredicate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => (UnifiedVariable variable, TermLike variable)
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => (UnifiedVariable variable, TermLike variable)
+  -> Predicate variable
 singleSubstitutionToPredicate (var, patt) =
-    makeEqualsPredicate (TermLike.mkVar var) patt
+  makeEqualsPredicate (TermLike.mkVar var) patt
 
 {- | @fromSubstitution@ constructs a 'Predicate' equivalent to 'Substitution'.
 
@@ -560,13 +581,13 @@ returns a conjunction of variable-substitution equalities.
 
 -}
 fromSubstitution
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Substitution variable
-    -> Predicate variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Substitution variable
+  -> Predicate variable
 fromSubstitution = substitutionToPredicate
 
 {- | Traverse the predicate from the top down and apply substitutions.
@@ -576,12 +597,12 @@ contain none of the targeted variables.
 
  -}
 substitute
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        )
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> Predicate variable
-    -> Predicate variable
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable
+       )
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> Predicate variable
+  -> Predicate variable
 substitute subst (GenericPredicate termLike) =
-    GenericPredicate (TermLike.substitute subst termLike)
+  GenericPredicate (TermLike.substitute subst termLike)

--- a/kore/src/Kore/Profiler/Data.hs
+++ b/kore/src/Kore/Profiler/Data.hs
@@ -3,76 +3,98 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 module Kore.Profiler.Data
-    ( MonadProfiler (..)
-    , profileDurationEvent
-    , profileDurationStartStop
-    , ProfileEvent (..)
-    , Configuration (..)
-    ) where
+  ( MonadProfiler (..),
+    profileDurationEvent,
+    profileDurationStartStop,
+    ProfileEvent (..),
+    Configuration (..)
+    )
+where
 
-import           Control.Monad.IO.Class
-                 ( MonadIO (liftIO) )
-import           Control.Monad.Morph
-                 ( MFunctor (..) )
-import           Control.Monad.Reader
-                 ( ReaderT )
+import Control.Monad.IO.Class
+  ( MonadIO (liftIO)
+    )
+import Control.Monad.Morph
+  ( MFunctor (..)
+    )
+import Control.Monad.Reader
+  ( ReaderT
+    )
 import qualified Control.Monad.State.Strict as Strict
-import           Control.Monad.Trans.Accum
-                 ( AccumT (AccumT), runAccumT )
-import           Control.Monad.Trans.Except
-                 ( ExceptT )
-import           Control.Monad.Trans.Identity
-                 ( IdentityT )
-import           Control.Monad.Trans.Maybe
-                 ( MaybeT )
-import           Data.Functor.Identity
-                 ( Identity )
+import Control.Monad.Trans.Accum
+  ( AccumT (AccumT),
+    runAccumT
+    )
+import Control.Monad.Trans.Except
+  ( ExceptT
+    )
+import Control.Monad.Trans.Identity
+  ( IdentityT
+    )
+import Control.Monad.Trans.Maybe
+  ( MaybeT
+    )
+import Data.Functor.Identity
+  ( Identity
+    )
 import qualified Data.List as List
-import           Debug.Trace.String
-                 ( traceEventIO )
-import           System.Clock
-                 ( Clock (Monotonic), TimeSpec (TimeSpec), getTime )
-import qualified System.Clock as Clock.DoNotUse
-
-import           ListT
-                 ( ListT (..) )
+import Debug.Trace.String
+  ( traceEventIO
+    )
+import ListT
+  ( ListT (..)
+    )
 import qualified ListT
-                 ( mapListT )
+  ( mapListT
+    )
+import System.Clock
+  ( Clock (Monotonic),
+    TimeSpec (TimeSpec),
+    getTime
+    )
+import qualified System.Clock as Clock.DoNotUse
 
 {- Monad that can also handle profiling events.
 -}
 class Monad profiler => MonadProfiler profiler where
-    profileDuration :: [String] -> profiler a -> profiler a
-    default profileDuration
-        :: (MonadProfiler m, MFunctor t, profiler ~ t m)
-        => [String] -> profiler a -> profiler a
-    profileDuration a = hoist (profileDuration a)
-    {-# INLINE profileDuration #-}
 
-    -- TODO(virgil): Add a command line flag for this.
-    profileConfiguration :: profiler Configuration
-    profileConfiguration =
-        return Configuration
-            {identifierFilter = Nothing, dumpIdentifier = Nothing}
-    {-# INLINE profileConfiguration #-}
+  profileDuration :: [String] -> profiler a -> profiler a
+
+  default profileDuration
+    :: (MonadProfiler m, MFunctor t, profiler ~ t m)
+    => [String]
+    -> profiler a
+    -> profiler a
+  profileDuration a = hoist (profileDuration a)
+  {-# INLINE profileDuration #-}
+
+  -- TODO(virgil): Add a command line flag for this.
+  profileConfiguration :: profiler Configuration
+  profileConfiguration =
+    return Configuration
+      { identifierFilter = Nothing,
+        dumpIdentifier = Nothing
+        }
+  {-# INLINE profileConfiguration #-}
 
 -- Instance for tests.
 instance MonadProfiler Identity where
-    profileDuration = \_ x -> x
-    {-# INLINE profileDuration #-}
 
-    profileConfiguration =
-        return Configuration
-            { identifierFilter = Nothing
-            , dumpIdentifier = Nothing
-            }
-    {-# INLINE profileConfiguration #-}
+  profileDuration = \_ x -> x
+  {-# INLINE profileDuration #-}
 
-data Configuration =
-    Configuration
-        { identifierFilter :: !(Maybe String)
+  profileConfiguration =
+    return Configuration
+      { identifierFilter = Nothing,
+        dumpIdentifier = Nothing
+        }
+  {-# INLINE profileConfiguration #-}
+
+data Configuration
+  = Configuration
+      { identifierFilter :: !(Maybe String),
         -- ^ If present, only emits events for this identifier.
-        , dumpIdentifier :: !(Maybe String)
+        dumpIdentifier :: !(Maybe String)
         -- ^ If present, dump extra information for this identifier.
         }
 
@@ -83,54 +105,55 @@ one at the start, with @endPico=Nothing@, and one at the end with an @Just@
 value for @endPico@
 -}
 data ProfileEvent
-    = ProfileEvent
-        { startPico :: !Integer
+  = ProfileEvent
+      { startPico :: !Integer,
         -- The start CPU time, in picoseconds.
-        , endPico :: !(Maybe Integer)
+        endPico :: !(Maybe Integer),
         -- The end CPU time, in picoseconds. Nothing if this is a start event.
-        , tags :: ![String]
+        tags :: ![String]
         -- Tags for the event. If @tags=[t1, t2, t3]@ then this event will be
         -- counted as part of @t1@, @t1-t2@ and @t1-t2-t3@.
         }
-    deriving (Show, Read)
+  deriving (Show, Read)
 
 getTimePicos :: IO Integer
 getTimePicos = timeSpecToPicos <$> getTime Monotonic
   where
     timeSpecToPicos TimeSpec {sec, nsec} =
-         ((toInteger sec * 1000 * 1000 * 1000) + toInteger nsec) * 1000
+      ((toInteger sec * 1000 * 1000 * 1000) + toInteger nsec) * 1000
 
 {- Times an action.
 -}
 profileDurationEvent :: MonadIO profiler => [String] -> profiler a -> profiler a
 profileDurationEvent tags action = do
-    startTime <- liftIO getTimePicos
-    let event = ProfileEvent
-            { startPico = startTime
-            , endPico = Nothing
-            , tags
-            }
-    liftIO $ traceEventIO (show event)
-    a <- action
-    endTime <- liftIO (getTime Monotonic)
-    liftIO $ traceEventIO
+  startTime <- liftIO getTimePicos
+  let event = ProfileEvent
+        { startPico = startTime,
+          endPico = Nothing,
+          tags
+          }
+  liftIO $ traceEventIO (show event)
+  a <- action
+  endTime <- liftIO (getTime Monotonic)
+  liftIO
+    $ traceEventIO
         (show event {endPico = Just (timeSpecToPicos endTime)})
-    return a
+  return a
   where
     timeSpecToPicos TimeSpec {sec, nsec} =
-         ((toInteger sec * 1000 * 1000 * 1000) + toInteger nsec) * 1000
+      ((toInteger sec * 1000 * 1000 * 1000) + toInteger nsec) * 1000
 
 {- Times an action in the format required by @ghc-events-analyze@.
 -}
 profileDurationStartStop
-    :: MonadIO profiler => [String] -> profiler a -> profiler a
+  :: MonadIO profiler => [String] -> profiler a -> profiler a
 profileDurationStartStop event action = do
-    liftIO $ traceEventIO ("START " ++ List.intercalate "/" event)
-    a <- action
-    liftIO $ traceEventIO ("STOP " ++ List.intercalate "/" event)
-    return a
+  liftIO $ traceEventIO ("START " ++ List.intercalate "/" event)
+  a <- action
+  liftIO $ traceEventIO ("STOP " ++ List.intercalate "/" event)
+  return a
 
-instance (MonadProfiler m) => MonadProfiler (ReaderT thing m )
+instance (MonadProfiler m) => MonadProfiler (ReaderT thing m)
 
 instance MonadProfiler m => MonadProfiler (Strict.StateT s m)
 
@@ -141,11 +164,10 @@ instance MonadProfiler m => MonadProfiler (IdentityT m)
 instance MonadProfiler m => MonadProfiler (ExceptT e m)
 
 instance MonadProfiler m => MonadProfiler (ListT m) where
-    profileDuration a action =
-        ListT.mapListT (profileDuration a) action
-    {-# INLINE profileDuration #-}
+  profileDuration a action =
+    ListT.mapListT (profileDuration a) action
+  {-# INLINE profileDuration #-}
 
-instance (MonadProfiler m, Monoid w) => MonadProfiler (AccumT w m)
-  where
-    profileDuration a action = AccumT (profileDuration a . runAccumT action)
-    {-# INLINE profileDuration #-}
+instance (MonadProfiler m, Monoid w) => MonadProfiler (AccumT w m) where
+  profileDuration a action = AccumT (profileDuration a . runAccumT action)
+  {-# INLINE profileDuration #-}

--- a/kore/src/Kore/Profiler/Profile.hs
+++ b/kore/src/Kore/Profiler/Profile.hs
@@ -5,109 +5,132 @@ License     : NCSA
 This should be imported @qualified@.
 -}
 module Kore.Profiler.Profile
-    ( axiomEvaluation
-    , equalitySimplification
-    , executionQueueLength
-    , mergeSubstitutions
-    , resimplification
-    , smtDecision
-    ) where
+  ( axiomEvaluation,
+    equalitySimplification,
+    executionQueueLength,
+    mergeSubstitutions,
+    resimplification,
+    smtDecision
+    )
+where
 
-import           Control.Monad
-                 ( when )
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty (..) )
+import Control.Monad
+  ( when
+    )
+import Data.Text.Prettyprint.Doc
+  ( Pretty (..)
+    )
 import qualified Data.Text.Prettyprint.Doc as Doc
-                 ( LayoutOptions (LayoutOptions), PageWidth (Unbounded), group,
-                 layoutSmart )
+  ( LayoutOptions (LayoutOptions),
+    PageWidth (Unbounded),
+    group,
+    layoutSmart
+    )
 import qualified Data.Text.Prettyprint.Doc.Render.String as Doc
-                 ( renderString )
-
-import           Kore.Profiler.Data
-                 ( Configuration (Configuration),
-                 MonadProfiler (profileConfiguration, profileDuration) )
-import qualified Kore.Profiler.Data as Profiler.DoNotUse
-import           Kore.Step.Axiom.Identifier
-                 ( AxiomIdentifier )
-import           Kore.Unparser
-                 ( Unparse, unparseToString )
-import           SMT
-
+  ( renderString
+    )
 import Debug.Trace
+import Kore.Profiler.Data
+  ( Configuration (Configuration),
+    MonadProfiler (profileConfiguration, profileDuration)
+    )
+import qualified Kore.Profiler.Data as Profiler.DoNotUse
+import Kore.Step.Axiom.Identifier
+  ( AxiomIdentifier
+    )
+import Kore.Unparser
+  ( Unparse,
+    unparseToString
+    )
+import SMT
 
 oneLiner :: Pretty a => a -> String
 oneLiner =
-    Doc.renderString
+  Doc.renderString
     . Doc.layoutSmart (Doc.LayoutOptions Doc.Unbounded)
     . Doc.group
     . pretty
 
 equalitySimplification
-    :: (MonadProfiler profiler, Unparse thing)
-    => AxiomIdentifier -> thing -> profiler result -> profiler result
+  :: (MonadProfiler profiler, Unparse thing)
+  => AxiomIdentifier
+  -> thing
+  -> profiler result
+  -> profiler result
 equalitySimplification identifier thing action = do
-    Configuration {dumpIdentifier} <- profileConfiguration
-    let strIdentifier = oneLiner identifier
-    -- TODO(virgil): Move this in the logger.
-    case dumpIdentifier of
-        Just toDump ->
-            when (toDump == strIdentifier)
-                (traceM (unparseToString thing))
-        Nothing -> return ()
-    filteredLogging
-        identifier ["equalitySimplification", strIdentifier] action
+  Configuration {dumpIdentifier} <- profileConfiguration
+  let strIdentifier = oneLiner identifier
+  -- TODO(virgil): Move this in the logger.
+  case dumpIdentifier of
+    Just toDump ->
+      when (toDump == strIdentifier)
+        (traceM (unparseToString thing))
+    Nothing -> return ()
+  filteredLogging
+    identifier
+    ["equalitySimplification", strIdentifier]
+    action
 
 -- TODO(virgil): Enable this on-demand.
 axiomEvaluation
-    :: MonadProfiler profiler
-    => AxiomIdentifier -> profiler result -> profiler result
+  :: MonadProfiler profiler
+  => AxiomIdentifier
+  -> profiler result
+  -> profiler result
 axiomEvaluation identifier =
-    filteredLogging identifier ["axiomEvaluation", oneLiner identifier]
+  filteredLogging identifier ["axiomEvaluation", oneLiner identifier]
 
 -- TODO(virgil): Enable this on-demand.
 resimplification
-    :: MonadProfiler profiler
-    => AxiomIdentifier -> Int -> profiler result -> profiler result
+  :: MonadProfiler profiler
+  => AxiomIdentifier
+  -> Int
+  -> profiler result
+  -> profiler result
 resimplification identifier size =
-    filteredLogging
-        identifier
-        ["resimplification", oneLiner identifier, show size]
+  filteredLogging
+    identifier
+    ["resimplification", oneLiner identifier, show size]
 
 -- TODO(virgil): Enable this on-demand.
 mergeSubstitutions
-    :: MonadProfiler profiler
-    => AxiomIdentifier -> profiler result -> profiler result
+  :: MonadProfiler profiler
+  => AxiomIdentifier
+  -> profiler result
+  -> profiler result
 mergeSubstitutions identifier =
-    filteredLogging identifier ["mergeSubstitutions", oneLiner identifier]
+  filteredLogging identifier ["mergeSubstitutions", oneLiner identifier]
 
 filteredLogging
-    :: MonadProfiler profiler
-    => AxiomIdentifier
-    -> [String]
-    -> profiler result
-    -> profiler result
+  :: MonadProfiler profiler
+  => AxiomIdentifier
+  -> [String]
+  -> profiler result
+  -> profiler result
 filteredLogging identifier tags action = do
-    Configuration {identifierFilter} <- profileConfiguration
-    case identifierFilter of
-        Nothing -> profileDuration tags action
-        Just idFilter
-          | isSelected idFilter identifier ->
-            profileDuration tags action
-          | otherwise -> action
+  Configuration {identifierFilter} <- profileConfiguration
+  case identifierFilter of
+    Nothing -> profileDuration tags action
+    Just idFilter
+      | isSelected idFilter identifier ->
+        profileDuration tags action
+      | otherwise -> action
 
 isSelected :: String -> AxiomIdentifier -> Bool
 isSelected identifierFilter = (== identifierFilter) . oneLiner
 
 smtDecision
-    :: MonadProfiler profiler
-    => SExpr
-    -> profiler result
-    -> profiler result
+  :: MonadProfiler profiler
+  => SExpr
+  -> profiler result
+  -> profiler result
 smtDecision sexpr =
-    profileDuration ["SMT", show $ length $ show sexpr]
+  profileDuration ["SMT", show $ length $ show sexpr]
 
 executionQueueLength
-    :: MonadProfiler profiler
-    => Int -> profiler result -> profiler result
+  :: MonadProfiler profiler
+  => Int
+  -> profiler result
+  -> profiler result
 executionQueueLength len =
-    profileDuration ["ExecutionQueueLength", show len]
+  profileDuration ["ExecutionQueueLength", show len]

--- a/kore/src/Kore/Proof/Functional.hs
+++ b/kore/src/Kore/Proof/Functional.hs
@@ -5,22 +5,25 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 -}
-
 module Kore.Proof.Functional
-    ( ConstructorLikeProof (..)
-    , FunctionProof (..)
-    , FunctionalProof (..)
-    , TotalProof (..)
-    , mapVariables
-    ) where
+  ( ConstructorLikeProof (..),
+    FunctionProof (..),
+    FunctionalProof (..),
+    TotalProof (..),
+    mapVariables
+    )
+where
 
 import Data.Hashable
-       ( Hashable )
+  ( Hashable
+    )
 import GHC.Generics
-       ( Generic )
-
+  ( Generic
+    )
 import Kore.Internal.TermLike
-       ( Builtin, Symbol )
+  ( Builtin,
+    Symbol
+    )
 import Kore.Sort
 import Kore.Syntax.CharLiteral
 import Kore.Syntax.DomainValue
@@ -33,27 +36,29 @@ import Kore.Syntax.StringLiteral
 -- TODO: replace this datastructures with proper ones representing
 -- both hypotheses and conclusions in the proof object.
 data FunctionalProof variable
-    = FunctionalVariable variable
+  = FunctionalVariable variable
     -- ^Variables are functional as per Corollary 5.19
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
     -- |= ∃y . x = y
-    | FunctionalBuiltin (Builtin ())
+  | FunctionalBuiltin (Builtin ())
     -- ^ Builtin pattern without children are functional: they represent
     -- one value in the model.
-    | FunctionalDomainValue (DomainValue Sort ())
+  | FunctionalDomainValue (DomainValue Sort ())
     -- ^ Domain value pattern without children are functional: they represent
     -- one value in the model.
-    | FunctionalHead Symbol
+  | FunctionalHead Symbol
     -- ^Head of a total function, conforming to Definition 5.21
     -- https://arxiv.org/pdf/1705.06312.pdf#subsection.5.4
-    | FunctionalStringLiteral StringLiteral
+  | FunctionalStringLiteral StringLiteral
     -- ^A string literal is the repeated application of functional constructors.
-    | FunctionalCharLiteral CharLiteral
+  | FunctionalCharLiteral CharLiteral
     -- ^A char literal is a functional constructor without arguments.
-  deriving Generic
+  deriving (Generic)
 
 deriving instance Eq variable => Eq (FunctionalProof variable)
+
 deriving instance Ord variable => Ord (FunctionalProof variable)
+
 deriving instance Show variable => Show (FunctionalProof variable)
 
 instance Hashable variable => Hashable (FunctionalProof variable)
@@ -66,13 +71,15 @@ instance Hashable variable => Hashable (FunctionalProof variable)
 -- TODO: replace this datastructures with proper ones representing
 -- both hypotheses and conclusions in the proof object.
 data FunctionProof variable
-    = FunctionProofFunctional (FunctionalProof variable)
+  = FunctionProofFunctional (FunctionalProof variable)
     -- ^ A functional component is also function-like.
-    | FunctionHead Symbol
+  | FunctionHead Symbol
     -- ^Head of a partial function.
 
 deriving instance Eq variable => Eq (FunctionProof variable)
+
 deriving instance Ord variable => Ord (FunctionProof variable)
+
 deriving instance Show variable => Show (FunctionProof variable)
 
 -- |'TotalProof' is used for providing arguments that a pattern is
@@ -82,13 +89,15 @@ deriving instance Show variable => Show (FunctionProof variable)
 -- TODO: replace this datastructures with proper ones representing
 -- both hypotheses and conclusions in the proof object.
 data TotalProof variable
-    = TotalProofFunctional (FunctionalProof variable)
+  = TotalProofFunctional (FunctionalProof variable)
     -- ^A functional component is also total.
-    | TotalHead Symbol
+  | TotalHead Symbol
     -- ^Head of a total symbol.
 
 deriving instance Eq variable => Eq (TotalProof variable)
+
 deriving instance Ord variable => Ord (TotalProof variable)
+
 deriving instance Show variable => Show (TotalProof variable)
 
 -- |Used for providing arguments that a pattern is made of constructor-like
@@ -97,14 +106,14 @@ data ConstructorLikeProof = ConstructorLikeProof
   deriving (Eq, Show)
 
 mapVariables
-    :: (variable1 -> variable2)
-    -> FunctionalProof variable1
-    -> FunctionalProof variable2
+  :: (variable1 -> variable2)
+  -> FunctionalProof variable1
+  -> FunctionalProof variable2
 mapVariables mapping =
-    \case
-        FunctionalVariable variable -> FunctionalVariable (mapping variable)
-        FunctionalBuiltin value -> FunctionalBuiltin value
-        FunctionalDomainValue value -> FunctionalDomainValue value
-        FunctionalHead symbol -> FunctionalHead symbol
-        FunctionalStringLiteral string -> FunctionalStringLiteral string
-        FunctionalCharLiteral char -> FunctionalCharLiteral char
+  \case
+    FunctionalVariable variable -> FunctionalVariable (mapping variable)
+    FunctionalBuiltin value -> FunctionalBuiltin value
+    FunctionalDomainValue value -> FunctionalDomainValue value
+    FunctionalHead symbol -> FunctionalHead symbol
+    FunctionalStringLiteral string -> FunctionalStringLiteral string
+    FunctionalCharLiteral char -> FunctionalCharLiteral char

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -5,225 +5,224 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 -}
-
 module Kore.Repl
-    ( runRepl
-    ) where
+  ( runRepl
+    )
+where
 
-import           Control.Concurrent.MVar
-import           Control.Exception
-                 ( AsyncException (UserInterrupt) )
+import Control.Concurrent.MVar
+import Control.Exception
+  ( AsyncException (UserInterrupt)
+    )
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
-import           Control.Monad
-                 ( forever, void, when )
-import           Control.Monad.Catch
-                 ( MonadCatch, catch )
-import           Control.Monad.IO.Class
-                 ( MonadIO, liftIO )
-import           Control.Monad.Reader
-                 ( ReaderT (..) )
-import           Control.Monad.RWS.Strict
-                 ( RWST, execRWST )
-import           Control.Monad.State.Strict
-                 ( MonadState, StateT, evalStateT )
-import           Data.Coerce
-                 ( coerce )
-import           Data.Generics.Product
+  ( makeLenses
+    )
+import Control.Monad
+  ( forever,
+    void,
+    when
+    )
+import Control.Monad.Catch
+  ( MonadCatch,
+    catch
+    )
+import Control.Monad.IO.Class
+  ( MonadIO,
+    liftIO
+    )
+import Control.Monad.RWS.Strict
+  ( RWST,
+    execRWST
+    )
+import Control.Monad.Reader
+  ( ReaderT (..)
+    )
+import Control.Monad.State.Strict
+  ( MonadState,
+    StateT,
+    evalStateT
+    )
+import Data.Coerce
+  ( coerce
+    )
+import Data.Generics.Product
 import qualified Data.Graph.Inductive.Graph as Graph
-import           Data.List
-                 ( findIndex )
+import Data.List
+  ( findIndex
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
+import Data.Maybe
 import qualified Data.Sequence as Seq
-import           Kore.Attribute.RuleIndex
-import           System.IO
-                 ( hFlush, stdout )
-import           Text.Megaparsec
-                 ( parseMaybe )
-
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Goal
+import Kore.Attribute.RuleIndex
+import Kore.Goal
 import qualified Kore.Logger as Logger
-import           Kore.OnePath.Verification
-import           Kore.Repl.Data
-import           Kore.Repl.Interpreter
-import           Kore.Repl.Parser
-import           Kore.Repl.State
+import Kore.OnePath.Verification
+import Kore.Repl.Data
+import Kore.Repl.Interpreter
+import Kore.Repl.Parser
+import Kore.Repl.State
 import qualified Kore.Step.Rule as Rule
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.Syntax.Variable
-import           Kore.Unification.Procedure
-                 ( unificationProcedure )
+import Kore.Syntax.Variable
+import Kore.Unification.Procedure
+  ( unificationProcedure
+    )
+import System.IO
+  ( hFlush,
+    stdout
+    )
+import Text.Megaparsec
+  ( parseMaybe
+    )
 
 -- | Runs the repl for proof mode. It requires all the tooling and simplifiers
 -- that would otherwise be required in the proof and allows for step-by-step
 -- execution of proofs. Currently works via stdin/stdout interaction.
 runRepl
-    :: forall claim axiom m
-    .  MonadSimplify m
-    => MonadIO m
-    => MonadCatch m
-    => Claim claim
-    => axiom ~ Rule claim
-    => [axiom]
-    -- ^ list of axioms to used in the proof
-    -> [claim]
-    -- ^ list of claims to be proven
-    -> MVar (Logger.LogAction IO Logger.LogMessage)
-    -> ReplScript
-    -- ^ optional script
-    -> ReplMode
-    -- ^ mode to run in
-    -> OutputFile
-    -- ^ optional output file
-    -> m ()
+  :: forall claim axiom m. MonadSimplify m
+  => MonadIO m
+  => MonadCatch m
+  => Claim claim
+  => axiom ~ Rule claim
+  => [axiom]
+  -- ^ list of axioms to used in the proof
+  -> [claim]
+  -- ^ list of claims to be proven
+  -> MVar (Logger.LogAction IO Logger.LogMessage)
+  -> ReplScript
+  -- ^ optional script
+  -> ReplMode
+  -- ^ mode to run in
+  -> OutputFile
+  -- ^ optional output file
+  -> m ()
 runRepl axioms' claims' logger replScript replMode outputFile = do
-    (newState, _) <-
-            (\rwst -> execRWST rwst config state)
-            $ evaluateScript replScript
-    case replMode of
-        Interactive -> do
-            replGreeting
-            flip evalStateT newState
-                $ flip runReaderT config
-                $ forever repl0
-        RunScript ->
-            runReplCommand Exit newState
-
+  (newState, _) <-
+    (\rwst -> execRWST rwst config state)
+      $ evaluateScript replScript
+  case replMode of
+    Interactive -> do
+      replGreeting
+      flip evalStateT newState
+        $ flip runReaderT config
+        $ forever repl0
+    RunScript ->
+      runReplCommand Exit newState
   where
-
     runReplCommand :: ReplCommand -> ReplState claim -> m ()
     runReplCommand cmd st =
-        void
-            $ flip evalStateT st
-            $ flip runReaderT config
-            $ replInterpreter printIfNotEmpty cmd
-
+      void
+        $ flip evalStateT st
+        $ flip runReaderT config
+        $ replInterpreter printIfNotEmpty cmd
     evaluateScript :: ReplScript -> RWST (Config claim m) String (ReplState claim) m ()
     evaluateScript = maybe (pure ()) parseEvalScript . unReplScript
-
     repl0 :: ReaderT (Config claim m) (StateT (ReplState claim) m) ()
     repl0 = do
-        str <- prompt
-        let command = fromMaybe ShowUsage $ parseMaybe commandParser str
-        when (shouldStore command) $ field @"commands" Lens.%= (Seq.|> str)
-        void $ replInterpreter printIfNotEmpty command
-
+      str <- prompt
+      let command = fromMaybe ShowUsage $ parseMaybe commandParser str
+      when (shouldStore command) $ field @"commands" Lens.%= (Seq.|> str)
+      void $ replInterpreter printIfNotEmpty command
     state :: ReplState claim
     state =
-        ReplState
-            { axioms     = addIndexesToAxioms axioms'
-            , claims     = addIndexesToClaims (length axioms') claims'
-            , claim      = firstClaim
-            , claimIndex = firstClaimIndex
-            , graphs     = Map.singleton firstClaimIndex firstClaimExecutionGraph
-            , node       = ReplNode (Strategy.root firstClaimExecutionGraph)
-            , commands   = Seq.empty
-            -- TODO(Vladimir): should initialize this to the value obtained from
-            -- the frontend via '--omit-labels'.
-            , omit       = mempty
-            , labels     = Map.empty
-            , aliases    = Map.empty
-            , logging    = (Logger.Debug, NoLogging)
-            }
-
+      ReplState
+        { axioms = addIndexesToAxioms axioms',
+          claims = addIndexesToClaims (length axioms') claims',
+          claim = firstClaim,
+          claimIndex = firstClaimIndex,
+          graphs = Map.singleton firstClaimIndex firstClaimExecutionGraph,
+          node = ReplNode (Strategy.root firstClaimExecutionGraph),
+          commands = Seq.empty,
+          -- TODO(Vladimir): should initialize this to the value obtained from
+          -- the frontend via '--omit-labels'.
+          omit = mempty,
+          labels = Map.empty,
+          aliases = Map.empty,
+          logging = (Logger.Debug, NoLogging)
+          }
     config :: Config claim m
     config =
-        Config
-            { stepper    = stepper0
-            , unifier    = unificationProcedure
-            , logger
-            , outputFile
-            }
-
+      Config
+        { stepper = stepper0,
+          unifier = unificationProcedure,
+          logger,
+          outputFile
+          }
     firstClaimIndex :: ClaimIndex
     firstClaimIndex =
-        ClaimIndex
+      ClaimIndex
         . fromMaybe (error "No claims found")
         $ findIndex (not . isTrusted) claims'
-
     addIndexesToAxioms
-        :: [axiom]
-        -> [axiom]
+      :: [axiom]
+      -> [axiom]
     addIndexesToAxioms axs =
-        fmap addIndex (zip axs [0..])
-
+      fmap addIndex (zip axs [0 ..])
     addIndexesToClaims
-        :: Int
-        -> [claim]
-        -> [claim]
+      :: Int
+      -> [claim]
+      -> [claim]
     addIndexesToClaims len cls =
-        fmap
-            (coerce . addIndex)
-            (zip (fmap coerce cls) [len..])
-
+      fmap
+        (coerce . addIndex)
+        (zip (fmap coerce cls) [len ..])
     addIndex
-        :: (axiom, Int)
-        -> axiom
+      :: (axiom, Int)
+      -> axiom
     addIndex (rw, n) =
-        modifyAttribute (mapAttribute n (getAttribute rw)) rw
-
+      modifyAttribute (mapAttribute n (getAttribute rw)) rw
     modifyAttribute
-        :: Attribute.Axiom
-        -> axiom
-        -> axiom
+      :: Attribute.Axiom
+      -> axiom
+      -> axiom
     modifyAttribute att rule =
-        let rp = axiomToRulePatt rule in
-            coerce $ rp { Rule.attributes = att }
-
+      let rp = axiomToRulePatt rule
+       in coerce $ rp {Rule.attributes = att}
     axiomToRulePatt :: axiom -> Rule.RulePattern Variable
     axiomToRulePatt = coerce
-
     getAttribute :: axiom -> Attribute.Axiom
     getAttribute = Rule.attributes . axiomToRulePatt
-
     mapAttribute :: Int -> Attribute.Axiom -> Attribute.Axiom
     mapAttribute n attr =
-        Lens.over (field @"identifier") (makeRuleIndex n) attr
-
+      Lens.over (field @"identifier") (makeRuleIndex n) attr
     makeRuleIndex :: Int -> RuleIndex -> RuleIndex
     makeRuleIndex n _ = RuleIndex (Just n)
-
     firstClaim :: Claim claim => claim
     firstClaim =
-        claims' !! unClaimIndex firstClaimIndex
-
+      claims' !! unClaimIndex firstClaimIndex
     firstClaimExecutionGraph :: ExecutionGraph axiom
     firstClaimExecutionGraph = emptyExecutionGraph firstClaim
-
     stepper0
-        :: claim
-        -> [claim]
-        -> [axiom]
-        -> ExecutionGraph axiom
-        -> ReplNode
-        -> m (ExecutionGraph axiom)
+      :: claim
+      -> [claim]
+      -> [axiom]
+      -> ExecutionGraph axiom
+      -> ReplNode
+      -> m (ExecutionGraph axiom)
     stepper0 claim claims axioms graph rnode = do
-        let node = unReplNode rnode
-        if Graph.outdeg (Strategy.graph graph) node == 0
-            then
-                catchInterruptWithDefault graph
-                $ verifyClaimStep claim claims axioms graph node
-            else pure graph
-
+      let node = unReplNode rnode
+      if Graph.outdeg (Strategy.graph graph) node == 0
+        then
+          catchInterruptWithDefault graph
+            $ verifyClaimStep claim claims axioms graph node
+        else pure graph
     catchInterruptWithDefault :: MonadCatch m => MonadIO m => a -> m a -> m a
     catchInterruptWithDefault def sa =
-        catch sa $ \UserInterrupt -> do
-            liftIO $ putStrLn "Step evaluation interrupted."
-            pure def
-
+      catch sa $ \UserInterrupt -> do
+        liftIO $ putStrLn "Step evaluation interrupted."
+        pure def
     replGreeting :: MonadIO m => m ()
     replGreeting =
-        liftIO $
-            putStrLn "Welcome to the Kore Repl! Use 'help' to get started.\n"
-
+      liftIO
+        $ putStrLn "Welcome to the Kore Repl! Use 'help' to get started.\n"
     prompt :: MonadIO n => MonadState (ReplState claim) n => n String
     prompt = do
-        node <- Lens.use (field @"node")
-        liftIO $ do
-            putStr $ "Kore (" <> show (unReplNode node) <> ")> "
-            hFlush stdout
-            getLine
+      node <- Lens.use (field @"node")
+      liftIO $ do
+        putStr $ "Kore (" <> show (unReplNode node) <> ")> "
+        hFlush stdout
+        getLine

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -5,259 +5,326 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 -}
-
 module Kore.Repl.Interpreter
-    ( replInterpreter
-    , replInterpreter0
-    , showUsageMessage
-    , showStepStoppedMessage
-    , showProofStatus
-    , showClaimSwitch
-    , printIfNotEmpty
-    , showRewriteRule
-    , parseEvalScript
-    , showAliasError
-    , formatUnificationMessage
-    , allProofs
-    , ReplStatus(..)
-    , showCurrentClaimIndex
-    ) where
+  ( replInterpreter,
+    replInterpreter0,
+    showUsageMessage,
+    showStepStoppedMessage,
+    showProofStatus,
+    showClaimSwitch,
+    printIfNotEmpty,
+    showRewriteRule,
+    parseEvalScript,
+    showAliasError,
+    formatUnificationMessage,
+    allProofs,
+    ReplStatus (..),
+    showCurrentClaimIndex
+    )
+where
 
-import           Control.Comonad.Trans.Cofree
-                 ( CofreeF (..) )
-import           Control.Lens
-                 ( (%=), (.=) )
+import Control.Comonad.Trans.Cofree
+  ( CofreeF (..)
+    )
+import Control.Lens
+  ( (%=),
+    (.=)
+    )
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
-import           Control.Monad
-                 ( foldM, void )
-import           Control.Monad.Extra
-                 ( ifM, loop, loopM )
-import           Control.Monad.IO.Class
-                 ( MonadIO, liftIO )
-import           Control.Monad.Reader
-                 ( MonadReader, ReaderT (..) )
+  ( makeLenses
+    )
+import Control.Monad
+  ( foldM,
+    void
+    )
+import Control.Monad.Extra
+  ( ifM,
+    loop,
+    loopM
+    )
+import Control.Monad.IO.Class
+  ( MonadIO,
+    liftIO
+    )
+import Control.Monad.RWS.Strict
+  ( MonadWriter,
+    RWST,
+    ask,
+    asks,
+    lift,
+    runRWST,
+    tell
+    )
+import Control.Monad.Reader
+  ( MonadReader,
+    ReaderT (..)
+    )
 import qualified Control.Monad.Reader as Reader
-                 ( ask )
-import           Control.Monad.RWS.Strict
-                 ( MonadWriter, RWST, ask, asks, lift, runRWST, tell )
-import           Control.Monad.State.Class
-                 ( get, put )
-import           Control.Monad.State.Strict
-                 ( MonadState, StateT (..), execStateT )
+  ( ask
+    )
+import Control.Monad.State.Class
+  ( get,
+    put
+    )
+import Control.Monad.State.Strict
+  ( MonadState,
+    StateT (..),
+    execStateT
+    )
 import qualified Control.Monad.Trans.Class as Monad.Trans
-import           Control.Monad.Trans.Except
-                 ( runExceptT )
-import           Data.Coerce
-                 ( Coercible, coerce )
+import Control.Monad.Trans.Except
+  ( runExceptT
+    )
+import Data.Coerce
+  ( Coercible,
+    coerce
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Functor
-                 ( ($>) )
+import Data.Functor
+  ( ($>)
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Generics.Product
+import Data.Generics.Product
 import qualified Data.Graph.Inductive.Graph as Graph
 import qualified Data.GraphViz as Graph
-import           Data.IORef
-                 ( IORef, modifyIORef, newIORef, readIORef )
+import Data.IORef
+  ( IORef,
+    modifyIORef,
+    newIORef,
+    readIORef
+    )
 import qualified Data.List as List
-import           Data.List.NonEmpty
-                 ( NonEmpty )
+import Data.List.NonEmpty
+  ( NonEmpty
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Sequence
-                 ( Seq )
-import           Data.Set
-                 ( Set )
+import Data.Maybe
+import Data.Sequence
+  ( Seq
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import           GHC.Exts
-                 ( toList )
-import           GHC.IO.Handle
-                 ( hGetContents, hPutStr )
-import           System.Exit
-
-import           Kore.Attribute.Axiom
-                 ( SourceLocation (..) )
+import GHC.Exts
+  ( toList
+    )
+import GHC.IO.Handle
+  ( hGetContents,
+    hPutStr
+    )
+import Kore.Attribute.Axiom
+  ( SourceLocation (..)
+    )
 import qualified Kore.Attribute.Axiom as Attribute
-                 ( Axiom (..), RuleIndex (..), sourceLocation )
+  ( Axiom (..),
+    RuleIndex (..),
+    sourceLocation
+    )
 import qualified Kore.Attribute.Label as AttrLabel
-import           Kore.Attribute.RuleIndex
-import           Kore.Goal
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
+import Kore.Attribute.RuleIndex
+import Kore.Goal
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Predicate )
-import           Kore.Internal.TermLike
-                 ( TermLike )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
+import Kore.Internal.TermLike
+  ( TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Logger
-import           Kore.OnePath.Verification
-                 ( Claim, CommonProofState )
-import           Kore.Repl.Data
-import           Kore.Repl.Parser
-import           Kore.Repl.State
-import           Kore.Step.Rule
-                 ( RulePattern (..) )
+import Kore.OnePath.Verification
+  ( Claim,
+    CommonProofState
+    )
+import Kore.Repl.Data
+import Kore.Repl.Parser
+import Kore.Repl.State
+import Kore.Step.Rule
+  ( RulePattern (..)
+    )
 import qualified Kore.Step.Rule as Rule
 import qualified Kore.Step.Rule as Axiom
-                 ( attributes )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+  ( attributes
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.Syntax.Application
+import Kore.Syntax.Application
 import qualified Kore.Syntax.Id as Id
-                 ( Id (..) )
-import           Kore.Syntax.Variable
-                 ( Variable )
-import           Kore.Unparser
-                 ( Unparse, unparse, unparseToString )
-import           Numeric.Natural
-import           System.Directory
-                 ( doesDirectoryExist, doesFileExist, findExecutable )
-import           System.FilePath.Posix
-                 ( splitFileName )
-import           System.Process
-                 ( StdStream (CreatePipe), createProcess, proc, std_in,
-                 std_out )
-import           Text.Megaparsec
-                 ( ParseErrorBundle (..), errorBundlePretty, parseMaybe,
-                 runParser )
+  ( Id (..)
+    )
+import Kore.Syntax.Variable
+  ( Variable
+    )
+import Kore.Unparser
+  ( Unparse,
+    unparse,
+    unparseToString
+    )
+import Numeric.Natural
+import System.Directory
+  ( doesDirectoryExist,
+    doesFileExist,
+    findExecutable
+    )
+import System.Exit
+import System.FilePath.Posix
+  ( splitFileName
+    )
+import System.Process
+  ( StdStream (CreatePipe),
+    createProcess,
+    proc,
+    std_in,
+    std_out
+    )
+import Text.Megaparsec
+  ( ParseErrorBundle (..),
+    errorBundlePretty,
+    parseMaybe,
+    runParser
+    )
 
 -- | Warning: you should never use WriterT or RWST. It is used here with
 -- _great care_ of evaluating the RWST to a StateT immediatly, and thus getting
 -- rid of the WriterT part of the stack. This happens in the implementation of
 -- 'replInterpreter'.
-type ReplM claim m a =
-    RWST (Config claim m) ReplOutput (ReplState claim) m a
+type ReplM claim m a
+  = RWST (Config claim m) ReplOutput (ReplState claim) m a
 
 data ReplStatus = Continue | SuccessStop | FailStop
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 -- | Interprets a REPL command in a stateful Simplifier context.
 replInterpreter
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => (String -> IO ())
-    -> ReplCommand
-    -> ReaderT (Config claim m) (StateT (ReplState claim) m) ReplStatus
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => (String -> IO ())
+  -> ReplCommand
+  -> ReaderT (Config claim m) (StateT (ReplState claim) m) ReplStatus
 replInterpreter fn cmd =
-    replInterpreter0
-        (PrintAuxOutput fn)
-        (PrintKoreOutput fn)
-        cmd
+  replInterpreter0
+    (PrintAuxOutput fn)
+    (PrintKoreOutput fn)
+    cmd
 
 replInterpreter0
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => PrintAuxOutput
-    -> PrintKoreOutput
-    -> ReplCommand
-    -> ReaderT (Config claim m) (StateT (ReplState claim) m) ReplStatus
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => PrintAuxOutput
+  -> PrintKoreOutput
+  -> ReplCommand
+  -> ReaderT (Config claim m) (StateT (ReplState claim) m) ReplStatus
 replInterpreter0 printAux printKore replCmd = do
-    let command = case replCmd of
-                ShowUsage          -> showUsage          $> Continue
-                Help               -> help               $> Continue
-                ShowClaim mc       -> showClaim mc       $> Continue
-                ShowAxiom ea       -> showAxiom ea       $> Continue
-                Prove i            -> prove i            $> Continue
-                ShowGraph mfile    -> showGraph mfile    $> Continue
-                ProveSteps n       -> proveSteps n       $> Continue
-                ProveStepsF n      -> proveStepsF n      $> Continue
-                SelectNode i       -> selectNode i       $> Continue
-                ShowConfig mc      -> showConfig mc      $> Continue
-                OmitCell c         -> omitCell c         $> Continue
-                ShowLeafs          -> showLeafs          $> Continue
-                ShowRule   mc      -> showRule mc        $> Continue
-                ShowPrecBranch mn  -> showPrecBranch mn  $> Continue
-                ShowChildren mn    -> showChildren mn    $> Continue
-                Label ms           -> label ms           $> Continue
-                LabelAdd l mn      -> labelAdd l mn      $> Continue
-                LabelDel l         -> labelDel l         $> Continue
-                Redirect inn file  -> redirect inn file  $> Continue
-                Try ref            -> tryAxiomClaim ref  $> Continue
-                TryF ac            -> tryFAxiomClaim ac  $> Continue
-                Clear n            -> clear n            $> Continue
-                SaveSession file   -> saveSession file   $> Continue
-                Pipe inn file args -> pipe inn file args $> Continue
-                AppendTo inn file  -> appendTo inn file  $> Continue
-                Alias a            -> alias a            $> Continue
-                TryAlias name      -> tryAlias name printAux printKore
-                LoadScript file    -> loadScript file    $> Continue
-                ProofStatus        -> proofStatus        $> Continue
-                Log s t            -> handleLog (s,t)    $> Continue
-                Exit               -> exit
-    (ReplOutput output, shouldContinue) <- evaluateCommand command
-    liftIO $ Foldable.traverse_
-            ( replOut
-                (unPrintAuxOutput printAux)
-                (unPrintKoreOutput printKore)
-            )
-            output
-    case shouldContinue of
-        Continue -> pure Continue
-        SuccessStop -> liftIO exitSuccess
-        FailStop -> liftIO . exitWith $ ExitFailure 2
+  let command = case replCmd of
+        ShowUsage -> showUsage $> Continue
+        Help -> help $> Continue
+        ShowClaim mc -> showClaim mc $> Continue
+        ShowAxiom ea -> showAxiom ea $> Continue
+        Prove i -> prove i $> Continue
+        ShowGraph mfile -> showGraph mfile $> Continue
+        ProveSteps n -> proveSteps n $> Continue
+        ProveStepsF n -> proveStepsF n $> Continue
+        SelectNode i -> selectNode i $> Continue
+        ShowConfig mc -> showConfig mc $> Continue
+        OmitCell c -> omitCell c $> Continue
+        ShowLeafs -> showLeafs $> Continue
+        ShowRule mc -> showRule mc $> Continue
+        ShowPrecBranch mn -> showPrecBranch mn $> Continue
+        ShowChildren mn -> showChildren mn $> Continue
+        Label ms -> label ms $> Continue
+        LabelAdd l mn -> labelAdd l mn $> Continue
+        LabelDel l -> labelDel l $> Continue
+        Redirect inn file -> redirect inn file $> Continue
+        Try ref -> tryAxiomClaim ref $> Continue
+        TryF ac -> tryFAxiomClaim ac $> Continue
+        Clear n -> clear n $> Continue
+        SaveSession file -> saveSession file $> Continue
+        Pipe inn file args -> pipe inn file args $> Continue
+        AppendTo inn file -> appendTo inn file $> Continue
+        Alias a -> alias a $> Continue
+        TryAlias name -> tryAlias name printAux printKore
+        LoadScript file -> loadScript file $> Continue
+        ProofStatus -> proofStatus $> Continue
+        Log s t -> handleLog (s, t) $> Continue
+        Exit -> exit
+  (ReplOutput output, shouldContinue) <- evaluateCommand command
+  liftIO
+    $ Foldable.traverse_
+        ( replOut
+            (unPrintAuxOutput printAux)
+            (unPrintKoreOutput printKore)
+          )
+        output
+  case shouldContinue of
+    Continue -> pure Continue
+    SuccessStop -> liftIO exitSuccess
+    FailStop -> liftIO . exitWith $ ExitFailure 2
   where
     -- Extracts the Writer out of the RWST monad using the current state
     -- and updates the state, returning the writer output along with the
     -- monadic result.
     evaluateCommand
-        :: ReplM claim m ReplStatus
-        -> ReaderT (Config claim m) (StateT (ReplState claim) m) (ReplOutput, ReplStatus)
+      :: ReplM claim m ReplStatus
+      -> ReaderT (Config claim m) (StateT (ReplState claim) m) (ReplOutput, ReplStatus)
     evaluateCommand c = do
-        st <- get
-        config <- Reader.ask
-        (ext, st', w) <-
-            Monad.Trans.lift
-                $ Monad.Trans.lift
-                $ runRWST c config st
-        put st'
-        pure (w, ext)
+      st <- get
+      config <- Reader.ask
+      (ext, st', w) <-
+        Monad.Trans.lift
+          $ Monad.Trans.lift
+          $ runRWST c config st
+      put st'
+      pure (w, ext)
 
 showUsageMessage :: String
 showUsageMessage = "Could not parse command, try using 'help'."
 
 showStepStoppedMessage :: Natural -> StepResult -> String
 showStepStoppedMessage n sr =
-    "Stopped after "
+  "Stopped after "
     <> show n
     <> " step(s) due to "
     <> case sr of
-        NoResult ->
-            "reaching end of proof on current branch."
-        SingleResult _ -> ""
-        BranchResult xs ->
-            "branching on "
-            <> show (fmap unReplNode xs)
+      NoResult ->
+        "reaching end of proof on current branch."
+      SingleResult _ -> ""
+      BranchResult xs ->
+        "branching on "
+          <> show (fmap unReplNode xs)
 
 showUsage :: MonadWriter ReplOutput m => m ()
 showUsage = putStrLn' showUsageMessage
 
 exit
-    :: Claim claim
-    => MonadIO m
-    => ReplM claim m ReplStatus
+  :: Claim claim
+  => MonadIO m
+  => ReplM claim m ReplStatus
 exit = do
-    proofs <- allProofs
-    ofile <- Lens.view (field @"outputFile")
-    let fileName =
-            fromMaybe (error "Output file not specified") (unOutputFile ofile)
-    onePathClaims <- generateInProgressOPClaims
-    sort <- currentClaimSort
-    let conj = conjOfOnePathClaims onePathClaims sort
-    liftIO $ writeFile
-            fileName
-            ( unparseToString conj )
-    if isCompleted (Map.elems proofs)
-       then return SuccessStop
-       else return FailStop
+  proofs <- allProofs
+  ofile <- Lens.view (field @"outputFile")
+  let fileName =
+        fromMaybe (error "Output file not specified") (unOutputFile ofile)
+  onePathClaims <- generateInProgressOPClaims
+  sort <- currentClaimSort
+  let conj = conjOfOnePathClaims onePathClaims sort
+  liftIO
+    $ writeFile
+        fileName
+        (unparseToString conj)
+  if isCompleted (Map.elems proofs)
+    then return SuccessStop
+    else return FailStop
   where
     isCompleted :: [GraphProofStatus] -> Bool
     isCompleted = all (\x -> x == Completed || x == TrustedClaim)
@@ -267,596 +334,573 @@ help = putStrLn' helpText
 
 -- | Prints a claim using an index in the claims list.
 showClaim
-    :: Claim claim
-    => MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => Maybe (Either ClaimIndex RuleName)
-    -> m ()
+  :: Claim claim
+  => MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => Maybe (Either ClaimIndex RuleName)
+  -> m ()
 showClaim =
-    \case
-        Nothing -> do
-            currentCindex <- Lens.use (field @"claimIndex")
-            putStrLn' . showCurrentClaimIndex $ currentCindex
-        Just indexOrName -> do
-            claim <- either
-                        (getClaimByIndex . unClaimIndex)
-                        (getClaimByName . unRuleName)
-                        indexOrName
-            maybe printNotFound (tell . showRewriteRule) claim
+  \case
+    Nothing -> do
+      currentCindex <- Lens.use (field @"claimIndex")
+      putStrLn' . showCurrentClaimIndex $ currentCindex
+    Just indexOrName -> do
+      claim <-
+        either
+          (getClaimByIndex . unClaimIndex)
+          (getClaimByName . unRuleName)
+          indexOrName
+      maybe printNotFound (tell . showRewriteRule) claim
 
 -- | Prints an axiom using an index in the axioms list.
 showAxiom
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Coercible axiom (RulePattern Variable)
-    => Coercible (RulePattern Variable) axiom
-    => Unparse axiom
-    => MonadWriter ReplOutput m
-    => Either AxiomIndex RuleName
-    -- ^ index in the axioms list
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Coercible axiom (RulePattern Variable)
+  => Coercible (RulePattern Variable) axiom
+  => Unparse axiom
+  => MonadWriter ReplOutput m
+  => Either AxiomIndex RuleName
+  -- ^ index in the axioms list
+  -> m ()
 showAxiom indexOrName = do
-    axiom <- either
-                (getAxiomByIndex . unAxiomIndex)
-                (getAxiomByName . unRuleName)
-                indexOrName
-    maybe printNotFound (tell . showRewriteRule) axiom
+  axiom <-
+    either
+      (getAxiomByIndex . unAxiomIndex)
+      (getAxiomByName . unRuleName)
+      indexOrName
+  maybe printNotFound (tell . showRewriteRule) axiom
 
 -- | Changes the currently focused proof, using an index in the claims list.
 prove
-    :: forall claim m
-    .  Claim claim
-    => MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => Either ClaimIndex RuleName
-    -- ^ index in the claims list
-    -> m ()
+  :: forall claim m. Claim claim
+  => MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => Either ClaimIndex RuleName
+  -- ^ index in the claims list
+  -> m ()
 prove indexOrName = do
-    claim' <- either
-                (getClaimByIndex . unClaimIndex)
-                (getClaimByName . unRuleName)
-                indexOrName
-    maybe
-        printNotFound
-        startProving
-        claim'
+  claim' <-
+    either
+      (getClaimByIndex . unClaimIndex)
+      (getClaimByName . unRuleName)
+      indexOrName
+  maybe
+    printNotFound
+    startProving
+    claim'
   where
     startProving
-        :: claim
-        -> m ()
+      :: claim
+      -> m ()
     startProving claim
       | isTrusted claim =
         putStrLn'
-            $ "Cannot switch to proving claim "
-            <> showIndexOrName indexOrName
-            <> ". Claim is trusted."
-      | otherwise = do
-        claimIndex <-
+          $ "Cannot switch to proving claim "
+          <> showIndexOrName indexOrName
+          <> ". Claim is trusted."
+      | otherwise =
+        do
+          claimIndex <-
             either
-                (return . return)
-                (getClaimIndexByName . unRuleName)
-                indexOrName
-        switchToProof claim $ fromJust claimIndex
-        putStrLn'
+              (return . return)
+              (getClaimIndexByName . unRuleName)
+              indexOrName
+          switchToProof claim $ fromJust claimIndex
+          putStrLn'
             $ "Switched to proving claim "
             <> showIndexOrName indexOrName
 
 showClaimSwitch :: Either ClaimIndex RuleName -> String
 showClaimSwitch indexOrName =
-    "Switched to proving claim "
+  "Switched to proving claim "
     <> showIndexOrName indexOrName
 
 showIndexOrName
-    :: Either ClaimIndex RuleName
-    -> String
+  :: Either ClaimIndex RuleName
+  -> String
 showIndexOrName =
-        either (show . unClaimIndex) (show . unRuleName)
+  either (show . unClaimIndex) (show . unRuleName)
 
 showGraph
-    :: MonadIO m
-    => MonadWriter ReplOutput m
-    => Claim claim
-    => Maybe FilePath
-    -> MonadState (ReplState claim) m
-    => m ()
+  :: MonadIO m
+  => MonadWriter ReplOutput m
+  => Claim claim
+  => Maybe FilePath
+  -> MonadState (ReplState claim) m
+  => m ()
 showGraph mfile = do
-    graph <- getInnerGraph
-    axioms <- Lens.use (field @"axioms")
-    installed <- liftIO Graph.isGraphvizInstalled
-    if installed
-       then liftIO $ maybe
-                        (showDotGraph (length axioms) graph)
-                        (saveDotGraph (length axioms) graph)
-                        mfile
-       else putStrLn' "Graphviz is not installed."
+  graph <- getInnerGraph
+  axioms <- Lens.use (field @"axioms")
+  installed <- liftIO Graph.isGraphvizInstalled
+  if installed
+    then
+      liftIO
+        $ maybe
+            (showDotGraph (length axioms) graph)
+            (saveDotGraph (length axioms) graph)
+            mfile
+    else putStrLn' "Graphviz is not installed."
 
 -- | Executes 'n' prove steps, or until branching occurs.
 proveSteps
-    :: Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => Natural
-    -- ^ maximum number of steps to perform
-    -> ReplM claim m ()
+  :: Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => Natural
+  -- ^ maximum number of steps to perform
+  -> ReplM claim m ()
 proveSteps n = do
-    let node = ReplNode . fromEnum $ n
-    result <- loopM performStepNoBranching (n, SingleResult node)
-    case result of
-        (0, SingleResult _) -> pure ()
-        (done, res) ->
-            putStrLn' $ showStepStoppedMessage (n - done - 1) res
+  let node = ReplNode . fromEnum $ n
+  result <- loopM performStepNoBranching (n, SingleResult node)
+  case result of
+    (0, SingleResult _) -> pure ()
+    (done, res) ->
+      putStrLn' $ showStepStoppedMessage (n - done - 1) res
 
 -- | Executes 'n' prove steps, distributing over branches. It will perform less
 -- than 'n' steps if the proof is stuck or completed in less than 'n' steps.
 proveStepsF
-    :: Claim claim
-    => Monad m
-    => Natural
-    -- ^ maximum number of steps to perform
-    -> ReplM claim m ()
+  :: Claim claim
+  => Monad m
+  => Natural
+  -- ^ maximum number of steps to perform
+  -> ReplM claim m ()
 proveStepsF n = do
-    graph  <- getExecutionGraph
-    node   <- Lens.use (field @"node")
-    graph' <- recursiveForcedStep n graph node
-    updateExecutionGraph graph'
+  graph <- getExecutionGraph
+  node <- Lens.use (field @"node")
+  graph' <- recursiveForcedStep n graph node
+  updateExecutionGraph graph'
 
 -- | Loads a script from a file.
 loadScript
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => FilePath
-    -- ^ path to file
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => FilePath
+  -- ^ path to file
+  -> ReplM claim m ()
 loadScript file = parseEvalScript file
 
 handleLog
-    :: MonadState (ReplState claim) m
-    => (Logger.Severity, LogType)
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => (Logger.Severity, LogType)
+  -> m ()
 handleLog t = field @"logging" .= t
 
 -- | Focuses the node with id equals to 'n'.
 selectNode
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => MonadWriter ReplOutput m
-    => ReplNode
-    -- ^ node identifier
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => MonadWriter ReplOutput m
+  => ReplNode
+  -- ^ node identifier
+  -> m ()
 selectNode rnode = do
-    graph <- getInnerGraph
-    let i = unReplNode rnode
-    if i `elem` Graph.nodes graph
-        then field @"node" .= rnode
-        else putStrLn' "Invalid node!"
+  graph <- getInnerGraph
+  let i = unReplNode rnode
+  if i `elem` Graph.nodes graph
+    then field @"node" .= rnode
+    else putStrLn' "Invalid node!"
 
 -- | Shows configuration at node 'n', or current node if 'Nothing' is passed.
 showConfig
-    :: Claim claim
-    => Monad m
-    => Maybe ReplNode
-    -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
-    -> ReplM claim m ()
+  :: Claim claim
+  => Monad m
+  => Maybe ReplNode
+  -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
+  -> ReplM claim m ()
 showConfig configNode = do
-    maybeConfig <- getConfigAt configNode
-    case maybeConfig of
-        Nothing -> putStrLn' "Invalid node!"
-        Just (ReplNode node, config) -> do
-            omit <- Lens.use (field @"omit")
-            putStrLn' $ "Config at node " <> show node <> " is:"
-            tell $ unparseStrategy omit config
+  maybeConfig <- getConfigAt configNode
+  case maybeConfig of
+    Nothing -> putStrLn' "Invalid node!"
+    Just (ReplNode node, config) -> do
+      omit <- Lens.use (field @"omit")
+      putStrLn' $ "Config at node " <> show node <> " is:"
+      tell $ unparseStrategy omit config
 
 -- | Shows current omit list if passed 'Nothing'. Adds/removes from the list
 -- depending on whether the string already exists in the list or not.
 omitCell
-    :: forall claim m
-    .  Monad m
-    => Maybe String
-    -- ^ Nothing to show current list, @Just str@ to add/remove to list
-    -> ReplM claim m ()
+  :: forall claim m. Monad m
+  => Maybe String
+  -- ^ Nothing to show current list, @Just str@ to add/remove to list
+  -> ReplM claim m ()
 omitCell =
-    \case
-        Nothing  -> showCells
-        Just str -> addOrRemove str
+  \case
+    Nothing -> showCells
+    Just str -> addOrRemove str
   where
     showCells :: ReplM claim m ()
     showCells = do
-        omit <- Lens.use (field @"omit")
-        if Set.null omit
-            then putStrLn' "Omit list is currently empty."
-            else Foldable.traverse_ putStrLn' omit
-
+      omit <- Lens.use (field @"omit")
+      if Set.null omit
+        then putStrLn' "Omit list is currently empty."
+        else Foldable.traverse_ putStrLn' omit
     addOrRemove :: String -> ReplM claim m ()
     addOrRemove str = field @"omit" %= toggle str
-
     toggle :: String -> Set String -> Set String
     toggle x xs
       | x `Set.member` xs = x `Set.delete` xs
-      | otherwise         = x `Set.insert` xs
+      | otherwise = x `Set.insert` xs
 
 -- | Shows all leaf nodes identifiers which are either stuck or can be
 -- evaluated further.
 showLeafs
-    :: forall claim m
-    .  Claim claim
-    => Monad m
-    => ReplM claim m ()
+  :: forall claim m. Claim claim
+  => Monad m
+  => ReplM claim m ()
 showLeafs = do
-    leafsByType <- sortLeafsByType <$> getInnerGraph
-    case Map.foldMapWithKey showPair leafsByType of
-        "" -> putStrLn' "No leafs found, proof is complete."
-        xs -> putStrLn' xs
+  leafsByType <- sortLeafsByType <$> getInnerGraph
+  case Map.foldMapWithKey showPair leafsByType of
+    "" -> putStrLn' "No leafs found, proof is complete."
+    xs -> putStrLn' xs
   where
     showPair :: NodeState -> [Graph.Node] -> String
     showPair ns xs = show ns <> ": " <> show xs
 
 proofStatus
-    :: forall claim m
-    .  Claim claim
-    => Monad m
-    => ReplM claim m ()
+  :: forall claim m. Claim claim
+  => Monad m
+  => ReplM claim m ()
 proofStatus = do
-    proofs <- allProofs
-    putStrLn' . showProofStatus $ proofs
+  proofs <- allProofs
+  putStrLn' . showProofStatus $ proofs
 
 allProofs
-    :: forall claim axiom m
-    .  Claim claim
-    => axiom ~ Rule claim
-    => Monad m
-    => ReplM claim m (Map.Map ClaimIndex GraphProofStatus)
+  :: forall claim axiom m. Claim claim
+  => axiom ~ Rule claim
+  => Monad m
+  => ReplM claim m (Map.Map ClaimIndex GraphProofStatus)
 allProofs = do
-    graphs <- Lens.use (field @"graphs")
-    claims <- Lens.use (field @"claims")
-    let cindexes = ClaimIndex <$> [0..length claims - 1]
-    return
-        $ Map.union
-            (fmap inProgressProofs graphs)
-            (notStartedProofs graphs (Map.fromList $ zip cindexes claims))
+  graphs <- Lens.use (field @"graphs")
+  claims <- Lens.use (field @"claims")
+  let cindexes = ClaimIndex <$> [0 .. length claims - 1]
+  return
+    $ Map.union
+        (fmap inProgressProofs graphs)
+        (notStartedProofs graphs (Map.fromList $ zip cindexes claims))
   where
     inProgressProofs
-        :: ExecutionGraph axiom
-        -> GraphProofStatus
+      :: ExecutionGraph axiom
+      -> GraphProofStatus
     inProgressProofs =
-        findProofStatus
+      findProofStatus
         . sortLeafsByType
         . Strategy.graph
-
     notStartedProofs
-        :: Claim claim
-        => Map.Map ClaimIndex (ExecutionGraph axiom)
-        -> Map.Map ClaimIndex claim
-        -> Map.Map ClaimIndex GraphProofStatus
+      :: Claim claim
+      => Map.Map ClaimIndex (ExecutionGraph axiom)
+      -> Map.Map ClaimIndex claim
+      -> Map.Map ClaimIndex GraphProofStatus
     notStartedProofs gphs cls =
-        notStartedOrTrusted <$> cls `Map.difference` gphs
-
+      notStartedOrTrusted <$> cls `Map.difference` gphs
     notStartedOrTrusted :: claim -> GraphProofStatus
     notStartedOrTrusted cl =
-        if isTrusted cl
-           then TrustedClaim
-           else NotStarted
-
+      if isTrusted cl
+        then TrustedClaim
+        else NotStarted
     findProofStatus :: Map.Map NodeState [Graph.Node] -> GraphProofStatus
     findProofStatus m =
-        case Map.lookup StuckNode m of
-            Nothing -> case Map.lookup UnevaluatedNode m of
-                           Nothing -> Completed
-                           Just ns -> InProgress ns
-            Just ns -> StuckProof ns
+      case Map.lookup StuckNode m of
+        Nothing -> case Map.lookup UnevaluatedNode m of
+          Nothing -> Completed
+          Just ns -> InProgress ns
+        Just ns -> StuckProof ns
 
 showRule
-    :: MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => Claim claim
-    => Maybe ReplNode
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => Claim claim
+  => Maybe ReplNode
+  -> m ()
 showRule configNode = do
-    maybeRule <- getRuleFor configNode
-    case maybeRule of
-        Nothing -> putStrLn' "Invalid node!"
-        Just rule -> do
-            axioms <- Lens.use (field @"axioms")
-            tell . showRewriteRule $ rule
-            let ruleIndex = getRuleIndex . coerce $ rule
-            putStrLn'
-                $ fromMaybe "Error: identifier attribute wasn't initialized."
-                $ showAxiomOrClaim (length axioms) ruleIndex
+  maybeRule <- getRuleFor configNode
+  case maybeRule of
+    Nothing -> putStrLn' "Invalid node!"
+    Just rule -> do
+      axioms <- Lens.use (field @"axioms")
+      tell . showRewriteRule $ rule
+      let ruleIndex = getRuleIndex . coerce $ rule
+      putStrLn'
+        $ fromMaybe "Error: identifier attribute wasn't initialized."
+        $ showAxiomOrClaim (length axioms) ruleIndex
   where
     getRuleIndex :: RulePattern Variable -> Attribute.RuleIndex
     getRuleIndex = Attribute.identifier . Rule.attributes
 
 -- | Shows the previous branching point.
 showPrecBranch
-    :: Claim claim
-    => Monad m
-    => Maybe ReplNode
-    -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
-    -> ReplM claim m ()
+  :: Claim claim
+  => Monad m
+  => Maybe ReplNode
+  -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
+  -> ReplM claim m ()
 showPrecBranch maybeNode = do
-    graph <- getInnerGraph
-    node' <- getTargetNode maybeNode
-    case node' of
-        Nothing -> putStrLn' "Invalid node!"
-        Just node -> putStrLn' . show $ loop (loopCond graph) (unReplNode node)
+  graph <- getInnerGraph
+  node' <- getTargetNode maybeNode
+  case node' of
+    Nothing -> putStrLn' "Invalid node!"
+    Just node -> putStrLn' . show $ loop (loopCond graph) (unReplNode node)
   where
     -- "Left n" means continue looping with value being n
     -- "Right n" means "stop and return n"
     loopCond gph n
       | isNotBranch gph n && isNotRoot gph n = Left $ head (Graph.pre gph n)
       | otherwise = Right n
-
     isNotBranch gph n = Graph.outdeg gph n <= 1
     isNotRoot gph n = not . null . Graph.pre gph $ n
 
 -- | Shows the next node(s) for the selected node.
 showChildren
-    :: Claim claim
-    => Monad m
-    => Maybe ReplNode
-    -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
-    -> ReplM claim m ()
+  :: Claim claim
+  => Monad m
+  => Maybe ReplNode
+  -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
+  -> ReplM claim m ()
 showChildren maybeNode = do
-    graph <- getInnerGraph
-    node' <- getTargetNode maybeNode
-    case node' of
-        Nothing -> putStrLn' "Invalid node!"
-        Just node -> putStrLn' . show . Graph.suc graph $ unReplNode node
+  graph <- getInnerGraph
+  node' <- getTargetNode maybeNode
+  case node' of
+    Nothing -> putStrLn' "Invalid node!"
+    Just node -> putStrLn' . show . Graph.suc graph $ unReplNode node
 
 -- | Shows existing labels or go to an existing label.
 label
-    :: forall m claim
-    .  MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => Claim claim
-    => Maybe String
-    -- ^ 'Nothing' for show labels, @Just str@ for jumping to the string label.
-    -> m ()
+  :: forall m claim. MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => Claim claim
+  => Maybe String
+  -- ^ 'Nothing' for show labels, @Just str@ for jumping to the string label.
+  -> m ()
 label =
-    \case
-        Nothing  -> showLabels
-        Just lbl -> gotoLabel lbl
+  \case
+    Nothing -> showLabels
+    Just lbl -> gotoLabel lbl
   where
     showLabels :: m ()
     showLabels = do
-        lbls <- getLabels
-        putStrLn' $ Map.foldrWithKey acc "Labels: " lbls
-
+      lbls <- getLabels
+      putStrLn' $ Map.foldrWithKey acc "Labels: " lbls
     gotoLabel :: String -> m ()
     gotoLabel l = do
-        lbls <- getLabels
-        selectNode $ fromMaybe (ReplNode $ -1) (Map.lookup l lbls)
-
+      lbls <- getLabels
+      selectNode $ fromMaybe (ReplNode $ -1) (Map.lookup l lbls)
     acc :: String -> ReplNode -> String -> String
     acc key node res =
-        res <> "\n  " <> key <> ": " <> show (unReplNode node)
+      res <> "\n  " <> key <> ": " <> show (unReplNode node)
 
 -- | Adds label for selected node.
 labelAdd
-    :: MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => Claim claim
-    => String
-    -- ^ label
-    -> Maybe ReplNode
-    -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => Claim claim
+  => String
+  -- ^ label
+  -> Maybe ReplNode
+  -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
+  -> m ()
 labelAdd lbl maybeNode = do
-    node' <- getTargetNode maybeNode
-    case node' of
-        Nothing -> putStrLn' "Target node is not in the graph."
-        Just node -> do
-            labels <- getLabels
-            if lbl `Map.notMember` labels
-                then do
-                    setLabels $ Map.insert lbl node labels
-                    putStrLn' "Label added."
-                else
-                    putStrLn' "Label already exists."
+  node' <- getTargetNode maybeNode
+  case node' of
+    Nothing -> putStrLn' "Target node is not in the graph."
+    Just node -> do
+      labels <- getLabels
+      if lbl `Map.notMember` labels
+        then do
+          setLabels $ Map.insert lbl node labels
+          putStrLn' "Label added."
+        else putStrLn' "Label already exists."
 
 -- | Removes a label.
 labelDel
-    :: MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => String
-    -- ^ label
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => String
+  -- ^ label
+  -> m ()
 labelDel lbl = do
-    labels <- getLabels
-    if lbl `Map.member` labels
-       then do
-           setLabels $ Map.delete lbl labels
-           putStrLn' "Removed label."
-       else
-           putStrLn' "Label doesn't exist."
+  labels <- getLabels
+  if lbl `Map.member` labels
+    then do
+      setLabels $ Map.delete lbl labels
+      putStrLn' "Removed label."
+    else putStrLn' "Label doesn't exist."
 
 -- | Redirect command to specified file.
 redirect
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => ReplCommand
-    -- ^ command to redirect
-    -> FilePath
-    -- ^ file path
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => ReplCommand
+  -- ^ command to redirect
+  -> FilePath
+  -- ^ file path
+  -> ReplM claim m ()
 redirect cmd file = do
-    liftIO $ withExistingDirectory file (`writeFile` "")
-    appendCommand cmd file
+  liftIO $ withExistingDirectory file (`writeFile` "")
+  appendCommand cmd file
 
 runInterpreterWithOutput
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => PrintAuxOutput
-    -> PrintKoreOutput
-    -> ReplCommand
-    -> Config claim m
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => PrintAuxOutput
+  -> PrintKoreOutput
+  -> ReplCommand
+  -> Config claim m
+  -> ReplM claim m ()
 runInterpreterWithOutput printAux printKore cmd config =
-    get >>= (\st -> lift
-            $ execStateReader config st
-            $ replInterpreter0 printAux printKore cmd
-            )
-        >>= put
+  get
+    >>= ( \st ->
+            lift
+              $ execStateReader config st
+              $ replInterpreter0 printAux printKore cmd
+          )
+    >>= put
 
 data AlsoApplyRule = Never | IfPossible
 
 -- | Attempt to use a specific axiom or claim to see if it unifies with the
 -- current node.
 tryAxiomClaim
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => RuleReference
-    -- ^ tagged index in the axioms or claims list
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => RuleReference
+  -- ^ tagged index in the axioms or claims list
+  -> ReplM claim m ()
 tryAxiomClaim = tryAxiomClaimWorker Never
 
 -- | Attempt to use a specific axiom or claim to progress the current proof.
 tryFAxiomClaim
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => RuleReference
-    -- ^ tagged index in the axioms or claims list
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => RuleReference
+  -- ^ tagged index in the axioms or claims list
+  -> ReplM claim m ()
 tryFAxiomClaim = tryAxiomClaimWorker IfPossible
 
 tryAxiomClaimWorker
-    :: forall claim axiom m
-    .  Claim claim
-    => axiom ~ Rule claim
-    => MonadSimplify m
-    => MonadIO m
-    => AlsoApplyRule
-    -> RuleReference
-    -- ^ tagged index in the axioms or claims list
-    -> ReplM claim m ()
+  :: forall claim axiom m. Claim claim
+  => axiom ~ Rule claim
+  => MonadSimplify m
+  => MonadIO m
+  => AlsoApplyRule
+  -> RuleReference
+  -- ^ tagged index in the axioms or claims list
+  -> ReplM claim m ()
 tryAxiomClaimWorker mode ref = do
-    maybeAxiomOrClaim <-
-        ruleReference
-            getAxiomOrClaimByIndex
-            getAxiomOrClaimByName
-            ref
-    case maybeAxiomOrClaim of
-       Nothing ->
-           putStrLn' "Could not find axiom or claim."
-       Just axiomOrClaim -> do
-           node <- Lens.use (field @"node")
-           case mode of
-               Never ->
-                   showUnificationFailure axiomOrClaim node
-               IfPossible ->
-                   tryForceAxiomOrClaim axiomOrClaim node
+  maybeAxiomOrClaim <-
+    ruleReference
+      getAxiomOrClaimByIndex
+      getAxiomOrClaimByName
+      ref
+  case maybeAxiomOrClaim of
+    Nothing ->
+      putStrLn' "Could not find axiom or claim."
+    Just axiomOrClaim -> do
+      node <- Lens.use (field @"node")
+      case mode of
+        Never ->
+          showUnificationFailure axiomOrClaim node
+        IfPossible ->
+          tryForceAxiomOrClaim axiomOrClaim node
   where
     showUnificationFailure
-        :: Either axiom claim
-        -> ReplNode
-        -> ReplM claim m ()
+      :: Either axiom claim
+      -> ReplNode
+      -> ReplM claim m ()
     showUnificationFailure axiomOrClaim' node = do
-        let first = extractLeftPattern axiomOrClaim'
-        maybeSecond <- getConfigAt (Just node)
-        case maybeSecond of
-            Nothing -> putStrLn' "Unexpected error getting current config."
-            Just (_, second) ->
-                proofState
-                    ProofStateTransformer
-                        { provenValue        = putStrLn' "Cannot unify bottom"
-                        , goalTransformer    = runUnifier' first . term
-                        , goalRemTransformer = runUnifier' first . term
-                        }
-                    second
-
+      let first = extractLeftPattern axiomOrClaim'
+      maybeSecond <- getConfigAt (Just node)
+      case maybeSecond of
+        Nothing -> putStrLn' "Unexpected error getting current config."
+        Just (_, second) ->
+          proofState ProofStateTransformer
+            { provenValue = putStrLn' "Cannot unify bottom",
+              goalTransformer = runUnifier' first . term,
+              goalRemTransformer = runUnifier' first . term
+              }
+            second
     tryForceAxiomOrClaim
-        :: Either axiom claim
-        -> ReplNode
-        -> ReplM claim m ()
+      :: Either axiom claim
+      -> ReplNode
+      -> ReplM claim m ()
     tryForceAxiomOrClaim axiomOrClaim node = do
-        (graph, result) <-
-            runStepper'
-                (either mempty pure   axiomOrClaim)
-                (either pure   mempty axiomOrClaim)
-                node
-        case result of
-            NoResult ->
-                showUnificationFailure axiomOrClaim node
-            SingleResult nextNode -> do
-                updateExecutionGraph graph
-                field @"node" .= nextNode
-            BranchResult _ ->
-                updateExecutionGraph graph
-
+      (graph, result) <-
+        runStepper'
+          (either mempty pure axiomOrClaim)
+          (either pure mempty axiomOrClaim)
+          node
+      case result of
+        NoResult ->
+          showUnificationFailure axiomOrClaim node
+        SingleResult nextNode -> do
+          updateExecutionGraph graph
+          field @"node" .= nextNode
+        BranchResult _ ->
+          updateExecutionGraph graph
     runUnifier'
-        :: TermLike Variable
-        -> TermLike Variable
-        -> ReplM claim m ()
+      :: TermLike Variable
+      -> TermLike Variable
+      -> ReplM claim m ()
     runUnifier' first second =
-        runUnifier first second
-        >>= tell . formatUnificationMessage
-
+      runUnifier first second
+        >>= tell
+        . formatUnificationMessage
     extractLeftPattern :: Either axiom claim -> TermLike Variable
     extractLeftPattern = left . either coerce coerce
 
 -- | Removes specified node and all its child nodes.
 clear
-    :: forall m claim axiom
-    .  MonadState (ReplState claim) m
-    => Claim claim
-    => axiom ~ Rule claim
-    => MonadWriter ReplOutput m
-    => Maybe ReplNode
-    -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
-    -> m ()
+  :: forall m claim axiom. MonadState (ReplState claim) m
+  => Claim claim
+  => axiom ~ Rule claim
+  => MonadWriter ReplOutput m
+  => Maybe ReplNode
+  -- ^ 'Nothing' for current node, or @Just n@ for a specific node identifier
+  -> m ()
 clear =
-    \case
-        Nothing -> Just <$> Lens.use (field @"node") >>= clear
-        Just node
-          | unReplNode node == 0 -> putStrLn' "Cannot clear initial node (0)."
-          | otherwise -> clear0 node
+  \case
+    Nothing -> Just <$> Lens.use (field @"node") >>= clear
+    Just node
+      | unReplNode node == 0 -> putStrLn' "Cannot clear initial node (0)."
+      | otherwise -> clear0 node
   where
     clear0 :: ReplNode -> m ()
     clear0 rnode = do
-        graph <- getInnerGraph
-        let node = unReplNode rnode
-        let
-            nodesToBeRemoved = collect (next graph) node
-            graph' = Graph.delNodes nodesToBeRemoved graph
-        updateInnerGraph graph'
-        field @"node" .= ReplNode (prevNode graph' node)
-        putStrLn' $ "Removed " <> show (length nodesToBeRemoved) <> " node(s)."
-
+      graph <- getInnerGraph
+      let node = unReplNode rnode
+      let nodesToBeRemoved = collect (next graph) node
+          graph' = Graph.delNodes nodesToBeRemoved graph
+      updateInnerGraph graph'
+      field @"node" .= ReplNode (prevNode graph' node)
+      putStrLn' $ "Removed " <> show (length nodesToBeRemoved) <> " node(s)."
     next :: InnerGraph axiom -> Graph.Node -> [Graph.Node]
     next gr n = fst <$> Graph.lsuc gr n
-
     collect :: (a -> [a]) -> a -> [a]
-    collect f x = x : [ z | y <- f x, z <- collect f y]
-
+    collect f x = x : [z | y <- f x, z <- collect f y]
     prevNode :: InnerGraph axiom -> Graph.Node -> Graph.Node
     prevNode graph = fromMaybe 0 . listToMaybe . fmap fst . Graph.lpre graph
 
 -- | Save this sessions' commands to the specified file.
 saveSession
-    :: forall m claim
-    .  MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => MonadIO m
-    => FilePath
-    -- ^ path to file
-    -> m ()
+  :: forall m claim. MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => MonadIO m
+  => FilePath
+  -- ^ path to file
+  -> m ()
 saveSession path =
-    withExistingDirectory path saveToFile
+  withExistingDirectory path saveToFile
   where
     saveToFile :: FilePath -> m ()
     saveToFile file = do
-        content <- seqUnlines <$> Lens.use (field @"commands")
-        liftIO $ writeFile file content
-        putStrLn' "Done."
+      content <- seqUnlines <$> Lens.use (field @"commands")
+      liftIO $ writeFile file content
+      putStrLn' "Done."
     seqUnlines :: Seq String -> String
     seqUnlines = unlines . toList
 
@@ -864,124 +908,122 @@ saveSession path =
 -- one process for each KoreOut in the command's output. AuxOut will not be piped,
 -- instead it will be sent directly to the repl's output.
 pipe
-    :: forall claim m
-    .  Claim claim
-    => MonadIO m
-    => MonadSimplify m
-    => ReplCommand
-    -- ^ command to pipe
-    -> String
-    -- ^ path to the program that will receive the command's output
-    -> [String]
-    -- ^ additional arguments to be passed to the program
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadIO m
+  => MonadSimplify m
+  => ReplCommand
+  -- ^ command to pipe
+  -> String
+  -- ^ path to the program that will receive the command's output
+  -> [String]
+  -- ^ additional arguments to be passed to the program
+  -> ReplM claim m ()
 pipe cmd file args = do
-    exists <- liftIO $ findExecutable file
-    case exists of
-        Nothing -> putStrLn' "Cannot find executable."
-        Just exec -> do
-            config <- ask
-            pipeOutRef <- liftIO $ newIORef (mempty :: ReplOutput)
-            runInterpreterWithOutput
-                (PrintAuxOutput $ justPrint pipeOutRef)
-                (PrintKoreOutput $ runExternalProcess pipeOutRef exec)
-                cmd
-                config
-            pipeOut <- liftIO $ readIORef pipeOutRef
-            tell pipeOut
+  exists <- liftIO $ findExecutable file
+  case exists of
+    Nothing -> putStrLn' "Cannot find executable."
+    Just exec -> do
+      config <- ask
+      pipeOutRef <- liftIO $ newIORef (mempty :: ReplOutput)
+      runInterpreterWithOutput
+        (PrintAuxOutput $ justPrint pipeOutRef)
+        (PrintKoreOutput $ runExternalProcess pipeOutRef exec)
+        cmd
+        config
+      pipeOut <- liftIO $ readIORef pipeOutRef
+      tell pipeOut
   where
     createProcess' exec =
-        liftIO $ createProcess (proc exec args)
-            { std_in = CreatePipe, std_out = CreatePipe }
+      liftIO
+        $ createProcess
+            (proc exec args)
+              { std_in = CreatePipe,
+                std_out = CreatePipe
+                }
     runExternalProcess :: IORef ReplOutput -> String -> String -> IO ()
     runExternalProcess pipeOut exec str = do
-        (maybeInput, maybeOutput, _, _) <- createProcess' exec
-        let outputFunc = maybe putStrLn hPutStr maybeInput
-        outputFunc str
-        case maybeOutput of
-            Nothing ->
-                putStrLn "Error: couldn't access output handle."
-            Just handle -> do
-                output <- liftIO $ hGetContents handle
-                modifyIORef pipeOut (appReplOut . AuxOut $ output)
+      (maybeInput, maybeOutput, _, _) <- createProcess' exec
+      let outputFunc = maybe putStrLn hPutStr maybeInput
+      outputFunc str
+      case maybeOutput of
+        Nothing ->
+          putStrLn "Error: couldn't access output handle."
+        Just handle -> do
+          output <- liftIO $ hGetContents handle
+          modifyIORef pipeOut (appReplOut . AuxOut $ output)
     justPrint :: IORef ReplOutput -> String -> IO ()
     justPrint outRef = modifyIORef outRef . appReplOut . AuxOut
 
 -- | Appends output of a command to a file.
 appendTo
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => ReplCommand
-    -- ^ command
-    -> FilePath
-    -- ^ file to append to
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => ReplCommand
+  -- ^ command
+  -> FilePath
+  -- ^ file to append to
+  -> ReplM claim m ()
 appendTo cmd file =
-    withExistingDirectory file (appendCommand cmd)
+  withExistingDirectory file (appendCommand cmd)
 
 appendCommand
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => ReplCommand
-    -> FilePath
-    -> ReplM claim m ()
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => ReplCommand
+  -> FilePath
+  -> ReplM claim m ()
 appendCommand cmd file = do
-    config <- ask
-    runInterpreterWithOutput
-        (PrintAuxOutput $ appendFile file)
-        (PrintKoreOutput $ appendFile file)
-        cmd
-        config
-    putStrLn' $ "Redirected output to \"" <> file <> "\"."
+  config <- ask
+  runInterpreterWithOutput
+    (PrintAuxOutput $ appendFile file)
+    (PrintKoreOutput $ appendFile file)
+    cmd
+    config
+  putStrLn' $ "Redirected output to \"" <> file <> "\"."
 
 alias
-    :: forall m claim
-    .  MonadState (ReplState claim) m
-    => MonadWriter ReplOutput m
-    => AliasDefinition
-    -> m ()
+  :: forall m claim. MonadState (ReplState claim) m
+  => MonadWriter ReplOutput m
+  => AliasDefinition
+  -> m ()
 alias a = do
-    result <- runExceptT $ addOrUpdateAlias a
-    case result of
-        Left err -> putStrLn' $ showAliasError err
-        Right _  -> pure ()
+  result <- runExceptT $ addOrUpdateAlias a
+  case result of
+    Left err -> putStrLn' $ showAliasError err
+    Right _ -> pure ()
 
 tryAlias
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => ReplAlias
-    -> PrintAuxOutput
-    -> PrintKoreOutput
-    -> ReplM claim m ReplStatus
-tryAlias replAlias@ReplAlias { name } printAux printKore = do
-    res <- findAlias name
-    case res of
-        Nothing  -> showUsage $> Continue
-        Just aliasDef -> do
-            let
-                command = substituteAlias aliasDef replAlias
-                parsedCommand =
-                    fromMaybe ShowUsage $ parseMaybe commandParser command
-            config <- ask
-            (cont, st') <- get >>= runInterpreter parsedCommand config
-            put st'
-            return cont
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => ReplAlias
+  -> PrintAuxOutput
+  -> PrintKoreOutput
+  -> ReplM claim m ReplStatus
+tryAlias replAlias@ReplAlias {name} printAux printKore = do
+  res <- findAlias name
+  case res of
+    Nothing -> showUsage $> Continue
+    Just aliasDef -> do
+      let command = substituteAlias aliasDef replAlias
+          parsedCommand =
+            fromMaybe ShowUsage $ parseMaybe commandParser command
+      config <- ask
+      (cont, st') <- get >>= runInterpreter parsedCommand config
+      put st'
+      return cont
   where
     runInterpreter
-        :: ReplCommand
-        -> Config claim m
-        -> ReplState claim
-        -> ReplM claim m (ReplStatus, ReplState claim)
+      :: ReplCommand
+      -> Config claim m
+      -> ReplState claim
+      -> ReplM claim m (ReplStatus, ReplState claim)
     runInterpreter cmd config st =
-        lift
-            $ (`runStateT` st)
-            $ runReaderT (replInterpreter0 printAux printKore cmd) config
+      lift
+        $ (`runStateT` st)
+        $ runReaderT (replInterpreter0 printAux printKore cmd) config
 
 -- | Performs n proof steps, picking the next node unless branching occurs.
 -- Returns 'Left' while it has to continue looping, and 'Right' when done
@@ -989,108 +1031,104 @@ tryAlias replAlias@ReplAlias { name } printAux printKore = do
 --
 -- See 'loopM' for details.
 performStepNoBranching
-    :: forall claim m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => (Natural, StepResult)
-    -- ^ (current step, last result)
-    -> ReplM claim m (Either (Natural, StepResult) (Natural, StepResult))
+  :: forall claim m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => (Natural, StepResult)
+  -- ^ (current step, last result)
+  -> ReplM claim m (Either (Natural, StepResult) (Natural, StepResult))
 performStepNoBranching =
-    \case
-        -- Termination branch
-        (0, res) -> pure $ Right (0, res)
-        -- Loop branch
-        (n, SingleResult _) -> do
-            res <- runStepper
-            pure $ Left (n-1, res)
-        -- Early exit when there is a branch or there is no next.
-        (n, res) -> pure $ Right (n, res)
+  \case
+    -- Termination branch
+    (0, res) -> pure $ Right (0, res)
+    -- Loop branch
+    (n, SingleResult _) -> do
+      res <- runStepper
+      pure $ Left (n -1, res)
+    -- Early exit when there is a branch or there is no next.
+    (n, res) -> pure $ Right (n, res)
 
 -- TODO(Vladimir): It would be ideal for this to be implemented in terms of
 -- 'performStepNoBranching'.
 recursiveForcedStep
-    :: Claim claim
-    => axiom ~ Rule claim
-    => Monad m
-    => Natural
-    -> ExecutionGraph axiom
-    -> ReplNode
-    -> ReplM claim m (ExecutionGraph axiom)
+  :: Claim claim
+  => axiom ~ Rule claim
+  => Monad m
+  => Natural
+  -> ExecutionGraph axiom
+  -> ReplNode
+  -> ReplM claim m (ExecutionGraph axiom)
 recursiveForcedStep n graph node
-  | n == 0    = return graph
-  | otherwise = do
-      ReplState { claims , axioms , claim } <- get
+  | n == 0 = return graph
+  | otherwise =
+    do
+      ReplState {claims, axioms, claim} <- get
       stepper <- asks stepper
-      graph'@Strategy.ExecutionGraph { graph = gr } <-
-          lift $ stepper claim claims axioms graph node
+      graph'@Strategy.ExecutionGraph {graph = gr} <-
+        lift $ stepper claim claims axioms graph node
       case Graph.suc gr (unReplNode node) of
-          [] -> return graph'
-          xs -> foldM (recursiveForcedStep $ n-1) graph' (fmap ReplNode xs)
+        [] -> return graph'
+        xs -> foldM (recursiveForcedStep $ n -1) graph' (fmap ReplNode xs)
 
 -- | Display a rule as a String.
 showRewriteRule
-    :: Coercible (RulePattern Variable) rule
-    => Unparse rule
-    => rule
-    -> ReplOutput
+  :: Coercible (RulePattern Variable) rule
+  => Unparse rule
+  => rule
+  -> ReplOutput
 showRewriteRule rule =
-    makeKoreReplOutput (unparseToString rule)
+  makeKoreReplOutput (unparseToString rule)
     <> makeAuxReplOutput
-        (show . Pretty.pretty . extractSourceAndLocation $ rule')
+         (show . Pretty.pretty . extractSourceAndLocation $ rule')
   where
     rule' = coerce rule
-
     extractSourceAndLocation
-        :: RulePattern Variable
-        -> SourceLocation
-    extractSourceAndLocation
-        (RulePattern { Axiom.attributes }) =
-            Attribute.sourceLocation attributes
+      :: RulePattern Variable
+      -> SourceLocation
+    extractSourceAndLocation (RulePattern {Axiom.attributes}) =
+      Attribute.sourceLocation attributes
 
 -- | Unparses a strategy node, using an omit list to hide specified children.
 unparseStrategy
-    :: Set String
-    -- ^ omit list
-    -> CommonProofState
-    -- ^ pattern
-    -> ReplOutput
+  :: Set String
+  -- ^ omit list
+  -> CommonProofState
+  -- ^ pattern
+  -> ReplOutput
 unparseStrategy omitList =
-    proofState ProofStateTransformer
-        { goalTransformer = makeKoreReplOutput . unparseToString . fmap hide
-        , goalRemTransformer = \pat ->
-            makeAuxReplOutput "Stuck: \n"
-            <> makeKoreReplOutput (unparseToString $ fmap hide pat)
-        , provenValue = makeAuxReplOutput "Reached bottom"
-        }
+  proofState ProofStateTransformer
+    { goalTransformer = makeKoreReplOutput . unparseToString . fmap hide,
+      goalRemTransformer = \pat ->
+        makeAuxReplOutput "Stuck: \n"
+          <> makeKoreReplOutput (unparseToString $ fmap hide pat),
+      provenValue = makeAuxReplOutput "Reached bottom"
+      }
   where
     hide :: TermLike Variable -> TermLike Variable
     hide =
-        Recursive.unfold $ \termLike ->
-            case Recursive.project termLike of
-                ann :< TermLike.ApplySymbolF app
-                  | shouldBeExcluded (applicationSymbolOrAlias app) ->
-                    -- Do not display children
-                    ann :< TermLike.ApplySymbolF (withoutChildren app)
-                projected -> projected
-
-    withoutChildren app = app { applicationChildren = [] }
-
+      Recursive.unfold $ \termLike ->
+        case Recursive.project termLike of
+          ann :< TermLike.ApplySymbolF app
+            | shouldBeExcluded (applicationSymbolOrAlias app) ->
+              -- Do not display children
+              ann :< TermLike.ApplySymbolF (withoutChildren app)
+          projected -> projected
+    withoutChildren app = app {applicationChildren = []}
     shouldBeExcluded =
-       (`elem` omitList)
-           . Text.unpack
-           . Id.getId
-           . TermLike.symbolConstructor
+      (`elem` omitList)
+        . Text.unpack
+        . Id.getId
+        . TermLike.symbolConstructor
 
 putStrLn' :: MonadWriter ReplOutput m => String -> m ()
 putStrLn' str =
-    tell . makeAuxReplOutput $ str
+  tell . makeAuxReplOutput $ str
 
 printIfNotEmpty :: String -> IO ()
 printIfNotEmpty =
-    \case
-        "" -> pure ()
-        xs -> putStr xs
+  \case
+    "" -> pure ()
+    xs -> putStr xs
 
 printNotFound :: MonadWriter ReplOutput m => m ()
 printNotFound = putStrLn' "Variable or index not found"
@@ -1099,152 +1137,158 @@ printNotFound = putStrLn' "Variable or index not found"
 -- parameter is needed in order to distinguish between axioms and claims and
 -- represents the number of available axioms.
 showDotGraph
-    :: Coercible axiom (RulePattern Variable)
-    => Int -> InnerGraph axiom -> IO ()
+  :: Coercible axiom (RulePattern Variable)
+  => Int
+  -> InnerGraph axiom
+  -> IO ()
 showDotGraph len =
-    flip Graph.runGraphvizCanvas' Graph.Xlib
-        . Graph.graphToDot (graphParams len)
+  flip Graph.runGraphvizCanvas' Graph.Xlib
+    . Graph.graphToDot (graphParams len)
 
 saveDotGraph
-    :: Coercible axiom (RulePattern Variable)
-    => Int -> InnerGraph axiom -> FilePath -> IO ()
+  :: Coercible axiom (RulePattern Variable)
+  => Int
+  -> InnerGraph axiom
+  -> FilePath
+  -> IO ()
 saveDotGraph len gr file =
-    withExistingDirectory file saveGraphImg
+  withExistingDirectory file saveGraphImg
   where
     saveGraphImg :: FilePath -> IO ()
     saveGraphImg path =
-        void
+      void
         . Graph.runGraphviz
-            (Graph.graphToDot (graphParams len) gr) Graph.Jpeg
-        $ path <> ".jpeg"
+            (Graph.graphToDot (graphParams len) gr)
+            Graph.Jpeg
+        $ path
+        <> ".jpeg"
 
 graphParams
-    :: Coercible axiom (RulePattern Variable)
-    => Int
-    -> Graph.GraphvizParams
-         Graph.Node
-         CommonProofState
-         (Seq axiom)
-         ()
-         CommonProofState
-graphParams len = Graph.nonClusteredParams
+  :: Coercible axiom (RulePattern Variable)
+  => Int
+  -> Graph.GraphvizParams
+       Graph.Node
+       CommonProofState
+       (Seq axiom)
+       ()
+       CommonProofState
+graphParams len =
+  Graph.nonClusteredParams
     { Graph.fmtEdge = \(_, _, l) ->
         [Graph.textLabel (ruleIndex l len)]
-    }
+      }
   where
     ruleIndex lbl ln =
-        case listToMaybe . toList $ lbl of
-            Nothing -> "Simpl/RD"
-            Just rule ->
-                maybe
-                    ( maybe "Unknown"
-                        Text.Lazy.pack
-                        ( showAxiomOrClaim ln
-                        . getInternalIdentifier
-                        $ rule
-                        )
-                    )
-                    Text.Lazy.fromStrict
-                    ( showAxiomOrClaimName ln (getInternalIdentifier rule)
-                    . getNameText
+      case listToMaybe . toList $ lbl of
+        Nothing -> "Simpl/RD"
+        Just rule ->
+          maybe
+            ( maybe "Unknown"
+                Text.Lazy.pack
+                ( showAxiomOrClaim ln
+                    . getInternalIdentifier
                     $ rule
-                    )
+                  )
+              )
+            Text.Lazy.fromStrict
+            ( showAxiomOrClaimName ln (getInternalIdentifier rule)
+                . getNameText
+                $ rule
+              )
 
 showAliasError :: AliasError -> String
 showAliasError =
-    \case
-        NameAlreadyDefined -> "Error: Alias name is already defined."
-        UnknownCommand     -> "Error: Command does not exist."
+  \case
+    NameAlreadyDefined -> "Error: Alias name is already defined."
+    UnknownCommand -> "Error: Command does not exist."
 
 showAxiomOrClaim :: Int -> Attribute.RuleIndex -> Maybe String
-showAxiomOrClaim _   (RuleIndex Nothing) = Nothing
+showAxiomOrClaim _ (RuleIndex Nothing) = Nothing
 showAxiomOrClaim len (RuleIndex (Just rid))
   | rid < len = Just $ "Axiom " <> show rid
   | otherwise = Just $ "Claim " <> show (rid - len)
 
 showAxiomOrClaimName
-    :: Int
-    -> Attribute.RuleIndex
-    -> AttrLabel.Label
-    -> Maybe Text.Text
+  :: Int
+  -> Attribute.RuleIndex
+  -> AttrLabel.Label
+  -> Maybe Text.Text
 showAxiomOrClaimName _ _ (AttrLabel.Label Nothing) = Nothing
 showAxiomOrClaimName _ (RuleIndex Nothing) _ = Nothing
 showAxiomOrClaimName
-    len
-    (RuleIndex (Just rid))
-    (AttrLabel.Label (Just ruleName))
-  | rid < len = Just $ "Axiom " <> ruleName
-  | otherwise = Just $ "Claim " <> ruleName
+  len
+  (RuleIndex (Just rid))
+  (AttrLabel.Label (Just ruleName))
+    | rid < len = Just $ "Axiom " <> ruleName
+    | otherwise = Just $ "Claim " <> ruleName
 
 parseEvalScript
-    :: forall claim t m
-    .  Claim claim
-    => MonadSimplify m
-    => MonadIO m
-    => MonadState (ReplState claim) (t m)
-    => MonadReader (Config claim m) (t m)
-    => Monad.Trans.MonadTrans t
-    => FilePath
-    -> t m ()
+  :: forall claim t m. Claim claim
+  => MonadSimplify m
+  => MonadIO m
+  => MonadState (ReplState claim) (t m)
+  => MonadReader (Config claim m) (t m)
+  => Monad.Trans.MonadTrans t
+  => FilePath
+  -> t m ()
 parseEvalScript file = do
-    exists <- lift . liftIO . doesFileExist $ file
-    if exists
-        then do
-            contents <- lift . liftIO $ readFile file
-            let result = runParser scriptParser file contents
-            either parseFailed executeScript result
-        else lift . liftIO . putStrLn $ "Cannot find " <> file
-
+  exists <- lift . liftIO . doesFileExist $ file
+  if exists
+    then do
+      contents <- lift . liftIO $ readFile file
+      let result = runParser scriptParser file contents
+      either parseFailed executeScript result
+    else lift . liftIO . putStrLn $ "Cannot find " <> file
   where
     parseFailed
-        :: ParseErrorBundle String String
-        -> t m ()
+      :: ParseErrorBundle String String
+      -> t m ()
     parseFailed err =
-        lift . liftIO . putStrLn
-            $ "\nCouldn't parse initial script file."
-            <> "\nParser error at: "
-            <> errorBundlePretty err
-
+      lift . liftIO . putStrLn
+        $ "\nCouldn't parse initial script file."
+        <> "\nParser error at: "
+        <> errorBundlePretty err
     executeScript
-        :: [ReplCommand]
-        -> t m ()
+      :: [ReplCommand]
+      -> t m ()
     executeScript cmds = do
-        config <- ask
-        get >>= executeCommands config >>= put
+      config <- ask
+      get >>= executeCommands config >>= put
       where
         executeCommands config st =
-           lift
-               $ execStateReader config st
-               $ Foldable.for_ cmds
-               $ replInterpreter0
-                    (PrintAuxOutput $ \_ -> return ())
-                    (PrintKoreOutput $ \_ -> return ())
+          lift
+            $ execStateReader config st
+            $ Foldable.for_ cmds
+            $ replInterpreter0
+                (PrintAuxOutput $ \_ -> return ())
+                (PrintKoreOutput $ \_ -> return ())
 
 formatUnificationMessage
-    :: Either ReplOutput (NonEmpty (Predicate Variable))
-    -> ReplOutput
+  :: Either ReplOutput (NonEmpty (Predicate Variable))
+  -> ReplOutput
 formatUnificationMessage docOrPredicate =
-    either id prettyUnifiers docOrPredicate
+  either id prettyUnifiers docOrPredicate
   where
     prettyUnifiers =
-        ReplOutput
+      ReplOutput
         . (:) (AuxOut "Succeeded with unifiers:\n")
         . List.intersperse (AuxOut . show $ Pretty.indent 2 "and")
         . map (KoreOut . show . Pretty.indent 4 . unparseUnifier)
         . Foldable.toList
     unparseUnifier c =
-        unparse
+      unparse
         . TermLike.externalizeFreshVariables
         . Pattern.toTermLike
-        $ TermLike.mkTop (TermLike.mkSortVariable "UNKNOWN") <$ c
+        $ TermLike.mkTop (TermLike.mkSortVariable "UNKNOWN")
+        <$ c
 
 showProofStatus :: Map.Map ClaimIndex GraphProofStatus -> String
 showProofStatus m =
-    Map.foldrWithKey acc "Current proof status: " m
+  Map.foldrWithKey acc "Current proof status: " m
   where
     acc :: ClaimIndex -> GraphProofStatus -> String -> String
     acc key elm res =
-        res
+      res
         <> "\n  claim "
         <> (show . unClaimIndex) key
         <> ": "
@@ -1252,7 +1296,7 @@ showProofStatus m =
 
 showCurrentClaimIndex :: ClaimIndex -> String
 showCurrentClaimIndex ci =
-    "You are currently proving claim "
+  "You are currently proving claim "
     <> show (unClaimIndex ci)
 
 execStateReader :: Monad m => env -> st -> ReaderT env (StateT st m) a -> m st
@@ -1260,15 +1304,17 @@ execStateReader config st = flip execStateT st . flip runReaderT config
 
 doesParentDirectoryExist :: MonadIO m => FilePath -> m Bool
 doesParentDirectoryExist =
-    liftIO . doesDirectoryExist . fst . splitFileName
+  liftIO . doesDirectoryExist . fst . splitFileName
 
 withExistingDirectory
-    :: MonadIO m
-    => FilePath
-    -> (FilePath -> m ())
-    -> m ()
+  :: MonadIO m
+  => FilePath
+  -> (FilePath -> m ())
+  -> m ()
 withExistingDirectory path action =
-    ifM
-        (doesParentDirectoryExist path)
-        (action path)
-        $ liftIO . putStrLn $ "Directory does not exist."
+  ifM
+    (doesParentDirectoryExist path)
+    (action path)
+    $ liftIO
+    . putStrLn
+    $ "Directory does not exist."

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -5,29 +5,43 @@ Copyright   : (c) Runtime Verification, 219
 License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 -}
-
 module Kore.Repl.Parser
-    ( commandParser
-    , scriptParser
-    ) where
+  ( commandParser,
+    scriptParser
+    )
+where
 
-import           Control.Applicative
-                 ( some, (<|>) )
+import Control.Applicative
+  ( (<|>),
+    some
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Functor
-                 ( void, ($>) )
-import           Data.List
-                 ( nub )
-import           Prelude hiding
-                 ( log )
-import           Text.Megaparsec
-                 ( Parsec, customFailure, eof, many, manyTill, noneOf, oneOf,
-                 option, optional, try )
+import Data.Functor
+  ( ($>),
+    void
+    )
+import Data.List
+  ( nub
+    )
+import qualified Kore.Logger as Logger
+import Kore.Repl.Data
+import Text.Megaparsec
+  ( Parsec,
+    customFailure,
+    eof,
+    many,
+    manyTill,
+    noneOf,
+    oneOf,
+    option,
+    optional,
+    try
+    )
 import qualified Text.Megaparsec.Char as Char
 import qualified Text.Megaparsec.Char.Lexer as L
-
-import qualified Kore.Logger as Logger
-import           Kore.Repl.Data
+import Prelude hiding
+  ( log
+    )
 
 type Parser = Parsec String String
 
@@ -35,70 +49,70 @@ type Parser = Parsec String String
 -- @
 -- maybe ShowUsage id . Text.Megaparsec.parseMaybe commandParser
 -- @
-
 scriptParser :: Parser [ReplCommand]
 scriptParser =
-    some ( skipSpacesAndComments
-         *> commandParser0 (void Char.newline)
-         <* many Char.newline
-         <* skipSpacesAndComments
-         )
+  some
+    ( skipSpacesAndComments
+        *> commandParser0 (void Char.newline)
+        <* many Char.newline
+        <* skipSpacesAndComments
+      )
     <* eof
   where
     skipSpacesAndComments :: Parser (Maybe ())
     skipSpacesAndComments =
-        optional $ spaceConsumer <* Char.newline
+      optional $ spaceConsumer <* Char.newline
 
 commandParser :: Parser ReplCommand
 commandParser = commandParser0 eof
 
 commandParser0 :: Parser () -> Parser ReplCommand
 commandParser0 endParser =
-    alias <|> log <|> commandParserExceptAlias endParser <|> tryAlias
+  alias <|> log <|> commandParserExceptAlias endParser <|> tryAlias
 
 commandParserExceptAlias :: Parser () -> Parser ReplCommand
 commandParserExceptAlias endParser = do
-    cmd <- nonRecursiveCommand
-    endOfInput cmd endParser
-        <|> pipeWith appendTo cmd
-        <|> pipeWith redirect cmd
-        <|> appendTo cmd
-        <|> redirect cmd
-        <|> pipe cmd
+  cmd <- nonRecursiveCommand
+  endOfInput cmd endParser
+    <|> pipeWith appendTo cmd
+    <|> pipeWith redirect cmd
+    <|> appendTo cmd
+    <|> redirect cmd
+    <|> pipe cmd
 
 nonRecursiveCommand :: Parser ReplCommand
 nonRecursiveCommand =
-    Foldable.asum
-        [ help
-        , showClaim
-        , showAxiom
-        , prove
-        , showGraph
-        , try proveStepsF
-        , proveSteps
-        , selectNode
-        , showConfig
-        , omitCell
-        , showLeafs
-        , showRule
-        , showPrecBranch
-        , showChildren
-        , try labelAdd
-        , try labelDel
-        , label
-        , tryForceAxiomClaim
-        , tryAxiomClaim
-        , clear
-        , saveSession
-        , loadScript
-        , proofStatus
-        , exit
-        ]
+  Foldable.asum
+    [ help,
+      showClaim,
+      showAxiom,
+      prove,
+      showGraph,
+      try proveStepsF,
+      proveSteps,
+      selectNode,
+      showConfig,
+      omitCell,
+      showLeafs,
+      showRule,
+      showPrecBranch,
+      showChildren,
+      try labelAdd,
+      try labelDel,
+      label,
+      tryForceAxiomClaim,
+      tryAxiomClaim,
+      clear,
+      saveSession,
+      loadScript,
+      proofStatus,
+      exit
+      ]
 
 pipeWith
-    :: (ReplCommand -> Parser ReplCommand)
-    -> ReplCommand
-    -> Parser ReplCommand
+  :: (ReplCommand -> Parser ReplCommand)
+  -> ReplCommand
+  -> Parser ReplCommand
 pipeWith parserCmd cmd = try (pipe cmd >>= parserCmd)
 
 endOfInput :: ReplCommand -> Parser () -> Parser ReplCommand
@@ -115,45 +129,47 @@ loadScript = LoadScript <$$> literal "load" *> quotedOrWordWithout ""
 
 showClaim :: Parser ReplCommand
 showClaim =
-    ShowClaim
+  ShowClaim
     <$$> literal "claim"
     *> optional
-        (Left <$> parseClaimDecimal <|> Right <$> ruleNameParser)
+         (Left <$> parseClaimDecimal <|> Right <$> ruleNameParser)
 
 showAxiom :: Parser ReplCommand
 showAxiom =
-    ShowAxiom
+  ShowAxiom
     <$$> literal "axiom"
     *> ( Left <$> parseAxiomDecimal
-        <|> Right <$> ruleNameParser
-       )
+           <|> Right
+           <$> ruleNameParser
+         )
 
 prove :: Parser ReplCommand
 prove =
-    Prove
+  Prove
     <$$> literal "prove"
     *> ( Left <$> parseClaimDecimal
-       <|> Right <$> ruleNameParser
-       )
+           <|> Right
+           <$> ruleNameParser
+         )
 
 showGraph :: Parser ReplCommand
 showGraph = ShowGraph <$$> literal "graph" *> optional (quotedOrWordWithout "")
 
 proveSteps :: Parser ReplCommand
 proveSteps =
-    ProveSteps <$$> literal "step" *> option 1 L.decimal <* spaceNoNewline
+  ProveSteps <$$> literal "step" *> option 1 L.decimal <* spaceNoNewline
 
 proveStepsF :: Parser ReplCommand
 proveStepsF =
-    ProveStepsF <$$> literal "stepf" *> option 1 L.decimal <* spaceNoNewline
+  ProveStepsF <$$> literal "stepf" *> option 1 L.decimal <* spaceNoNewline
 
 selectNode :: Parser ReplCommand
 selectNode = SelectNode . ReplNode <$$> literal "select" *> decimal
 
 showConfig :: Parser ReplCommand
 showConfig = do
-    dec <- literal "config" *> maybeDecimal
-    return $ ShowConfig (fmap ReplNode dec)
+  dec <- literal "config" *> maybeDecimal
+  return $ ShowConfig (fmap ReplNode dec)
 
 omitCell :: Parser ReplCommand
 omitCell = OmitCell <$$> literal "omit" *> maybeWord
@@ -163,28 +179,28 @@ showLeafs = const ShowLeafs <$$> literal "leafs"
 
 showRule :: Parser ReplCommand
 showRule = do
-    dec <- literal "rule" *> maybeDecimal
-    return $ ShowRule (fmap ReplNode dec)
+  dec <- literal "rule" *> maybeDecimal
+  return $ ShowRule (fmap ReplNode dec)
 
 showPrecBranch :: Parser ReplCommand
 showPrecBranch = do
-    dec <- literal "prec-branch" *> maybeDecimal
-    return $ ShowPrecBranch (fmap ReplNode dec)
+  dec <- literal "prec-branch" *> maybeDecimal
+  return $ ShowPrecBranch (fmap ReplNode dec)
 
 showChildren :: Parser ReplCommand
 showChildren = do
-    dec <- literal "children" *> maybeDecimal
-    return $ ShowChildren (fmap ReplNode dec)
+  dec <- literal "children" *> maybeDecimal
+  return $ ShowChildren (fmap ReplNode dec)
 
 label :: Parser ReplCommand
 label = Label <$$> literal "label" *> maybeWord
 
 labelAdd :: Parser ReplCommand
 labelAdd = do
-    literal "label"
-    literal "+"
-    w <- word
-    LabelAdd w . fmap ReplNode <$> maybeDecimal
+  literal "label"
+  literal "+"
+  w <- word
+  LabelAdd w . fmap ReplNode <$> maybeDecimal
 
 labelDel :: Parser ReplCommand
 labelDel = LabelDel <$$> literal "label" *> literal "-" *> word
@@ -194,23 +210,25 @@ exit = const Exit <$$> literal "exit"
 
 tryAxiomClaim :: Parser ReplCommand
 tryAxiomClaim =
-    Try
+  Try
     <$$> literal "try"
     *> ( try (ByIndex <$> ruleIndexParser)
-        <|> ByName <$> ruleNameParser
-       )
+           <|> ByName
+           <$> ruleNameParser
+         )
 
 tryForceAxiomClaim :: Parser ReplCommand
 tryForceAxiomClaim =
-    TryF
+  TryF
     <$$> literal "tryf"
     *> ( try (ByIndex <$> ruleIndexParser)
-        <|> ByName <$> ruleNameParser
-       )
+           <|> ByName
+           <$> ruleNameParser
+         )
 
 ruleIndexParser :: Parser (Either AxiomIndex ClaimIndex)
 ruleIndexParser =
-    Left <$> axiomIndexParser <|> Right <$> claimIndexParser
+  Left <$> axiomIndexParser <|> Right <$> claimIndexParser
 
 axiomIndexParser :: Parser AxiomIndex
 axiomIndexParser = AxiomIndex <$$> Char.string "a" *> decimal
@@ -223,72 +241,75 @@ ruleNameParser = RuleName <$$> quotedOrWordWithout ""
 
 clear :: Parser ReplCommand
 clear = do
-    dec <- literal "clear" *> maybeDecimal
-    return $ Clear (fmap ReplNode dec)
+  dec <- literal "clear" *> maybeDecimal
+  return $ Clear (fmap ReplNode dec)
 
 saveSession :: Parser ReplCommand
 saveSession =
-    SaveSession <$$> literal "save-session" *> quotedOrWordWithout ""
+  SaveSession <$$> literal "save-session" *> quotedOrWordWithout ""
 
 log :: Parser ReplCommand
 log =
-    Log
-        <$$> literal "log" *> severity
-        <**> logType
+  Log
+    <$$> literal "log"
+    *> severity
+    <**> logType
 
 severity :: Parser Logger.Severity
 severity = sDebug <|> sInfo <|> sWarning <|> sError <|> sCritical
   where
-    sDebug    = Logger.Debug    <$ literal "debug"
-    sInfo     = Logger.Info     <$ literal "info"
-    sWarning  = Logger.Warning  <$ literal "warning"
-    sError    = Logger.Error    <$ literal "error"
+    sDebug = Logger.Debug <$ literal "debug"
+    sInfo = Logger.Info <$ literal "info"
+    sWarning = Logger.Warning <$ literal "warning"
+    sError = Logger.Error <$ literal "error"
     sCritical = Logger.Critical <$ literal "critical"
 
 logType :: Parser LogType
 logType = noLogging <|> logStdOut <|> logFile
   where
-    noLogging = NoLogging   <$  literal "none"
-    logStdOut = LogToStdOut <$  literal "stdout"
-    logFile   = LogToFile   <$$> literal "file" *> quotedOrWordWithout ""
+    noLogging = NoLogging <$ literal "none"
+    logStdOut = LogToStdOut <$ literal "stdout"
+    logFile = LogToFile <$$> literal "file" *> quotedOrWordWithout ""
 
 redirect :: ReplCommand -> Parser ReplCommand
 redirect cmd =
-    Redirect cmd <$$> literal ">" *> quotedOrWordWithout ">"
+  Redirect cmd <$$> literal ">" *> quotedOrWordWithout ">"
 
 pipe :: ReplCommand -> Parser ReplCommand
 pipe cmd =
-    Pipe cmd
+  Pipe cmd
     <$$> literal "|"
     *> quotedOrWordWithout ">"
     <**> many (quotedOrWordWithout ">")
 
 appendTo :: ReplCommand -> Parser ReplCommand
 appendTo cmd =
-    AppendTo cmd
+  AppendTo cmd
     <$$> literal ">>"
     *> quotedOrWordWithout ""
 
 alias :: Parser ReplCommand
 alias = do
-    literal "alias"
-    name <- word
-    arguments <- many $ wordWithout "="
-    if nub arguments /= arguments
-        then customFailure "Error when parsing alias: duplicate argument name."
-        else pure ()
-    literal "="
-    command <- some (noneOf ['\n'])
-    return . Alias $ AliasDefinition { name, arguments, command }
+  literal "alias"
+  name <- word
+  arguments <- many $ wordWithout "="
+  if nub arguments /= arguments
+    then customFailure "Error when parsing alias: duplicate argument name."
+    else pure ()
+  literal "="
+  command <- some (noneOf ['\n'])
+  return . Alias $ AliasDefinition {name, arguments, command}
 
 tryAlias :: Parser ReplCommand
 tryAlias = do
-    name <- some (noneOf [' ']) <* Char.space
-    arguments <- many
-        (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
-    return . TryAlias $ ReplAlias { name, arguments }
+  name <- some (noneOf [' ']) <* Char.space
+  arguments <-
+    many
+      (QuotedArgument <$> quotedWord <|> SimpleArgument <$> wordWithout "")
+  return . TryAlias $ ReplAlias {name, arguments}
 
 infixr 2 <$$>
+
 infixr 1 <**>
 
 -- | These are just low-precedence versions of the original operators used for
@@ -299,21 +320,20 @@ infixr 1 <**>
 (<**>) :: Applicative f => f (a -> b) -> f a -> f b
 (<**>) = (<*>)
 
-
 spaceConsumer :: Parser ()
 spaceConsumer =
-    L.space
-        space1NoNewline
-        (L.skipLineComment "//")
-        (L.skipBlockComment "/*" "*/")
+  L.space
+    space1NoNewline
+    (L.skipLineComment "//")
+    (L.skipBlockComment "/*" "*/")
 
 space1NoNewline :: Parser ()
 space1NoNewline =
-    void . some $ oneOf [' ', '\t', '\r', '\f', '\v']
+  void . some $ oneOf [' ', '\t', '\r', '\f', '\v']
 
 spaceNoNewline :: Parser ()
 spaceNoNewline =
-    void . many $ oneOf [' ', '\t', '\r', '\f', '\v']
+  void . many $ oneOf [' ', '\t', '\r', '\f', '\v']
 
 literal :: String -> Parser ()
 literal str = void $ Char.string str <* spaceNoNewline
@@ -332,13 +352,13 @@ quotedOrWordWithout s = quotedWord <|> wordWithout s
 
 quotedWord :: Parser String
 quotedWord =
-    Char.char '"'
+  Char.char '"'
     *> manyTill L.charLiteral (Char.char '"')
     <* spaceNoNewline
 
 wordWithout :: [Char] -> Parser String
 wordWithout xs =
-    some (noneOf $ [' ', '\t', '\r', '\f', '\v', '\n'] <> xs)
+  some (noneOf $ [' ', '\t', '\r', '\f', '\v', '\n'] <> xs)
     <* spaceNoNewline
 
 maybeWord :: Parser (Maybe String)

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -5,683 +5,726 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : vladimir.ciobanu@runtimeverification.com
 -}
-
 module Kore.Repl.State
-    ( emptyExecutionGraph
-    , getClaimByIndex, getAxiomByIndex, getAxiomOrClaimByIndex
-    , getInternalIdentifier
-    , getAxiomByName, getClaimByName, getAxiomOrClaimByName
-    , getClaimIndexByName, getNameText
-    , ruleReference
-    , switchToProof
-    , getTargetNode, getInnerGraph, getExecutionGraph
-    , getConfigAt, getRuleFor, getLabels, setLabels
-    , runStepper, runStepper'
-    , runUnifier
-    , updateInnerGraph, updateExecutionGraph
-    , addOrUpdateAlias, findAlias, substituteAlias
-    , sortLeafsByType
-    , generateInProgressOPClaims
-    , currentClaimSort
-    , conjOfOnePathClaims
-    , appReplOut
-    , replOut, replOutputToString
+  ( emptyExecutionGraph,
+    getClaimByIndex,
+    getAxiomByIndex,
+    getAxiomOrClaimByIndex,
+    getInternalIdentifier,
+    getAxiomByName,
+    getClaimByName,
+    getAxiomOrClaimByName,
+    getClaimIndexByName,
+    getNameText,
+    ruleReference,
+    switchToProof,
+    getTargetNode,
+    getInnerGraph,
+    getExecutionGraph,
+    getConfigAt,
+    getRuleFor,
+    getLabels,
+    setLabels,
+    runStepper,
+    runStepper',
+    runUnifier,
+    updateInnerGraph,
+    updateExecutionGraph,
+    addOrUpdateAlias,
+    findAlias,
+    substituteAlias,
+    sortLeafsByType,
+    generateInProgressOPClaims,
+    currentClaimSort,
+    conjOfOnePathClaims,
+    appReplOut,
+    replOut,
+    replOutputToString
     )
-    where
+where
 
-import           Control.Concurrent.MVar
+import Control.Concurrent.MVar
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
-import           Control.Monad.Error.Class
-                 ( MonadError )
+  ( makeLenses
+    )
+import Control.Monad.Error.Class
+  ( MonadError
+    )
 import qualified Control.Monad.Error.Class as Monad.Error
-import           Control.Monad.IO.Class
-                 ( MonadIO, liftIO )
-import           Control.Monad.State.Strict
-                 ( MonadState, get, modify )
+import Control.Monad.IO.Class
+  ( MonadIO,
+    liftIO
+    )
+import Control.Monad.Reader
+  ( MonadReader,
+    asks
+    )
+import Control.Monad.State.Strict
+  ( MonadState,
+    get,
+    modify
+    )
 import qualified Control.Monad.Trans.Class as Monad.Trans
 import qualified Data.Bifunctor as Bifunctor
-import           Data.Bitraversable
-                 ( bisequence, bitraverse )
-import           Data.Coerce
-                 ( Coercible, coerce )
+import Data.Bitraversable
+  ( bisequence,
+    bitraverse
+    )
+import Data.Coerce
+  ( Coercible,
+    coerce
+    )
 import qualified Data.Default as Default
-import           Data.Foldable
-                 ( find )
-import           Data.Generics.Product
+import Data.Foldable
+  ( find
+    )
+import Data.Generics.Product
 import qualified Data.Graph.Inductive.Graph as Graph
-import           Data.List.Extra
-                 ( findIndex, groupSort )
-import           Data.List.NonEmpty
-                 ( NonEmpty (..) )
+import Data.List.Extra
+  ( findIndex,
+    groupSort
+    )
+import Data.List.NonEmpty
+  ( NonEmpty (..)
+    )
 import qualified Data.Map as Map
-import           Data.Map.Strict
-                 ( Map )
-import           Data.Maybe
-import           Data.Sequence
-                 ( Seq )
-import           Data.Set
-                 ( Set )
+import Data.Map.Strict
+  ( Map
+    )
+import Data.Maybe
+import Data.Sequence
+  ( Seq
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import           Data.Text
-                 ( Text, unpack )
-import           GHC.Exts
-                 ( toList )
-import           System.IO
-                 ( Handle, IOMode (AppendMode), hClose, openFile )
-
-import           Control.Monad.Reader
-                 ( MonadReader, asks )
+import Data.Text
+  ( Text,
+    unpack
+    )
+import GHC.Exts
+  ( toList
+    )
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Label as AttrLabel
-import           Kore.Goal
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
-import           Kore.Internal.Pattern
-                 ( toTermLike )
+import Kore.Goal
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
+import Kore.Internal.Pattern
+  ( toTermLike
+    )
 import qualified Kore.Internal.Predicate as IPredicate
-import           Kore.Internal.TermLike
-                 ( Sort, TermLike )
+import Kore.Internal.TermLike
+  ( Sort,
+    TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger.Output as Logger
-import           Kore.OnePath.Verification
-import           Kore.Predicate.Predicate as Predicate
-import           Kore.Repl.Data
-import           Kore.Step.Rule
-                 ( RewriteRule (..), RulePattern (..) )
-import           Kore.Step.Rule as Rule
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+import Kore.OnePath.Verification
+import Kore.Predicate.Predicate as Predicate
+import Kore.Repl.Data
+import Kore.Step.Rule
+  ( RewriteRule (..),
+    RulePattern (..)
+    )
+import Kore.Step.Rule as Rule
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.Syntax.Variable
-                 ( Variable )
+import Kore.Syntax.Variable
+  ( Variable
+    )
+import System.IO
+  ( Handle,
+    IOMode (AppendMode),
+    hClose,
+    openFile
+    )
 
 -- | Creates a fresh execution graph for the given claim.
 emptyExecutionGraph
-    :: Claim claim
-    => axiom ~ Rule claim
-    => claim -> ExecutionGraph axiom
+  :: Claim claim
+  => axiom ~ Rule claim
+  => claim
+  -> ExecutionGraph axiom
 emptyExecutionGraph =
-    Strategy.emptyExecutionGraph . extractConfig . RewriteRule . coerce
+  Strategy.emptyExecutionGraph . extractConfig . RewriteRule . coerce
   where
     extractConfig
-        :: RewriteRule Variable
-        -> CommonProofState
-    extractConfig (RewriteRule RulePattern { left, requires }) =
-        Goal $ Conditional left requires mempty
+      :: RewriteRule Variable
+      -> CommonProofState
+    extractConfig (RewriteRule RulePattern {left, requires}) =
+      Goal $ Conditional left requires mempty
 
 ruleReference
-    :: (Either AxiomIndex ClaimIndex -> a)
-    -> (RuleName -> a)
-    -> RuleReference
-    -> a
+  :: (Either AxiomIndex ClaimIndex -> a)
+  -> (RuleName -> a)
+  -> RuleReference
+  -> a
 ruleReference f g ref =
-    case ref of
-        ByIndex axiomOrClaimIndex ->
-            f axiomOrClaimIndex
-        ByName ruleName ->
-            g ruleName
+  case ref of
+    ByIndex axiomOrClaimIndex ->
+      f axiomOrClaimIndex
+    ByName ruleName ->
+      g ruleName
 
 -- | Get nth claim from the claims list.
 getClaimByIndex
-    :: MonadState (ReplState claim) m
-    => Int
-    -- ^ index in the claims list
-    -> m (Maybe claim)
+  :: MonadState (ReplState claim) m
+  => Int
+  -- ^ index in the claims list
+  -> m (Maybe claim)
 getClaimByIndex index = Lens.preuse $ field @"claims" . Lens.element index
 
 -- | Get nth axiom from the axioms list.
 getAxiomByIndex
-    :: MonadState (ReplState claim) m
-    => Int
-    -- ^ index in the axioms list
-    -> m (Maybe (Rule claim))
+  :: MonadState (ReplState claim) m
+  => Int
+  -- ^ index in the axioms list
+  -> m (Maybe (Rule claim))
 getAxiomByIndex index = Lens.preuse $ field @"axioms" . Lens.element index
 
 -- | Get the leftmost axiom with a specific name from the axioms list.
 getAxiomByName
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Coercible axiom (RulePattern Variable)
-    => Coercible (RulePattern Variable) axiom
-    => String
-    -- ^ label attribute
-    -> m (Maybe axiom)
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Coercible axiom (RulePattern Variable)
+  => Coercible (RulePattern Variable) axiom
+  => String
+  -- ^ label attribute
+  -> m (Maybe axiom)
 getAxiomByName name = do
-    axioms <- Lens.use (field @"axioms")
-    return $ find (isNameEqual name) axioms
+  axioms <- Lens.use (field @"axioms")
+  return $ find (isNameEqual name) axioms
 
 -- | Get the leftmost claim with a specific name from the claim list.
 getClaimByName
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => String
-    -- ^ label attribute
-    -> m (Maybe claim)
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => String
+  -- ^ label attribute
+  -> m (Maybe claim)
 getClaimByName name = do
-    claims <- Lens.use (field @"claims")
-    return $ find (isNameEqual name) claims
+  claims <- Lens.use (field @"claims")
+  return $ find (isNameEqual name) claims
 
 getClaimIndexByName
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => String
-    -- ^ label attribute
-    -> m (Maybe ClaimIndex)
-getClaimIndexByName name= do
-    claims <- Lens.use (field @"claims")
-    return $ ClaimIndex <$> findIndex (isNameEqual name) claims
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => String
+  -- ^ label attribute
+  -> m (Maybe ClaimIndex)
+getClaimIndexByName name = do
+  claims <- Lens.use (field @"claims")
+  return $ ClaimIndex <$> findIndex (isNameEqual name) claims
 
 getAxiomOrClaimByName
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => axiom ~ Rule claim
-    => RuleName
-    -> m (Maybe (Either axiom claim))
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => axiom ~ Rule claim
+  => RuleName
+  -> m (Maybe (Either axiom claim))
 getAxiomOrClaimByName (RuleName name) = do
-    mAxiom <- getAxiomByName name
-    case mAxiom of
-        Nothing -> do
-            mClaim <- getClaimByName name
-            case mClaim of
-                Nothing -> return Nothing
-                Just claim ->
-                    return . Just . Right $ claim
-        Just axiom ->
-            return . Just . Left $ axiom
+  mAxiom <- getAxiomByName name
+  case mAxiom of
+    Nothing -> do
+      mClaim <- getClaimByName name
+      case mClaim of
+        Nothing -> return Nothing
+        Just claim ->
+          return . Just . Right $ claim
+    Just axiom ->
+      return . Just . Left $ axiom
 
 isNameEqual
-    :: Coercible rule (RulePattern Variable)
-    => String -> rule -> Bool
+  :: Coercible rule (RulePattern Variable)
+  => String
+  -> rule
+  -> Bool
 isNameEqual name rule =
-    maybe
-        False
-        ( (== name) . unpack)
-          (AttrLabel.unLabel
-          . getNameText
-          $ rule
-        )
+  maybe
+    False
+    ((== name) . unpack)
+    ( AttrLabel.unLabel
+        . getNameText
+        $ rule
+      )
 
 getNameText
-    :: Coercible rule (RulePattern Variable)
-    => rule -> AttrLabel.Label
+  :: Coercible rule (RulePattern Variable)
+  => rule
+  -> AttrLabel.Label
 getNameText =
-    Attribute.label
+  Attribute.label
     . attributes
     . coerce
 
 -- | Transforms an axiom or claim index into an axiom or claim if they could be
 -- found.
 getAxiomOrClaimByIndex
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Either AxiomIndex ClaimIndex
-    -> m (Maybe (Either axiom claim))
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Either AxiomIndex ClaimIndex
+  -> m (Maybe (Either axiom claim))
 getAxiomOrClaimByIndex =
-    fmap bisequence
-        . bitraverse
-            (getAxiomByIndex . coerce)
-            (getClaimByIndex . coerce)
+  fmap bisequence
+    . bitraverse
+        (getAxiomByIndex . coerce)
+        (getClaimByIndex . coerce)
 
 getInternalIdentifier
-    :: Coercible rule (RulePattern Variable)
-    => rule -> Attribute.RuleIndex
+  :: Coercible rule (RulePattern Variable)
+  => rule
+  -> Attribute.RuleIndex
 getInternalIdentifier =
-    Attribute.identifier
+  Attribute.identifier
     . Rule.attributes
     . coerce
 
 -- | Update the currently selected claim to prove.
 switchToProof
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => claim
-    -> ClaimIndex
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => claim
+  -> ClaimIndex
+  -> m ()
 switchToProof claim cindex =
-    modify (\st -> st
-        { claim = claim
-        , claimIndex = cindex
-        , node = ReplNode 0
-        })
+  modify
+    ( \st ->
+        st
+          { claim = claim,
+            claimIndex = cindex,
+            node = ReplNode 0
+            }
+      )
 
 -- | Get the internal representation of the execution graph.
 getInnerGraph
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Claim claim
-    => m (InnerGraph axiom)
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Claim claim
+  => m (InnerGraph axiom)
 getInnerGraph =
-    fmap Strategy.graph getExecutionGraph
+  fmap Strategy.graph getExecutionGraph
 
 -- | Get the current execution graph
 getExecutionGraph
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Claim claim
-    => m (ExecutionGraph axiom)
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Claim claim
+  => m (ExecutionGraph axiom)
 getExecutionGraph = do
-    ReplState { claimIndex, graphs, claim } <- get
-    let mgraph = Map.lookup claimIndex graphs
-    return $ fromMaybe (emptyExecutionGraph claim) mgraph
+  ReplState {claimIndex, graphs, claim} <- get
+  let mgraph = Map.lookup claimIndex graphs
+  return $ fromMaybe (emptyExecutionGraph claim) mgraph
 
 -- | Update the internal representation of the current execution graph.
 updateInnerGraph
-    :: forall claim axiom m
-    .  MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => InnerGraph axiom
-    -> m ()
+  :: forall claim axiom m. MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => InnerGraph axiom
+  -> m ()
 updateInnerGraph ig = do
-    ReplState { claimIndex, graphs } <- get
-    field @"graphs" Lens..=
-        Map.adjust (updateInnerGraph0 ig) claimIndex graphs
+  ReplState {claimIndex, graphs} <- get
+  field @"graphs"
+    Lens..= Map.adjust (updateInnerGraph0 ig) claimIndex graphs
   where
     updateInnerGraph0
-        :: InnerGraph axiom
-        -> ExecutionGraph axiom
-        -> ExecutionGraph axiom
-    updateInnerGraph0 graph Strategy.ExecutionGraph { root } =
-        Strategy.ExecutionGraph { root, graph }
+      :: InnerGraph axiom
+      -> ExecutionGraph axiom
+      -> ExecutionGraph axiom
+    updateInnerGraph0 graph Strategy.ExecutionGraph {root} =
+      Strategy.ExecutionGraph {root, graph}
 
 -- | Update the current execution graph.
 updateExecutionGraph
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => ExecutionGraph axiom
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => ExecutionGraph axiom
+  -> m ()
 updateExecutionGraph gph = do
-    ReplState { claimIndex, graphs } <- get
-    field @"graphs" Lens..= Map.insert claimIndex gph graphs
+  ReplState {claimIndex, graphs} <- get
+  field @"graphs" Lens..= Map.insert claimIndex gph graphs
 
 -- | Get the node labels for the current claim.
 getLabels
-    :: MonadState (ReplState claim) m
-    => m (Map String ReplNode)
+  :: MonadState (ReplState claim) m
+  => m (Map String ReplNode)
 getLabels = do
-    ReplState { claimIndex, labels } <- get
-    let mlabels = Map.lookup claimIndex labels
-    return $ fromMaybe Map.empty mlabels
+  ReplState {claimIndex, labels} <- get
+  let mlabels = Map.lookup claimIndex labels
+  return $ fromMaybe Map.empty mlabels
 
 -- | Update the node labels for the current claim.
 setLabels
-    :: MonadState (ReplState claim) m
-    => Map String ReplNode
-    -> m ()
+  :: MonadState (ReplState claim) m
+  => Map String ReplNode
+  -> m ()
 setLabels lbls = do
-    ReplState { claimIndex, labels } <- get
-    field @"labels" Lens..= Map.insert claimIndex lbls labels
-
+  ReplState {claimIndex, labels} <- get
+  field @"labels" Lens..= Map.insert claimIndex lbls labels
 
 -- | Get selected node (or current node for 'Nothing') and validate that it's
 -- part of the execution graph.
 getTargetNode
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => Maybe ReplNode
-    -- ^ node index
-    -> m (Maybe ReplNode)
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => Maybe ReplNode
+  -- ^ node index
+  -> m (Maybe ReplNode)
 getTargetNode maybeNode = do
-    currentNode <- Lens.use (field @"node")
-    let node' = unReplNode $ fromMaybe currentNode maybeNode
-    graph <- getInnerGraph
-    if node' `elem` Graph.nodes graph
-       then pure . Just . ReplNode $ node'
-       else pure Nothing
+  currentNode <- Lens.use (field @"node")
+  let node' = unReplNode $ fromMaybe currentNode maybeNode
+  graph <- getInnerGraph
+  if node' `elem` Graph.nodes graph
+    then pure . Just . ReplNode $ node'
+    else pure Nothing
 
 -- | Get the configuration at selected node (or current node for 'Nothing').
 getConfigAt
-    :: MonadState (ReplState claim) m
-    => Claim claim
-    => Maybe ReplNode
-    -> m (Maybe (ReplNode, CommonProofState))
+  :: MonadState (ReplState claim) m
+  => Claim claim
+  => Maybe ReplNode
+  -> m (Maybe (ReplNode, CommonProofState))
 getConfigAt maybeNode = do
-    node' <- getTargetNode maybeNode
-    case node' of
-        Nothing -> pure Nothing
-        Just n -> do
-            graph' <- getInnerGraph
-            pure $ Just (n, getLabel graph' (unReplNode n))
+  node' <- getTargetNode maybeNode
+  case node' of
+    Nothing -> pure Nothing
+    Just n -> do
+      graph' <- getInnerGraph
+      pure $ Just (n, getLabel graph' (unReplNode n))
   where
     getLabel gr n = Graph.lab' . Graph.context gr $ n
 
 -- | Get the rule used to reach selected node.
 getRuleFor
-    :: MonadState (ReplState claim) m
-    => axiom ~ Rule claim
-    => Claim claim
-    => Maybe ReplNode
-    -- ^ node index
-    -> m (Maybe axiom)
+  :: MonadState (ReplState claim) m
+  => axiom ~ Rule claim
+  => Claim claim
+  => Maybe ReplNode
+  -- ^ node index
+  -> m (Maybe axiom)
 getRuleFor maybeNode = do
-    targetNode <- getTargetNode maybeNode
-    graph' <- getInnerGraph
-    pure $ fmap unReplNode targetNode >>= getRewriteRule . Graph.inn graph'
+  targetNode <- getTargetNode maybeNode
+  graph' <- getInnerGraph
+  pure $ fmap unReplNode targetNode >>= getRewriteRule . Graph.inn graph'
   where
     getRewriteRule
-        :: [(a, b, Seq axiom)]
-        -> Maybe axiom
+      :: [(a, b, Seq axiom)]
+      -> Maybe axiom
     getRewriteRule = listToMaybe . concatMap (toList . third)
-
     third :: forall a b c. (a, b, c) -> c
     third (_, _, c) = c
 
 -- | Lifting function that takes logging into account.
 liftSimplifierWithLogger
-    :: forall a t m claim
-    .  MonadState (ReplState claim) (t m)
-    => MonadSimplify m
-    => MonadIO m
-    => Monad.Trans.MonadTrans t
-    => MVar (Logger.LogAction IO Logger.LogMessage)
-    -> m a
-    -> t m a
+  :: forall a t m claim. MonadState (ReplState claim) (t m)
+  => MonadSimplify m
+  => MonadIO m
+  => Monad.Trans.MonadTrans t
+  => MVar (Logger.LogAction IO Logger.LogMessage)
+  -> m a
+  -> t m a
 liftSimplifierWithLogger mLogger simplifier = do
-   (severity, logType) <- logging <$> get
-   (textLogger, maybeHandle) <- logTypeToLogger logType
-   let logger = Logger.makeKoreLogger severity mempty textLogger
-   _ <- Monad.Trans.lift . liftIO $ swapMVar mLogger logger
-   result <- Monad.Trans.lift simplifier
-   maybe (pure ()) (Monad.Trans.lift . liftIO . hClose) maybeHandle
-   pure result
+  (severity, logType) <- logging <$> get
+  (textLogger, maybeHandle) <- logTypeToLogger logType
+  let logger = Logger.makeKoreLogger severity mempty textLogger
+  _ <- Monad.Trans.lift . liftIO $ swapMVar mLogger logger
+  result <- Monad.Trans.lift simplifier
+  maybe (pure ()) (Monad.Trans.lift . liftIO . hClose) maybeHandle
+  pure result
   where
     logTypeToLogger
-        :: LogType
-        -> t m (Logger.LogAction IO Text, Maybe Handle)
+      :: LogType
+      -> t m (Logger.LogAction IO Text, Maybe Handle)
     logTypeToLogger =
-        \case
-            NoLogging   -> pure (mempty, Nothing)
-            LogToStdOut -> pure (Logger.logTextStderr, Nothing)
-            LogToFile file -> do
-                handle <- Monad.Trans.lift . liftIO $ openFile file AppendMode
-                pure (Logger.logTextHandle handle, Just handle)
+      \case
+        NoLogging -> pure (mempty, Nothing)
+        LogToStdOut -> pure (Logger.logTextStderr, Nothing)
+        LogToFile file -> do
+          handle <- Monad.Trans.lift . liftIO $ openFile file AppendMode
+          pure (Logger.logTextHandle handle, Just handle)
 
 -- | Run a single step for the data in state
 -- (claim, axioms, claims, current node and execution graph).
 runStepper
-    :: MonadState (ReplState claim) (t m)
-    => MonadReader (Config claim m) (t m)
-    => Monad.Trans.MonadTrans t
-    => MonadSimplify m
-    => MonadIO m
-    => Claim claim
-    => t m StepResult
+  :: MonadState (ReplState claim) (t m)
+  => MonadReader (Config claim m) (t m)
+  => Monad.Trans.MonadTrans t
+  => MonadSimplify m
+  => MonadIO m
+  => Claim claim
+  => t m StepResult
 runStepper = do
-    ReplState { claims, axioms, node } <- get
-    (graph', res) <- runStepper' claims axioms node
-    updateExecutionGraph graph'
-    case res of
-        SingleResult nextNode -> do
-            field @"node" Lens..= nextNode
-            pure res
-        _                     -> pure res
+  ReplState {claims, axioms, node} <- get
+  (graph', res) <- runStepper' claims axioms node
+  updateExecutionGraph graph'
+  case res of
+    SingleResult nextNode -> do
+      field @"node" Lens..= nextNode
+      pure res
+    _ -> pure res
 
 -- | Run a single step for the current claim with the selected claims, axioms
 -- starting at the selected node.
 runStepper'
-    :: MonadState (ReplState claim) (t m)
-    => MonadReader (Config claim m) (t m)
-    => axiom ~ Rule claim
-    => Monad.Trans.MonadTrans t
-    => MonadSimplify m
-    => MonadIO m
-    => Claim claim
-    => [claim]
-    -> [axiom]
-    -> ReplNode
-    -> t m (ExecutionGraph axiom, StepResult)
+  :: MonadState (ReplState claim) (t m)
+  => MonadReader (Config claim m) (t m)
+  => axiom ~ Rule claim
+  => Monad.Trans.MonadTrans t
+  => MonadSimplify m
+  => MonadIO m
+  => Claim claim
+  => [claim]
+  -> [axiom]
+  -> ReplNode
+  -> t m (ExecutionGraph axiom, StepResult)
 runStepper' claims axioms node = do
-    ReplState { claim } <- get
-    stepper <- asks stepper
-    mvar <- asks logger
-    gph <- getExecutionGraph
-    gr@Strategy.ExecutionGraph { graph = innerGraph } <-
-        liftSimplifierWithLogger mvar $ stepper claim claims axioms gph node
-    pure . (,) gr $ case Graph.suc innerGraph (unReplNode node) of
-        []       -> NoResult
-        [single] -> case getNodeState innerGraph single of
-                        Nothing -> NoResult
-                        Just (StuckNode, _) -> NoResult
-                        _ -> SingleResult . ReplNode $ single
-        nodes    -> BranchResult $ fmap ReplNode nodes
+  ReplState {claim} <- get
+  stepper <- asks stepper
+  mvar <- asks logger
+  gph <- getExecutionGraph
+  gr@Strategy.ExecutionGraph {graph = innerGraph} <-
+    liftSimplifierWithLogger mvar $ stepper claim claims axioms gph node
+  pure . (,) gr $ case Graph.suc innerGraph (unReplNode node) of
+    [] -> NoResult
+    [single] -> case getNodeState innerGraph single of
+      Nothing -> NoResult
+      Just (StuckNode, _) -> NoResult
+      _ -> SingleResult . ReplNode $ single
+    nodes -> BranchResult $ fmap ReplNode nodes
 
 runUnifier
-    :: MonadState (ReplState claim) (t m)
-    => MonadReader (Config claim m) (t m)
-    => Monad.Trans.MonadTrans t
-    => MonadSimplify m
-    => MonadIO m
-    => TermLike Variable
-    -> TermLike Variable
-    -> t m (Either ReplOutput (NonEmpty (IPredicate.Predicate Variable)))
+  :: MonadState (ReplState claim) (t m)
+  => MonadReader (Config claim m) (t m)
+  => Monad.Trans.MonadTrans t
+  => MonadSimplify m
+  => MonadIO m
+  => TermLike Variable
+  -> TermLike Variable
+  -> t m (Either ReplOutput (NonEmpty (IPredicate.Predicate Variable)))
 runUnifier first second = do
-    unifier <- asks unifier
-    mvar <- asks logger
-    liftSimplifierWithLogger mvar
-        . runUnifierWithExplanation
-        $ unifier first second
+  unifier <- asks unifier
+  mvar <- asks logger
+  liftSimplifierWithLogger mvar
+    . runUnifierWithExplanation
+    $ unifier first second
 
 getNodeState :: InnerGraph axiom -> Graph.Node -> Maybe (NodeState, Graph.Node)
 getNodeState graph node =
-        fmap (\nodeState -> (nodeState, node))
-        . proofState ProofStateTransformer
-            { goalTransformer = const . Just $ UnevaluatedNode
-            , goalRemTransformer = const . Just $ StuckNode
-            , provenValue = Nothing
-            }
-        . Graph.lab'
-        . Graph.context graph
-        $ node
+  fmap (\nodeState -> (nodeState, node))
+    . proofState ProofStateTransformer
+        { goalTransformer = const . Just $ UnevaluatedNode,
+          goalRemTransformer = const . Just $ StuckNode,
+          provenValue = Nothing
+          }
+    . Graph.lab'
+    . Graph.context graph
+    $ node
 
 nodeToPattern
-    :: InnerGraph axiom
-    -> Graph.Node
-    -> Maybe (TermLike Variable)
+  :: InnerGraph axiom
+  -> Graph.Node
+  -> Maybe (TermLike Variable)
 nodeToPattern graph node =
-    proofState ProofStateTransformer
-        { goalTransformer = Just . toTermLike
-        , goalRemTransformer = Just . toTermLike
-        , provenValue = Nothing
-        }
+  proofState ProofStateTransformer
+    { goalTransformer = Just . toTermLike,
+      goalRemTransformer = Just . toTermLike,
+      provenValue = Nothing
+      }
     . Graph.lab'
     . Graph.context graph
     $ node
 
 -- | Adds or updates the provided alias.
 addOrUpdateAlias
-    :: forall m claim
-    .  MonadState (ReplState claim) m
-    => MonadError AliasError m
-    => AliasDefinition
-    -> m ()
-addOrUpdateAlias alias@AliasDefinition { name, command } = do
-    checkNameIsNotUsed
-    checkCommandExists
-    field @"aliases" Lens.%= Map.insert name alias
+  :: forall m claim. MonadState (ReplState claim) m
+  => MonadError AliasError m
+  => AliasDefinition
+  -> m ()
+addOrUpdateAlias alias@AliasDefinition {name, command} = do
+  checkNameIsNotUsed
+  checkCommandExists
+  field @"aliases" Lens.%= Map.insert name alias
   where
     checkNameIsNotUsed :: m ()
     checkNameIsNotUsed =
-        not . Set.member name <$> existingCommands
-            >>= falseToError NameAlreadyDefined
-
+      not . Set.member name <$> existingCommands
+        >>= falseToError NameAlreadyDefined
     checkCommandExists :: m ()
     checkCommandExists = do
-        cmds <- existingCommands
-        let
-            maybeCommand = listToMaybe $ words command
-            maybeExists = Set.member <$> maybeCommand <*> pure cmds
-        maybe
-            (Monad.Error.throwError UnknownCommand)
-            (falseToError UnknownCommand)
-            maybeExists
-
+      cmds <- existingCommands
+      let maybeCommand = listToMaybe $ words command
+          maybeExists = Set.member <$> maybeCommand <*> pure cmds
+      maybe
+        (Monad.Error.throwError UnknownCommand)
+        (falseToError UnknownCommand)
+        maybeExists
     existingCommands :: m (Set String)
     existingCommands =
-        Set.union commandSet
+      Set.union commandSet
         . Set.fromList
         . Map.keys
         <$> Lens.use (field @"aliases")
-
     falseToError :: AliasError -> Bool -> m ()
     falseToError e b =
-        if b then pure () else Monad.Error.throwError e
-
+      if b then pure () else Monad.Error.throwError e
 
 findAlias
-    :: MonadState (ReplState claim) m
-    => String
-    -> m (Maybe AliasDefinition)
+  :: MonadState (ReplState claim) m
+  => String
+  -> m (Maybe AliasDefinition)
 findAlias name = Map.lookup name <$> Lens.use (field @"aliases")
 
 substituteAlias
-    :: AliasDefinition
-    -> ReplAlias
-    -> String
+  :: AliasDefinition
+  -> ReplAlias
+  -> String
 substituteAlias
-    AliasDefinition { arguments, command }
-    ReplAlias { arguments = actualArguments } =
+  AliasDefinition {arguments, command}
+  ReplAlias {arguments = actualArguments} =
     unwords
       . fmap replaceArguments
       . words
       $ command
-  where
-    values :: Map String AliasArgument
-    values
-      | length arguments == length actualArguments
-        = Map.fromList $ zip arguments actualArguments
-      | otherwise = Map.empty
-
-    replaceArguments :: String -> String
-    replaceArguments s = maybe s toString $ Map.lookup s values
-
-    toString :: AliasArgument -> String
-    toString = \case
+    where
+      values :: Map String AliasArgument
+      values
+        | length arguments == length actualArguments =
+          Map.fromList $ zip arguments actualArguments
+        | otherwise = Map.empty
+      replaceArguments :: String -> String
+      replaceArguments s = maybe s toString $ Map.lookup s values
+      toString :: AliasArgument -> String
+      toString = \case
         SimpleArgument str -> str
         QuotedArgument str -> "\"" <> str <> "\""
 
 createOnePathClaim
-    :: Claim claim
-    => (claim, TermLike Variable)
-    -> Rule.OnePathRule Variable
+  :: Claim claim
+  => (claim, TermLike Variable)
+  -> Rule.OnePathRule Variable
 createOnePathClaim (claim, cpattern) =
-    Rule.OnePathRule
+  Rule.OnePathRule
     $ Rule.RulePattern
-        { left = cpattern
-        , right = Rule.right . coerce $ claim
-        , requires = Predicate.makeTruePredicate
-        , ensures = Rule.ensures . coerce $ claim
-        , attributes = Default.def
+      { left = cpattern,
+        right = Rule.right . coerce $ claim,
+        requires = Predicate.makeTruePredicate,
+        ensures = Rule.ensures . coerce $ claim,
+        attributes = Default.def
         }
 
 conjOfOnePathClaims
-    :: [Rule.OnePathRule Variable]
-    -> Sort
-    -> TermLike Variable
+  :: [Rule.OnePathRule Variable]
+  -> Sort
+  -> TermLike Variable
 conjOfOnePathClaims claims sort =
-    foldr
-        TermLike.mkAnd
-        (TermLike.mkTop sort)
-        $ fmap Rule.onePathRuleToPattern claims
+  foldr
+    TermLike.mkAnd
+    (TermLike.mkTop sort)
+    $ fmap Rule.onePathRuleToPattern claims
 
 generateInProgressOPClaims
-    :: Claim claim
-    => axiom ~ Rule claim
-    => MonadState (ReplState claim) m
-    => m [Rule.OnePathRule Variable]
+  :: Claim claim
+  => axiom ~ Rule claim
+  => MonadState (ReplState claim) m
+  => m [Rule.OnePathRule Variable]
 generateInProgressOPClaims = do
-    graphs <- Lens.use (field @"graphs")
-    claims <- Lens.use (field @"claims")
-    let started = startedOPClaims graphs claims
-        notStarted = notStartedOPClaims graphs claims
-    return $ started <> notStarted
+  graphs <- Lens.use (field @"graphs")
+  claims <- Lens.use (field @"claims")
+  let started = startedOPClaims graphs claims
+      notStarted = notStartedOPClaims graphs claims
+  return $ started <> notStarted
   where
     startedOPClaims
-        :: Claim claim
-        => Map.Map ClaimIndex (ExecutionGraph axiom)
-        -> [claim]
-        -> [Rule.OnePathRule Variable]
+      :: Claim claim
+      => Map.Map ClaimIndex (ExecutionGraph axiom)
+      -> [claim]
+      -> [Rule.OnePathRule Variable]
     startedOPClaims graphs claims =
-        fmap createOnePathClaim
+      fmap createOnePathClaim
         $ claimsWithPatterns graphs claims
         >>= sequence
     notStartedOPClaims
-        :: Claim claim
-        => Map.Map ClaimIndex (ExecutionGraph axiom)
-        -> [claim]
-        -> [Rule.OnePathRule Variable]
+      :: Claim claim
+      => Map.Map ClaimIndex (ExecutionGraph axiom)
+      -> [claim]
+      -> [Rule.OnePathRule Variable]
     notStartedOPClaims graphs claims =
-        Rule.OnePathRule
+      Rule.OnePathRule
         . coerce
         <$> filter (not . isTrusted)
-                ( (claims !!)
-                . unClaimIndex
-                <$> Set.toList
-                    (Set.difference
-                        ( Set.fromList
-                        $ fmap ClaimIndex [0..length claims - 1]
-                        )
-                        ( Set.fromList
-                        $ Map.keys graphs
-                        )
-                    )
+              ( (claims !!)
+                  . unClaimIndex
+                  <$> Set.toList
+                        ( Set.difference
+                            ( Set.fromList
+                                $ fmap ClaimIndex [0 .. length claims - 1]
+                              )
+                            ( Set.fromList
+                                $ Map.keys graphs
+                              )
+                          )
                 )
 
 claimsWithPatterns
-    :: Map ClaimIndex (ExecutionGraph axiom)
-    -> [claim]
-    -> [(claim, [TermLike Variable])]
+  :: Map ClaimIndex (ExecutionGraph axiom)
+  -> [claim]
+  -> [(claim, [TermLike Variable])]
 claimsWithPatterns graphs claims =
-    Bifunctor.bimap
-        ((claims !!) . unClaimIndex)
-        (findTerminalPatterns . Strategy.graph)
+  Bifunctor.bimap
+    ((claims !!) . unClaimIndex)
+    (findTerminalPatterns . Strategy.graph)
     <$> Map.toList graphs
 
 findTerminalPatterns
-    :: InnerGraph axiom
-    -> [TermLike Variable]
+  :: InnerGraph axiom
+  -> [TermLike Variable]
 findTerminalPatterns graph =
-    mapMaybe (nodeToPattern graph)
+  mapMaybe (nodeToPattern graph)
     . findLeafNodes
     $ graph
 
 currentClaimSort
-    :: Claim claim
-    => MonadState (ReplState claim) m
-    => m Sort
+  :: Claim claim
+  => MonadState (ReplState claim) m
+  => m Sort
 currentClaimSort = do
-    claims <- Lens.use (field @"claim")
-    return . TermLike.termLikeSort
-        . Rule.onePathRuleToPattern
-        . Rule.OnePathRule
-        . coerce
-        $ claims
+  claims <- Lens.use (field @"claim")
+  return . TermLike.termLikeSort
+    . Rule.onePathRuleToPattern
+    . Rule.OnePathRule
+    . coerce
+    $ claims
 
 sortLeafsByType :: InnerGraph axiom -> Map.Map NodeState [Graph.Node]
 sortLeafsByType graph =
-    Map.fromList
-        . groupSort
-        . mapMaybe (getNodeState graph)
-        . findLeafNodes
-        $ graph
-
+  Map.fromList
+    . groupSort
+    . mapMaybe (getNodeState graph)
+    . findLeafNodes
+    $ graph
 
 findLeafNodes :: InnerGraph axiom -> [Graph.Node]
 findLeafNodes graph =
-    filter ((==) 0 . Graph.outdeg graph) $ Graph.nodes graph
+  filter ((==) 0 . Graph.outdeg graph) $ Graph.nodes graph
 
 appReplOut :: ReplOut -> ReplOutput -> ReplOutput
 appReplOut rout routput = routput <> ReplOutput [rout]
 
 replOut
-    :: (String -> a)
-    -> (String -> a)
-    -> ReplOut
-    -> a
+  :: (String -> a)
+  -> (String -> a)
+  -> ReplOut
+  -> a
 replOut f g =
-    \case
-        AuxOut str  -> f str
-        KoreOut str -> g str
+  \case
+    AuxOut str -> f str
+    KoreOut str -> g str
 
 replOutputToString :: ReplOutput -> String
 replOutputToString (ReplOutput out) =
-    out >>= replOut id id
+  out >>= replOut id id

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -5,54 +5,61 @@ License     : NCSA
 Strategy-based interface to rule application (step-wise execution).
 
  -}
-
 module Kore.Step
-    ( -- * Primitive strategies
-      Prim (..)
-    , rewrite
-    , simplify
-    , rewriteStep
-    , transitionRule
-    , allRewrites
-    , anyRewrite
-    , heatingCooling
-      -- * Re-exports
-    , RulePattern
-    , Natural
-    , Strategy
-    , pickLongest
-    , pickFinal
-    , runStrategy
-    ) where
+  ( -- * Primitive strategies
+    Prim (..),
+    rewrite,
+    simplify,
+    rewriteStep,
+    transitionRule,
+    allRewrites,
+    anyRewrite,
+    heatingCooling,
+    -- * Re-exports
+    RulePattern,
+    Natural,
+    Strategy,
+    pickLongest,
+    pickFinal,
+    runStrategy
+    )
+where
 
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Foldable as Foldable
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified GHC.Stack as GHC
-import           Numeric.Natural
-                 ( Natural )
-
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Step.Result as Result
-                 ( mergeResults )
-import           Kore.Step.Rule
-                 ( RewriteRule (RewriteRule), RulePattern, isCoolingRule,
-                 isHeatingRule, isNormalRule )
-import           Kore.Step.Simplification.Data as Simplifier
-import qualified Kore.Step.Simplification.Pattern as Pattern
-                 ( simplifyAndRemoveTopExists )
+  ( mergeResults
+    )
+import Kore.Step.Rule
+  ( RewriteRule (RewriteRule),
+    RulePattern,
+    isCoolingRule,
+    isHeatingRule,
+    isNormalRule
+    )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
-                 ( filterMultiOr )
+  ( filterMultiOr
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import qualified Kore.Step.Simplification.Pattern as Pattern
+  ( simplifyAndRemoveTopExists
+    )
 import qualified Kore.Step.Step as Step
-import           Kore.Step.Strategy
+import Kore.Step.Strategy
 import qualified Kore.Step.Strategy as Strategy
 import qualified Kore.Step.Transition as Transition
-import           Kore.Syntax.Variable
+import Kore.Syntax.Variable
 import qualified Kore.Unification.Procedure as Unification
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-
+import Kore.Unparser
+import Numeric.Natural
+  ( Natural
+    )
 
 {- | A strategy primitive: a rewrite rule or builtin simplification step.
  -}
@@ -74,7 +81,7 @@ evaluator are applied (see 'Pattern.simplify' for details).
  -}
 rewriteStep :: rewrite -> Strategy (Prim rewrite)
 rewriteStep a =
-    Strategy.sequence [Strategy.apply (rewrite a), Strategy.apply simplify]
+  Strategy.sequence [Strategy.apply (rewrite a), Strategy.apply simplify]
 
 {- | Transition rule for primitive strategies in 'Prim'.
 
@@ -82,45 +89,45 @@ rewriteStep a =
 'Strategy.runStrategy'.
  -}
 transitionRule
-    :: GHC.HasCallStack
-    => MonadSimplify m
-    => Prim (RewriteRule Variable)
-    -> Pattern Variable
-    -- ^ Configuration being rewritten
-    -> TransitionT (RewriteRule Variable) m (Pattern Variable)
+  :: GHC.HasCallStack
+  => MonadSimplify m
+  => Prim (RewriteRule Variable)
+  -> Pattern Variable
+  -- ^ Configuration being rewritten
+  -> TransitionT (RewriteRule Variable) m (Pattern Variable)
 transitionRule =
-    \case
-        Simplify -> transitionSimplify
-        Rewrite a -> transitionRewrite a
+  \case
+    Simplify -> transitionSimplify
+    Rewrite a -> transitionRewrite a
   where
     transitionSimplify config =
-        do
-            configs <- Monad.Trans.lift $
-                Pattern.simplifyAndRemoveTopExists config
-            filteredConfigs <- SMT.Evaluator.filterMultiOr configs
-            Foldable.asum (pure <$> filteredConfigs)
+      do
+        configs <-
+          Monad.Trans.lift
+            $ Pattern.simplifyAndRemoveTopExists config
+        filteredConfigs <- SMT.Evaluator.filterMultiOr configs
+        Foldable.asum (pure <$> filteredConfigs)
     transitionRewrite rule config = do
-        Transition.addRule rule
-        let unificationProcedure =
-                Step.UnificationProcedure Unification.unificationProcedure
-        eitherResults <-
-            Monad.Trans.lift
-            $ Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesParallel unificationProcedure [rule] config
-        case eitherResults of
-            Left err ->
-                (error . show . Pretty.vsep)
-                    [ "Could not apply the axiom:"
-                    , unparse rule
-                    , "to the configuration:"
-                    , unparse config
-                    , "Un-implemented unification case; aborting execution."
-                    , "err=" <> Pretty.pretty err
-                    ]
-            Right results ->
-                Foldable.asum
-                    (pure <$> Step.gatherResults (Result.mergeResults results))
-
+      Transition.addRule rule
+      let unificationProcedure =
+            Step.UnificationProcedure Unification.unificationProcedure
+      eitherResults <-
+        Monad.Trans.lift
+          $ Monad.Unify.runUnifierT
+          $ Step.applyRewriteRulesParallel unificationProcedure [rule] config
+      case eitherResults of
+        Left err ->
+          (error . show . Pretty.vsep)
+            [ "Could not apply the axiom:",
+              unparse rule,
+              "to the configuration:",
+              unparse config,
+              "Un-implemented unification case; aborting execution.",
+              "err=" <> Pretty.pretty err
+              ]
+        Right results ->
+          Foldable.asum
+            (pure <$> Step.gatherResults (Result.mergeResults results))
 
 {- | A strategy that applies all the rewrites in parallel.
 
@@ -131,10 +138,10 @@ See also: 'Strategy.all'
 
  -}
 allRewrites
-    :: [rewrite]
-    -> Strategy (Prim rewrite)
+  :: [rewrite]
+  -> Strategy (Prim rewrite)
 allRewrites rewrites =
-    Strategy.all (rewriteStep <$> rewrites)
+  Strategy.all (rewriteStep <$> rewrites)
 
 {- | A strategy that applies the rewrites until one succeeds.
 
@@ -146,10 +153,10 @@ See also: 'Strategy.any'
 
  -}
 anyRewrite
-    :: [rewrite]
-    -> Strategy (Prim rewrite)
+  :: [rewrite]
+  -> Strategy (Prim rewrite)
 anyRewrite rewrites =
-    Strategy.any (rewriteStep <$> rewrites)
+  Strategy.any (rewriteStep <$> rewrites)
 
 {- | Heat the configuration, apply a normal rewrite, and cool the result.
  -}
@@ -157,12 +164,12 @@ anyRewrite rewrites =
 -- rules must have side conditions if encoded as \rewrites, or they must be
 -- \equals rules, which are not handled by this strategy.
 heatingCooling
-    :: (forall rewrite. [rewrite] -> Strategy (Prim rewrite))
-    -- ^ 'allRewrites' or 'anyRewrite'
-    -> [RewriteRule Variable]
-    -> Strategy (Prim (RewriteRule Variable))
+  :: (forall rewrite. [rewrite] -> Strategy (Prim rewrite))
+  -- ^ 'allRewrites' or 'anyRewrite'
+  -> [RewriteRule Variable]
+  -> Strategy (Prim (RewriteRule Variable))
 heatingCooling rewriteStrategy rewrites =
-    Strategy.sequence [Strategy.many heat, normal, Strategy.try cool]
+  Strategy.sequence [Strategy.many heat, normal, Strategy.try cool]
   where
     heatingRules = filter isHeating rewrites
     isHeating (RewriteRule rule) = isHeatingRule rule

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -8,71 +8,92 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Axiom.EvaluationStrategy
-    ( builtinEvaluation
-    , definitionEvaluation
-    , totalDefinitionEvaluation
-    , firstFullEvaluation
-    , simplifierWithFallback
-    ) where
+  ( builtinEvaluation,
+    definitionEvaluation,
+    totalDefinitionEvaluation,
+    firstFullEvaluation,
+    simplifierWithFallback
+    )
+where
 
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans.Class as Monad.Trans
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Maybe
-                 ( isJust )
+import Data.Function
+import Data.Maybe
+  ( isJust
+    )
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
 import qualified Kore.Attribute.Axiom as Attribute.Axiom
 import qualified Kore.Attribute.Axiom.Concrete as Axiom.Concrete
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Internal.Conditional
-                 ( andCondition )
+import Kore.Internal.Conditional
+  ( andCondition
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( extractPatterns )
+  ( extractPatterns
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Predicate )
-import           Kore.Internal.Symbol
-import           Kore.Internal.TermLike
+import Kore.Internal.Predicate
+  ( Predicate
+    )
+import Kore.Internal.Symbol
+import Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Proof.Value as Value
-import           Kore.Step.Axiom.Matcher
-                 ( matchIncremental )
-import           Kore.Step.Remainder
-                 ( ceilChildOfApplicationOrTop )
+import Kore.Step.Axiom.Matcher
+  ( matchIncremental
+    )
+import Kore.Step.Remainder
+  ( ceilChildOfApplicationOrTop
+    )
 import qualified Kore.Step.Result as Result
-import           Kore.Step.Rule
-                 ( EqualityRule (EqualityRule, getEqualityRule) )
+import Kore.Step.Rule
+  ( EqualityRule (EqualityRule, getEqualityRule)
+    )
 import qualified Kore.Step.Rule as RulePattern
-import           Kore.Step.Simplification.Data
-                 ( AttemptedAxiom,
-                 AttemptedAxiomResults (AttemptedAxiomResults),
-                 BuiltinAndAxiomSimplifier (..), BuiltinAndAxiomSimplifierMap,
-                 MonadSimplify, PredicateSimplifier, TermLikeSimplifier )
+import Kore.Step.Simplification.Data
+  ( AttemptedAxiom,
+    AttemptedAxiomResults (AttemptedAxiomResults),
+    BuiltinAndAxiomSimplifier (..),
+    BuiltinAndAxiomSimplifierMap,
+    MonadSimplify,
+    PredicateSimplifier,
+    TermLikeSimplifier
+    )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
-                 ( AttemptedAxiomResults (..) )
+  ( AttemptedAxiomResults (..)
+    )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..), hasRemainders, maybeNotApplicable )
+  ( AttemptedAxiom (..),
+    hasRemainders,
+    maybeNotApplicable
+    )
 import qualified Kore.Step.Simplification.OrPattern as OrPattern
-                 ( simplifyPredicatesWithSmt )
-import           Kore.Step.Step
-                 ( UnificationProcedure (UnificationProcedure) )
+  ( simplifyPredicatesWithSmt
+    )
+import Kore.Step.Step
+  ( UnificationProcedure (UnificationProcedure)
+    )
 import qualified Kore.Step.Step as Step
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse, unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.Unparser
+  ( Unparse,
+    unparse
+    )
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 {-|Describes whether simplifiers are allowed to return multiple results or not.
 -}
 data AcceptsMultipleResults = WithMultipleResults | OnlyOneResult
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-|Converts 'AcceptsMultipleResults' to Bool.
 -}
@@ -84,11 +105,11 @@ acceptsMultipleResults OnlyOneResult = False
 that define it.
 -}
 definitionEvaluation
-    :: [EqualityRule Variable]
-    -> BuiltinAndAxiomSimplifier
+  :: [EqualityRule Variable]
+  -> BuiltinAndAxiomSimplifier
 definitionEvaluation rules =
-    BuiltinAndAxiomSimplifier
-        (evaluateWithDefinitionAxioms rules)
+  BuiltinAndAxiomSimplifier
+    (evaluateWithDefinitionAxioms rules)
 
 {- | Creates an evaluator for a function from all the rules that define it.
 
@@ -100,43 +121,42 @@ See also: 'definitionEvaluation'
 
 -}
 totalDefinitionEvaluation
-    :: [EqualityRule Variable]
-    -> BuiltinAndAxiomSimplifier
+  :: [EqualityRule Variable]
+  -> BuiltinAndAxiomSimplifier
 totalDefinitionEvaluation rules =
-    BuiltinAndAxiomSimplifier totalDefinitionEvaluationWorker
+  BuiltinAndAxiomSimplifier totalDefinitionEvaluationWorker
   where
     totalDefinitionEvaluationWorker
-        ::  forall variable simplifier
-        .   ( FreshVariable variable
-            , SortedVariable variable
-            , Show variable
-            , Unparse variable
-            , MonadSimplify simplifier
-            )
-        => PredicateSimplifier
-        -> TermLikeSimplifier
-        -> BuiltinAndAxiomSimplifierMap
-        -> TermLike variable
-        -> Predicate variable
-        -> simplifier (AttemptedAxiom variable)
+      :: forall variable simplifier. ( FreshVariable variable,
+                                       SortedVariable variable,
+                                       Show variable,
+                                       Unparse variable,
+                                       MonadSimplify simplifier
+                                       )
+      => PredicateSimplifier
+      -> TermLikeSimplifier
+      -> BuiltinAndAxiomSimplifierMap
+      -> TermLike variable
+      -> Predicate variable
+      -> simplifier (AttemptedAxiom variable)
     totalDefinitionEvaluationWorker
-        predicateSimplifier
-        termSimplifier
-        axiomSimplifiers
-        term
-        predicate
-      = do
-        result <- evaluate term predicate
-        if AttemptedAxiom.hasRemainders result
+      predicateSimplifier
+      termSimplifier
+      axiomSimplifiers
+      term
+      predicate =
+        do
+          result <- evaluate term predicate
+          if AttemptedAxiom.hasRemainders result
             then return AttemptedAxiom.NotApplicable
             else return result
-      where
-        evaluate =
+        where
+          evaluate =
             evaluateWithDefinitionAxioms
-                rules
-                predicateSimplifier
-                termSimplifier
-                axiomSimplifiers
+              rules
+              predicateSimplifier
+              termSimplifier
+              axiomSimplifiers
 
 {-| Creates an evaluator that choses the result of the first evaluator that
 returns Applicable.
@@ -145,257 +165,241 @@ If that result contains more than one pattern, or it contains a reminder,
 the evaluation fails with 'error' (may change in the future).
 -}
 firstFullEvaluation
-    :: [BuiltinAndAxiomSimplifier]
-    -> BuiltinAndAxiomSimplifier
+  :: [BuiltinAndAxiomSimplifier]
+  -> BuiltinAndAxiomSimplifier
 firstFullEvaluation simplifiers =
-    BuiltinAndAxiomSimplifier
-        (applyFirstSimplifierThatWorks simplifiers OnlyOneResult)
+  BuiltinAndAxiomSimplifier
+    (applyFirstSimplifierThatWorks simplifiers OnlyOneResult)
 
 {-| Creates an evaluator that choses the result of the first evaluator if it
 returns Applicable, otherwise returns the result of the second.
 -}
 simplifierWithFallback
-    :: BuiltinAndAxiomSimplifier
-    -> BuiltinAndAxiomSimplifier
-    -> BuiltinAndAxiomSimplifier
+  :: BuiltinAndAxiomSimplifier
+  -> BuiltinAndAxiomSimplifier
+  -> BuiltinAndAxiomSimplifier
 simplifierWithFallback first second =
-    BuiltinAndAxiomSimplifier
-        (applyFirstSimplifierThatWorks [first, second] WithMultipleResults)
+  BuiltinAndAxiomSimplifier
+    (applyFirstSimplifierThatWorks [first, second] WithMultipleResults)
 
 {-| Wraps an evaluator for builtins. Will fail with error if there is no result
 on concrete patterns.
 -}
 builtinEvaluation
-    :: BuiltinAndAxiomSimplifier
-    -> BuiltinAndAxiomSimplifier
+  :: BuiltinAndAxiomSimplifier
+  -> BuiltinAndAxiomSimplifier
 builtinEvaluation evaluator =
-    BuiltinAndAxiomSimplifier (evaluateBuiltin evaluator)
-
+  BuiltinAndAxiomSimplifier (evaluateBuiltin evaluator)
 
 evaluateBuiltin
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => BuiltinAndAxiomSimplifier
-    -> PredicateSimplifier
-    -> TermLikeSimplifier
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> TermLike variable
-    -> Predicate variable
-    -> simplifier (AttemptedAxiom variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier
+                                   )
+  => BuiltinAndAxiomSimplifier
+  -> PredicateSimplifier
+  -> TermLikeSimplifier
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> TermLike variable
+  -> Predicate variable
+  -> simplifier (AttemptedAxiom variable)
 evaluateBuiltin
-    (BuiltinAndAxiomSimplifier builtinEvaluator)
-    substitutionSimplifier
-    simplifier
-    axiomIdToSimplifier
-    patt
-    predicate
-  = do
-    result <-
+  (BuiltinAndAxiomSimplifier builtinEvaluator)
+  substitutionSimplifier
+  simplifier
+  axiomIdToSimplifier
+  patt
+  predicate =
+    do
+      result <-
         builtinEvaluator
-            substitutionSimplifier
-            simplifier
-            axiomIdToSimplifier
-            patt
-            predicate
-    case result of
+          substitutionSimplifier
+          simplifier
+          axiomIdToSimplifier
+          patt
+          predicate
+      case result of
         AttemptedAxiom.NotApplicable
-          | App_ appHead children <- patt
-          , Just hook_ <- Text.unpack <$> Attribute.getHook (symbolHook appHead)
-          , all isValue children ->
+          | App_ appHead children <- patt,
+            Just hook_ <- Text.unpack <$> Attribute.getHook (symbolHook appHead),
+            all isValue children ->
             (error . show . Pretty.vsep)
-                [ "Expecting hook "
-                    <> Pretty.squotes (Pretty.pretty hook_)
-                    <> " to reduce concrete pattern:"
-                , Pretty.indent 4 (unparse patt)
+              [ "Expecting hook "
+                  <> Pretty.squotes (Pretty.pretty hook_)
+                  <> " to reduce concrete pattern:",
+                Pretty.indent 4 (unparse patt)
                 ]
         _ -> return result
-  where
-    isValue pat = isJust $ Value.fromTermLike =<< asConcrete pat
+    where
+      isValue pat = isJust $ Value.fromTermLike =<< asConcrete pat
 
 applyFirstSimplifierThatWorks
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => [BuiltinAndAxiomSimplifier]
-    -> AcceptsMultipleResults
-    -> PredicateSimplifier
-    -> TermLikeSimplifier
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> TermLike variable
-    -> Predicate variable
-    -> simplifier (AttemptedAxiom variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier
+                                   )
+  => [BuiltinAndAxiomSimplifier]
+  -> AcceptsMultipleResults
+  -> PredicateSimplifier
+  -> TermLikeSimplifier
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> TermLike variable
+  -> Predicate variable
+  -> simplifier (AttemptedAxiom variable)
 applyFirstSimplifierThatWorks [] _ _ _ _ _ _ =
-    return AttemptedAxiom.NotApplicable
+  return AttemptedAxiom.NotApplicable
 applyFirstSimplifierThatWorks
-    (BuiltinAndAxiomSimplifier evaluator : evaluators)
-    multipleResults
-    substitutionSimplifier
-    simplifier
-    axiomIdToSimplifier
-    patt
-    predicate
-  = do
-    applicationResult <-
+  (BuiltinAndAxiomSimplifier evaluator : evaluators)
+  multipleResults
+  substitutionSimplifier
+  simplifier
+  axiomIdToSimplifier
+  patt
+  predicate =
+    do
+      applicationResult <-
         evaluator
+          substitutionSimplifier
+          simplifier
+          axiomIdToSimplifier
+          patt
+          predicate
+      case applicationResult of
+        AttemptedAxiom.Applied
+          AttemptedAxiomResults
+            { results = orResults,
+              remainders = orRemainders
+              } -> do
+            Monad.when
+              ( length (MultiOr.extractPatterns orResults) > 1
+                  && not (acceptsMultipleResults multipleResults)
+                )
+              -- We should only allow multiple simplification results
+              -- when they are created by unification splitting the
+              -- configuration.
+              -- However, right now, we shouldn't be able to get more
+              -- than one result, so we throw an error.
+              ( error
+                  ( "Unexpected simplification result with more "
+                      ++ "than one configuration: "
+                      ++ show applicationResult
+                    )
+                )
+            Monad.when
+              ( not (OrPattern.isFalse orRemainders)
+                  && not (acceptsMultipleResults multipleResults)
+                )
+              -- It's not obvious that we should accept simplifications
+              -- that change only a part of the configuration, since
+              -- that will probably make things more complicated.
+              --
+              -- Until we have a clear example that this can actually
+              -- happen, we throw an error.
+              ( (error . show . Pretty.vsep)
+                  [ "Unexpected simplification result with remainder:",
+                    Pretty.indent 2 "input:",
+                    Pretty.indent 4 (unparse patt),
+                    Pretty.indent 2 "results:",
+                    (Pretty.indent 4 . Pretty.vsep)
+                      (unparse <$> Foldable.toList orResults),
+                    Pretty.indent 2 "remainders:",
+                    (Pretty.indent 4 . Pretty.vsep)
+                      (unparse <$> Foldable.toList orRemainders)
+                    ]
+                )
+            return applicationResult
+        AttemptedAxiom.NotApplicable ->
+          applyFirstSimplifierThatWorks
+            evaluators
+            multipleResults
             substitutionSimplifier
             simplifier
             axiomIdToSimplifier
             patt
             predicate
 
-    case applicationResult of
-        AttemptedAxiom.Applied AttemptedAxiomResults
-            { results = orResults
-            , remainders = orRemainders
-            } -> do
-                Monad.when
-                    (length (MultiOr.extractPatterns orResults) > 1
-                    && not (acceptsMultipleResults multipleResults)
-                    )
-                    -- We should only allow multiple simplification results
-                    -- when they are created by unification splitting the
-                    -- configuration.
-                    -- However, right now, we shouldn't be able to get more
-                    -- than one result, so we throw an error.
-                    (error
-                        (  "Unexpected simplification result with more "
-                        ++ "than one configuration: "
-                        ++ show applicationResult
-                        )
-                    )
-                Monad.when
-                    (not (OrPattern.isFalse orRemainders)
-                    && not (acceptsMultipleResults multipleResults)
-                    )
-                    -- It's not obvious that we should accept simplifications
-                    -- that change only a part of the configuration, since
-                    -- that will probably make things more complicated.
-                    --
-                    -- Until we have a clear example that this can actually
-                    -- happen, we throw an error.
-                    ((error . show . Pretty.vsep)
-                        [ "Unexpected simplification result with remainder:"
-                        , Pretty.indent 2 "input:"
-                        , Pretty.indent 4 (unparse patt)
-                        , Pretty.indent 2 "results:"
-                        , (Pretty.indent 4 . Pretty.vsep)
-                            (unparse <$> Foldable.toList orResults)
-                        , Pretty.indent 2 "remainders:"
-                        , (Pretty.indent 4 . Pretty.vsep)
-                            (unparse <$> Foldable.toList orRemainders)
-                        ]
-                    )
-                return applicationResult
-        AttemptedAxiom.NotApplicable ->
-            applyFirstSimplifierThatWorks
-                evaluators
-                multipleResults
-                substitutionSimplifier
-                simplifier
-                axiomIdToSimplifier
-                patt
-                predicate
-
 evaluateWithDefinitionAxioms
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => [EqualityRule Variable]
-    -> PredicateSimplifier
-    -> TermLikeSimplifier
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> TermLike variable
-    -> Predicate variable
-    -> simplifier (AttemptedAxiom variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier
+                                   )
+  => [EqualityRule Variable]
+  -> PredicateSimplifier
+  -> TermLikeSimplifier
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> TermLike variable
+  -> Predicate variable
+  -> simplifier (AttemptedAxiom variable)
 evaluateWithDefinitionAxioms
-    definitionRules
-    _predicateSimplifier
-    _termSimplifier
-    _axiomSimplifiers
-    patt
-    _predicate
-  | any ruleIsConcrete definitionRules
-  , not (TermLike.isConcrete patt)
-  = return AttemptedAxiom.NotApplicable
-  | otherwise
-  = AttemptedAxiom.maybeNotApplicable $ do
-    let
-        -- TODO (thomas.tuegel): Figure out how to get the initial conditions
-        -- and apply them here, to remove remainder branches sooner.
-        expanded :: Pattern variable
-        expanded = Pattern.fromTermLike patt
-
-    results <- applyRules expanded (map unwrapEqualityRule definitionRules)
-    Monad.guard (any Result.hasResults results)
-    mapM_ rejectNarrowing results
-
-    ceilChild <- ceilChildOfApplicationOrTop patt
-    let
-        result =
-            Result.mergeResults results
-            & Result.mapConfigs
-                keepResultUnchanged
-                ( markRemainderEvaluated
-                . introduceDefinedness ceilChild
-                )
-        keepResultUnchanged = id
-        introduceDefinedness = flip andCondition
-        markRemainderEvaluated = fmap mkEvaluated
-
-    simplifiedResults <-
-        Monad.Trans.lift
-        $ OrPattern.simplifyPredicatesWithSmt (Step.gatherResults result)
-    simplifiedRemainders <-
-        Monad.Trans.lift
-        $ OrPattern.simplifyPredicatesWithSmt (Step.remainders result)
-
-    return $ AttemptedAxiom.Applied AttemptedAxiomResults
-        { results = simplifiedResults
-        , remainders = simplifiedRemainders
-        }
-
-  where
-    ruleIsConcrete =
+  definitionRules
+  _predicateSimplifier
+  _termSimplifier
+  _axiomSimplifiers
+  patt
+  _predicate
+    | any ruleIsConcrete definitionRules,
+      not (TermLike.isConcrete patt) =
+      return AttemptedAxiom.NotApplicable
+    | otherwise =
+      AttemptedAxiom.maybeNotApplicable $ do
+        let -- TODO (thomas.tuegel): Figure out how to get the initial conditions
+            -- and apply them here, to remove remainder branches sooner.
+            expanded :: Pattern variable
+            expanded = Pattern.fromTermLike patt
+        results <- applyRules expanded (map unwrapEqualityRule definitionRules)
+        Monad.guard (any Result.hasResults results)
+        mapM_ rejectNarrowing results
+        ceilChild <- ceilChildOfApplicationOrTop patt
+        let result =
+              Result.mergeResults results
+                & Result.mapConfigs
+                    keepResultUnchanged
+                    ( markRemainderEvaluated
+                        . introduceDefinedness ceilChild
+                      )
+            keepResultUnchanged = id
+            introduceDefinedness = flip andCondition
+            markRemainderEvaluated = fmap mkEvaluated
+        simplifiedResults <-
+          Monad.Trans.lift
+            $ OrPattern.simplifyPredicatesWithSmt (Step.gatherResults result)
+        simplifiedRemainders <-
+          Monad.Trans.lift
+            $ OrPattern.simplifyPredicatesWithSmt (Step.remainders result)
+        return
+          $ AttemptedAxiom.Applied AttemptedAxiomResults
+              { results = simplifiedResults,
+                remainders = simplifiedRemainders
+                }
+    where
+      ruleIsConcrete =
         Axiom.Concrete.isConcrete
-        . Attribute.Axiom.concrete
-        . RulePattern.attributes
-        . getEqualityRule
-
-    unwrapEqualityRule (EqualityRule rule) =
+          . Attribute.Axiom.concrete
+          . RulePattern.attributes
+          . getEqualityRule
+      unwrapEqualityRule (EqualityRule rule) =
         RulePattern.mapVariables fromVariable rule
-
-    rejectNarrowing (Result.results -> results) =
+      rejectNarrowing (Result.results -> results) =
         (Monad.guard . not) (Foldable.any Step.isNarrowingResult results)
-
-    applyRules initial rules =
+      applyRules initial rules =
         Monad.Unify.maybeUnifierT
-        $ Step.applyRulesSequence unificationProcedure initial rules
-
-    ignoreUnificationErrors unification pattern1 pattern2 =
+          $ Step.applyRulesSequence unificationProcedure initial rules
+      ignoreUnificationErrors unification pattern1 pattern2 =
         Monad.Unify.runUnifierT (unification pattern1 pattern2)
-        >>= either (couldNotMatch pattern1 pattern2) Monad.Unify.scatter
-
-    couldNotMatch pattern1 pattern2 _ =
+          >>= either (couldNotMatch pattern1 pattern2) Monad.Unify.scatter
+      couldNotMatch pattern1 pattern2 _ =
         Monad.Unify.explainAndReturnBottom
-            "Could not match patterns"
-            pattern1
-            pattern2
-
-    unificationProcedure =
+          "Could not match patterns"
+          pattern1
+          pattern2
+      unificationProcedure =
         UnificationProcedure (ignoreUnificationErrors matchIncremental)

--- a/kore/src/Kore/Step/Axiom/Identifier.hs
+++ b/kore/src/Kore/Step/Axiom/Identifier.hs
@@ -18,27 +18,34 @@ import Kore.Step.Axiom.Identifier ( AxiomIdentifier )
 import Kore.Step.Axiom.Identifier as AxiomIdentifier
 @
 -}
-
 module Kore.Step.Axiom.Identifier
-    ( AxiomIdentifier (..)
-    , matchAxiomIdentifier
-    ) where
+  ( AxiomIdentifier (..),
+    matchAxiomIdentifier
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty (..) )
+import Data.Text.Prettyprint.Doc
+  ( Pretty (..)
+    )
 import qualified Data.Text.Prettyprint.Doc as Doc
-                 ( parens, (<+>) )
-
-import           Kore.Internal.TermLike
-                 ( CofreeF (..), TermLike )
+  ( (<+>),
+    parens
+    )
+import Kore.Internal.TermLike
+  ( CofreeF (..),
+    TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Syntax.Id
-                 ( Id (..) )
-import           Kore.Unparser
-                 ( unparse )
+import Kore.Syntax.Id
+  ( Id (..)
+    )
+import Kore.Unparser
+  ( unparse
+    )
 
 {-| Identifer for the left-hand-side of axioms and for the terms with which
 these can be identified.
@@ -47,29 +54,29 @@ The expectation is that an axiom can be applied to a term only if the
 identifier of its left-hand-side is the same as the term's identifier.
 -}
 data AxiomIdentifier
-    = Application !Id
+  = Application !Id
     -- ^ An application pattern with the given symbol identifier.
-    | Ceil !AxiomIdentifier
+  | Ceil !AxiomIdentifier
     -- ^ A @\\ceil@ pattern with the given child.
-    | Equals !AxiomIdentifier !AxiomIdentifier
+  | Equals !AxiomIdentifier !AxiomIdentifier
     -- ^ An @\\equals@ pattern with the given children.
-    | Exists !AxiomIdentifier
+  | Exists !AxiomIdentifier
     -- ^ An @\\exists@ pattern with the given child.
-    | Variable
+  | Variable
     -- ^ Any variable pattern.
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 instance Pretty AxiomIdentifier where
-    pretty (Application name) = unparse name
-    pretty (Ceil axiomIdentifier) =
-        "ceil" Doc.<+> Doc.parens (pretty axiomIdentifier)
-    pretty (Equals first second) =
-        "equals"
-        Doc.<+> Doc.parens
-            (pretty first Doc.<+> "," Doc.<+> pretty second)
-    pretty (Exists axiomIdentifier) =
-        "exists" Doc.<+> Doc.parens (pretty axiomIdentifier)
-    pretty Variable = "variable"
+  pretty (Application name) = unparse name
+  pretty (Ceil axiomIdentifier) =
+    "ceil" Doc.<+> Doc.parens (pretty axiomIdentifier)
+  pretty (Equals first second) =
+    "equals"
+      Doc.<+> Doc.parens
+                (pretty first Doc.<+> "," Doc.<+> pretty second)
+  pretty (Exists axiomIdentifier) =
+    "exists" Doc.<+> Doc.parens (pretty axiomIdentifier)
+  pretty Variable = "variable"
 
 {- | Match 'TermLike' pattern to determine its 'AxiomIdentifier'.
 
@@ -81,20 +88,20 @@ matchAxiomIdentifier :: TermLike variable -> Maybe AxiomIdentifier
 matchAxiomIdentifier = Recursive.fold matchWorker
   where
     matchWorker (_ :< termLikeF) =
-        case termLikeF of
-            TermLike.ApplySymbolF application ->
-                pure (Application symbolId)
-              where
-                symbol = TermLike.applicationSymbolOrAlias application
-                symbolId = TermLike.symbolConstructor symbol
-            TermLike.CeilF ceil ->
-                Ceil <$> TermLike.ceilChild ceil
-            TermLike.EqualsF equals ->
-                Equals
-                    <$> TermLike.equalsFirst equals
-                    <*> TermLike.equalsSecond equals
-            TermLike.ExistsF exists ->
-                Exists <$> TermLike.existsChild exists
-            TermLike.VariableF _ ->
-                pure Variable
-            _ -> empty
+      case termLikeF of
+        TermLike.ApplySymbolF application ->
+          pure (Application symbolId)
+          where
+            symbol = TermLike.applicationSymbolOrAlias application
+            symbolId = TermLike.symbolConstructor symbol
+        TermLike.CeilF ceil ->
+          Ceil <$> TermLike.ceilChild ceil
+        TermLike.EqualsF equals ->
+          Equals
+            <$> TermLike.equalsFirst equals
+            <*> TermLike.equalsSecond equals
+        TermLike.ExistsF exists ->
+          Exists <$> TermLike.existsChild exists
+        TermLike.VariableF _ ->
+          pure Variable
+        _ -> empty

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -9,78 +9,103 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Axiom.Matcher
-    ( MatchingVariable
-    , matchIncremental
-    ) where
+  ( MatchingVariable,
+    matchIncremental
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Control.Error as Error
-import           Control.Lens
-                 ( (%=), (.=), (<>=) )
+import Control.Lens
+  ( (%=),
+    (.=),
+    (<>=)
+    )
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
-import           Control.Monad.State.Strict
-                 ( MonadState, StateT )
+import Control.Monad.State.Strict
+  ( MonadState,
+    StateT
+    )
 import qualified Control.Monad.State.Strict as Monad.State
 import qualified Control.Monad.Trans as Monad.Trans
-import           Control.Monad.Trans.Maybe
-                 ( MaybeT (..) )
+import Control.Monad.Trans.Maybe
+  ( MaybeT (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Generics.Product
-import           Data.Map
-                 ( Map )
+import Data.Function
+import Data.Generics.Product
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Sequence
-                 ( pattern (:<|), pattern (:|>), Seq )
+import Data.Maybe
+import Data.Sequence
+  ( Seq,
+    pattern (:<|),
+    pattern (:|>)
+    )
 import qualified Data.Sequence as Seq
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables (..) )
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables (..)
+    )
 import qualified Kore.Builtin as Builtin
 import qualified Kore.Builtin.List as List
 import qualified Kore.Domain.Builtin as Builtin
-import           Kore.Internal.MultiAnd
-                 ( MultiAnd )
+import Kore.Internal.MultiAnd
+  ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike hiding
-                 ( substitute )
+import Kore.Internal.TermLike hiding
+  ( substitute
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Predicate.Predicate
-                 ( makeCeilPredicate )
+import Kore.Predicate.Predicate
+  ( makeCeilPredicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.Step.Simplification.AndTerms
-                 ( SortInjectionMatch (SortInjectionMatch),
-                 simplifySortInjections )
+import Kore.Step.Simplification.AndTerms
+  ( SortInjectionMatch (SortInjectionMatch),
+    simplifySortInjections
+    )
 import qualified Kore.Step.Simplification.AndTerms as SortInjectionMatch
-                 ( SortInjectionMatch (..) )
+  ( SortInjectionMatch (..)
+    )
 import qualified Kore.Step.Simplification.AndTerms as SortInjectionSimplification
-                 ( SortInjectionSimplification (..) )
+  ( SortInjectionSimplification (..)
+    )
 import qualified Kore.Step.Simplification.Data as Simplifier
-import           Kore.Unification.Error
-                 ( unsupportedPatterns )
+import Kore.Unification.Error
+  ( unsupportedPatterns
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-import           Kore.Variables.Binding
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.Unparser
+import Kore.Variables.Binding
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 import qualified Kore.Variables.Fresh as Variables
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 -- * Matching
 
@@ -93,18 +118,18 @@ pair, it is deferred until we have more information.
 
  -}
 matchOne
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MatcherT variable unifier ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MatcherT variable unifier ()
 matchOne pair =
-    (   matchVariable    pair
-    <|> matchEqualHeads  pair
-    <|> matchExists      pair
-    <|> matchForall      pair
-    <|> matchApplication pair
-    <|> matchBuiltinList pair
-    <|> matchBuiltinMap  pair
-    <|> matchBuiltinSet  pair
+  ( matchVariable pair
+      <|> matchEqualHeads pair
+      <|> matchExists pair
+      <|> matchForall pair
+      <|> matchApplication pair
+      <|> matchBuiltinList pair
+      <|> matchBuiltinMap pair
+      <|> matchBuiltinSet pair
     )
     & Error.maybeT (defer pair) return
 
@@ -115,113 +140,109 @@ deferred constraints, then matching fails.
 
  -}
 matchIncremental
-    :: forall variable unifier
-    .  (MatchingVariable variable, MonadUnify unifier)
-    => TermLike variable
-    -> TermLike variable
-    -> unifier (Predicate variable)
+  :: forall variable unifier. (MatchingVariable variable, MonadUnify unifier)
+  => TermLike variable
+  -> TermLike variable
+  -> unifier (Predicate variable)
 matchIncremental termLike1 termLike2 =
-    Monad.State.evalStateT matcher initial
+  Monad.State.evalStateT matcher initial
   where
     matcher = pop >>= maybe done (\pair -> matchOne pair >> matcher)
-
     initial =
-        MatcherState
-            { queued = Seq.singleton (Pair termLike1 termLike2)
-            , deferred = empty
-            , predicate = empty
-            , substitution = mempty
-            , bound = mempty
-            , targets = free1
-            , avoiding = free1 <> free2
-            }
+      MatcherState
+        { queued = Seq.singleton (Pair termLike1 termLike2),
+          deferred = empty,
+          predicate = empty,
+          substitution = mempty,
+          bound = mempty,
+          targets = free1,
+          avoiding = free1 <> free2
+          }
     free1 = (getFreeVariables . TermLike.freeVariables) termLike1
     free2 = (getFreeVariables . TermLike.freeVariables) termLike2
-
     -- | Check that matching is finished and construct the result.
     done :: MatcherT variable unifier (Predicate variable)
     done = do
-        final@MatcherState { queued, deferred } <- Monad.State.get
-        let isDone = null queued && null deferred
-        Monad.unless isDone throwUnknown
-        let MatcherState { predicate, substitution } = final
-            predicate' =
-                Predicate.fromPredicate
-                $ MultiAnd.toPredicate predicate
-            substitution' =
-                Predicate.fromSubstitution
-                $ Substitution.fromMap substitution
-            solution = predicate' <> substitution'
-        return solution
-
+      final@MatcherState {queued, deferred} <- Monad.State.get
+      let isDone = null queued && null deferred
+      Monad.unless isDone throwUnknown
+      let MatcherState {predicate, substitution} = final
+          predicate' =
+            Predicate.fromPredicate
+              $ MultiAnd.toPredicate predicate
+          substitution' =
+            Predicate.fromSubstitution
+              $ Substitution.fromMap substitution
+          solution = predicate' <> substitution'
+      return solution
     throwUnknown =
-        Monad.Trans.lift
+      Monad.Trans.lift
         $ Monad.Unify.throwUnificationError
         $ unsupportedPatterns "Unknown match case" termLike1 termLike2
 
 matchEqualHeads
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 -- Terminal patterns
 matchEqualHeads (Pair (StringLiteral_ string1) (StringLiteral_ string2)) =
-    Monad.guard (string1 == string2)
+  Monad.guard (string1 == string2)
 matchEqualHeads (Pair (CharLiteral_ char1) (CharLiteral_ char2)) =
-    Monad.guard (char1 == char2)
+  Monad.guard (char1 == char2)
 matchEqualHeads (Pair (BuiltinInt_ int1) (BuiltinInt_ int2)) =
-    Monad.guard (int1 == int2)
+  Monad.guard (int1 == int2)
 matchEqualHeads (Pair (BuiltinBool_ bool1) (BuiltinBool_ bool2)) =
-    Monad.guard (bool1 == bool2)
+  Monad.guard (bool1 == bool2)
 matchEqualHeads (Pair (BuiltinString_ string1) (BuiltinString_ string2)) =
-    Monad.guard (string1 == string2)
+  Monad.guard (string1 == string2)
 matchEqualHeads (Pair (Bottom_ _) (Bottom_ _)) =
-    return ()
+  return ()
 matchEqualHeads (Pair (Top_ _) (Top_ _)) =
-    return ()
+  return ()
 -- Non-terminal patterns
 matchEqualHeads (Pair (Ceil_ _ _ term1) (Ceil_ _ _ term2)) =
-    push (Pair term1 term2)
+  push (Pair term1 term2)
 matchEqualHeads (Pair (DV_ sort1 dv1) (DV_ sort2 dv2)) = do
-    Monad.guard (sort1 == sort2)
-    push (Pair dv1 dv2)
+  Monad.guard (sort1 == sort2)
+  push (Pair dv1 dv2)
 matchEqualHeads (Pair (Equals_ _ _ term11 term12) (Equals_ _ _ term21 term22)) =
-    push (Pair term11 term21) >> push (Pair term12 term22)
+  push (Pair term11 term21) >> push (Pair term12 term22)
 matchEqualHeads _ = empty
 
 matchExists
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchExists (Pair (Exists_ _ variable1 term1) (Exists_ _ variable2 term2)) =
-    matchBinder (Binder variable1 term1) (Binder variable2 term2)
+  matchBinder (Binder variable1 term1) (Binder variable2 term2)
 matchExists _ = empty
 
 matchForall
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchForall (Pair (Forall_ _ variable1 term1) (Forall_ _ variable2 term2)) =
-    matchBinder (Binder variable1 term1) (Binder variable2 term2)
+  matchBinder (Binder variable1 term1) (Binder variable2 term2)
 matchForall _ = empty
 
 matchBinder
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Binder (ElementVariable variable) (TermLike variable)
-    -> Binder (ElementVariable variable) (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Binder (ElementVariable variable) (TermLike variable)
+  -> Binder (ElementVariable variable) (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchBinder (Binder variable1 term1) (Binder variable2 term2) = do
-    Monad.guard (variableSort1 == variableSort2)
-    -- Lift the bound variable to the top level.
-    lifted1 <- liftVariable unified1
-    let term1' = fromMaybe term1 $ do
-            subst1 <- Map.singleton unified1 . mkVar <$> lifted1
-            return $ substituteTermLike subst1 term1
-    let variable1' = fromMaybe unified1 lifted1
-        subst2 = Map.singleton unified2 (mkVar variable1')
-        term2' = substituteTermLike subst2 term2
-    -- Record the uniquely-named variable so it will not be shadowed later.
-    bindVariable variable1'
-    push (Pair term1' term2')
+  Monad.guard (variableSort1 == variableSort2)
+  -- Lift the bound variable to the top level.
+  lifted1 <- liftVariable unified1
+  let term1' = fromMaybe term1 $ do
+        subst1 <- Map.singleton unified1 . mkVar <$> lifted1
+        return $ substituteTermLike subst1 term1
+  let variable1' = fromMaybe unified1 lifted1
+      subst2 = Map.singleton unified2 (mkVar variable1')
+      term2' = substituteTermLike subst2 term2
+  -- Record the uniquely-named variable so it will not be shadowed later.
+  bindVariable variable1'
+  push (Pair term1' term2')
   where
     unified1 = ElemVar variable1
     unified2 = ElemVar variable2
@@ -230,39 +251,37 @@ matchBinder (Binder variable1 term1) (Binder variable2 term2) = do
     variableSort2 = elementVariableSort variable2
 
 matchVariable
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchVariable (Pair (Var_ variable1) (Var_ variable2))
   | variable1 == variable2 = return ()
 matchVariable (Pair (ElemVar_ variable1) term2) = do
-    targetCheck (ElemVar variable1)
-    Monad.guard (isFunctionPattern term2)
-    substitute variable1 term2
+  targetCheck (ElemVar variable1)
+  Monad.guard (isFunctionPattern term2)
+  substitute variable1 term2
 matchVariable (Pair (SetVar_ variable1) term2) = do
-    targetCheck (SetVar variable1)
-    setSubstitute variable1 term2
+  targetCheck (SetVar variable1)
+  setSubstitute variable1 term2
 matchVariable _ = empty
 
 matchApplication
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
-matchApplication
-    (Pair term1@(App_ symbol1 children1) term2@(App_ symbol2 children2))
-
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
+matchApplication (Pair term1@(App_ symbol1 children1) term2@(App_ symbol2 children2))
   -- Match identical symbols.
   | symbol1 == symbol2 =
     Foldable.traverse_ push (zipWith Pair children1 children2)
-
   -- Match conformable sort injections.
-  | otherwise = do
-    Monad.guard (sort1 == sort2)
-    tools <- Simplifier.askMetadataTools
-    case simplifySortInjections tools term1 term2 of
+  | otherwise =
+    do
+      Monad.guard (sort1 == sort2)
+      tools <- Simplifier.askMetadataTools
+      case simplifySortInjections tools term1 term2 of
         Just (SortInjectionSimplification.Matching injMatch) -> do
-            let SortInjectionMatch { firstChild, secondChild } = injMatch
-            push (Pair firstChild secondChild)
+          let SortInjectionMatch {firstChild, secondChild} = injMatch
+          push (Pair firstChild secondChild)
         _ -> empty
   where
     sort1 = termLikeSort term1
@@ -270,75 +289,71 @@ matchApplication
 matchApplication _ = empty
 
 matchBuiltinList
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchBuiltinList (Pair (BuiltinList_ list1) (BuiltinList_ list2)) = do
-    (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
-    Monad.guard (null tail2)
-    Foldable.traverse_ push aligned
+  (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
+  Monad.guard (null tail2)
+  Foldable.traverse_ push aligned
 matchBuiltinList (Pair (App_ symbol1 children1) (BuiltinList_ list2))
   | List.isSymbolConcat symbol1 = matchBuiltinListConcat children1 list2
 matchBuiltinList _ = empty
 
 matchBuiltinListConcat
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => [TermLike variable]
-    -> Builtin.InternalList (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
-
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => [TermLike variable]
+  -> Builtin.InternalList (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchBuiltinListConcat [BuiltinList_ list1, frame1] list2 = do
-    (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
-    Foldable.traverse_ push aligned
-    push (Pair frame1 (mkBuiltinList tail2))
-
+  (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
+  Foldable.traverse_ push aligned
+  push (Pair frame1 (mkBuiltinList tail2))
 matchBuiltinListConcat [frame1, BuiltinList_ list1] list2 = do
-    (head2, aligned) <- rightAlignLists list1 list2 & Error.hoistMaybe
-    push (Pair frame1 (mkBuiltinList head2))
-    Foldable.traverse_ push aligned
-
+  (head2, aligned) <- rightAlignLists list1 list2 & Error.hoistMaybe
+  push (Pair frame1 (mkBuiltinList head2))
+  Foldable.traverse_ push aligned
 matchBuiltinListConcat _ _ = empty
 
 matchBuiltinSet
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchBuiltinSet (Pair (BuiltinSet_ set1) (BuiltinSet_ set2)) = do
-    matchNormalizedAc pushSetValue wrapTermLike normalized1 normalized2
+  matchNormalizedAc pushSetValue wrapTermLike normalized1 normalized2
   where
     normalized1 = Builtin.unwrapAc $ Builtin.builtinAcChild set1
     normalized2 = Builtin.unwrapAc $ Builtin.builtinAcChild set2
     pushSetValue _ = return ()
     wrapTermLike unwrapped =
-        set2
+      set2
         & Lens.set (field @"builtinAcChild") (Builtin.wrapAc unwrapped)
         & mkBuiltinSet
 matchBuiltinSet _ = empty
 
 matchBuiltinMap
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => Pair (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchBuiltinMap (Pair (BuiltinMap_ map1) (BuiltinMap_ map2)) =
-    matchNormalizedAc pushMapValue wrapTermLike normalized1 normalized2
+  matchNormalizedAc pushMapValue wrapTermLike normalized1 normalized2
   where
     normalized1 = Builtin.unwrapAc $ Builtin.builtinAcChild map1
     normalized2 = Builtin.unwrapAc $ Builtin.builtinAcChild map2
     pushMapValue = push . fmap Builtin.getMapValue
     wrapTermLike unwrapped =
-        map2
+      map2
         & Lens.set (field @"builtinAcChild") (Builtin.wrapAc unwrapped)
         & mkBuiltinMap
 matchBuiltinMap _ = empty
 
 -- * Implementation
-
-type MatchingVariable variable =
-    ( FreshVariable variable
-    , SortedVariable variable
-    , Show variable
-    , Unparse variable
-    )
+type MatchingVariable variable
+  = ( FreshVariable variable,
+      SortedVariable variable,
+      Show variable,
+      Unparse variable
+      )
 
 {- | A matching constraint is a @Pair@ of patterns.
 
@@ -346,51 +361,51 @@ The first pattern will be made to match the second.
 
  -}
 data Pair a = Pair !a !a
-    deriving (Foldable, Functor)
+  deriving (Foldable, Functor)
 
 {- | The internal state of the matching algorithm.
  -}
-data MatcherState variable =
-    MatcherState
-        { queued :: !(Seq (Pair (TermLike variable)))
+data MatcherState variable
+  = MatcherState
+      { queued :: !(Seq (Pair (TermLike variable))),
         -- ^ Solvable matching constraints.
-        , deferred :: !(Seq (Pair (TermLike variable)))
+        deferred :: !(Seq (Pair (TermLike variable))),
         -- ^ Unsolvable matching constraints; may become solvable with more
         -- information.
-        , substitution :: !(Map (UnifiedVariable variable) (TermLike variable))
+        substitution :: !(Map (UnifiedVariable variable) (TermLike variable)),
         -- ^ Matching solution: Substitutions for target variables.
-        , predicate :: !(MultiAnd (Syntax.Predicate variable))
+        predicate :: !(MultiAnd (Syntax.Predicate variable)),
         -- ^ Matching solution: Additional constraints.
-        , bound :: !(Set (UnifiedVariable variable))
+        bound :: !(Set (UnifiedVariable variable)),
         -- ^ Bound variable that must not escape in the solution.
-        , targets :: !(Set (UnifiedVariable variable))
+        targets :: !(Set (UnifiedVariable variable)),
         -- ^ Target variables that may be substituted.
-        , avoiding :: !(Set (UnifiedVariable variable))
+        avoiding :: !(Set (UnifiedVariable variable))
         -- ^ Variables that must not be shadowed.
         }
-    deriving (GHC.Generic)
+  deriving (GHC.Generic)
 
 type MatcherT variable unifier = StateT (MatcherState variable) unifier
 
 {- | Pop the next constraint from the matching queue.
  -}
 pop
-    :: MonadState (MatcherState variable) matcher
-    => matcher (Maybe (Pair (TermLike variable)))
+  :: MonadState (MatcherState variable) matcher
+  => matcher (Maybe (Pair (TermLike variable)))
 pop =
-    Lens.use (field @"queued") >>= \case
-        next :<| queued' -> do
-            field @"queued" .= queued'
-            return (Just next)
-        _ ->
-            return Nothing
+  Lens.use (field @"queued") >>= \case
+    next :<| queued' -> do
+      field @"queued" .= queued'
+      return (Just next)
+    _ ->
+      return Nothing
 
 {- | Push a new constraint onto the matching queue.
  -}
 push
-    :: MonadState (MatcherState variable) matcher
-    => Pair (TermLike variable)
-    -> matcher ()
+  :: MonadState (MatcherState variable) matcher
+  => Pair (TermLike variable)
+  -> matcher ()
 push pair = field @"queued" %= (pair :<|)
 
 {- | Defer a constraint until more information is available.
@@ -399,9 +414,9 @@ The constraint will be retried after the next substitution which affects it.
 
  -}
 defer
-    :: MonadState (MatcherState variable) matcher
-    => Pair (TermLike variable)
-    -> matcher ()
+  :: MonadState (MatcherState variable) matcher
+  => Pair (TermLike variable)
+  -> matcher ()
 defer pair = field @"deferred" %= (:|> pair)
 
 {- | Record an element substitution in the matching solution.
@@ -415,36 +430,32 @@ matching solution (so that it is always normalized). @substitute@ ensures that:
 
  -}
 substitute
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => ElementVariable variable
-    -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => ElementVariable variable
+  -> TermLike variable
+  -> MaybeT (MatcherT variable unifier) ()
 substitute eVariable termLike = do
-    -- Ensure that the variable does not occur free in the TermLike.
-    occursCheck variable termLike
-    -- Ensure that no bound variable would escape.
-    escapeCheck termLike
-    -- Ensure that the TermLike is defined.
-    definedTerm termLike
-    -- Record the substitution.
-    field @"substitution" <>= Map.singleton variable termLike
-
-    -- Isolate the deferred pairs which depend on the variable.
-    -- After substitution, the dependent pairs go to the front of the queue.
-    MatcherState { deferred } <- Monad.State.get
-    let (indep, dep) = Seq.partition isIndependent deferred
-    field @"deferred" .= indep
-
-    -- Push the dependent deferred pairs to the front of the queue.
-    Foldable.traverse_ push dep
-    -- Apply the substitution to the queued pairs.
-    field @"queued" . Lens.mapped %= substitute2
-
-    -- Apply the substitution to the accumulated matching solution.
-    field @"substitution" . Lens.mapped %= substitute1
-    field @"predicate" . Lens.mapped %= Syntax.Predicate.substitute subst
-
-    return ()
+  -- Ensure that the variable does not occur free in the TermLike.
+  occursCheck variable termLike
+  -- Ensure that no bound variable would escape.
+  escapeCheck termLike
+  -- Ensure that the TermLike is defined.
+  definedTerm termLike
+  -- Record the substitution.
+  field @"substitution" <>= Map.singleton variable termLike
+  -- Isolate the deferred pairs which depend on the variable.
+  -- After substitution, the dependent pairs go to the front of the queue.
+  MatcherState {deferred} <- Monad.State.get
+  let (indep, dep) = Seq.partition isIndependent deferred
+  field @"deferred" .= indep
+  -- Push the dependent deferred pairs to the front of the queue.
+  Foldable.traverse_ push dep
+  -- Apply the substitution to the queued pairs.
+  field @"queued" . Lens.mapped %= substitute2
+  -- Apply the substitution to the accumulated matching solution.
+  field @"substitution" . Lens.mapped %= substitute1
+  field @"predicate" . Lens.mapped %= Syntax.Predicate.substitute subst
+  return ()
   where
     variable = ElemVar eVariable
     isIndependent = not . any (hasFreeVariable variable)
@@ -460,32 +471,28 @@ the variable does not occur on the right-hand side of the substitution.
 
  -}
 setSubstitute
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => SetVariable variable
-    -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => SetVariable variable
+  -> TermLike variable
+  -> MaybeT (MatcherT variable unifier) ()
 setSubstitute sVariable termLike = do
-    -- Ensure that the variable does not occur free in the TermLike.
-    occursCheck variable termLike
-    -- Record the substitution.
-    field @"substitution" <>= Map.singleton variable termLike
-
-    -- Isolate the deferred pairs which depend on the variable.
-    -- After substitution, the dependent pairs go to the front of the queue.
-    MatcherState { deferred } <- Monad.State.get
-    let (indep, dep) = Seq.partition isIndependent deferred
-    field @"deferred" .= indep
-
-    -- Push the dependent deferred pairs to the front of the queue.
-    Foldable.traverse_ push dep
-    -- Apply the substitution to the queued pairs.
-    field @"queued" . Lens.mapped %= substitute2
-
-    -- Apply the substitution to the accumulated matching solution.
-    field @"substitution" . Lens.mapped %= substitute1
-    field @"predicate" . Lens.mapped %= Syntax.Predicate.substitute subst
-
-    return ()
+  -- Ensure that the variable does not occur free in the TermLike.
+  occursCheck variable termLike
+  -- Record the substitution.
+  field @"substitution" <>= Map.singleton variable termLike
+  -- Isolate the deferred pairs which depend on the variable.
+  -- After substitution, the dependent pairs go to the front of the queue.
+  MatcherState {deferred} <- Monad.State.get
+  let (indep, dep) = Seq.partition isIndependent deferred
+  field @"deferred" .= indep
+  -- Push the dependent deferred pairs to the front of the queue.
+  Foldable.traverse_ push dep
+  -- Apply the substitution to the queued pairs.
+  field @"queued" . Lens.mapped %= substitute2
+  -- Apply the substitution to the accumulated matching solution.
+  field @"substitution" . Lens.mapped %= substitute1
+  field @"predicate" . Lens.mapped %= Syntax.Predicate.substitute subst
+  return ()
   where
     variable = SetVar sVariable
     isIndependent = not . any (hasFreeVariable variable)
@@ -494,25 +501,25 @@ setSubstitute sVariable termLike = do
     substitute1 = substituteTermLike subst
 
 substituteTermLike
-    :: (FreshVariable variable, SortedVariable variable)
-    => (Show variable, Unparse variable)
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> TermLike variable
-    -> TermLike variable
+  :: (FreshVariable variable, SortedVariable variable)
+  => (Show variable, Unparse variable)
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> TermLike variable
+  -> TermLike variable
 substituteTermLike subst = Builtin.renormalize . TermLike.substitute subst
 
 occursCheck
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => UnifiedVariable variable
-    -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => UnifiedVariable variable
+  -> TermLike variable
+  -> MaybeT (MatcherT variable unifier) ()
 occursCheck variable termLike =
-    (Monad.guard . not) (hasFreeVariable variable termLike)
+  (Monad.guard . not) (hasFreeVariable variable termLike)
 
 definedTerm
-    :: (MatchingVariable variable, MonadState (MatcherState variable) matcher)
-    => TermLike variable
-    -> matcher ()
+  :: (MatchingVariable variable, MonadState (MatcherState variable) matcher)
+  => TermLike variable
+  -> matcher ()
 definedTerm termLike
   | isDefinedPattern termLike = return ()
   | otherwise = field @"predicate" <>= definedTermLike
@@ -528,12 +535,12 @@ do not attempt to match on them.
 
  -}
 targetCheck
-    :: (MatchingVariable variable, Monad unifier)
-    => UnifiedVariable variable
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, Monad unifier)
+  => UnifiedVariable variable
+  -> MaybeT (MatcherT variable unifier) ()
 targetCheck variable = do
-    MatcherState { targets } <- Monad.State.get
-    Monad.guard (Set.member variable targets)
+  MatcherState {targets} <- Monad.State.get
+  Monad.guard (Set.member variable targets)
 
 {- | Ensure that no bound variables occur free in the pattern.
 
@@ -542,13 +549,13 @@ escape.
 
  -}
 escapeCheck
-    :: (MatchingVariable variable, Monad unifier)
-    => TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, Monad unifier)
+  => TermLike variable
+  -> MaybeT (MatcherT variable unifier) ()
 escapeCheck termLike = do
-    let free = getFreeVariables (TermLike.freeVariables termLike)
-    MatcherState { bound } <- Monad.State.get
-    Monad.guard (Set.disjoint bound free)
+  let free = getFreeVariables (TermLike.freeVariables termLike)
+  MatcherState {bound} <- Monad.State.get
+  Monad.guard (Set.disjoint bound free)
 
 {- | Record the bound variable.
 
@@ -556,13 +563,13 @@ The bound variable will not escape, nor will it be shadowed.
 
  -}
 bindVariable
-    :: Ord variable
-    => MonadState (MatcherState variable) matcher
-    => UnifiedVariable variable
-    -> matcher ()
+  :: Ord variable
+  => MonadState (MatcherState variable) matcher
+  => UnifiedVariable variable
+  -> matcher ()
 bindVariable variable = do
-    field @"bound" %= Set.insert variable
-    field @"avoiding" %= Set.insert variable
+  field @"bound" %= Set.insert variable
+  field @"avoiding" %= Set.insert variable
 
 {- | Lift a (bound) variable to the top level by with a globally-unique name.
 
@@ -570,26 +577,26 @@ Returns 'Nothing' if the variable name is already globally-unique.
 
  -}
 liftVariable
-    :: FreshVariable variable
-    => MonadState (MatcherState variable) matcher
-    => UnifiedVariable variable
-    -> matcher (Maybe (UnifiedVariable variable))
+  :: FreshVariable variable
+  => MonadState (MatcherState variable) matcher
+  => UnifiedVariable variable
+  -> matcher (Maybe (UnifiedVariable variable))
 liftVariable variable =
-    flip Variables.refreshVariable variable <$> Lens.use (field @"avoiding")
+  flip Variables.refreshVariable variable <$> Lens.use (field @"avoiding")
 
 leftAlignLists
-    ::  Builtin.InternalList (TermLike variable)
-    ->  Builtin.InternalList (TermLike variable)
-    ->  Maybe
-            ( Builtin.InternalList (Pair (TermLike variable))
-            , Builtin.InternalList (TermLike variable)
-            )
+  :: Builtin.InternalList (TermLike variable)
+  -> Builtin.InternalList (TermLike variable)
+  -> Maybe
+       ( Builtin.InternalList (Pair (TermLike variable)),
+         Builtin.InternalList (TermLike variable)
+         )
 leftAlignLists internal1 internal2
   | length list2 < length list1 = empty
   | otherwise =
     return
-        ( internal1 { Builtin.builtinListChild = list12 }
-        , internal1 { Builtin.builtinListChild = tail2 }
+      ( internal1 {Builtin.builtinListChild = list12},
+        internal1 {Builtin.builtinListChild = tail2}
         )
   where
     list1 = Builtin.builtinListChild internal1
@@ -598,18 +605,18 @@ leftAlignLists internal1 internal2
     (head2, tail2) = Seq.splitAt (length list1) list2
 
 rightAlignLists
-    ::  Builtin.InternalList (TermLike variable)
-    ->  Builtin.InternalList (TermLike variable)
-    ->  Maybe
-            ( Builtin.InternalList (TermLike variable)
-            , Builtin.InternalList (Pair (TermLike variable))
-            )
+  :: Builtin.InternalList (TermLike variable)
+  -> Builtin.InternalList (TermLike variable)
+  -> Maybe
+       ( Builtin.InternalList (TermLike variable),
+         Builtin.InternalList (Pair (TermLike variable))
+         )
 rightAlignLists internal1 internal2
   | length list2 < length list1 = empty
   | otherwise =
     return
-        ( internal1 { Builtin.builtinListChild = head2 }
-        , internal1 { Builtin.builtinListChild = list12 }
+      ( internal1 {Builtin.builtinListChild = head2},
+        internal1 {Builtin.builtinListChild = list12}
         )
   where
     list1 = Builtin.builtinListChild internal1
@@ -618,27 +625,28 @@ rightAlignLists internal1 internal2
     (head2, tail2) = Seq.splitAt (length list2 - length list1) list2
 
 matchNormalizedAc
-    :: (MatchingVariable variable, MonadUnify unifier)
-    => (Pair (Builtin.Value normalized (TermLike variable)) -> MatcherT variable unifier ())
-    ->  (Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-        -> TermLike variable
-        )
-    -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-    -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+  :: (MatchingVariable variable, MonadUnify unifier)
+  => (Pair (Builtin.Value normalized (TermLike variable)) -> MatcherT variable unifier ())
+  -> ( Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
+       -> TermLike variable
+       )
+  -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
+  -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
+  -> MaybeT (MatcherT variable unifier) ()
 matchNormalizedAc pushValue wrapTermLike normalized1 normalized2
-  | [] <- abstract2, [] <- opaque2
-  , [] <- abstract1
-  = do
-    Monad.guard (null excess1)
-    case opaque1 of
-        []       -> Monad.guard (null excess2)
+  | [] <- abstract2,
+    [] <- opaque2,
+    [] <- abstract1 =
+    do
+      Monad.guard (null excess1)
+      case opaque1 of
+        [] -> Monad.guard (null excess2)
         [frame1] -> push (Pair frame1 normalized2')
-        _        -> empty
-    Monad.Trans.lift $ Foldable.traverse_ pushValue concrete12
+        _ -> empty
+      Monad.Trans.lift $ Foldable.traverse_ pushValue concrete12
   where
     normalized2' =
-        wrapTermLike normalized2 { Builtin.concreteElements = excess2 }
+      wrapTermLike normalized2 {Builtin.concreteElements = excess2}
     abstract1 = Builtin.elementsWithVariables normalized1
     concrete1 = Builtin.concreteElements normalized1
     opaque1 = Builtin.opaque normalized1

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -8,150 +8,160 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Axiom.Registry
-    ( extractEqualityAxioms
-    , axiomPatternsToEvaluators
-    ) where
+  ( extractEqualityAxioms,
+    axiomPatternsToEvaluators
+    )
+where
 
 import qualified Data.Foldable as Foldable
-import           Data.List
-                 ( partition )
-import           Data.Map
-                 ( Map )
+import Data.List
+  ( partition
+    )
+import Data.Map
+  ( Map
+    )
 import qualified Data.Map as Map
-import           Data.Maybe
-                 ( fromMaybe, mapMaybe )
-
-import           Kore.Attribute.Axiom
-                 ( Assoc (Assoc), Comm (Comm), Idem (Idem), Unit (Unit) )
+import Data.Maybe
+  ( fromMaybe,
+    mapMaybe
+    )
+import Kore.Attribute.Axiom
+  ( Assoc (Assoc),
+    Comm (Comm),
+    Idem (Idem),
+    Unit (Unit)
+    )
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Attribute.Overload
-import           Kore.Attribute.Simplification
-                 ( Simplification (..) )
-import           Kore.Attribute.Symbol
-import           Kore.IndexedModule.IndexedModule
-import           Kore.Internal.TermLike
-import           Kore.Step.Axiom.EvaluationStrategy
-                 ( definitionEvaluation, firstFullEvaluation,
-                 simplifierWithFallback )
-import           Kore.Step.Axiom.Identifier
-                 ( AxiomIdentifier )
+import Kore.Attribute.Overload
+import Kore.Attribute.Simplification
+  ( Simplification (..)
+    )
+import Kore.Attribute.Symbol
+import Kore.IndexedModule.IndexedModule
+import Kore.Internal.TermLike
+import Kore.Step.Axiom.EvaluationStrategy
+  ( definitionEvaluation,
+    firstFullEvaluation,
+    simplifierWithFallback
+    )
+import Kore.Step.Axiom.Identifier
+  ( AxiomIdentifier
+    )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
-import           Kore.Step.Axiom.UserDefined
-                 ( equalityRuleEvaluator )
-import           Kore.Step.Rule
-                 ( EqualityRule (EqualityRule),
-                 QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, ImplicationAxiomPattern, OnePathClaimPattern, RewriteAxiomPattern),
-                 RulePattern (RulePattern) )
+import Kore.Step.Axiom.UserDefined
+  ( equalityRuleEvaluator
+    )
+import Kore.Step.Rule
+  ( EqualityRule (EqualityRule),
+    QualifiedAxiomPattern (AllPathClaimPattern, FunctionAxiomPattern, ImplicationAxiomPattern, OnePathClaimPattern, RewriteAxiomPattern),
+    RulePattern (RulePattern)
+    )
 import qualified Kore.Step.Rule as Rule
-import           Kore.Step.Simplification.Data
-                 ( BuiltinAndAxiomSimplifier (..) )
-import           Kore.Syntax.Sentence
-                 ( SentenceAxiom (..) )
+import Kore.Step.Simplification.Data
+  ( BuiltinAndAxiomSimplifier (..)
+    )
+import Kore.Syntax.Sentence
+  ( SentenceAxiom (..)
+    )
 import qualified Kore.Verified as Verified
 
 {- | Create a mapping from symbol identifiers to their defining axioms.
 
  -}
 extractEqualityAxioms
-    :: VerifiedModule StepperAttributes Attribute.Axiom
-    -> Map AxiomIdentifier [EqualityRule Variable]
+  :: VerifiedModule StepperAttributes Attribute.Axiom
+  -> Map AxiomIdentifier [EqualityRule Variable]
 extractEqualityAxioms =
-    Foldable.foldl' extractModuleAxioms Map.empty
+  Foldable.foldl' extractModuleAxioms Map.empty
     . indexedModulesInScope
   where
     -- | Update the map of function axioms with all the axioms in one module.
     extractModuleAxioms
-        :: Map AxiomIdentifier [EqualityRule Variable]
-        -> VerifiedModule StepperAttributes Attribute.Axiom
-        -> Map AxiomIdentifier [EqualityRule Variable]
+      :: Map AxiomIdentifier [EqualityRule Variable]
+      -> VerifiedModule StepperAttributes Attribute.Axiom
+      -> Map AxiomIdentifier [EqualityRule Variable]
     extractModuleAxioms axioms imod =
-        Foldable.foldl' extractSentenceAxiom axioms sentences
+      Foldable.foldl' extractSentenceAxiom axioms sentences
       where
         sentences = indexedModuleAxioms imod
-
     -- | Extract an axiom from one sentence and update the map of function
     -- axioms with it. The map is returned unmodified in case the sentence is
     -- not a function axiom.
     extractSentenceAxiom
-        :: Map AxiomIdentifier [EqualityRule Variable]
-        -> (attrs, Verified.SentenceAxiom)
-        -> Map AxiomIdentifier [EqualityRule Variable]
+      :: Map AxiomIdentifier [EqualityRule Variable]
+      -> (attrs, Verified.SentenceAxiom)
+      -> Map AxiomIdentifier [EqualityRule Variable]
     extractSentenceAxiom axioms (_, sentence) =
-        let
-            namedAxiom = axiomToIdAxiomPatternPair sentence
-        in
-            Foldable.foldl' insertAxiom axioms namedAxiom
-
+      let namedAxiom = axiomToIdAxiomPatternPair sentence
+       in Foldable.foldl' insertAxiom axioms namedAxiom
     -- | Update the map of function axioms by inserting the axiom at the key.
     insertAxiom
-        :: Map AxiomIdentifier [EqualityRule Variable]
-        -> (AxiomIdentifier, EqualityRule Variable)
-        -> Map AxiomIdentifier [EqualityRule Variable]
+      :: Map AxiomIdentifier [EqualityRule Variable]
+      -> (AxiomIdentifier, EqualityRule Variable)
+      -> Map AxiomIdentifier [EqualityRule Variable]
     insertAxiom axioms (name, patt) =
-        Map.alter (Just . (patt :) . fromMaybe []) name axioms
+      Map.alter (Just . (patt :) . fromMaybe []) name axioms
 
 axiomToIdAxiomPatternPair
-    :: SentenceAxiom (TermLike Variable)
-    -> Maybe (AxiomIdentifier, EqualityRule Variable)
+  :: SentenceAxiom (TermLike Variable)
+  -> Maybe (AxiomIdentifier, EqualityRule Variable)
 axiomToIdAxiomPatternPair axiom =
-    case Rule.fromSentenceAxiom axiom of
-        Left _ -> Nothing
-        Right
-            (FunctionAxiomPattern axiomPat@(EqualityRule RulePattern { left }))
-          -> do
-            identifier <- AxiomIdentifier.matchAxiomIdentifier left
-            return (identifier, axiomPat)
-        Right (RewriteAxiomPattern _) -> Nothing
-        Right (OnePathClaimPattern _) -> Nothing
-        Right (AllPathClaimPattern _) -> Nothing
-        Right (ImplicationAxiomPattern _) -> Nothing
+  case Rule.fromSentenceAxiom axiom of
+    Left _ -> Nothing
+    Right
+      (FunctionAxiomPattern axiomPat@(EqualityRule RulePattern {left})) ->
+        do
+          identifier <- AxiomIdentifier.matchAxiomIdentifier left
+          return (identifier, axiomPat)
+    Right (RewriteAxiomPattern _) -> Nothing
+    Right (OnePathClaimPattern _) -> Nothing
+    Right (AllPathClaimPattern _) -> Nothing
+    Right (ImplicationAxiomPattern _) -> Nothing
 
 -- |Converts a registry of 'RulePattern's to one of
 -- 'BuiltinAndAxiomSimplifier's
 axiomPatternsToEvaluators
-    :: Map.Map AxiomIdentifier [EqualityRule Variable]
-    -> Map.Map AxiomIdentifier BuiltinAndAxiomSimplifier
+  :: Map.Map AxiomIdentifier [EqualityRule Variable]
+  -> Map.Map AxiomIdentifier BuiltinAndAxiomSimplifier
 axiomPatternsToEvaluators =
-    Map.fromAscList . mapMaybe equalitiesToEvaluators . Map.toAscList
+  Map.fromAscList . mapMaybe equalitiesToEvaluators . Map.toAscList
   where
     equalitiesToEvaluators
-        :: (AxiomIdentifier, [EqualityRule Variable])
-        -> Maybe (AxiomIdentifier, BuiltinAndAxiomSimplifier)
-    equalitiesToEvaluators
-        (symbolId, filter (not . ignoreEqualityRule) -> equalities)
-      =
-        case (simplificationEvaluator, definitionEvaluator) of
-            (Nothing, Nothing) -> Nothing
-            (Just evaluator, Nothing) -> Just (symbolId, evaluator)
-            (Nothing, Just evaluator) -> Just (symbolId, evaluator)
-            (Just sEvaluator, Just dEvaluator) ->
-                Just (symbolId, simplifierWithFallback sEvaluator dEvaluator)
+      :: (AxiomIdentifier, [EqualityRule Variable])
+      -> Maybe (AxiomIdentifier, BuiltinAndAxiomSimplifier)
+    equalitiesToEvaluators (symbolId, filter (not . ignoreEqualityRule) -> equalities) =
+      case (simplificationEvaluator, definitionEvaluator) of
+        (Nothing, Nothing) -> Nothing
+        (Just evaluator, Nothing) -> Just (symbolId, evaluator)
+        (Nothing, Just evaluator) -> Just (symbolId, evaluator)
+        (Just sEvaluator, Just dEvaluator) ->
+          Just (symbolId, simplifierWithFallback sEvaluator dEvaluator)
       where
         simplifications, evaluations :: [EqualityRule Variable]
         (simplifications, evaluations) =
-            partition isSimplificationRule equalities
+          partition isSimplificationRule equalities
           where
-            isSimplificationRule (EqualityRule RulePattern { attributes }) =
-                isSimplification
+            isSimplificationRule (EqualityRule RulePattern {attributes}) =
+              isSimplification
               where
-                Simplification { isSimplification } =
-                    Attribute.simplification attributes
+                Simplification {isSimplification} =
+                  Attribute.simplification attributes
         simplification :: [BuiltinAndAxiomSimplifier]
         simplification = mkSimplifier <$> simplifications
           where
             mkSimplifier
-                :: EqualityRule Variable
-                -> BuiltinAndAxiomSimplifier
+              :: EqualityRule Variable
+              -> BuiltinAndAxiomSimplifier
             mkSimplifier simpl =
-                BuiltinAndAxiomSimplifier $ equalityRuleEvaluator simpl
+              BuiltinAndAxiomSimplifier $ equalityRuleEvaluator simpl
         simplificationEvaluator =
-            if null simplification
-                then Nothing
-                else Just (firstFullEvaluation simplification)
+          if null simplification
+            then Nothing
+            else Just (firstFullEvaluation simplification)
         definitionEvaluator =
-            if null evaluations
-                then Nothing
-                else Just (definitionEvaluation evaluations)
+          if null evaluations
+            then Nothing
+            else Just (definitionEvaluation evaluations)
 
 {- | Return the evaluator corresponding to the 'AxiomPattern'.
 
@@ -161,18 +171,18 @@ axiom; this is determined by checking the 'AxiomPatternAttributes'.
 
  -}
 ignoreEqualityRule :: EqualityRule Variable -> Bool
-ignoreEqualityRule (EqualityRule RulePattern { attributes })
-    | isAssoc = True
-    | isComm = True
-    -- TODO (thomas.tuegel): Add unification cases for builtin units and enable
-    -- extraction of their axioms.
-    | isUnit = True
-    | isIdem = True
-    | Just _ <- getOverload = True
-    | otherwise = False
+ignoreEqualityRule (EqualityRule RulePattern {attributes})
+  | isAssoc = True
+  | isComm = True
+  -- TODO (thomas.tuegel): Add unification cases for builtin units and enable
+  -- extraction of their axioms.
+  | isUnit = True
+  | isIdem = True
+  | Just _ <- getOverload = True
+  | otherwise = False
   where
-    Assoc { isAssoc } = Attribute.assoc attributes
-    Comm { isComm } = Attribute.comm attributes
-    Unit { isUnit } = Attribute.unit attributes
-    Idem { isIdem } = Attribute.idem attributes
-    Overload { getOverload } = Attribute.overload attributes
+    Assoc {isAssoc} = Attribute.assoc attributes
+    Comm {isComm} = Attribute.comm attributes
+    Unit {isUnit} = Attribute.unit attributes
+    Idem {isIdem} = Attribute.idem attributes
+    Overload {getOverload} = Attribute.overload attributes

--- a/kore/src/Kore/Step/Axiom/UserDefined.hs
+++ b/kore/src/Kore/Step/Axiom/UserDefined.hs
@@ -8,119 +8,131 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Axiom.UserDefined
-    ( TermLikeSimplifier
-    , equalityRuleEvaluator
-    ) where
+  ( TermLikeSimplifier,
+    equalityRuleEvaluator
+    )
+where
 
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Axiom.Concrete as Axiom.Concrete
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Predicate )
-import           Kore.Internal.TermLike
-                 ( TermLike )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
+import Kore.Internal.TermLike
+  ( TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Step.Axiom.Matcher
-                 ( matchIncremental )
-import           Kore.Step.Rule
-                 ( EqualityRule (EqualityRule), RulePattern (..) )
+import Kore.Step.Axiom.Matcher
+  ( matchIncremental
+    )
+import Kore.Step.Rule
+  ( EqualityRule (EqualityRule),
+    RulePattern (..)
+    )
 import qualified Kore.Step.Rule as RulePattern
-import           Kore.Step.Simplification.Data
-                 ( AttemptedAxiom,
-                 AttemptedAxiomResults (AttemptedAxiomResults),
-                 BuiltinAndAxiomSimplifierMap, MonadSimplify,
-                 PredicateSimplifier, TermLikeSimplifier )
+import Kore.Step.Simplification.Data
+  ( AttemptedAxiom,
+    AttemptedAxiomResults (AttemptedAxiomResults),
+    BuiltinAndAxiomSimplifierMap,
+    MonadSimplify,
+    PredicateSimplifier,
+    TermLikeSimplifier
+    )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
-                 ( AttemptedAxiomResults (..) )
+  ( AttemptedAxiomResults (..)
+    )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..) )
+  ( AttemptedAxiom (..)
+    )
 import qualified Kore.Step.Simplification.OrPattern as OrPattern
-                 ( simplifyPredicatesWithSmt )
-import           Kore.Step.Step
-                 ( UnificationProcedure (..) )
+  ( simplifyPredicatesWithSmt
+    )
+import Kore.Step.Step
+  ( UnificationProcedure (..)
+    )
 import qualified Kore.Step.Step as Step
-import           Kore.Unification.Error
-                 ( UnificationOrSubstitutionError )
+import Kore.Unification.Error
+  ( UnificationOrSubstitutionError
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
+import Kore.Unparser
+  ( Unparse
+    )
+import Kore.Variables.Fresh
 
 {-| Evaluates a pattern using user-defined axioms. After
 evaluating the pattern, it tries to re-apply all axioms on the result.
 -}
 equalityRuleEvaluator
-    ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => EqualityRule Variable
-    -- ^ Axiom defining the current function.
-    -> PredicateSimplifier
-    -> TermLikeSimplifier
-    -- ^ Evaluates functions in patterns
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> TermLike variable
-    -- ^ The function on which to evaluate the current function.
-    -> Predicate variable
-    -> simplifier (AttemptedAxiom variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier
+                                   )
+  => EqualityRule Variable
+  -- ^ Axiom defining the current function.
+  -> PredicateSimplifier
+  -> TermLikeSimplifier
+  -- ^ Evaluates functions in patterns
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> TermLike variable
+  -- ^ The function on which to evaluate the current function.
+  -> Predicate variable
+  -> simplifier (AttemptedAxiom variable)
 equalityRuleEvaluator
-    (EqualityRule rule)
-    _substitutionSimplifier
-    _simplifier
-    _axiomIdToSimplifier
-    patt
-    _predicate
-  -- TODO(traiansf): never apply smt-lemma axioms,
-  -- neither as simplification rules nor as function definition rules
-  | Axiom.Concrete.isConcrete (Attribute.concrete $ attributes rule)
-  , not (TermLike.isConcrete patt)
-  = notApplicable
-  | otherwise = do
-    result <- applyRule patt rule
-    case result of
-        Left _        -> notApplicable
-        Right results -> AttemptedAxiom.Applied <$> simplifyResults results
-  where
-    notApplicable :: simplifier (AttemptedAxiom variable)
-    notApplicable = return AttemptedAxiom.NotApplicable
-
-    unificationProcedure :: UnificationProcedure
-    unificationProcedure = UnificationProcedure matchIncremental
-
-    applyRule
+  (EqualityRule rule)
+  _substitutionSimplifier
+  _simplifier
+  _axiomIdToSimplifier
+  patt
+  _predicate
+    -- TODO(traiansf): never apply smt-lemma axioms,
+    -- neither as simplification rules nor as function definition rules
+    | Axiom.Concrete.isConcrete (Attribute.concrete $ attributes rule),
+      not (TermLike.isConcrete patt) =
+      notApplicable
+    | otherwise =
+      do
+        result <- applyRule patt rule
+        case result of
+          Left _ -> notApplicable
+          Right results -> AttemptedAxiom.Applied <$> simplifyResults results
+    where
+      notApplicable :: simplifier (AttemptedAxiom variable)
+      notApplicable = return AttemptedAxiom.NotApplicable
+      unificationProcedure :: UnificationProcedure
+      unificationProcedure = UnificationProcedure matchIncremental
+      applyRule
         :: TermLike variable
         -> RulePattern Variable
         -> simplifier
-            (Either UnificationOrSubstitutionError [Step.Results variable])
-    applyRule patt' rule' =
+             (Either UnificationOrSubstitutionError [Step.Results variable])
+      applyRule patt' rule' =
         Monad.Unify.runUnifierT
-        $ Step.applyRulesParallel
-            unificationProcedure
-            [RulePattern.mapVariables fromVariable rule']
-            (Pattern.fromTermLike patt')
-
-    simplifyOrPatternsWithSmt
+          $ Step.applyRulesParallel
+              unificationProcedure
+              [RulePattern.mapVariables fromVariable rule']
+              (Pattern.fromTermLike patt')
+      simplifyOrPatternsWithSmt
         :: [OrPattern variable] -> simplifier (OrPattern variable)
-    simplifyOrPatternsWithSmt patterns = do
+      simplifyOrPatternsWithSmt patterns = do
         simplified <- traverse OrPattern.simplifyPredicatesWithSmt patterns
         return (MultiOr.mergeAll simplified)
-
-    simplifyResults
+      simplifyResults
         :: [Step.Results variable]
         -> simplifier (AttemptedAxiomResults variable)
-    simplifyResults stepResults = do
+      simplifyResults stepResults = do
         results <-
-            simplifyOrPatternsWithSmt
+          simplifyOrPatternsWithSmt
             $ map Step.gatherResults stepResults
         remainders <-
-            simplifyOrPatternsWithSmt
+          simplifyOrPatternsWithSmt
             $ map Step.remainders stepResults
-        return AttemptedAxiomResults { results, remainders }
+        return AttemptedAxiomResults {results, remainders}

--- a/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -8,46 +8,53 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Condition.Evaluator
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
+  ( gather
+    )
 import qualified Kore.Step.Simplification.Predicate as Predicate
-                 ( simplify )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+  ( simplify
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 {- | Attempt to simplify a predicate. -}
 simplify
-    ::  forall variable m .
-        ( FreshVariable variable
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify m
-        )
-    => Syntax.Predicate variable
-    -- ^ The condition to be evaluated.
-    -> m (Predicate variable)
-    -- TODO (virgil): use a BranchT m here and stop converting substitutions
-    -- to predicates. Even better, delete this one and use Predicate.simplify.
+  :: forall variable m. ( FreshVariable variable,
+                          SortedVariable variable,
+                          Ord variable,
+                          Show variable,
+                          Unparse variable,
+                          MonadSimplify m
+                          )
+  => Syntax.Predicate variable
+  -- ^ The condition to be evaluated.
+  -> m (Predicate variable)
+-- TODO (virgil): use a BranchT m here and stop converting substitutions
+-- to predicates. Even better, delete this one and use Predicate.simplify.
 simplify predicate = do
-    simplifiedPredicates <- BranchT.gather
-        $ Predicate.simplify 0 (Predicate.fromPredicate predicate)
-    return
-        ( Predicate.fromPredicate
+  simplifiedPredicates <-
+    BranchT.gather
+      $ Predicate.simplify 0 (Predicate.fromPredicate predicate)
+  return
+    ( Predicate.fromPredicate
         $ Syntax.Predicate.makeMultipleOrPredicate
         $ map Predicate.toPredicate simplifiedPredicates
-        )
+      )

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -8,157 +8,170 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Function.Evaluator
-    ( evaluateApplication
-    , evaluatePattern
-    ) where
+  ( evaluateApplication,
+    evaluatePattern
+    )
+where
 
-import           Control.Exception
-                 ( assert )
+import Control.Exception
+  ( assert
+    )
 import qualified Data.Map as Map
-import           Data.Maybe
-                 ( fromMaybe )
+import Data.Maybe
+  ( fromMaybe
+    )
 import qualified Data.Text as Text
-
-import           Kore.Attribute.Hook
+import Kore.Attribute.Hook
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Attribute.Synthetic
-import           Kore.Debug
+import Kore.Attribute.Synthetic
+import Kore.Debug
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( flatten, merge, mergeAll )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+  ( flatten,
+    merge,
+    mergeAll
+    )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern, Predicate )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern,
+    Predicate
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Internal.TermLike
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+import Kore.Internal.TermLike
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Profiler.Profile as Profile
-                 ( axiomEvaluation, equalitySimplification, mergeSubstitutions,
-                 resimplification )
-import           Kore.Step.Axiom.Identifier
-                 ( AxiomIdentifier )
+  ( axiomEvaluation,
+    equalitySimplification,
+    mergeSubstitutions,
+    resimplification
+    )
+import Kore.Step.Axiom.Identifier
+  ( AxiomIdentifier
+    )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import qualified Kore.Step.Merging.OrPattern as OrPattern
-import           Kore.Step.Simplification.Data as AttemptedAxiom
-                 ( AttemptedAxiom (..) )
-import           Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Data as AttemptedAxiom
+  ( AttemptedAxiom (..)
+    )
+import Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
-                 ( AttemptedAxiomResults (..) )
+  ( AttemptedAxiomResults (..)
+    )
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
+  ( gather
+    )
 import qualified Kore.Step.Simplification.Pattern as Pattern
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 {-| Evaluates functions on an application pattern.
 -}
 evaluateApplication
-    ::  forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Predicate variable
-    -- ^ The predicate from the configuration
-    -> Predicate variable
-    -- ^ Aggregated children predicate and substitution.
-    -> Application Symbol (TermLike variable)
-    -- ^ The pattern to be evaluated
-    -> simplifier (OrPattern variable)
+  :: forall variable simplifier. ( Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => Predicate variable
+  -- ^ The predicate from the configuration
+  -> Predicate variable
+  -- ^ Aggregated children predicate and substitution.
+  -> Application Symbol (TermLike variable)
+  -- ^ The pattern to be evaluated
+  -> simplifier (OrPattern variable)
 evaluateApplication configurationPredicate childrenPredicate application = do
-    substitutionSimplifier <- Simplifier.askSimplifierPredicate
-    simplifier <- Simplifier.askSimplifierTermLike
-    axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
-    let
-        afterInj = evaluateSortInjection application
-        Application { applicationSymbolOrAlias = appHead } = afterInj
-        Symbol { symbolConstructor = symbolId } = appHead
-        termLike = synthesize (ApplySymbolF afterInj)
-
-        maybeEvaluatedPattSimplifier =
-            maybeEvaluatePattern
-                substitutionSimplifier
-                simplifier
-                axiomIdToEvaluator
-                childrenPredicate
-                termLike
-                unchanged
-                configurationPredicate
-        unchangedPatt =
-            Conditional
-                { term         = termLike
-                , predicate    = predicate
-                , substitution = substitution
-                }
-          where
-            Conditional { term = (), predicate, substitution } =
-                childrenPredicate
-        unchanged = OrPattern.fromPattern unchangedPatt
-
-        getSymbolHook = getHook . Attribute.hook . symbolAttributes
-        getAppHookString = Text.unpack <$> getSymbolHook appHead
-
-    case maybeEvaluatedPattSimplifier of
-        Nothing
-          | Just hook <- getAppHookString
-          , not(null axiomIdToEvaluator) ->
-            error
-                (   "Attempting to evaluate unimplemented hooked operation "
-                ++  hook ++ ".\nSymbol: " ++ getIdForError symbolId
-                )
-          | otherwise ->
-            return unchanged
-        Just evaluatedPattSimplifier -> evaluatedPattSimplifier
+  substitutionSimplifier <- Simplifier.askSimplifierPredicate
+  simplifier <- Simplifier.askSimplifierTermLike
+  axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
+  let afterInj = evaluateSortInjection application
+      Application {applicationSymbolOrAlias = appHead} = afterInj
+      Symbol {symbolConstructor = symbolId} = appHead
+      termLike = synthesize (ApplySymbolF afterInj)
+      maybeEvaluatedPattSimplifier =
+        maybeEvaluatePattern
+          substitutionSimplifier
+          simplifier
+          axiomIdToEvaluator
+          childrenPredicate
+          termLike
+          unchanged
+          configurationPredicate
+      unchangedPatt =
+        Conditional
+          { term = termLike,
+            predicate = predicate,
+            substitution = substitution
+            }
+        where
+          Conditional {term = (), predicate, substitution} =
+            childrenPredicate
+      unchanged = OrPattern.fromPattern unchangedPatt
+      getSymbolHook = getHook . Attribute.hook . symbolAttributes
+      getAppHookString = Text.unpack <$> getSymbolHook appHead
+  case maybeEvaluatedPattSimplifier of
+    Nothing
+      | Just hook <- getAppHookString,
+        not (null axiomIdToEvaluator) ->
+        error
+          ( "Attempting to evaluate unimplemented hooked operation "
+              ++ hook
+              ++ ".\nSymbol: "
+              ++ getIdForError symbolId
+            )
+      | otherwise ->
+        return unchanged
+    Just evaluatedPattSimplifier -> evaluatedPattSimplifier
 
 {-| Evaluates axioms on patterns.
 -}
 evaluatePattern
-    ::  forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => PredicateSimplifier
-    -> TermLikeSimplifier
-    -- ^ Evaluates functions.
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> Predicate variable
-    -- ^ The predicate from the configuration
-    -> Predicate variable
-    -- ^ Aggregated children predicate and substitution.
-    -> TermLike variable
-    -- ^ The pattern to be evaluated
-    -> OrPattern variable
-    -- ^ The default value
-    -> simplifier (OrPattern variable)
+  :: forall variable simplifier. ( Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier,
+                                   WithLog LogMessage simplifier
+                                   )
+  => PredicateSimplifier
+  -> TermLikeSimplifier
+  -- ^ Evaluates functions.
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> Predicate variable
+  -- ^ The predicate from the configuration
+  -> Predicate variable
+  -- ^ Aggregated children predicate and substitution.
+  -> TermLike variable
+  -- ^ The pattern to be evaluated
+  -> OrPattern variable
+  -- ^ The default value
+  -> simplifier (OrPattern variable)
 evaluatePattern
-    substitutionSimplifier
-    simplifier
-    axiomIdToEvaluator
-    configurationPredicate
-    childrenPredicate
-    patt
-    defaultValue
-  =
+  substitutionSimplifier
+  simplifier
+  axiomIdToEvaluator
+  configurationPredicate
+  childrenPredicate
+  patt
+  defaultValue =
     fromMaybe
-        (return defaultValue)
-        (maybeEvaluatePattern
-            substitutionSimplifier
-            simplifier
-            axiomIdToEvaluator
-            childrenPredicate
-            patt
-            defaultValue
-            configurationPredicate
+      (return defaultValue)
+      ( maybeEvaluatePattern
+          substitutionSimplifier
+          simplifier
+          axiomIdToEvaluator
+          childrenPredicate
+          patt
+          defaultValue
+          configurationPredicate
         )
 
 {-| Evaluates axioms on patterns.
@@ -166,147 +179,141 @@ evaluatePattern
 Returns Nothing if there is no axiom for the pattern's identifier.
 -}
 maybeEvaluatePattern
-    ::  forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => PredicateSimplifier
-    -> TermLikeSimplifier
-    -- ^ Evaluates functions.
-    -> BuiltinAndAxiomSimplifierMap
-    -- ^ Map from axiom IDs to axiom evaluators
-    -> Predicate variable
-    -- ^ Aggregated children predicate and substitution.
-    -> TermLike variable
-    -- ^ The pattern to be evaluated
-    -> OrPattern variable
-    -- ^ The default value
-    -> Predicate variable
-    -> Maybe (simplifier (OrPattern variable))
+  :: forall variable simplifier. ( Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier,
+                                   WithLog LogMessage simplifier
+                                   )
+  => PredicateSimplifier
+  -> TermLikeSimplifier
+  -- ^ Evaluates functions.
+  -> BuiltinAndAxiomSimplifierMap
+  -- ^ Map from axiom IDs to axiom evaluators
+  -> Predicate variable
+  -- ^ Aggregated children predicate and substitution.
+  -> TermLike variable
+  -- ^ The pattern to be evaluated
+  -> OrPattern variable
+  -- ^ The default value
+  -> Predicate variable
+  -> Maybe (simplifier (OrPattern variable))
 maybeEvaluatePattern
-    substitutionSimplifier
-    simplifier
-    axiomIdToEvaluator
-    childrenPredicate
-    patt
-    defaultValue
-    configurationPredicate
-  =
+  substitutionSimplifier
+  simplifier
+  axiomIdToEvaluator
+  childrenPredicate
+  patt
+  defaultValue
+  configurationPredicate =
     case maybeEvaluator of
-        Nothing -> Nothing
-        Just (BuiltinAndAxiomSimplifier evaluator) ->
-            Just . tracing $ do
-                result <- axiomEvaluationTracing $
-                    evaluator
-                        substitutionSimplifier
-                        simplifier
-                        axiomIdToEvaluator
-                        patt
-                        configurationPredicate
-                flattened <- case result of
-                    AttemptedAxiom.NotApplicable ->
-                        return AttemptedAxiom.NotApplicable
-                    AttemptedAxiom.Applied AttemptedAxiomResults
-                        { results = orResults
-                        , remainders = orRemainders
-                        } -> do
-                            simplified <-
-                                resimplificationTracing (length orResults)
-                                $ mapM simplifyIfNeeded orResults
-                            return
-                                (AttemptedAxiom.Applied AttemptedAxiomResults
-                                    { results =
-                                        MultiOr.flatten simplified
-                                    , remainders = orRemainders
-                                    }
-                                )
-                merged <-
-                    mergeTracing
-                    $ mergeWithConditionAndSubstitution
-                        childrenPredicate
-                        flattened
-                case merged of
-                    AttemptedAxiom.NotApplicable -> return defaultValue
-                    AttemptedAxiom.Applied attemptResults ->
-                        return $ MultiOr.merge results remainders
-                      where
-                        AttemptedAxiomResults { results, remainders } =
-                            attemptResults
-  where
-    identifier :: Maybe AxiomIdentifier
-    identifier = AxiomIdentifier.matchAxiomIdentifier patt
-
-    maybeEvaluator :: Maybe BuiltinAndAxiomSimplifier
-    maybeEvaluator = do
+      Nothing -> Nothing
+      Just (BuiltinAndAxiomSimplifier evaluator) ->
+        Just . tracing $ do
+          result <-
+            axiomEvaluationTracing
+              $ evaluator
+                  substitutionSimplifier
+                  simplifier
+                  axiomIdToEvaluator
+                  patt
+                  configurationPredicate
+          flattened <-
+            case result of
+              AttemptedAxiom.NotApplicable ->
+                return AttemptedAxiom.NotApplicable
+              AttemptedAxiom.Applied
+                AttemptedAxiomResults
+                  { results = orResults,
+                    remainders = orRemainders
+                    } -> do
+                  simplified <-
+                    resimplificationTracing (length orResults)
+                      $ mapM simplifyIfNeeded orResults
+                  return
+                    ( AttemptedAxiom.Applied AttemptedAxiomResults
+                        { results =
+                            MultiOr.flatten simplified,
+                          remainders = orRemainders
+                          }
+                      )
+          merged <-
+            mergeTracing
+              $ mergeWithConditionAndSubstitution
+                  childrenPredicate
+                  flattened
+          case merged of
+            AttemptedAxiom.NotApplicable -> return defaultValue
+            AttemptedAxiom.Applied attemptResults ->
+              return $ MultiOr.merge results remainders
+              where
+                AttemptedAxiomResults {results, remainders} =
+                  attemptResults
+    where
+      identifier :: Maybe AxiomIdentifier
+      identifier = AxiomIdentifier.matchAxiomIdentifier patt
+      maybeEvaluator :: Maybe BuiltinAndAxiomSimplifier
+      maybeEvaluator = do
         identifier' <- identifier
         Map.lookup identifier' axiomIdToEvaluator
-
-    tracing =
+      tracing =
         traceNonErrorMonad
-            D_Function_evaluatePattern
-            [ debugArg "axiomIdentifier" identifier ]
-        . case identifier of
+          D_Function_evaluatePattern
+          [debugArg "axiomIdentifier" identifier]
+          . case identifier of
             Nothing -> id
             Just identifier' ->
-                Profile.equalitySimplification identifier' patt
-
-    axiomEvaluationTracing = maybe id Profile.axiomEvaluation identifier
-    resimplificationTracing resultCount =
+              Profile.equalitySimplification identifier' patt
+      axiomEvaluationTracing = maybe id Profile.axiomEvaluation identifier
+      resimplificationTracing resultCount =
         case identifier of
-            Nothing -> id
-            Just identifier' -> Profile.resimplification identifier' resultCount
-    mergeTracing =
+          Nothing -> id
+          Just identifier' -> Profile.resimplification identifier' resultCount
+      mergeTracing =
         case identifier of
-            Nothing -> id
-            Just identifier' -> Profile.mergeSubstitutions identifier'
-
-    unchangedPatt =
+          Nothing -> id
+          Just identifier' -> Profile.mergeSubstitutions identifier'
+      unchangedPatt =
         Conditional
-            { term         = patt
-            , predicate    = predicate
-            , substitution = substitution
+          { term = patt,
+            predicate = predicate,
+            substitution = substitution
             }
-      where
-        Conditional { term = (), predicate, substitution } = childrenPredicate
-
-    simplifyIfNeeded :: Pattern variable -> simplifier (OrPattern variable)
-    simplifyIfNeeded toSimplify
-      | toSimplify == unchangedPatt =
-        return (OrPattern.fromPattern unchangedPatt)
-      | otherwise =
-        reevaluateFunctions toSimplify
+        where
+          Conditional {term = (), predicate, substitution} = childrenPredicate
+      simplifyIfNeeded :: Pattern variable -> simplifier (OrPattern variable)
+      simplifyIfNeeded toSimplify
+        | toSimplify == unchangedPatt =
+          return (OrPattern.fromPattern unchangedPatt)
+        | otherwise =
+          reevaluateFunctions toSimplify
 
 evaluateSortInjection
-    :: Ord variable
-    => Application Symbol (TermLike variable)
-    -> Application Symbol (TermLike variable)
+  :: Ord variable
+  => Application Symbol (TermLike variable)
+  -> Application Symbol (TermLike variable)
 evaluateSortInjection ap
-  | Symbol.isSortInjection apHead
-  = case apChild of
-    App_ apHeadChild grandChildren
-      | Symbol.isSortInjection apHeadChild ->
-        let
-            [fromSort', toSort'] = symbolParams apHeadChild
-            apHeadNew = updateSortInjectionSource apHead fromSort'
-            resultApp = apHeadNew grandChildren
-        in
-            assert (toSort' == fromSort) resultApp
-    _ -> ap
+  | Symbol.isSortInjection apHead =
+    case apChild of
+      App_ apHeadChild grandChildren
+        | Symbol.isSortInjection apHeadChild ->
+          let [fromSort', toSort'] = symbolParams apHeadChild
+              apHeadNew = updateSortInjectionSource apHead fromSort'
+              resultApp = apHeadNew grandChildren
+           in assert (toSort' == fromSort) resultApp
+      _ -> ap
   | otherwise = ap
   where
     apHead = applicationSymbolOrAlias ap
     [fromSort, _] = symbolParams apHead
     [apChild] = applicationChildren ap
     updateSortInjectionSource head1 fromSort1 children =
-        Application
-            { applicationSymbolOrAlias =
-                Symbol.coerceSortInjection head1 fromSort1 toSort1
-            , applicationChildren = children
-            }
+      Application
+        { applicationSymbolOrAlias =
+            Symbol.coerceSortInjection head1 fromSort1 toSort1,
+          applicationChildren = children
+          }
       where
         [_, toSort1] = symbolParams head1
 
@@ -314,47 +321,48 @@ evaluateSortInjection ap
 was evaluated.
 -}
 reevaluateFunctions
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Pattern variable
-    -- ^ Function evaluation result.
-    -> simplifier (OrPattern variable)
+  :: ( SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Pattern variable
+  -- ^ Function evaluation result.
+  -> simplifier (OrPattern variable)
 reevaluateFunctions rewriting = do
-    pattOr <- simplifyTerm (Pattern.term rewriting)
-    mergedPatt <-
-        OrPattern.mergeWithPredicate (Pattern.withoutTerm rewriting) pattOr
-    orResults <- BranchT.gather $ traverse Pattern.simplifyPredicate mergedPatt
-    return (MultiOr.mergeAll orResults)
+  pattOr <- simplifyTerm (Pattern.term rewriting)
+  mergedPatt <-
+    OrPattern.mergeWithPredicate (Pattern.withoutTerm rewriting) pattOr
+  orResults <- BranchT.gather $ traverse Pattern.simplifyPredicate mergedPatt
+  return (MultiOr.mergeAll orResults)
 
 {-| Ands the given condition-substitution to the given function evaluation.
 -}
 mergeWithConditionAndSubstitution
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate variable
-    -- ^ Condition and substitution to add.
-    -> AttemptedAxiom variable
-    -- ^ AttemptedAxiom to which the condition should be added.
-    -> simplifier (AttemptedAxiom variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate variable
+  -- ^ Condition and substitution to add.
+  -> AttemptedAxiom variable
+  -- ^ AttemptedAxiom to which the condition should be added.
+  -> simplifier (AttemptedAxiom variable)
 mergeWithConditionAndSubstitution _ AttemptedAxiom.NotApplicable =
-    return AttemptedAxiom.NotApplicable
+  return AttemptedAxiom.NotApplicable
 mergeWithConditionAndSubstitution
-    toMerge
-    (AttemptedAxiom.Applied AttemptedAxiomResults { results, remainders })
-  = do
-    evaluatedResults <- OrPattern.mergeWithPredicate toMerge results
-    evaluatedRemainders <- OrPattern.mergeWithPredicate toMerge remainders
-    return $ AttemptedAxiom.Applied AttemptedAxiomResults
-        { results = evaluatedResults
-        , remainders = evaluatedRemainders
-        }
+  toMerge
+  (AttemptedAxiom.Applied AttemptedAxiomResults {results, remainders}) =
+    do
+      evaluatedResults <- OrPattern.mergeWithPredicate toMerge results
+      evaluatedRemainders <- OrPattern.mergeWithPredicate toMerge remainders
+      return
+        $ AttemptedAxiom.Applied AttemptedAxiomResults
+            { results = evaluatedResults,
+              remainders = evaluatedRemainders
+              }

--- a/kore/src/Kore/Step/Merging/OrPattern.hs
+++ b/kore/src/Kore/Step/Merging/OrPattern.hs
@@ -4,53 +4,65 @@ License     : NCSA
 
 -}
 module Kore.Step.Merging.OrPattern
-    ( mergeWithPredicate
-    , mergeWithPredicateAssumesEvaluated
-    ) where
+  ( mergeWithPredicate,
+    mergeWithPredicateAssumesEvaluated
+    )
+where
 
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( mergeAll )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
-import           Kore.Internal.Pattern
-                 ( Conditional, Predicate )
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+  ( mergeAll
+    )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
+import Kore.Internal.Pattern
+  ( Conditional,
+    Predicate
+    )
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Step.Merging.Pattern as Pattern
-import           Kore.Step.Simplification.Data
+import Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
-import           Kore.Step.Substitution
-                 ( PredicateMerger )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.TopBottom
-                 ( TopBottom )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( gather
+    )
+import Kore.Step.Substitution
+  ( PredicateMerger
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.TopBottom
+  ( TopBottom
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 {-| 'mergeWithPredicate' ands the given predicate/substitution
 to the given OrPattern.
 -}
 mergeWithPredicate
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate variable
-    -- ^ Predicate to add.
-    -> OrPattern variable
-    -- ^ Pattern to which the condition should be added.
-    -> simplifier (OrPattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate variable
+  -- ^ Predicate to add.
+  -> OrPattern variable
+  -- ^ Pattern to which the condition should be added.
+  -> simplifier (OrPattern variable)
 mergeWithPredicate toMerge patt = do
-    patterns <-
-        BranchT.gather $ traverse (Pattern.mergeWithPredicate toMerge) patt
-    return (MultiOr.mergeAll patterns)
+  patterns <-
+    BranchT.gather $ traverse (Pattern.mergeWithPredicate toMerge) patt
+  return (MultiOr.mergeAll patterns)
 
 {-| Ands the given predicate/substitution with the given 'MultiOr'.
 
@@ -58,21 +70,21 @@ Assumes that the initial patterns are simplified, so it does not attempt
 to re-simplify them.
 -}
 mergeWithPredicateAssumesEvaluated
-    ::  ( FreshVariable variable
-        , Monad m
-        , Ord term
-        , Show variable
-        , SortedVariable variable
-        , TopBottom term
-        , Unparse variable
-        )
-    => PredicateMerger variable m
-    -> Predicate variable
-    -- ^ Predicate to add.
-    -> MultiOr (Conditional variable term)
-    -- ^ Pattern to which the condition should be added.
-    -> m (MultiOr (Conditional variable term))
+  :: ( FreshVariable variable,
+       Monad m,
+       Ord term,
+       Show variable,
+       SortedVariable variable,
+       TopBottom term,
+       Unparse variable
+       )
+  => PredicateMerger variable m
+  -> Predicate variable
+  -- ^ Predicate to add.
+  -> MultiOr (Conditional variable term)
+  -- ^ Pattern to which the condition should be added.
+  -> m (MultiOr (Conditional variable term))
 mergeWithPredicateAssumesEvaluated substitutionMerger toMerge patt =
-    traverse
-        (Pattern.mergeWithPredicateAssumesEvaluated substitutionMerger toMerge)
-        patt
+  traverse
+    (Pattern.mergeWithPredicateAssumesEvaluated substitutionMerger toMerge)
+    patt

--- a/kore/src/Kore/Step/Merging/Pattern.hs
+++ b/kore/src/Kore/Step/Merging/Pattern.hs
@@ -4,91 +4,101 @@ License     : NCSA
 
 -}
 module Kore.Step.Merging.Pattern
-    ( mergeWithPredicateAssumesEvaluated
-    , mergeWithPredicate
-    ) where
+  ( mergeWithPredicateAssumesEvaluated,
+    mergeWithPredicate
+    )
+where
 
 import qualified Control.Monad.Trans.Class as Monad.Trans
-
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern, Predicate )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern,
+    Predicate
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Step.Condition.Evaluator as Predicate
-                 ( simplify )
-import           Kore.Step.Simplification.Data as Simplifier
-import           Kore.Step.Substitution
-                 ( PredicateMerger (PredicateMerger),
-                 mergePredicatesAndSubstitutions )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( simplify
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Substitution
+  ( PredicateMerger (PredicateMerger),
+    mergePredicatesAndSubstitutions
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 {-| 'mergeWithPredicate' ands the given predicate-substitution
 with the given pattern.
 -}
 mergeWithPredicate
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate variable
-    -- ^ Condition and substitution to add.
-    -> Pattern variable
-    -- ^ pattern to which the above should be added.
-    -> BranchT simplifier (Pattern variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate variable
+  -- ^ Condition and substitution to add.
+  -> Pattern variable
+  -- ^ pattern to which the above should be added.
+  -> BranchT simplifier (Pattern variable)
 mergeWithPredicate
-    Conditional
-        { predicate = conditionToMerge
-        , substitution = substitutionToMerge
-        }
-    patt@Conditional
-        { predicate = pattPredicate
-        , substitution = pattSubstitution
-        }
-  = do
-    merged <-
+  Conditional
+    { predicate = conditionToMerge,
+      substitution = substitutionToMerge
+      }
+  patt@Conditional
+    { predicate = pattPredicate,
+      substitution = pattSubstitution
+      } =
+    do
+      merged <-
         mergePredicatesAndSubstitutions
-            [pattPredicate, conditionToMerge]
-            [pattSubstitution, substitutionToMerge]
-    let Conditional { predicate = mergedCondition } = merged
-    evaluatedCondition <- Monad.Trans.lift $ Predicate.simplify mergedCondition
-    let Conditional { substitution = mergedSubstitution } = merged
-    mergeWithEvaluatedCondition
+          [pattPredicate, conditionToMerge]
+          [pattSubstitution, substitutionToMerge]
+      let Conditional {predicate = mergedCondition} = merged
+      evaluatedCondition <- Monad.Trans.lift $ Predicate.simplify mergedCondition
+      let Conditional {substitution = mergedSubstitution} = merged
+      mergeWithEvaluatedCondition
         patt {substitution = mergedSubstitution}
         evaluatedCondition
 
 mergeWithEvaluatedCondition
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Pattern variable
-    -> Predicate variable
-    -> BranchT simplifier (Pattern variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Pattern variable
+  -> Predicate variable
+  -> BranchT simplifier (Pattern variable)
 mergeWithEvaluatedCondition
-    Conditional
-        { term = pattTerm
-        , substitution = pattSubstitution
-        }  -- The predicate was already included in the Predicate
-    Conditional
-        { predicate = predPredicate, substitution = predSubstitution }
-  = do
-    merged <-
+  Conditional
+    { term = pattTerm,
+      substitution = pattSubstitution
+      } -- The predicate was already included in the Predicate
+  Conditional
+    { predicate = predPredicate,
+      substitution = predSubstitution
+      } =
+    do
+      merged <-
         mergePredicatesAndSubstitutions
-            [predPredicate]
-            [pattSubstitution, predSubstitution]
-    return $ Pattern.withCondition pattTerm merged
+          [predPredicate]
+          [pattSubstitution, predSubstitution]
+      return $ Pattern.withCondition pattTerm merged
 
 {-| Ands the given predicate/substitution with the given pattern.
 
@@ -96,32 +106,32 @@ Assumes that the initial patterns are simplified, so it does not attempt
 to re-simplify them.
 -}
 mergeWithPredicateAssumesEvaluated
-    ::  ( FreshVariable variable
-        , Monad m
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => PredicateMerger variable m
-    -> Predicate variable
-    -> Conditional variable term
-    -> m (Conditional variable term)
+  :: ( FreshVariable variable,
+       Monad m,
+       Ord variable,
+       Show variable,
+       SortedVariable variable,
+       Unparse variable
+       )
+  => PredicateMerger variable m
+  -> Predicate variable
+  -> Conditional variable term
+  -> m (Conditional variable term)
 mergeWithPredicateAssumesEvaluated
-    (PredicateMerger substitutionMerger)
-    Conditional
-        { term = ()
-        , predicate = predPredicate
-        , substitution = predSubstitution
-        }
-    Conditional
-        { term
-        , predicate = pattPredicate
-        , substitution = pattSubstitution
-        }  -- The predicate was already included in the Predicate
-  = do
-    merged <-
+  (PredicateMerger substitutionMerger)
+  Conditional
+    { term = (),
+      predicate = predPredicate,
+      substitution = predSubstitution
+      }
+  Conditional
+    { term,
+      predicate = pattPredicate,
+      substitution = pattSubstitution
+      } = -- The predicate was already included in the Predicate
+    do
+      merged <-
         substitutionMerger
-            [pattPredicate, predPredicate]
-            [pattSubstitution, predSubstitution]
-    return (Pattern.withCondition term merged)
+          [pattPredicate, predPredicate]
+          [pattSubstitution, predSubstitution]
+      return (Pattern.withCondition term merged)

--- a/kore/src/Kore/Step/PatternAttributes.hs
+++ b/kore/src/Kore/Step/PatternAttributes.hs
@@ -7,144 +7,149 @@ Maintainer  : virgil@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Step.PatternAttributes
-    ( isConstructorLikePattern
-    , isConstructorLikeTop
-    , isConstructorModuloLikePattern
-    ) where
+  ( isConstructorLikePattern,
+    isConstructorLikeTop,
+    isConstructorModuloLikePattern
+    )
+where
 
-import           Data.Either
-                 ( isRight )
-import           Data.Functor.Const
+import Data.Either
+  ( isRight
+    )
+import Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Reflection
-                 ( give )
-
+import Data.Reflection
+  ( give
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.Builtin.Attributes
-                 ( isConstructorModulo_ )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
+import Kore.Builtin.Attributes
+  ( isConstructorModulo_
+    )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Internal.TermLike
-import           Kore.Proof.Functional
-import           Kore.Step.PatternAttributesError
-                 ( ConstructorLikeError (..) )
+import Kore.Internal.TermLike
+import Kore.Proof.Functional
+import Kore.Step.PatternAttributesError
+  ( ConstructorLikeError (..)
+    )
 
 {-| Checks whether a pattern is constructor-like or not and, if it is,
     returns a proof certifying that.
 -}
 isConstructorLikePattern
-    :: SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> Either ConstructorLikeError [ConstructorLikeProof]
+  :: SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> Either ConstructorLikeError [ConstructorLikeProof]
 isConstructorLikePattern tools =
-    provePattern (checkConstructorLikeHead tools)
+  provePattern (checkConstructorLikeHead tools)
 
 {-| Checks whether a pattern is constructor-like, including
     constructors modulo associativity, commutativity and neutral element.
     If it is, returns a proof certifying that.
 -}
 isConstructorModuloLikePattern
-    :: Show variable
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> Either ConstructorLikeError [ConstructorLikeProof]
+  :: Show variable
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> Either ConstructorLikeError [ConstructorLikeProof]
 isConstructorModuloLikePattern tools =
-    provePattern (checkConstructorModuloLikeHead tools)
+  provePattern (checkConstructorModuloLikeHead tools)
 
 data PartialPatternProof proof
-    = Descend proof
-    | DoNotDescend proof
-  deriving Functor
+  = Descend proof
+  | DoNotDescend proof
+  deriving (Functor)
 
 provePattern
-    ::  (  Recursive.Base (TermLike variable) (Either error [proof])
-        -> Either error (PartialPatternProof proof)
-        )
-    -> TermLike variable
-    -> Either error [proof]
+  :: ( Recursive.Base (TermLike variable) (Either error [proof])
+       -> Either error (PartialPatternProof proof)
+       )
+  -> TermLike variable
+  -> Either error [proof]
 provePattern levelProver =
-    Recursive.fold reduceM
+  Recursive.fold reduceM
   where
     reduceM base = do
-        wrappedProof <- levelProver base
-        case wrappedProof of
-            DoNotDescend proof -> return [proof]
-            Descend proof -> do
-                proofs <- concat <$> sequence base
-                return (proof : proofs)
+      wrappedProof <- levelProver base
+      case wrappedProof of
+        DoNotDescend proof -> return [proof]
+        Descend proof -> do
+          proofs <- concat <$> sequence base
+          return (proof : proofs)
 
 -- Tells whether the pattern is a built-in constructor-like pattern
 isPreconstructedPattern
-    :: err
-    -> Recursive.Base (TermLike variable) pat
-    -> Either err (PartialPatternProof (FunctionalProof variable))
+  :: err
+  -> Recursive.Base (TermLike variable) pat
+  -> Either err (PartialPatternProof (FunctionalProof variable))
 isPreconstructedPattern err (_ :< pattern') =
-    case pattern' of
-        DomainValueF domain ->
-            (Right . Descend) (FunctionalDomainValue $ () <$ domain)
-        BuiltinF domain ->
-            (Right . Descend) (FunctionalBuiltin $ () <$ domain)
-        StringLiteralF (Const str) ->
-            Right $ DoNotDescend $ FunctionalStringLiteral str
-        CharLiteralF (Const char) ->
-            Right $ DoNotDescend $ FunctionalCharLiteral char
-        _ -> Left err
+  case pattern' of
+    DomainValueF domain ->
+      (Right . Descend) (FunctionalDomainValue $ () <$ domain)
+    BuiltinF domain ->
+      (Right . Descend) (FunctionalBuiltin $ () <$ domain)
+    StringLiteralF (Const str) ->
+      Right $ DoNotDescend $ FunctionalStringLiteral str
+    CharLiteralF (Const char) ->
+      Right $ DoNotDescend $ FunctionalCharLiteral char
+    _ -> Left err
 
 {-|@isConstructorLikeTop@ checks whether the given 'Pattern' is topped in a
 constructor / syntactic sugar for a constructor (literal / domain value)
 construct.
 -}
 isConstructorLikeTop
-    :: SmtMetadataTools Attribute.Symbol
-    -> Recursive.Base (TermLike variable) pat
-    -> Bool
+  :: SmtMetadataTools Attribute.Symbol
+  -> Recursive.Base (TermLike variable) pat
+  -> Bool
 isConstructorLikeTop _tools base@(_ :< pattern') =
-    case pattern' of
-        ApplySymbolF ap ->
-            Symbol.isConstructor patternHead
-          where
-            patternHead = applicationSymbolOrAlias ap
-        _ -> isRight (isPreconstructedPattern undefined base)
+  case pattern' of
+    ApplySymbolF ap ->
+      Symbol.isConstructor patternHead
+      where
+        patternHead = applicationSymbolOrAlias ap
+    _ -> isRight (isPreconstructedPattern undefined base)
 
 checkConstructorLikeHead
-    :: SmtMetadataTools Attribute.Symbol
-    -> Recursive.Base (TermLike variable) a
-    -> Either
-        ConstructorLikeError
-        (PartialPatternProof ConstructorLikeProof)
+  :: SmtMetadataTools Attribute.Symbol
+  -> Recursive.Base (TermLike variable) a
+  -> Either
+       ConstructorLikeError
+       (PartialPatternProof ConstructorLikeProof)
 checkConstructorLikeHead _tools base@(_ :< pattern') =
-    case pattern' of
-        ApplySymbolF Application { applicationSymbolOrAlias }
-          | isConstructor || isSortInjection ->
-            return (Descend ConstructorLikeProof)
-          where
-            (isConstructor, isSortInjection) =
-                ((,) <$> Symbol.isConstructor <*> Symbol.isSortInjection)
-                    applicationSymbolOrAlias
-        VariableF _ ->
-            return (Descend ConstructorLikeProof)
-        _ | Right _ <- isPreconstructedPattern undefined base ->
-            return (DoNotDescend ConstructorLikeProof)
-          | otherwise -> Left NonConstructorLikeHead
+  case pattern' of
+    ApplySymbolF Application {applicationSymbolOrAlias}
+      | isConstructor || isSortInjection ->
+        return (Descend ConstructorLikeProof)
+      where
+        (isConstructor, isSortInjection) =
+          ((,) <$> Symbol.isConstructor <*> Symbol.isSortInjection)
+            applicationSymbolOrAlias
+    VariableF _ ->
+      return (Descend ConstructorLikeProof)
+    _
+      | Right _ <- isPreconstructedPattern undefined base ->
+        return (DoNotDescend ConstructorLikeProof)
+      | otherwise -> Left NonConstructorLikeHead
 
 checkConstructorModuloLikeHead
-    :: (Show a, Show variable)
-    => SmtMetadataTools Attribute.Symbol
-    -> Recursive.Base (TermLike variable) a
-    -> Either
-        ConstructorLikeError
-        (PartialPatternProof ConstructorLikeProof)
+  :: (Show a, Show variable)
+  => SmtMetadataTools Attribute.Symbol
+  -> Recursive.Base (TermLike variable) a
+  -> Either
+       ConstructorLikeError
+       (PartialPatternProof ConstructorLikeProof)
 checkConstructorModuloLikeHead tools base@(_ :< pattern') =
-    case checkConstructorLikeHead tools base of
-        r@(Right _) -> r
-        Left _ ->
-            case pattern' of
-                ApplySymbolF Application { applicationSymbolOrAlias }
-                  | isConstructorModulo -> return (Descend ConstructorLikeProof)
-                  where
-                    isConstructorModulo =
-                        give tools isConstructorModulo_ applicationSymbolOrAlias
-                _ -> Left NonConstructorLikeHead
+  case checkConstructorLikeHead tools base of
+    r@(Right _) -> r
+    Left _ ->
+      case pattern' of
+        ApplySymbolF Application {applicationSymbolOrAlias}
+          | isConstructorModulo -> return (Descend ConstructorLikeProof)
+          where
+            isConstructorModulo =
+              give tools isConstructorModulo_ applicationSymbolOrAlias
+        _ -> Left NonConstructorLikeHead

--- a/kore/src/Kore/Step/PatternAttributesError.hs
+++ b/kore/src/Kore/Step/PatternAttributesError.hs
@@ -7,54 +7,55 @@ Maintainer  : virgil@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Step.PatternAttributesError
-    ( ConstructorLikeError (..)
-    , FunctionError (..)
-    , FunctionalError (..)
-    , TotalError (..)
-    ) where
+  ( ConstructorLikeError (..),
+    FunctionError (..),
+    FunctionalError (..),
+    TotalError (..)
+    )
+where
 
 import Kore.Internal.Symbol
-       ( Symbol )
+  ( Symbol
+    )
 
 {-| An error explaining why a pattern is not composed of function heads and
 things like StringLiteral, DomainValue and variables.
 -}
 data FunctionError
-    = NonFunctionHead Symbol
+  = NonFunctionHead Symbol
     -- ^ The pattern was the application of a non-function head to something
-    | NonFunctionPattern
+  | NonFunctionPattern
     -- ^ The pattern is neither an application pattern nor one of the basic
     -- pattern types (e.g. domain values).
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 {-| An error explaining why a pattern is not composed of functional heads and
 things like StringLiteral, DomainValue and variables.
 -}
 data FunctionalError
-    = NonFunctionalHead Symbol
+  = NonFunctionalHead Symbol
     -- ^ The pattern was the application of a non-functional head to something
-    | NonFunctionalPattern
+  | NonFunctionalPattern
     -- ^ The pattern is neither an application pattern nor one of the basic
     -- pattern types (e.g. domain values).
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 {-| An error explaining why a pattern is not composed of constructor-like heads
 and things like StringLiteral, DomainValue and variables.
 -}
 data ConstructorLikeError
-    = NonConstructorLikeHead
+  = NonConstructorLikeHead
     -- ^ The pattern was the application of a non-functional head to something
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 {-| An error explaining why a pattern is not composed of total heads and
 things like StringLiteral, DomainValue and variables.
 -}
 data TotalError
-    = NonTotalHead Symbol
+  = NonTotalHead Symbol
     -- ^ The pattern was the application of a non-total head to something
-    | NonTotalPattern
+  | NonTotalPattern
     -- ^ The pattern is neither an application pattern nor one of the basic
     -- pattern types (e.g. domain values).
-    deriving (Eq, Show)
+  deriving (Eq, Show)

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -3,47 +3,58 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Step.Remainder
-    ( remainder, remainder'
-    , existentiallyQuantifyTarget
-    , ceilChildOfApplicationOrTop
-    ) where
+  ( remainder,
+    remainder',
+    existentiallyQuantifyTarget,
+    ceilChildOfApplicationOrTop
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Data.Foldable as Foldable
-
-import           Kore.Internal.Conditional
-                 ( Conditional (Conditional) )
-import           Kore.Internal.MultiAnd
-                 ( MultiAnd )
+import Kore.Internal.Conditional
+  ( Conditional (Conditional)
+    )
+import Kore.Internal.MultiAnd
+  ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.OrPredicate as OrPredicate
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import qualified Kore.Step.Simplification.AndPredicates as AndPredicates
 import qualified Kore.Step.Simplification.Ceil as Ceil
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify (..) )
-import           Kore.Unification.Substitution
-                 ( Substitution )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify (..)
+    )
+import Kore.Unification.Substitution
+  ( Substitution
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
-import           Kore.Variables.Target
-                 ( Target )
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
+import Kore.Variables.Target
+  ( Target
+    )
 import qualified Kore.Variables.Target as Target
-import           Kore.Variables.UnifiedVariable
-                 ( foldMapVariable )
+import Kore.Variables.UnifiedVariable
+  ( foldMapVariable
+    )
 
 {- | Negate the disjunction of unification solutions to form the /remainder/.
 
@@ -56,15 +67,15 @@ See also: 'remainder\''
 
  -}
 remainder
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => MultiOr (Predicate (Target variable))
-    -> Syntax.Predicate variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => MultiOr (Predicate (Target variable))
+  -> Syntax.Predicate variable
 remainder =
-    Syntax.Predicate.mapVariables Target.unwrapVariable . remainder'
+  Syntax.Predicate.mapVariables Target.unwrapVariable . remainder'
 
 {- | Negate the disjunction of unification solutions to form the /remainder/.
 
@@ -73,33 +84,33 @@ by any applied rule.
 
  -}
 remainder'
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => MultiOr (Predicate (Target variable))
-    -> Syntax.Predicate (Target variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => MultiOr (Predicate (Target variable))
+  -> Syntax.Predicate (Target variable)
 remainder' results =
-    mkMultiAndPredicate $ mkNotExists conditions
+  mkMultiAndPredicate $ mkNotExists conditions
   where
     conditions = mkMultiAndPredicate . unificationConditions <$> results
     mkNotExists = mkNotMultiOr . fmap existentiallyQuantifyTarget
 
 -- | Existentially-quantify target (axiom) variables in the 'Predicate'.
 existentiallyQuantifyTarget
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Syntax.Predicate (Target variable)
-    -> Syntax.Predicate (Target variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Syntax.Predicate (Target variable)
+  -> Syntax.Predicate (Target variable)
 existentiallyQuantifyTarget predicate =
-    Syntax.Predicate.makeMultipleExists freeTargetVariables predicate
+  Syntax.Predicate.makeMultipleExists freeTargetVariables predicate
   where
     freeTargetVariables =
-        filter (Target.isTarget . getElementVariable)
+      filter (Target.isTarget . getElementVariable)
         . Syntax.Predicate.freeElementVariables
         $ predicate
 
@@ -111,85 +122,84 @@ existentiallyQuantifyTarget predicate =
 
  -}
 mkNotMultiOr
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => MultiOr  (Syntax.Predicate variable)
-    -> MultiAnd (Syntax.Predicate variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => MultiOr (Syntax.Predicate variable)
+  -> MultiAnd (Syntax.Predicate variable)
 mkNotMultiOr =
-    MultiAnd.make
+  MultiAnd.make
     . map Syntax.Predicate.makeNotPredicate
     . Foldable.toList
 
 mkMultiAndPredicate
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => MultiAnd (Syntax.Predicate variable)
-    ->           Syntax.Predicate variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => MultiAnd (Syntax.Predicate variable)
+  -> Syntax.Predicate variable
 mkMultiAndPredicate =
-    Syntax.Predicate.makeMultipleAndPredicate . Foldable.toList
+  Syntax.Predicate.makeMultipleAndPredicate . Foldable.toList
 
 {- | Represent the unification solution as a conjunction of predicates.
  -}
 unificationConditions
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Predicate (Target variable)
-    -- ^ Unification solution
-    -> MultiAnd (Syntax.Predicate (Target variable))
-unificationConditions Conditional { predicate, substitution } =
-    pure predicate <|> substitutionConditions substitution'
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Predicate (Target variable)
+  -- ^ Unification solution
+  -> MultiAnd (Syntax.Predicate (Target variable))
+unificationConditions Conditional {predicate, substitution} =
+  pure predicate <|> substitutionConditions substitution'
   where
     substitution' =
-        Substitution.filter (foldMapVariable Target.isNonTarget)
-            substitution
+      Substitution.filter (foldMapVariable Target.isNonTarget)
+        substitution
 
 substitutionConditions
-    ::  ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Substitution variable
-    -> MultiAnd (Syntax.Predicate variable)
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Substitution variable
+  -> MultiAnd (Syntax.Predicate variable)
 substitutionConditions subst =
-    MultiAnd.make (substitutionCoverageWorker <$> Substitution.unwrap subst)
+  MultiAnd.make (substitutionCoverageWorker <$> Substitution.unwrap subst)
   where
     substitutionCoverageWorker (x, t) =
-        Syntax.Predicate.makeEqualsPredicate (mkVar x) t
+      Syntax.Predicate.makeEqualsPredicate (mkVar x) t
 
 ceilChildOfApplicationOrTop
-    :: forall variable m
-    .  ( FreshVariable variable
-       , SortedVariable variable
-       , Show variable
-       , Unparse variable
-       , MonadSimplify m
-       )
-    => TermLike variable
-    -> m (Predicate variable)
+  :: forall variable m. ( FreshVariable variable,
+                          SortedVariable variable,
+                          Show variable,
+                          Unparse variable,
+                          MonadSimplify m
+                          )
+  => TermLike variable
+  -> m (Predicate variable)
 ceilChildOfApplicationOrTop patt =
-    case patt of
-        App_ _ children -> do
-            ceil <-
-                traverse (Ceil.makeEvaluateTerm Predicate.topTODO) children
-                >>= ( AndPredicates.simplifyEvaluatedMultiPredicate
-                    . MultiAnd.make
-                    )
-            pure $ Conditional
-                { term = ()
-                , predicate =
-                    OrPredicate.toPredicate
-                    . fmap Predicate.toPredicate
-                    $ ceil
-                , substitution = mempty
-                }
-        _ -> pure Predicate.top
+  case patt of
+    App_ _ children -> do
+      ceil <-
+        traverse (Ceil.makeEvaluateTerm Predicate.topTODO) children
+          >>= ( AndPredicates.simplifyEvaluatedMultiPredicate
+                  . MultiAnd.make
+                )
+      pure $ Conditional
+        { term = (),
+          predicate =
+            OrPredicate.toPredicate
+              . fmap Predicate.toPredicate
+              $ ceil,
+          substitution = mempty
+          }
+    _ -> pure Predicate.top

--- a/kore/src/Kore/Step/Result.hs
+++ b/kore/src/Kore/Step/Result.hs
@@ -2,47 +2,51 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
  -}
-
 module Kore.Step.Result
-    ( Result (..)
-    , mapRule
-    , Results (..)
-    , remainder
-    , hasResults
-    , withoutRemainders
-    , gatherResults
-    , mergeResults
-    , transitionResult
-    , transitionResults
-    , mapRules
-    , mapConfigs
-    , traverseConfigs
-    ) where
+  ( Result (..),
+    mapRule,
+    Results (..),
+    remainder,
+    hasResults,
+    withoutRemainders,
+    gatherResults,
+    mergeResults,
+    transitionResult,
+    transitionResults,
+    mapRules,
+    mapConfigs,
+    traverseConfigs
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative ((<|>)) )
+import Control.Applicative
+  ( Alternative ((<|>))
+    )
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
-import           Data.Sequence
-                 ( Seq )
+import Data.Sequence
+  ( Seq
+    )
 import qualified GHC.Generics as GHC
-
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Step.Transition
-                 ( TransitionT )
+import Kore.Step.Transition
+  ( TransitionT
+    )
 import qualified Kore.Step.Transition as Transition
-import           Kore.TopBottom
-                 ( TopBottom )
+import Kore.TopBottom
+  ( TopBottom
+    )
 
 -- | The result of applying a single rule.
-data Result rule config =
-    Result
-        { appliedRule :: !rule
-        , result      :: !(MultiOr config)
+data Result rule config
+  = Result
+      { appliedRule :: !rule,
+        result :: !(MultiOr config)
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 {- | Apply a function to the 'appliedRule' of a 'Result'.
 
@@ -50,7 +54,7 @@ See also: 'mapRules'
 
  -}
 mapRule :: (rule1 -> rule2) -> Result rule1 config -> Result rule2 config
-mapRule f r@Result { appliedRule } = r { appliedRule = f appliedRule }
+mapRule f r@Result {appliedRule} = r {appliedRule = f appliedRule}
 
 {- | The results of applying many rules.
 
@@ -58,23 +62,25 @@ The rules may be applied in sequence or in parallel and the 'remainders' vary
 accordingly.
 
  -}
-data Results rule config =
-    Results
-        { results :: !(Seq (Result rule config))
-        , remainders :: !(MultiOr config)
+data Results rule config
+  = Results
+      { results :: !(Seq (Result rule config)),
+        remainders :: !(MultiOr config)
         }
-    deriving (Eq, GHC.Generic, Ord, Show)
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance (Ord config, TopBottom config) => Semigroup (Results rule config) where
-    (<>) results1 results2 =
-        Results
-            { results = Function.on (<>) results results1 results2
-            , remainders = Function.on (<>) remainders results1 results2
-            }
+  (<>) results1 results2 =
+    Results
+      { results = Function.on (<>) results results1 results2,
+        remainders = Function.on (<>) remainders results1 results2
+        }
 
 instance (Ord config, TopBottom config) => Monoid (Results rule config) where
-    mempty = Results { results = mempty, remainders = mempty }
-    mappend = (<>)
+
+  mempty = Results {results = mempty, remainders = mempty}
+
+  mappend = (<>)
 
 {- | 'True' if any rule applied.
  -}
@@ -82,44 +88,44 @@ hasResults :: Results rule config -> Bool
 hasResults = not . Foldable.null . results
 
 mergeResults
-    :: (Ord config, TopBottom config)
-    => [Results rule config]
-    -> Results rule config
+  :: (Ord config, TopBottom config)
+  => [Results rule config]
+  -> Results rule config
 mergeResults = Foldable.fold
 
 {- | Take the 'Results' without any 'remainders'.
  -}
 withoutRemainders
-    :: (Ord config, TopBottom config)
-    => Results rule config
-    -> Results rule config
-withoutRemainders results = results { remainders = mempty }
+  :: (Ord config, TopBottom config)
+  => Results rule config
+  -> Results rule config
+withoutRemainders results = results {remainders = mempty}
 
 {- | 'Results' consisting of one remainder and no results.
  -}
 remainder :: (Ord config, TopBottom config) => config -> Results rule config
-remainder config = mempty { remainders = MultiOr.singleton config }
+remainder config = mempty {remainders = MultiOr.singleton config}
 
 {- | Gather all the final configurations from the 'Results'.
  -}
 gatherResults
-    :: (Ord config, TopBottom config)
-    => Results rule config
-    -> MultiOr config
+  :: (Ord config, TopBottom config)
+  => Results rule config
+  -> MultiOr config
 gatherResults = Foldable.fold . fmap result . results
 
 {- | Distribute the 'Result' over a transition rule.
  -}
 transitionResult :: Monad m => Result rule config -> TransitionT rule m config
-transitionResult Result { appliedRule, result } = do
-    Transition.addRule appliedRule
-    Foldable.asum (return <$> result)
+transitionResult Result {appliedRule, result} = do
+  Transition.addRule appliedRule
+  Foldable.asum (return <$> result)
 
 {- | Distribute the 'Results' over a transition rule.
  -}
 transitionResults :: Monad m => Results rule config -> TransitionT rule m config
-transitionResults Results { results, remainders } =
-    transitionResultsResults <|> transitionResultsRemainders
+transitionResults Results {results, remainders} =
+  transitionResultsResults <|> transitionResultsRemainders
   where
     transitionResultsResults = Foldable.asum (transitionResult <$> results)
     transitionResultsRemainders = Foldable.asum (return <$> remainders)
@@ -130,31 +136,31 @@ See also: 'mapRule'
 
  -}
 mapRules :: (rule1 -> rule2) -> Results rule1 config -> Results rule2 config
-mapRules f rs@Results { results } = rs { results = mapRule f <$> results }
+mapRules f rs@Results {results} = rs {results = mapRule f <$> results}
 
 {- | Apply functions to the configurations of the 'results' and 'remainders'.
  -}
 mapConfigs
-   :: (config1 -> config2)  -- ^ map 'results'
-   -> (config1 -> config2)  -- ^ map 'remainders'
-   -> Results rule config1
-   -> Results rule config2
-mapConfigs mapResults mapRemainders Results { results, remainders } =
-    Results
-        { results = fmap mapResults <$> results
-        , remainders = mapRemainders <$> remainders
-        }
+  :: (config1 -> config2) -- ^ map 'results'
+  -> (config1 -> config2) -- ^ map 'remainders'
+  -> Results rule config1
+  -> Results rule config2
+mapConfigs mapResults mapRemainders Results {results, remainders} =
+  Results
+    { results = fmap mapResults <$> results,
+      remainders = mapRemainders <$> remainders
+      }
 
 {- | Apply 'Applicative' transformations to the configurations of the 'results'
 and 'remainders'.
  -}
 traverseConfigs
-   :: Applicative f
-   => (config1 -> f config2)  -- ^ traverse 'results'
-   -> (config1 -> f config2)  -- ^ traverse 'remainders'
-   -> Results rule config1
-   -> f (Results rule config2)
+  :: Applicative f
+  => (config1 -> f config2) -- ^ traverse 'results'
+  -> (config1 -> f config2) -- ^ traverse 'remainders'
+  -> Results rule config1
+  -> f (Results rule config2)
 traverseConfigs traverseResults traverseRemainders rs =
-    Results
-        <$> (traverse . traverse) traverseResults (results rs)
-        <*> traverse traverseRemainders (remainders rs)
+  Results
+    <$> (traverse . traverse) traverseResults (results rs)
+    <*> traverse traverseRemainders (remainders rs)

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -4,68 +4,76 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 
 -}
-
 module Kore.Step.Rule
-    ( EqualityRule (..)
-    , RewriteRule (..)
-    , OnePathRule (..)
-    , AllPathRule (..)
-    , ImplicationRule (..)
-    , RulePattern (..)
-    , allPathGlobally
-    , rulePattern
-    , isHeatingRule
-    , isCoolingRule
-    , isNormalRule
-    , QualifiedAxiomPattern (..)
-    , AxiomPatternError (..)
-    , fromSentenceAxiom
-    , fromSentence
-    , extractRewriteAxioms
-    , extractOnePathClaims
-    , extractAllPathClaims
-    , extractImplicationClaims
-    , mkRewriteAxiom
-    , mkEqualityAxiom
-    , mkCeilAxiom
-    , refreshRulePattern
-    , onePathRuleToPattern
-    , Kore.Step.Rule.freeVariables
-    , Kore.Step.Rule.mapVariables
-    , Kore.Step.Rule.substitute
-    ) where
+  ( EqualityRule (..),
+    RewriteRule (..),
+    OnePathRule (..),
+    AllPathRule (..),
+    ImplicationRule (..),
+    RulePattern (..),
+    allPathGlobally,
+    rulePattern,
+    isHeatingRule,
+    isCoolingRule,
+    isNormalRule,
+    QualifiedAxiomPattern (..),
+    AxiomPatternError (..),
+    fromSentenceAxiom,
+    fromSentence,
+    extractRewriteAxioms,
+    extractOnePathClaims,
+    extractAllPathClaims,
+    extractImplicationClaims,
+    mkRewriteAxiom,
+    mkEqualityAxiom,
+    mkCeilAxiom,
+    refreshRulePattern,
+    onePathRuleToPattern,
+    Kore.Step.Rule.freeVariables,
+    Kore.Step.Rule.mapVariables,
+    Kore.Step.Rule.substitute
+    )
+where
 
 import qualified Data.Default as Default
-import           Data.Map.Strict
-                 ( Map )
-import           Data.Maybe
-import           Data.Text
-                 ( Text )
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty )
+import Data.Map.Strict
+  ( Map
+    )
+import Data.Maybe
+import Data.Text
+  ( Text
+    )
+import Data.Text.Prettyprint.Doc
+  ( Pretty
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Parser as Attribute.Parser
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables )
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables
+    )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import           Kore.Debug
-import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
-import           Kore.Internal.ApplicationSorts
-import           Kore.Internal.TermLike as TermLike
-import           Kore.Predicate.Predicate
-                 ( Predicate )
+import Kore.Debug
+import Kore.Error
+import Kore.IndexedModule.IndexedModule
+import Kore.Internal.ApplicationSorts
+import Kore.Internal.TermLike as TermLike
+import Kore.Predicate.Predicate
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Predicate
 import qualified Kore.Syntax.Definition as Syntax
-import           Kore.Unparser
-                 ( Unparse, unparse, unparse2 )
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable )
+import Kore.Unparser
+  ( Unparse,
+    unparse,
+    unparse2
+    )
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable
+    )
 import qualified Kore.Verified as Verified
 
 newtype AxiomPatternError = AxiomPatternError ()
@@ -73,17 +81,20 @@ newtype AxiomPatternError = AxiomPatternError ()
 {- | Normal rewriting and function axioms, claims and patterns.
 
  -}
-data RulePattern variable = RulePattern
-    { left  :: !(TermLike variable)
-    , right :: !(TermLike variable)
-    , requires :: !(Predicate variable)
-    , ensures :: !(Predicate variable)
-    , attributes :: !Attribute.Axiom
-    }
-    deriving (GHC.Generic)
+data RulePattern variable
+  = RulePattern
+      { left :: !(TermLike variable),
+        right :: !(TermLike variable),
+        requires :: !(Predicate variable),
+        ensures :: !(Predicate variable),
+        attributes :: !Attribute.Axiom
+        }
+  deriving (GHC.Generic)
 
 deriving instance Eq variable => Eq (RulePattern variable)
+
 deriving instance Ord variable => Ord (RulePattern variable)
+
 deriving instance Show variable => Show (RulePattern variable)
 
 instance SOP.Generic (RulePattern variable)
@@ -93,42 +104,42 @@ instance SOP.HasDatatypeInfo (RulePattern variable)
 instance Debug variable => Debug (RulePattern variable)
 
 instance
-    (SortedVariable variable, Unparse variable) =>
-    Pretty (RulePattern variable)
+  (SortedVariable variable, Unparse variable)
+  => Pretty (RulePattern variable)
   where
-    pretty rulePattern'@(RulePattern _ _ _ _ _) =
-        Pretty.vsep
-            [ "left:"
-            , Pretty.indent 4 (unparse left)
-            , "right:"
-            , Pretty.indent 4 (unparse right)
-            , "requires:"
-            , Pretty.indent 4 (unparse requires)
-            , "ensures:"
-            , Pretty.indent 4 (unparse ensures)
-            ]
-      where
-        RulePattern { left, right, requires, ensures } = rulePattern'
+  pretty rulePattern'@(RulePattern _ _ _ _ _) =
+    Pretty.vsep
+      [ "left:",
+        Pretty.indent 4 (unparse left),
+        "right:",
+        Pretty.indent 4 (unparse right),
+        "requires:",
+        Pretty.indent 4 (unparse requires),
+        "ensures:",
+        Pretty.indent 4 (unparse ensures)
+        ]
+    where
+      RulePattern {left, right, requires, ensures} = rulePattern'
 
 rulePattern
-    :: (Ord variable, SortedVariable variable)
-    => TermLike variable
-    -> TermLike variable
-    -> RulePattern variable
+  :: (Ord variable, SortedVariable variable)
+  => TermLike variable
+  -> TermLike variable
+  -> RulePattern variable
 rulePattern left right =
-    RulePattern
-        { left
-        , right
-        , requires = Predicate.makeTruePredicate
-        , ensures  = Predicate.makeTruePredicate
-        , attributes = Default.def
-        }
+  RulePattern
+    { left,
+      right,
+      requires = Predicate.makeTruePredicate,
+      ensures = Predicate.makeTruePredicate,
+      attributes = Default.def
+      }
 
 {-  | Equality-based rule pattern.
 -}
-newtype EqualityRule variable =
-    EqualityRule { getEqualityRule :: RulePattern variable }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype EqualityRule variable
+  = EqualityRule {getEqualityRule :: RulePattern variable}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic (EqualityRule variable)
 
@@ -138,9 +149,9 @@ instance Debug variable => Debug (EqualityRule variable)
 
 {-  | Rewrite-based rule pattern.
 -}
-newtype RewriteRule variable =
-    RewriteRule { getRewriteRule :: RulePattern variable }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype RewriteRule variable
+  = RewriteRule {getRewriteRule :: RulePattern variable}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic (RewriteRule variable)
 
@@ -149,35 +160,43 @@ instance SOP.HasDatatypeInfo (RewriteRule variable)
 instance Debug variable => Debug (RewriteRule variable)
 
 instance
-    (Ord variable, SortedVariable variable, Unparse variable)
-    => Unparse (RewriteRule variable)
+  (Ord variable, SortedVariable variable, Unparse variable)
+  => Unparse (RewriteRule variable)
   where
-    unparse (RewriteRule RulePattern { left, right, requires } ) =
-        unparse $ mkImplies
-            (mkAnd left (Predicate.unwrapPredicate requires))
-            right
-    unparse2 (RewriteRule RulePattern { left, right, requires } ) =
-        unparse2 $ mkImplies
-            (mkAnd left (Predicate.unwrapPredicate requires))
-            right
+
+  unparse (RewriteRule RulePattern {left, right, requires}) =
+    unparse
+      $ mkImplies
+          (mkAnd left (Predicate.unwrapPredicate requires))
+          right
+
+  unparse2 (RewriteRule RulePattern {left, right, requires}) =
+    unparse2
+      $ mkImplies
+          (mkAnd left (Predicate.unwrapPredicate requires))
+          right
 
 {-  | Implication-based pattern.
 -}
-newtype ImplicationRule variable =
-    ImplicationRule { getImplicationRule :: RulePattern variable }
+newtype ImplicationRule variable
+  = ImplicationRule {getImplicationRule :: RulePattern variable}
 
 deriving instance Eq variable => Eq (ImplicationRule variable)
+
 deriving instance Ord variable => Ord (ImplicationRule variable)
+
 deriving instance Show variable => Show (ImplicationRule variable)
 
 instance
-    (Ord variable, SortedVariable variable, Unparse variable)
-    => Unparse (ImplicationRule variable)
+  (Ord variable, SortedVariable variable, Unparse variable)
+  => Unparse (ImplicationRule variable)
   where
-    unparse (ImplicationRule RulePattern { left, right } ) =
-        unparse $ mkImplies left right
-    unparse2 (ImplicationRule RulePattern { left, right } ) =
-        unparse2 $ mkImplies left right
+
+  unparse (ImplicationRule RulePattern {left, right}) =
+    unparse $ mkImplies left right
+
+  unparse2 (ImplicationRule RulePattern {left, right}) =
+    unparse2 $ mkImplies left right
 
 -- | modalities
 weakExistsFinally :: Text
@@ -190,20 +209,20 @@ allPathGlobally :: Text
 allPathGlobally = "allPathGlobally"
 
 qualifiedAxiomOpToConstructor
-    :: Alias
-    -> Maybe (RulePattern variable -> QualifiedAxiomPattern variable)
+  :: Alias
+  -> Maybe (RulePattern variable -> QualifiedAxiomPattern variable)
 qualifiedAxiomOpToConstructor patternHead
-    | headName == weakExistsFinally = Just $ OnePathClaimPattern . OnePathRule
-    | headName == weakAlwaysFinally = Just $ AllPathClaimPattern . AllPathRule
-    | otherwise = Nothing
+  | headName == weakExistsFinally = Just $ OnePathClaimPattern . OnePathRule
+  | headName == weakAlwaysFinally = Just $ AllPathClaimPattern . AllPathRule
+  | otherwise = Nothing
   where
     headName = getId (aliasConstructor patternHead)
 
 {-  | One-Path-Claim rule pattern.
 -}
-newtype OnePathRule variable =
-    OnePathRule { getOnePathRule :: RulePattern variable }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype OnePathRule variable
+  = OnePathRule {getOnePathRule :: RulePattern variable}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance SOP.Generic (OnePathRule variable)
 
@@ -212,192 +231,197 @@ instance SOP.HasDatatypeInfo (OnePathRule variable)
 instance Debug variable => Debug (OnePathRule variable)
 
 instance
-    (Ord variable, SortedVariable variable, Unparse variable)
-    => Unparse (OnePathRule variable)
+  (Ord variable, SortedVariable variable, Unparse variable)
+  => Unparse (OnePathRule variable)
   where
-    unparse = unparse . onePathRuleToPattern
-    unparse2 = unparse2 . onePathRuleToPattern
+
+  unparse = unparse . onePathRuleToPattern
+
+  unparse2 = unparse2 . onePathRuleToPattern
 
 {-  | All-Path-Claim rule pattern.
 -}
-newtype AllPathRule variable =
-    AllPathRule { getAllPathRule :: RulePattern variable }
+newtype AllPathRule variable
+  = AllPathRule {getAllPathRule :: RulePattern variable}
 
 deriving instance Eq variable => Eq (AllPathRule variable)
+
 deriving instance Ord variable => Ord (AllPathRule variable)
+
 deriving instance Show variable => Show (AllPathRule variable)
 
 {- | Sum type to distinguish rewrite axioms (used for stepping)
 from function axioms (used for functional simplification).
 --}
 data QualifiedAxiomPattern variable
-    = RewriteAxiomPattern (RewriteRule variable)
-    | FunctionAxiomPattern (EqualityRule variable)
-    | OnePathClaimPattern (OnePathRule variable)
-    | AllPathClaimPattern (AllPathRule variable)
-    | ImplicationAxiomPattern (ImplicationRule variable)
-    -- TODO(virgil): Rename the above since it applies to all sorts of axioms,
-    -- not only to function-related ones.
+  = RewriteAxiomPattern (RewriteRule variable)
+  | FunctionAxiomPattern (EqualityRule variable)
+  | OnePathClaimPattern (OnePathRule variable)
+  | AllPathClaimPattern (AllPathRule variable)
+  | ImplicationAxiomPattern (ImplicationRule variable)
 
+-- TODO(virgil): Rename the above since it applies to all sorts of axioms,
+-- not only to function-related ones.
 deriving instance Eq variable => Eq (QualifiedAxiomPattern variable)
+
 deriving instance Ord variable => Ord (QualifiedAxiomPattern variable)
+
 deriving instance Show variable => Show (QualifiedAxiomPattern variable)
 
 {- | Does the axiom pattern represent a heating rule?
  -}
 isHeatingRule :: RulePattern variable -> Bool
-isHeatingRule RulePattern { attributes } =
-    case Attribute.heatCool attributes of
-        Attribute.Heat -> True
-        _ -> False
+isHeatingRule RulePattern {attributes} =
+  case Attribute.heatCool attributes of
+    Attribute.Heat -> True
+    _ -> False
 
 {- | Does the axiom pattern represent a cooling rule?
  -}
 isCoolingRule :: RulePattern variable -> Bool
-isCoolingRule RulePattern { attributes } =
-    case Attribute.heatCool attributes of
-        Attribute.Cool -> True
-        _ -> False
+isCoolingRule RulePattern {attributes} =
+  case Attribute.heatCool attributes of
+    Attribute.Cool -> True
+    _ -> False
 
 {- | Does the axiom pattern represent a normal rule?
  -}
 isNormalRule :: RulePattern variable -> Bool
-isNormalRule RulePattern { attributes } =
-    case Attribute.heatCool attributes of
-        Attribute.Normal -> True
-        _ -> False
-
+isNormalRule RulePattern {attributes} =
+  case Attribute.heatCool attributes of
+    Attribute.Normal -> True
+    _ -> False
 
 -- | Extracts all 'RewriteRule' axioms from a 'VerifiedModule'.
 extractRewriteAxioms
-    :: VerifiedModule declAtts axiomAtts
-    -> [RewriteRule Variable]
+  :: VerifiedModule declAtts axiomAtts
+  -> [RewriteRule Variable]
 extractRewriteAxioms idxMod =
-    mapMaybe (extractRewriteAxiomFrom . getIndexedSentence)
-        (indexedModuleAxioms idxMod)
+  mapMaybe (extractRewriteAxiomFrom . getIndexedSentence)
+    (indexedModuleAxioms idxMod)
 
 extractRewriteAxiomFrom
-    :: Verified.SentenceAxiom
-    -- ^ Sentence to extract axiom pattern from
-    -> Maybe (RewriteRule Variable)
+  :: Verified.SentenceAxiom
+  -- ^ Sentence to extract axiom pattern from
+  -> Maybe (RewriteRule Variable)
 extractRewriteAxiomFrom sentence =
-    case fromSentenceAxiom sentence of
-        Right (RewriteAxiomPattern axiomPat) -> Just axiomPat
-        _ -> Nothing
+  case fromSentenceAxiom sentence of
+    Right (RewriteAxiomPattern axiomPat) -> Just axiomPat
+    _ -> Nothing
 
 -- | Extracts all One-Path claims from a verified module.
 extractOnePathClaims
-    :: VerifiedModule declAtts axiomAtts
-    -- ^'IndexedModule' containing the definition
-    -> [(axiomAtts, OnePathRule Variable)]
+  :: VerifiedModule declAtts axiomAtts
+  -- ^'IndexedModule' containing the definition
+  -> [(axiomAtts, OnePathRule Variable)]
 extractOnePathClaims idxMod =
-    mapMaybe
-        -- applying on second component
-        (traverse extractOnePathClaimFrom)
-        (indexedModuleClaims idxMod)
+  mapMaybe
+    -- applying on second component
+    (traverse extractOnePathClaimFrom)
+    (indexedModuleClaims idxMod)
 
 extractOnePathClaimFrom
-    :: Verified.SentenceClaim
-    -- ^ Sentence to extract axiom pattern from
-    -> Maybe (OnePathRule Variable)
+  :: Verified.SentenceClaim
+  -- ^ Sentence to extract axiom pattern from
+  -> Maybe (OnePathRule Variable)
 extractOnePathClaimFrom sentence =
-    case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
-        Right (OnePathClaimPattern claim) -> Just claim
-        _ -> Nothing
+  case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
+    Right (OnePathClaimPattern claim) -> Just claim
+    _ -> Nothing
 
 -- | Extracts all All-Path claims from a verified definition.
 extractAllPathClaims
-    :: VerifiedModule declAtts axiomAtts
-    -- ^'IndexedModule' containing the definition
-    -> [(axiomAtts, AllPathRule Variable)]
+  :: VerifiedModule declAtts axiomAtts
+  -- ^'IndexedModule' containing the definition
+  -> [(axiomAtts, AllPathRule Variable)]
 extractAllPathClaims idxMod =
-    mapMaybe
-        -- applying on second component
-        (traverse extractAllPathClaimFrom)
-        (indexedModuleClaims idxMod)
+  mapMaybe
+    -- applying on second component
+    (traverse extractAllPathClaimFrom)
+    (indexedModuleClaims idxMod)
 
 extractAllPathClaimFrom
-    :: Verified.SentenceClaim
-    -- ^ Sentence to extract axiom pattern from
-    -> Maybe (AllPathRule Variable)
+  :: Verified.SentenceClaim
+  -- ^ Sentence to extract axiom pattern from
+  -> Maybe (AllPathRule Variable)
 extractAllPathClaimFrom sentence =
-    case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
-        Right (AllPathClaimPattern claim) -> Just claim
-        _ -> Nothing
+  case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
+    Right (AllPathClaimPattern claim) -> Just claim
+    _ -> Nothing
 
 -- | Extract all 'ImplicationRule' claims matching a given @level@ from
 -- a verified definition.
 extractImplicationClaims
-    :: VerifiedModule declAtts axiomAtts
-    -- ^'IndexedModule' containing the definition
-    -> [(axiomAtts, ImplicationRule Variable)]
+  :: VerifiedModule declAtts axiomAtts
+  -- ^'IndexedModule' containing the definition
+  -> [(axiomAtts, ImplicationRule Variable)]
 extractImplicationClaims idxMod =
-    mapMaybe
-        -- applying on second component
-        (traverse extractImplicationClaimFrom)
-        (indexedModuleClaims idxMod)
+  mapMaybe
+    -- applying on second component
+    (traverse extractImplicationClaimFrom)
+    (indexedModuleClaims idxMod)
 
 extractImplicationClaimFrom
-    :: Verified.SentenceClaim
-    -- ^ Sentence to extract axiom pattern from
-    -> Maybe (ImplicationRule Variable)
+  :: Verified.SentenceClaim
+  -- ^ Sentence to extract axiom pattern from
+  -> Maybe (ImplicationRule Variable)
 extractImplicationClaimFrom sentence =
-    case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
-        Right (ImplicationAxiomPattern axiomPat) -> Just axiomPat
-        _ -> Nothing
+  case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
+    Right (ImplicationAxiomPattern axiomPat) -> Just axiomPat
+    _ -> Nothing
 
 -- | Attempts to extract a rule from the 'Verified.Sentence'.
 fromSentence
-    :: Verified.Sentence
-    -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
+  :: Verified.Sentence
+  -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
 fromSentence (Syntax.SentenceAxiomSentence sentenceAxiom) =
-    fromSentenceAxiom sentenceAxiom
+  fromSentenceAxiom sentenceAxiom
 fromSentence _ =
-    koreFail "Only axiom sentences can be translated to rules"
+  koreFail "Only axiom sentences can be translated to rules"
 
 -- | Attempts to extract a rule from the 'Verified.SentenceAxiom'.
 fromSentenceAxiom
-    :: Verified.SentenceAxiom
-    -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
+  :: Verified.SentenceAxiom
+  -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
 fromSentenceAxiom sentenceAxiom = do
-    attributes <-
-        (Attribute.Parser.liftParser . Attribute.Parser.parseAttributes)
-            (Syntax.sentenceAxiomAttributes sentenceAxiom)
-    patternToAxiomPattern attributes (Syntax.sentenceAxiomPattern sentenceAxiom)
+  attributes <-
+    (Attribute.Parser.liftParser . Attribute.Parser.parseAttributes)
+      (Syntax.sentenceAxiomAttributes sentenceAxiom)
+  patternToAxiomPattern attributes (Syntax.sentenceAxiomPattern sentenceAxiom)
 
 onePathRuleToPattern
-    :: Ord variable
-    => SortedVariable variable
-    => Unparse variable
-    => OnePathRule variable
-    -> TermLike variable
+  :: Ord variable
+  => SortedVariable variable
+  => Unparse variable
+  => OnePathRule variable
+  -> TermLike variable
 onePathRuleToPattern (OnePathRule rulePatt) =
-    mkImplies
-        ( mkAnd
-            (Predicate.unwrapPredicate . requires $ rulePatt)
-            (left rulePatt)
-        )
-       ( mkApplyAlias
-            (wEF sort)
-            [mkAnd
-                (Predicate.unwrapPredicate . ensures $ rulePatt)
-                (right rulePatt)
-            ]
-       )
+  mkImplies
+    ( mkAnd
+        (Predicate.unwrapPredicate . requires $ rulePatt)
+        (left rulePatt)
+      )
+    ( mkApplyAlias
+        (wEF sort)
+        [ mkAnd
+            (Predicate.unwrapPredicate . ensures $ rulePatt)
+            (right rulePatt)
+          ]
+      )
   where
     sort :: Sort
     sort = termLikeSort . right $ rulePatt
 
 wEF :: Sort -> Alias
 wEF sort = Alias
-    { aliasConstructor = Id
-        { getId = weakExistsFinally
-        , idLocation = AstLocationNone
-        }
-    , aliasParams = []
-    , aliasSorts = ApplicationSorts
-        { applicationSortsOperands = [sort]
-        , applicationSortsResult = sort
+  { aliasConstructor = Id
+      { getId = weakExistsFinally,
+        idLocation = AstLocationNone
+        },
+    aliasParams = [],
+    aliasSorts = ApplicationSorts
+      { applicationSortsOperands = [sort],
+        applicationSortsResult = sort
         }
     }
 
@@ -407,79 +431,85 @@ wEF sort = Alias
 not encode a normal rewrite or function axiom.
 -}
 patternToAxiomPattern
-    :: Attribute.Axiom
-    -> TermLike Variable
-    -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
+  :: Attribute.Axiom
+  -> TermLike Variable
+  -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
 patternToAxiomPattern attributes pat =
-    case pat of
-        -- normal rewrite axioms
-        -- TODO (thomas.tuegel): Allow \and{_}(ensures, rhs) to be wrapped in
-        -- quantifiers.
-        Rewrites_ _ (And_ _ requires lhs) (And_ _ ensures rhs) ->
-            pure $ RewriteAxiomPattern $ RewriteRule RulePattern
-                { left = lhs
-                , right = rhs
-                , requires = Predicate.wrapPredicate requires
-                , ensures = Predicate.wrapPredicate ensures
-                , attributes
+  case pat of
+    -- normal rewrite axioms
+    -- TODO (thomas.tuegel): Allow \and{_}(ensures, rhs) to be wrapped in
+    -- quantifiers.
+    Rewrites_ _ (And_ _ requires lhs) (And_ _ ensures rhs) ->
+      pure $ RewriteAxiomPattern
+        $ RewriteRule RulePattern
+            { left = lhs,
+              right = rhs,
+              requires = Predicate.wrapPredicate requires,
+              ensures = Predicate.wrapPredicate ensures,
+              attributes
+              }
+    -- Reachability claims
+    Implies_ _ (And_ _ requires lhs) (ApplyAlias_ op [And_ _ ensures rhs])
+      | Just constructor <- qualifiedAxiomOpToConstructor op ->
+        pure
+          $ constructor RulePattern
+              { left = lhs,
+                right = rhs,
+                requires = Predicate.wrapPredicate requires,
+                ensures = Predicate.wrapPredicate ensures,
+                attributes
                 }
-        -- Reachability claims
-        Implies_ _ (And_ _ requires lhs) (ApplyAlias_ op [And_ _ ensures rhs])
-          | Just constructor <- qualifiedAxiomOpToConstructor op ->
-            pure $ constructor RulePattern
-                { left = lhs
-                , right = rhs
-                , requires = Predicate.wrapPredicate requires
-                , ensures = Predicate.wrapPredicate ensures
-                , attributes
+    -- function axioms: general
+    Implies_ _ requires (And_ _ (Equals_ _ _ lhs rhs) _ensures) ->
+      -- TODO (traiansf): ensure that _ensures is \top
+      pure $ FunctionAxiomPattern
+        $ EqualityRule RulePattern
+            { left = lhs,
+              right = rhs,
+              requires = Predicate.wrapPredicate requires,
+              ensures = Predicate.makeTruePredicate,
+              attributes
+              }
+    -- function axioms: trivial pre- and post-conditions
+    Equals_ _ _ lhs rhs ->
+      pure $ FunctionAxiomPattern
+        $ EqualityRule RulePattern
+            { left = lhs,
+              right = rhs,
+              requires = Predicate.makeTruePredicate,
+              ensures = Predicate.makeTruePredicate,
+              attributes
+              }
+    -- definedness axioms
+    ceil@(Ceil_ _ resultSort _) ->
+      pure $ FunctionAxiomPattern
+        $ EqualityRule RulePattern
+            { left = ceil,
+              right = mkTop resultSort,
+              requires = Predicate.makeTruePredicate,
+              ensures = Predicate.makeTruePredicate,
+              attributes
+              }
+    Forall_ _ _ child -> patternToAxiomPattern attributes child
+    -- implication axioms:
+    -- init -> modal_op ( prop )
+    Implies_ _ lhs rhs@(ApplyAlias_ op _)
+      | isModalSymbol op ->
+        pure $ ImplicationAxiomPattern
+          $ ImplicationRule RulePattern
+              { left = lhs,
+                right = rhs,
+                requires = Predicate.makeTruePredicate,
+                ensures = Predicate.makeTruePredicate,
+                attributes
                 }
-        -- function axioms: general
-        Implies_ _ requires (And_ _ (Equals_ _ _ lhs rhs) _ensures) ->
-            -- TODO (traiansf): ensure that _ensures is \top
-            pure $ FunctionAxiomPattern $ EqualityRule RulePattern
-                { left = lhs
-                , right = rhs
-                , requires = Predicate.wrapPredicate requires
-                , ensures = Predicate.makeTruePredicate
-                , attributes
-                }
-        -- function axioms: trivial pre- and post-conditions
-        Equals_ _ _ lhs rhs ->
-            pure $ FunctionAxiomPattern $ EqualityRule RulePattern
-                { left = lhs
-                , right = rhs
-                , requires = Predicate.makeTruePredicate
-                , ensures = Predicate.makeTruePredicate
-                , attributes
-                }
-        -- definedness axioms
-        ceil@(Ceil_ _ resultSort _) ->
-            pure $ FunctionAxiomPattern $ EqualityRule RulePattern
-                { left = ceil
-                , right = mkTop resultSort
-                , requires = Predicate.makeTruePredicate
-                , ensures = Predicate.makeTruePredicate
-                , attributes
-                }
-        Forall_ _ _ child -> patternToAxiomPattern attributes child
-        -- implication axioms:
-        -- init -> modal_op ( prop )
-        Implies_ _ lhs rhs@(ApplyAlias_ op _)
-            | isModalSymbol op ->
-                pure $ ImplicationAxiomPattern $ ImplicationRule RulePattern
-                    { left = lhs
-                    , right = rhs
-                    , requires = Predicate.makeTruePredicate
-                    , ensures = Predicate.makeTruePredicate
-                    , attributes
-                    }
-        _ -> koreFail "Unsupported pattern type in axiom"
+    _ -> koreFail "Unsupported pattern type in axiom"
+  where
+    isModalSymbol symbol
+      | headName == allPathGlobally = True
+      | otherwise = False
       where
-        isModalSymbol symbol
-            | headName == allPathGlobally = True
-            | otherwise = False
-          where
-            headName = getId (aliasConstructor symbol)
+        headName = getId (aliasConstructor symbol)
 
 {- | Construct a 'VerifiedKoreSentence' corresponding to 'RewriteRule'.
 
@@ -487,16 +517,16 @@ The requires clause must be a predicate, i.e. it can occur in any sort.
 
  -}
 mkRewriteAxiom
-    :: TermLike Variable  -- ^ left-hand side
-    -> TermLike Variable  -- ^ right-hand side
-    -> Maybe (Sort -> TermLike Variable)  -- ^ requires clause
-    -> Verified.Sentence
+  :: TermLike Variable -- ^ left-hand side
+  -> TermLike Variable -- ^ right-hand side
+  -> Maybe (Sort -> TermLike Variable) -- ^ requires clause
+  -> Verified.Sentence
 mkRewriteAxiom lhs rhs requires =
-    (Syntax.SentenceAxiomSentence . mkAxiom_)
-        (mkRewrites
-            (mkAnd (fromMaybe mkTop requires patternSort) lhs)
-            (mkAnd (mkTop patternSort) rhs)
-        )
+  (Syntax.SentenceAxiomSentence . mkAxiom_)
+    ( mkRewrites
+        (mkAnd (fromMaybe mkTop requires patternSort) lhs)
+        (mkAnd (mkTop patternSort) rhs)
+      )
   where
     patternSort = termLikeSort lhs
 
@@ -506,17 +536,17 @@ The requires clause must be a predicate, i.e. it can occur in any sort.
 
  -}
 mkEqualityAxiom
-    :: TermLike Variable  -- ^ left-hand side
-    -> TermLike Variable  -- ^ right-hand side
-    -> Maybe (Sort -> TermLike Variable)  -- ^ requires clause
-    -> Verified.Sentence
+  :: TermLike Variable -- ^ left-hand side
+  -> TermLike Variable -- ^ right-hand side
+  -> Maybe (Sort -> TermLike Variable) -- ^ requires clause
+  -> Verified.Sentence
 mkEqualityAxiom lhs rhs requires =
-    Syntax.SentenceAxiomSentence
+  Syntax.SentenceAxiomSentence
     $ mkAxiom [sortVariableR]
     $ case requires of
-        Just requires' ->
-            mkImplies (requires' sortR) (mkAnd function mkTop_)
-        Nothing -> function
+      Just requires' ->
+        mkImplies (requires' sortR) (mkAnd function mkTop_)
+      Nothing -> function
   where
     sortVariableR = SortVariable "R"
     sortR = SortVariableSort sortVariableR
@@ -526,10 +556,10 @@ mkEqualityAxiom lhs rhs requires =
 
  -}
 mkCeilAxiom
-    :: TermLike Variable  -- ^ the child of 'Ceil'
-    -> Verified.Sentence
+  :: TermLike Variable -- ^ the child of 'Ceil'
+  -> Verified.Sentence
 mkCeilAxiom child =
-    Syntax.SentenceAxiomSentence
+  Syntax.SentenceAxiomSentence
     $ mkAxiom [sortVariableR]
     $ mkCeil sortR child
   where
@@ -543,61 +573,59 @@ to avoid collision with any variables in the given set.
 
  -}
 refreshRulePattern
-    :: forall variable
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        )
-    => FreeVariables variable  -- ^ Variables to avoid
-    -> RulePattern variable
-    -> (Renaming variable, RulePattern variable)
+  :: forall variable. ( FreshVariable variable,
+                        SortedVariable variable,
+                        Show variable
+                        )
+  => FreeVariables variable -- ^ Variables to avoid
+  -> RulePattern variable
+  -> (Renaming variable, RulePattern variable)
 refreshRulePattern (FreeVariables.getFreeVariables -> avoid) rule1 =
-    let rename = refreshVariables avoid originalFreeVariables
-        subst = mkVar <$> rename
-        left' = TermLike.substitute subst left
-        right' = TermLike.substitute subst right
-        requires' = Predicate.substitute subst requires
-        rule2 =
-            rule1
-                { left = left'
-                , right = right'
-                , requires = requires'
-                }
-    in (rename, rule2)
+  let rename = refreshVariables avoid originalFreeVariables
+      subst = mkVar <$> rename
+      left' = TermLike.substitute subst left
+      right' = TermLike.substitute subst right
+      requires' = Predicate.substitute subst requires
+      rule2 =
+        rule1
+          { left = left',
+            right = right',
+            requires = requires'
+            }
+   in (rename, rule2)
   where
-    RulePattern { left, right, requires } = rule1
+    RulePattern {left, right, requires} = rule1
     originalFreeVariables =
-        FreeVariables.getFreeVariables
+      FreeVariables.getFreeVariables
         $ Kore.Step.Rule.freeVariables rule1
 
 {- | Extract the free variables of a 'RulePattern'.
  -}
 freeVariables
-    :: Ord variable
-    => RulePattern variable
-    -> FreeVariables variable
-freeVariables RulePattern { left, right, requires } =
-    TermLike.freeVariables left
+  :: Ord variable
+  => RulePattern variable
+  -> FreeVariables variable
+freeVariables RulePattern {left, right, requires} =
+  TermLike.freeVariables left
     <> TermLike.freeVariables right
     <> Predicate.freeVariables requires
 
 {- | Apply the given function to all variables in a 'RulePattern'.
  -}
 mapVariables
-    :: Ord variable2
-    => (variable1 -> variable2)
-    -> RulePattern variable1
-    -> RulePattern variable2
+  :: Ord variable2
+  => (variable1 -> variable2)
+  -> RulePattern variable1
+  -> RulePattern variable2
 mapVariables mapping rule1 =
-    rule1
-        { left = TermLike.mapVariables mapping left
-        , right = TermLike.mapVariables mapping right
-        , requires = Predicate.mapVariables mapping requires
-        , ensures = Predicate.mapVariables mapping ensures
-        }
+  rule1
+    { left = TermLike.mapVariables mapping left,
+      right = TermLike.mapVariables mapping right,
+      requires = Predicate.mapVariables mapping requires,
+      ensures = Predicate.mapVariables mapping ensures
+      }
   where
-    RulePattern { left, right, requires, ensures } = rule1
-
+    RulePattern {left, right, requires, ensures} = rule1
 
 {- | Traverse the predicate from the top down and apply substitutions.
 
@@ -606,19 +634,19 @@ contain none of the targeted variables.
 
  -}
 substitute
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        )
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> RulePattern variable
-    -> RulePattern variable
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable
+       )
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> RulePattern variable
+  -> RulePattern variable
 substitute subst rulePattern' =
-    rulePattern'
-        { left = TermLike.substitute subst left
-        , right = TermLike.substitute subst right
-        , requires = Predicate.substitute subst requires
-        , ensures = Predicate.substitute subst ensures
-        }
+  rulePattern'
+    { left = TermLike.substitute subst left,
+      right = TermLike.substitute subst right,
+      requires = Predicate.substitute subst requires,
+      ensures = Predicate.substitute subst ensures
+      }
   where
-    RulePattern { left, right, requires, ensures } = rulePattern'
+    RulePattern {left, right, requires, ensures} = rulePattern'

--- a/kore/src/Kore/Step/SMT/AST.hs
+++ b/kore/src/Kore/Step/SMT/AST.hs
@@ -5,50 +5,54 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.AST
-    ( Declarations (..)
-    , Encodable (AlreadyEncoded)
-    , IndirectSymbolDeclaration (..)
-    , KoreSortDeclaration (..)
-    , KoreSymbolDeclaration (..)
-    , SmtDeclarations
-    , SmtKoreSymbolDeclaration
-    , SmtSort
-    , SmtSymbol
-    , Sort (..)
-    , SortReference (..)
-    , Symbol (..)
-    , SymbolReference (..)
-    , UnresolvedConstructor
-    , UnresolvedConstructorArgument
-    , UnresolvedDataTypeDeclaration
-    , UnresolvedDeclarations
-    , UnresolvedFunctionDeclaration
-    , UnresolvedIndirectSymbolDeclaration
-    , UnresolvedKoreSortDeclaration
-    , UnresolvedKoreSymbolDeclaration
-    , UnresolvedSort
-    , UnresolvedSortDeclaration
-    , UnresolvedSymbol
-    , appendToEncoding
-    , encodable
-    , encode
-    , mergePreferFirst
-    ) where
+  ( Declarations (..),
+    Encodable (AlreadyEncoded),
+    IndirectSymbolDeclaration (..),
+    KoreSortDeclaration (..),
+    KoreSymbolDeclaration (..),
+    SmtDeclarations,
+    SmtKoreSymbolDeclaration,
+    SmtSort,
+    SmtSymbol,
+    Sort (..),
+    SortReference (..),
+    Symbol (..),
+    SymbolReference (..),
+    UnresolvedConstructor,
+    UnresolvedConstructorArgument,
+    UnresolvedDataTypeDeclaration,
+    UnresolvedDeclarations,
+    UnresolvedFunctionDeclaration,
+    UnresolvedIndirectSymbolDeclaration,
+    UnresolvedKoreSortDeclaration,
+    UnresolvedKoreSymbolDeclaration,
+    UnresolvedSort,
+    UnresolvedSortDeclaration,
+    UnresolvedSymbol,
+    appendToEncoding,
+    encodable,
+    encode,
+    mergePreferFirst
+    )
+where
 
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Text
-                 ( Text )
-
+import Data.Text
+  ( Text
+    )
 import qualified Kore.Sort as Kore
-                 ( Sort )
-import           Kore.Step.SMT.Encoder
-                 ( encodeName )
+  ( Sort
+    )
+import Kore.Step.SMT.Encoder
+  ( encodeName
+    )
 import qualified Kore.Syntax.Id as Kore
-                 ( Id (Id, getId) )
+  ( Id (Id, getId)
+    )
 import qualified SMT.AST as AST
 
 {-| A representation of the Kore Sort type together with its related
@@ -56,54 +60,55 @@ declarations (constructors, noJunk axioms), optimized for dealing with the SMT.
 
 The SmtSort type below instantiates Sort with the types used by the SMT.
 -}
-data Sort sort symbol name =
-    Sort
-        { smtFromSortArgs
-            :: !(Map Kore.Id SmtSort -> [Kore.Sort] -> Maybe AST.SExpr)
+data Sort sort symbol name
+  = Sort
+      { smtFromSortArgs
+          :: !(Map Kore.Id SmtSort -> [Kore.Sort] -> Maybe AST.SExpr),
         -- ^ Produces the SMT representation of a sort. Given a map with
         -- Smt representations for sorts and a list of sort arguments, returns
         -- an S-expression that can be used, say, when declaring symbols of
         -- that sort.
-        , declaration :: !(KoreSortDeclaration sort symbol name)
+        declaration :: !(KoreSortDeclaration sort symbol name)
         -- ^ Information needed for declaring the sort, also listing all
         -- dependencies on other sorts and symbols.
         }
 
-instance (Show sort, Show symbol, Show name)
-    => Show (Sort sort symbol name)
+instance
+  (Show sort, Show symbol, Show name)
+  => Show (Sort sort symbol name)
   where
-    show s@(Sort _ _) =
-        case s of
-            Sort { smtFromSortArgs = _, declaration } ->
-                   "Sort { smtFromSortArgs, declaration = "
-                ++ show declaration
-                ++ "}"
+  show s@(Sort _ _) =
+    case s of
+      Sort {smtFromSortArgs = _, declaration} ->
+        "Sort { smtFromSortArgs, declaration = "
+          ++ show declaration
+          ++ "}"
 
 {-| A representation of the Kore SymbolOrAlias type together with symbol
 declaration sentences, optimized for dealing with the SMT.
 
 The SmtSymbol type below instantiates Symbol with the types used by the SMT.
 -}
-data Symbol sort name =
-    Symbol
-        { smtFromSortArgs
-            :: !(Map Kore.Id SmtSort -> [Kore.Sort] -> Maybe AST.SExpr)
+data Symbol sort name
+  = Symbol
+      { smtFromSortArgs
+          :: !(Map Kore.Id SmtSort -> [Kore.Sort] -> Maybe AST.SExpr),
         -- ^ Produces the SMT representation of a symbol. Given a map with
         -- Smt representations for sorts and a list of sort arguments, returns
         -- an s-expression that can be used, say, when building assertions
         -- using that symbol.
-        , declaration :: !(KoreSymbolDeclaration sort name)
+        declaration :: !(KoreSymbolDeclaration sort name)
         -- ^ Information needed for declaring the symbol, also listing all
         -- dependencies on other sorts and symbols.
         }
 
 instance (Show sort, Show name) => Show (Symbol sort name) where
-    show s@(Symbol _ _) =
-        case s of
-            Symbol { smtFromSortArgs = _, declaration } ->
-                   "Symbol { smtFromSortArgs, declaration = "
-                ++ show declaration
-                ++ "}"
+  show s@(Symbol _ _) =
+    case s of
+      Symbol {smtFromSortArgs = _, declaration} ->
+        "Symbol { smtFromSortArgs, declaration = "
+          ++ show declaration
+          ++ "}"
 
 {-| Data needed for declaring an SMT sort.
 
@@ -111,14 +116,14 @@ The SmtKoreSortDeclaration type below instantiates Sort with the types used
 by the SMT.
 -}
 data KoreSortDeclaration sort symbol name
-    = SortDeclarationDataType !(AST.DataTypeDeclaration sort symbol name)
+  = SortDeclarationDataType !(AST.DataTypeDeclaration sort symbol name)
     -- ^ Constructor-based sort. Assumed to declare its own constructors.
-    | SortDeclarationSort !(AST.SortDeclaration name)
+  | SortDeclarationSort !(AST.SortDeclaration name)
     -- ^ Non-constructor sort.
-    | SortDeclaredIndirectly !name
+  | SortDeclaredIndirectly !name
     -- ^ Sort that we don't need to declare (e.g. builtins like Int) so we just
     -- represent that the SMT already knows about it.
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-| Data needed for declaring an SMT symbol.
 
@@ -126,44 +131,44 @@ The SmtKoreSymbolDeclaration type below instantiates Symbol with the types used
 by the SMT.
 -}
 data KoreSymbolDeclaration sort name
-    = SymbolDeclaredDirectly !(AST.FunctionDeclaration sort name)
+  = SymbolDeclaredDirectly !(AST.FunctionDeclaration sort name)
     -- ^ Normal symbol declaration
-    | SymbolDeclaredIndirectly !(IndirectSymbolDeclaration sort name)
+  | SymbolDeclaredIndirectly !(IndirectSymbolDeclaration sort name)
     -- ^ Symbol declared in a different way (e.g. builtin or constructor).
     -- The IndirectSymbolDeclaration value holds dependencies on other sorts
     -- and debug information.
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-| Holds the sorts on which an already declared symbol depends.
 -}
-data IndirectSymbolDeclaration sort name =
-    IndirectSymbolDeclaration
-        { name :: !name
-        , sorts :: ![sort]
+data IndirectSymbolDeclaration sort name
+  = IndirectSymbolDeclaration
+      { name :: !name,
+        sorts :: ![sort]
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-| Holds things that we declare to an SMT. When encountered in its
 SmtDeclarations instatiation, we usually assume that all dependencies between
 the various declarations can be resolved.
 -}
-data Declarations sort symbol name =
-    Declarations
-        { sorts :: Map Kore.Id (Sort sort symbol name)
-        , symbols :: Map Kore.Id (Symbol sort name)
+data Declarations sort symbol name
+  = Declarations
+      { sorts :: Map Kore.Id (Sort sort symbol name),
+        symbols :: Map Kore.Id (Symbol sort name)
         }
-    deriving Show
+  deriving (Show)
 
 {-| Marks a dependency on a given sort.
 -}
-newtype SortReference = SortReference { getSortReference :: Kore.Sort }
-    deriving (Eq, Ord, Show)
+newtype SortReference = SortReference {getSortReference :: Kore.Sort}
+  deriving (Eq, Ord, Show)
 
 {-| Marks a dependency on a given symbol.
 -}
-newtype SymbolReference =
-    SymbolReference { getSymbolReference :: Kore.Id }
-    deriving (Eq, Ord, Show)
+newtype SymbolReference
+  = SymbolReference {getSymbolReference :: Kore.Id}
+  deriving (Eq, Ord, Show)
 
 {-| Data that should be encoded before being used with the SMT.
 
@@ -171,42 +176,55 @@ Use @AlreadyEncoded@ and @encodable@ to create it, @encode@ to extract its data,
 and @appendToEncoding@ to modify it.
 -}
 data Encodable
-    = AlreadyEncoded !Text
-    | Encodable !Text
-    -- TODO (virgil): maybe use Id in Encodable to make it more obvious what
-    -- happens.
-    deriving (Eq, Ord, Show)
+  = AlreadyEncoded !Text
+  | Encodable !Text
+  -- TODO (virgil): maybe use Id in Encodable to make it more obvious what
+  -- happens.
+  deriving (Eq, Ord, Show)
 
 -- Type instantiations to be used by the SMT.
 type SmtDeclarations = Declarations AST.SExpr Text Text
+
 type SmtKoreSymbolDeclaration = KoreSymbolDeclaration AST.SExpr Text
+
 type SmtSort = Sort AST.SExpr Text Text
+
 type SmtSymbol = Symbol AST.SExpr Text
 
 -- Type instantiations with unresolved dependencies, produced direclty from the
 -- input module.
-type UnresolvedConstructorArgument =
-    AST.ConstructorArgument SortReference Encodable
-type UnresolvedConstructor =
-    AST.Constructor SortReference SymbolReference Encodable
-type UnresolvedDataTypeDeclaration =
-    AST.DataTypeDeclaration SortReference SymbolReference Encodable
-type UnresolvedDeclarations =
-    Declarations SortReference SymbolReference Encodable
-type UnresolvedFunctionDeclaration =
-    AST.FunctionDeclaration SortReference Encodable
-type UnresolvedIndirectSymbolDeclaration =
-    IndirectSymbolDeclaration SortReference Encodable
-type UnresolvedKoreSortDeclaration =
-    KoreSortDeclaration SortReference SymbolReference Encodable
-type UnresolvedKoreSymbolDeclaration =
-    KoreSymbolDeclaration SortReference Encodable
-type UnresolvedSort =
-    Sort SortReference SymbolReference Encodable
-type UnresolvedSortDeclaration =
-    AST.SortDeclaration Encodable
-type UnresolvedSymbol =
-    Symbol SortReference Encodable
+type UnresolvedConstructorArgument
+  = AST.ConstructorArgument SortReference Encodable
+
+type UnresolvedConstructor
+  = AST.Constructor SortReference SymbolReference Encodable
+
+type UnresolvedDataTypeDeclaration
+  = AST.DataTypeDeclaration SortReference SymbolReference Encodable
+
+type UnresolvedDeclarations
+  = Declarations SortReference SymbolReference Encodable
+
+type UnresolvedFunctionDeclaration
+  = AST.FunctionDeclaration SortReference Encodable
+
+type UnresolvedIndirectSymbolDeclaration
+  = IndirectSymbolDeclaration SortReference Encodable
+
+type UnresolvedKoreSortDeclaration
+  = KoreSortDeclaration SortReference SymbolReference Encodable
+
+type UnresolvedKoreSymbolDeclaration
+  = KoreSymbolDeclaration SortReference Encodable
+
+type UnresolvedSort
+  = Sort SortReference SymbolReference Encodable
+
+type UnresolvedSortDeclaration
+  = AST.SortDeclaration Encodable
+
+type UnresolvedSymbol
+  = Symbol SortReference Encodable
 
 encodable :: Kore.Id -> Encodable
 encodable Kore.Id {getId} = Encodable getId
@@ -220,14 +238,13 @@ appendToEncoding (AlreadyEncoded e) t = AlreadyEncoded (e <> t)
 appendToEncoding (Encodable e) t = Encodable (e <> t)
 
 mergePreferFirst
-    :: Declarations sort symbol name
-    -> Declarations sort symbol name
-    -> Declarations sort symbol name
+  :: Declarations sort symbol name
+  -> Declarations sort symbol name
+  -> Declarations sort symbol name
 mergePreferFirst
-    Declarations { sorts = sorts1, symbols = symbols1 }
-    Declarations { sorts = sorts2, symbols = symbols2 }
-  =
+  Declarations {sorts = sorts1, symbols = symbols1}
+  Declarations {sorts = sorts2, symbols = symbols2} =
     Declarations
-        { sorts = sorts1 `Map.union` sorts2
-        , symbols = symbols1 `Map.union` symbols2
+      { sorts = sorts1 `Map.union` sorts2,
+        symbols = symbols1 `Map.union` symbols2
         }

--- a/kore/src/Kore/Step/SMT/Declaration/All.hs
+++ b/kore/src/Kore/Step/SMT/Declaration/All.hs
@@ -5,22 +5,25 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Declaration.All
-    ( declare
-    ) where
+  ( declare
+    )
+where
 
 import qualified Kore.Step.SMT.AST as AST
-                 ( SmtDeclarations )
+  ( SmtDeclarations
+    )
 import qualified Kore.Step.SMT.Declaration.Sorts as Sorts
-                 ( declare )
+  ( declare
+    )
 import qualified Kore.Step.SMT.Declaration.Symbols as Symbols
-                 ( declare )
+  ( declare
+    )
 import qualified SMT
 
 {-| Sends all given declarations to the SMT.
 -}
 declare :: SMT.MonadSMT m => AST.SmtDeclarations -> m ()
 declare declarations = do
-    Sorts.declare declarations
-    Symbols.declare declarations
+  Sorts.declare declarations
+  Symbols.declare declarations

--- a/kore/src/Kore/Step/SMT/Declaration/Sorts.hs
+++ b/kore/src/Kore/Step/SMT/Declaration/Sorts.hs
@@ -5,48 +5,54 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Declaration.Sorts
-    ( declare
-    ) where
+  ( declare
+    )
+where
 
-import           Data.Either
-                 ( partitionEithers )
+import Data.Either
+  ( partitionEithers
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-                 ( mapMaybe )
-
+import Data.Maybe
+  ( mapMaybe
+    )
 import qualified Kore.Step.SMT.AST as AST
-                 ( Declarations (Declarations),
-                 KoreSortDeclaration (SortDeclarationDataType, SortDeclarationSort, SortDeclaredIndirectly),
-                 SmtDeclarations, SmtSort, Sort (Sort) )
+  ( Declarations (Declarations),
+    KoreSortDeclaration (SortDeclarationDataType, SortDeclarationSort, SortDeclaredIndirectly),
+    SmtDeclarations,
+    SmtSort,
+    Sort (Sort)
+    )
 import qualified Kore.Step.SMT.AST as SMT.AST.DoNotUse
 import qualified SMT
 
 {-| Sends all sorts in the given declarations to the SMT.
 -}
 declare :: SMT.MonadSMT m => AST.SmtDeclarations -> m ()
-declare AST.Declarations { sorts } = do
-    mapM_ SMT.declareSort sortDeclarations
-    SMT.declareDatatypes dataTypeDeclarations
+declare AST.Declarations {sorts} = do
+  mapM_ SMT.declareSort sortDeclarations
+  SMT.declareDatatypes dataTypeDeclarations
   where
     sortDeclarations :: [SMT.SmtSortDeclaration]
     dataTypeDeclarations :: [SMT.SmtDataTypeDeclaration]
     (sortDeclarations, dataTypeDeclarations) =
-        partitionEithers (mapMaybe eitherDeclaration (Map.elems sorts))
-
+      partitionEithers (mapMaybe eitherDeclaration (Map.elems sorts))
     eitherDeclaration
-        :: AST.SmtSort
-        -> Maybe (Either SMT.SmtSortDeclaration SMT.SmtDataTypeDeclaration)
+      :: AST.SmtSort
+      -> Maybe (Either SMT.SmtSortDeclaration SMT.SmtDataTypeDeclaration)
     eitherDeclaration
-        AST.Sort
-            { declaration = AST.SortDeclarationSort declaration }
-      = Just (Left declaration)
+      AST.Sort
+        { declaration = AST.SortDeclarationSort declaration
+          } =
+        Just (Left declaration)
     eitherDeclaration
-        AST.Sort
-            { declaration = AST.SortDeclarationDataType declaration }
-      = Just (Right declaration)
+      AST.Sort
+        { declaration = AST.SortDeclarationDataType declaration
+          } =
+        Just (Right declaration)
     eitherDeclaration
-        AST.Sort
-            { declaration = AST.SortDeclaredIndirectly _}
-      = Nothing
+      AST.Sort
+        { declaration = AST.SortDeclaredIndirectly _
+          } =
+        Nothing

--- a/kore/src/Kore/Step/SMT/Declaration/Symbols.hs
+++ b/kore/src/Kore/Step/SMT/Declaration/Symbols.hs
@@ -5,36 +5,36 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Declaration.Symbols
-    ( declare
-    ) where
+  ( declare
+    )
+where
 
 import qualified Data.Foldable as Foldable
-
 import qualified Kore.Step.SMT.AST as AST
-                 ( Declarations (Declarations),
-                 KoreSymbolDeclaration (SymbolDeclaredDirectly, SymbolDeclaredIndirectly),
-                 SmtDeclarations, SmtKoreSymbolDeclaration, SmtSymbol,
-                 Symbol (Symbol) )
+  ( Declarations (Declarations),
+    KoreSymbolDeclaration (SymbolDeclaredDirectly, SymbolDeclaredIndirectly),
+    SmtDeclarations,
+    SmtKoreSymbolDeclaration,
+    SmtSymbol,
+    Symbol (Symbol)
+    )
 import qualified Kore.Step.SMT.AST as AST.DoNotUse
 import qualified SMT
 
 {-| Sends all symbols in the given declarations to the SMT.
 -}
 declare :: SMT.MonadSMT m => AST.SmtDeclarations -> m ()
-declare AST.Declarations { symbols } =
-    Foldable.traverse_ declareSymbol symbols
+declare AST.Declarations {symbols} =
+  Foldable.traverse_ declareSymbol symbols
 
 declareSymbol :: SMT.MonadSMT m => AST.SmtSymbol -> m ()
 declareSymbol AST.Symbol {declaration} =
-    declareKoreSymbolDeclaration declaration
+  declareKoreSymbolDeclaration declaration
 
 declareKoreSymbolDeclaration
-    :: SMT.MonadSMT m => AST.SmtKoreSymbolDeclaration -> m ()
-declareKoreSymbolDeclaration
-    (AST.SymbolDeclaredDirectly declaration)
-  =
-    SMT.declareFun_ declaration
+  :: SMT.MonadSMT m => AST.SmtKoreSymbolDeclaration -> m ()
+declareKoreSymbolDeclaration (AST.SymbolDeclaredDirectly declaration) =
+  SMT.declareFun_ declaration
 declareKoreSymbolDeclaration (AST.SymbolDeclaredIndirectly _) =
-    return ()
+  return ()

--- a/kore/src/Kore/Step/SMT/Encoder.hs
+++ b/kore/src/Kore/Step/SMT/Encoder.hs
@@ -5,17 +5,21 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
-module Kore.Step.SMT.Encoder (encodeName) where
+module Kore.Step.SMT.Encoder
+  ( encodeName
+    )
+where
 
 import Data.Text
-       ( Text )
+  ( Text
+    )
 
 {-| Encodes a name in order to remove special characters and to
 prevent conflicts with SMT builtins.
 -}
 encodeName :: Text -> Text
 encodeName name =
-    "|HB_" <> name <> "|"
-    -- `HB` = Haskell backend
-    -- `|` is used to allow special characters like `'`
+  "|HB_" <> name <> "|"
+
+-- `HB` = Haskell backend
+-- `|` is used to allow special characters like `'`

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -5,179 +5,192 @@ Copyright   : (c) Runtime Verification, 2018-2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Evaluator
-    ( decidePredicate
-    , Evaluable (..)
-    , filterMultiOr
+  ( decidePredicate,
+    Evaluable (..),
+    filterMultiOr
     )
-    where
+where
 
-import           Control.Applicative
-                 ( (<|>) )
+import Control.Applicative
+  ( (<|>)
+    )
 import qualified Control.Applicative as Applicative
-import           Control.Error
-                 ( MaybeT, runMaybeT )
+import Control.Error
+  ( MaybeT,
+    runMaybeT
+    )
+import qualified Control.Monad.Counter as Counter
 import qualified Control.Monad.State.Strict as State
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-                 ( catMaybes )
-import           Data.Reflection
+import Data.Maybe
+  ( catMaybes
+    )
+import Data.Reflection
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
-import qualified Control.Monad.Counter as Counter
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
-import           Kore.Internal.Conditional
-                 ( Conditional )
+  ( Symbol
+    )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
+import Kore.Internal.Conditional
+  ( Conditional
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Logger
+import Kore.Logger
 import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
+  ( Predicate
+    )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import qualified Kore.Profiler.Profile as Profile
-                 ( smtDecision )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+  ( smtDecision
+    )
+import Kore.Step.SMT.Translate
+  ( Translator,
+    evalTranslator,
+    translatePredicate
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Data as Simplifier
-import           Kore.Step.SMT.Translate
-                 ( Translator, evalTranslator, translatePredicate )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.TopBottom
-                 ( TopBottom )
-import           Kore.Unparser
-import           SMT
-                 ( Result (..), SExpr (..) )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.TopBottom
+  ( TopBottom
+    )
+import Kore.Unparser
+import SMT
+  ( Result (..),
+    SExpr (..)
+    )
 import qualified SMT
 
 {- | Class for things that can be evaluated with an SMT solver,
 or which contain things that can be evaluated with an SMT solver.
 -}
 class Evaluable thing where
-    {- | Attempt to evaluate the argument wiith an external SMT solver.
-    -}
-    evaluate :: MonadSimplify m => thing -> m (Maybe Bool)
+  {- | Attempt to evaluate the argument wiith an external SMT solver.
+  -}
+  evaluate :: MonadSimplify m => thing -> m (Maybe Bool)
 
 instance
-    ( SortedVariable variable
-    , Ord variable
-    , Show variable
-    , Unparse variable
+  ( SortedVariable variable,
+    Ord variable,
+    Show variable,
+    Unparse variable
     )
-    => Evaluable (Syntax.Predicate variable)
+  => Evaluable (Syntax.Predicate variable)
   where
-    evaluate predicate = do
-        case predicate of
-            Syntax.Predicate.PredicateTrue -> return (Just True)
-            Syntax.Predicate.PredicateFalse -> return (Just False)
-            _ -> decidePredicate predicate
+  evaluate predicate = do
+    case predicate of
+      Syntax.Predicate.PredicateTrue -> return (Just True)
+      Syntax.Predicate.PredicateFalse -> return (Just False)
+      _ -> decidePredicate predicate
 
 instance
-    ( SortedVariable variable
-    , Ord variable
-    , Show variable
-    , Unparse variable
+  ( SortedVariable variable,
+    Ord variable,
+    Show variable,
+    Unparse variable
     )
-    => Evaluable (Conditional variable term)
+  => Evaluable (Conditional variable term)
   where
-    evaluate patt = evaluate (Predicate.toPredicate predicate)
-      where
-        (_term, predicate) = Conditional.splitTerm patt
+  evaluate patt = evaluate (Predicate.toPredicate predicate)
+    where
+      (_term, predicate) = Conditional.splitTerm patt
 
 {- | Removes from a MultiOr all items refuted by an external SMT solver. -}
 filterMultiOr
-    :: forall simplifier term variable
-    .   ( MonadSimplify simplifier
-        , Ord term
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , TopBottom term
-        , Unparse variable
-        )
-    => MultiOr (Conditional variable term)
-    -> simplifier (MultiOr (Conditional variable term))
+  :: forall simplifier term variable. ( MonadSimplify simplifier,
+                                        Ord term,
+                                        Ord variable,
+                                        Show variable,
+                                        SortedVariable variable,
+                                        TopBottom term,
+                                        Unparse variable
+                                        )
+  => MultiOr (Conditional variable term)
+  -> simplifier (MultiOr (Conditional variable term))
 filterMultiOr multiOr = do
-    elements <- mapM refute (MultiOr.extractPatterns multiOr)
-    return (MultiOr.make (catMaybes elements))
+  elements <- mapM refute (MultiOr.extractPatterns multiOr)
+  return (MultiOr.make (catMaybes elements))
   where
     refute
-        :: Conditional variable term
-        -> simplifier (Maybe (Conditional variable term))
+      :: Conditional variable term
+      -> simplifier (Maybe (Conditional variable term))
     refute p = do
-        evaluated <- evaluate p
-        return $ case evaluated of
-            Nothing -> Just p
-            Just False -> Nothing
-            Just True -> Just p
+      evaluated <- evaluate p
+      return $ case evaluated of
+        Nothing -> Just p
+        Just False -> Nothing
+        Just True -> Just p
 
 {- | Attempt to refute a predicate using an external SMT solver.
 
 The predicate is always sent to the external solver, even if it is trivial.
 -}
 decidePredicate
-    :: forall variable simplifier.
-        ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Syntax.Predicate variable
-    -> simplifier (Maybe Bool)
+  :: forall variable simplifier. ( Ord variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => Syntax.Predicate variable
+  -> simplifier (Maybe Bool)
 decidePredicate korePredicate =
-    withLogScope "decidePredicate" $ SMT.withSolver $ runMaybeT $ do
-        tools <- Simplifier.askMetadataTools
-        smtPredicate <- goTranslatePredicate tools korePredicate
-        result <-
-            Profile.smtDecision smtPredicate
-            $ SMT.withSolver (SMT.assert smtPredicate >> SMT.check)
-        case result of
-            Unsat   -> return False
-            Sat     -> Applicative.empty
-            Unknown -> do
-                (logWarning . Text.pack . show . Pretty.vsep)
-                    [ "Failed to decide predicate:"
-                    , Pretty.indent 4 (unparse korePredicate)
-                    ]
-                Applicative.empty
+  withLogScope "decidePredicate" $ SMT.withSolver $ runMaybeT $ do
+    tools <- Simplifier.askMetadataTools
+    smtPredicate <- goTranslatePredicate tools korePredicate
+    result <-
+      Profile.smtDecision smtPredicate
+        $ SMT.withSolver (SMT.assert smtPredicate >> SMT.check)
+    case result of
+      Unsat -> return False
+      Sat -> Applicative.empty
+      Unknown -> do
+        (logWarning . Text.pack . show . Pretty.vsep)
+          [ "Failed to decide predicate:",
+            Pretty.indent 4 (unparse korePredicate)
+            ]
+        Applicative.empty
 
 goTranslatePredicate
-    :: forall variable m.
-        ( Ord variable
-        , Unparse variable
-        , MonadSimplify m
-        )
-    => SmtMetadataTools Attribute.Symbol
-    -> Syntax.Predicate variable
-    -> MaybeT m SExpr
+  :: forall variable m. ( Ord variable,
+                          Unparse variable,
+                          MonadSimplify m
+                          )
+  => SmtMetadataTools Attribute.Symbol
+  -> Syntax.Predicate variable
+  -> MaybeT m SExpr
 goTranslatePredicate tools predicate = evalTranslator translator
   where
     translator =
-        give tools $ translatePredicate translateUninterpreted predicate
+      give tools $ translatePredicate translateUninterpreted predicate
 
 translateUninterpreted
-    :: Ord p
-    => SMT.MonadSMT m
-    => SExpr  -- ^ type name
-    -> p  -- ^ uninterpreted pattern
-    -> Translator m p SExpr
+  :: Ord p
+  => SMT.MonadSMT m
+  => SExpr -- ^ type name
+  -> p -- ^ uninterpreted pattern
+  -> Translator m p SExpr
 translateUninterpreted t pat =
-    lookupPattern <|> freeVariable
+  lookupPattern <|> freeVariable
   where
     lookupPattern = do
-        result <- State.gets $ Map.lookup pat
-        maybe Applicative.empty (return . fst) result
+      result <- State.gets $ Map.lookup pat
+      maybe Applicative.empty (return . fst) result
     freeVariable = do
-        n <- Counter.increment
-        var <- SMT.declare ("<" <> Text.pack (show n) <> ">") t
-        State.modify' (Map.insert pat (var, t))
-        return var
+      n <- Counter.increment
+      var <- SMT.declare ("<" <> Text.pack (show n) <> ">") t
+      State.modify' (Map.insert pat (var, t))
+      return var

--- a/kore/src/Kore/Step/SMT/Lemma.hs
+++ b/kore/src/Kore/Step/SMT/Lemma.hs
@@ -8,39 +8,46 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.SMT.Lemma
-    ( declareSMTLemmas
-    ) where
+  ( declareSMTLemmas
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Control.Error
-                 ( runMaybeT )
+import Control.Error
+  ( runMaybeT
+    )
 import qualified Control.Monad.Counter as Counter
-import           Control.Monad.Except
-import           Control.Monad.IO.Class
-                 ( MonadIO )
+import Control.Monad.Except
+import Control.Monad.IO.Class
+  ( MonadIO
+    )
 import qualified Control.Monad.State as State
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map.Strict as Map
-import           Data.Reflection
+import Data.Reflection
 import qualified Data.Text as Text
-
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Attribute.SmtLemma
-import           Kore.Attribute.Symbol
-import           Kore.IndexedModule.IndexedModule
-import           Kore.IndexedModule.MetadataTools
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
+import Kore.Attribute.SmtLemma
+import Kore.Attribute.Symbol
+import Kore.IndexedModule.IndexedModule
+import Kore.IndexedModule.MetadataTools
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
 import qualified Kore.Step.SMT.Declaration.All as SMT.All
-                 ( declare )
-import           Kore.Step.SMT.Translate
-import           Kore.Syntax.Sentence
-                 ( SentenceAxiom (..) )
-import           Kore.Unparser
-import           SMT
-                 ( MonadSMT (..), SExpr (..) )
+  ( declare
+    )
+import Kore.Step.SMT.Translate
+import Kore.Syntax.Sentence
+  ( SentenceAxiom (..)
+    )
+import Kore.Unparser
+import SMT
+  ( MonadSMT (..),
+    SExpr (..)
+    )
 
 -- | Given an indexed module, `declareSMTLemmas` translates all
 -- rewrite rules marked with the smt-lemma attribute into the
@@ -48,62 +55,62 @@ import           SMT
 -- It assumes that all symbols in all smt-lemma rules either have been
 -- declared in the smt prelude or they have an smtlib attribute.
 declareSMTLemmas
-    :: forall m
-    .   ( Given (SmtMetadataTools StepperAttributes)
-        , MonadIO m
-        , MonadSMT m
-        )
-    => VerifiedModule StepperAttributes Attribute.Axiom
-    -> m ()
+  :: forall m. ( Given (SmtMetadataTools StepperAttributes),
+                 MonadIO m,
+                 MonadSMT m
+                 )
+  => VerifiedModule StepperAttributes Attribute.Axiom
+  -> m ()
 declareSMTLemmas m = do
-    SMT.All.declare (smtData tools)
-    mapM_ declareRule (indexedModuleAxioms m)
+  SMT.All.declare (smtData tools)
+  mapM_ declareRule (indexedModuleAxioms m)
   where
     tools :: SmtMetadataTools StepperAttributes
     tools = given
-
     declareRule
-        :: Given (SmtMetadataTools StepperAttributes)
-        => ( Attribute.Axiom , SentenceAxiom (TermLike Variable) )
-        -> m (Maybe ())
+      :: Given (SmtMetadataTools StepperAttributes)
+      => (Attribute.Axiom, SentenceAxiom (TermLike Variable))
+      -> m (Maybe ())
     declareRule (atts, axiomDeclaration) = runMaybeT $ do
-        guard (isSmtLemma $ Attribute.smtLemma atts)
-        (lemma, vars) <-
-            runTranslator
-            $ translatePredicate translateUninterpreted
-            $ wrapPredicate $ sentenceAxiomPattern axiomDeclaration
-        SMT.assert (addQuantifiers vars lemma)
-
+      guard (isSmtLemma $ Attribute.smtLemma atts)
+      (lemma, vars) <-
+        runTranslator
+          $ translatePredicate translateUninterpreted
+          $ wrapPredicate
+          $ sentenceAxiomPattern axiomDeclaration
+      SMT.assert (addQuantifiers vars lemma)
     addQuantifiers vars lemma | null vars = lemma
-    addQuantifiers vars lemma = SMT.List
-        [ SMT.Atom "forall"
-        , SMT.List
-            [ SMT.List [sexpr, t] | (sexpr, t) <- Map.elems vars ]
-        , lemma
-        ]
+    addQuantifiers vars lemma =
+      SMT.List
+        [ SMT.Atom "forall",
+          SMT.List
+            [SMT.List [sexpr, t] | (sexpr, t) <- Map.elems vars],
+          lemma
+          ]
 
 translateUninterpreted
-    :: ( Ord p
-       , p ~ TermLike variable
-       , Unparse variable
-       , Monad m
+  :: ( Ord p,
+       p ~ TermLike variable,
+       Unparse variable,
+       Monad m
        )
-    => SExpr  -- ^ type name
-    -> p  -- ^ uninterpreted pattern
-    -> Translator m p SExpr
-translateUninterpreted t pat | isVariable pat =
+  => SExpr -- ^ type name
+  -> p -- ^ uninterpreted pattern
+  -> Translator m p SExpr
+translateUninterpreted t pat
+  | isVariable pat =
     lookupPattern <|> freeVariable
   where
     isVariable p =
-        case Cofree.tailF $ Recursive.project p of
-            VariableF _ -> True
-            _ -> False
+      case Cofree.tailF $ Recursive.project p of
+        VariableF _ -> True
+        _ -> False
     lookupPattern = do
-        result <- State.gets $ Map.lookup pat
-        maybe empty (return . fst) result
+      result <- State.gets $ Map.lookup pat
+      maybe empty (return . fst) result
     freeVariable = do
-        n <- Counter.increment
-        let var = SMT.Atom ("<" <> Text.pack (show n) <> ">")
-        State.modify' (Map.insert pat (var, t))
-        return var
+      n <- Counter.increment
+      let var = SMT.Atom ("<" <> Text.pack (show n) <> ">")
+      State.modify' (Map.insert pat (var, t))
+      return var
 translateUninterpreted _ _ = empty

--- a/kore/src/Kore/Step/SMT/Representation/All.hs
+++ b/kore/src/Kore/Step/SMT/Representation/All.hs
@@ -5,24 +5,30 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Representation.All
-    ( build
-    ) where
+  ( build
+    )
+where
 
 import qualified Kore.Attribute.Axiom as Attribute
-                 ( Axiom )
+  ( Axiom
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-                 ( Symbol )
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule )
+  ( Symbol
+    )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule
+    )
 import qualified Kore.Step.SMT.AST as AST
-import           Kore.Step.SMT.Representation.Resolve
-                 ( resolve )
+import Kore.Step.SMT.Representation.Resolve
+  ( resolve
+    )
 import qualified Kore.Step.SMT.Representation.Sorts as Sorts
-                 ( buildRepresentations )
+  ( buildRepresentations
+    )
 import qualified Kore.Step.SMT.Representation.Symbols as Symbols
-                 ( buildRepresentations )
+  ( buildRepresentations
+    )
 
 {-| Builds a consistent representation of the sorts and symbols in the given
 module and its submodules.
@@ -31,10 +37,10 @@ It may ignore sorts and symbols that it can't handle yet (e.g. parameterized
 sorts).
 -}
 build
-    :: VerifiedModule Attribute.Symbol Attribute.Axiom
-    -> AST.SmtDeclarations
+  :: VerifiedModule Attribute.Symbol Attribute.Axiom
+  -> AST.SmtDeclarations
 build indexedModule =
-    resolve (sorts `AST.mergePreferFirst` symbols)
+  resolve (sorts `AST.mergePreferFirst` symbols)
   where
     sorts = Sorts.buildRepresentations indexedModule
     symbols = Symbols.buildRepresentations indexedModule

--- a/kore/src/Kore/Step/SMT/Representation/Resolve.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Resolve.hs
@@ -5,297 +5,312 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Representation.Resolve
-    ( resolve
-    ) where
+  ( resolve
+    )
+where
 
 import qualified Data.Map as Map
-import           Data.Text
-                 ( Text )
-
+import Data.Text
+  ( Text
+    )
+import Kore.Debug
 import qualified Kore.Sort as Kore
-                 ( Sort (SortActualSort), SortActual (SortActual) )
+  ( Sort (SortActualSort),
+    SortActual (SortActual)
+    )
 import qualified Kore.Sort as SortActual
-                 ( SortActual (..) )
-import           Kore.Step.SMT.AST
-                 ( Declarations (Declarations), Encodable,
-                 IndirectSymbolDeclaration (IndirectSymbolDeclaration),
-                 KoreSortDeclaration (SortDeclarationDataType, SortDeclarationSort, SortDeclaredIndirectly),
-                 KoreSymbolDeclaration (SymbolDeclaredDirectly, SymbolDeclaredIndirectly),
-                 SmtDeclarations, Sort (Sort), SortReference (SortReference),
-                 Symbol (Symbol), SymbolReference (SymbolReference),
-                 UnresolvedConstructor, UnresolvedConstructorArgument,
-                 UnresolvedDataTypeDeclaration, UnresolvedDeclarations,
-                 UnresolvedFunctionDeclaration, UnresolvedKoreSortDeclaration,
-                 UnresolvedKoreSymbolDeclaration, UnresolvedSort,
-                 UnresolvedSortDeclaration, UnresolvedSymbol, encode )
+  ( SortActual (..)
+    )
+import Kore.Step.SMT.AST
+  ( Declarations (Declarations),
+    Encodable,
+    IndirectSymbolDeclaration (IndirectSymbolDeclaration),
+    KoreSortDeclaration (SortDeclarationDataType, SortDeclarationSort, SortDeclaredIndirectly),
+    KoreSymbolDeclaration (SymbolDeclaredDirectly, SymbolDeclaredIndirectly),
+    SmtDeclarations,
+    Sort (Sort),
+    SortReference (SortReference),
+    Symbol (Symbol),
+    SymbolReference (SymbolReference),
+    UnresolvedConstructor,
+    UnresolvedConstructorArgument,
+    UnresolvedDataTypeDeclaration,
+    UnresolvedDeclarations,
+    UnresolvedFunctionDeclaration,
+    UnresolvedKoreSortDeclaration,
+    UnresolvedKoreSymbolDeclaration,
+    UnresolvedSort,
+    UnresolvedSortDeclaration,
+    UnresolvedSymbol,
+    encode
+    )
 import qualified Kore.Step.SMT.AST as DoNotUse
 import qualified SMT
 
-import Kore.Debug
-
-data Resolvers sort symbol name = Resolvers
-    { sortResolver :: SortReference -> Maybe sort
-    , symbolResolver :: SymbolReference -> Maybe symbol
-    , nameResolver :: Encodable -> name
-    }
+data Resolvers sort symbol name
+  = Resolvers
+      { sortResolver :: SortReference -> Maybe sort,
+        symbolResolver :: SymbolReference -> Maybe symbol,
+        nameResolver :: Encodable -> name
+        }
 
 {-| Enforces consistency on the given declarations (i.e. all referenced sorts
 and symbols must be declared). Removes all declarations with missing references.
 -}
 resolve :: UnresolvedDeclarations -> SmtDeclarations
 resolve declarations =
-    resolveDeclarations (smtResolvers checkedDeclarations) checkedDeclarations
+  resolveDeclarations (smtResolvers checkedDeclarations) checkedDeclarations
   where
     checkedDeclarations = removeBrokenReferences declarations
 
 smtResolvers
-    :: UnresolvedDeclarations
-    -> Resolvers SMT.SExpr Text Text
+  :: UnresolvedDeclarations
+  -> Resolvers SMT.SExpr Text Text
 smtResolvers Declarations {sorts, symbols} =
-    Resolvers
-        { sortResolver = referenceCheckSort
-        , symbolResolver = referenceCheckSymbol
-        , nameResolver = encode
-        }
+  Resolvers
+    { sortResolver = referenceCheckSort,
+      symbolResolver = referenceCheckSymbol,
+      nameResolver = encode
+      }
   where
     referenceCheckSort
-        (SortReference
-            (Kore.SortActualSort Kore.SortActual
-                { sortActualName
-                , sortActualSorts = []
-                }
+      ( SortReference
+          ( Kore.SortActualSort
+              Kore.SortActual
+                { sortActualName,
+                  sortActualSorts = []
+                  }
             )
-        )
-      = case Map.lookup sortActualName sorts of
-        Nothing -> (error . unlines)
-            [ "All references should be resolved before transforming"
-            , "to smt declarations."
-            ]
-        Just Sort { smtFromSortArgs } ->
-            case smtFromSortArgs Map.empty [] of
-                Nothing -> (error . unlines)
-                    [ "Expecting to be able to produce sort representation"
-                    , "for defining it."
-                    ]
-                Just value -> return value
-    referenceCheckSort _ =
-        error "Unimplemented: sort with arguments."
-
-    referenceCheckSymbol SymbolReference {getSymbolReference} =
-        case Map.lookup getSymbolReference symbols of
-            Nothing -> (error . unlines)
-                [ "All references should be resolved before transforming"
-                , "to smt declarations."
+        ) =
+        case Map.lookup sortActualName sorts of
+          Nothing ->
+            (error . unlines)
+              [ "All references should be resolved before transforming",
+                "to smt declarations."
                 ]
-            Just Symbol { smtFromSortArgs } ->
-                case smtFromSortArgs Map.empty [] of
-                    Nothing -> (error . unlines)
-                        [ "Expecting to be able to produce symbol"
-                        , "representation for defining it."
-                        ]
-                    Just (SMT.Atom name) -> return name
-                    Just _ -> error
-                        "Unable to understand symbol representation."
+          Just Sort {smtFromSortArgs} ->
+            case smtFromSortArgs Map.empty [] of
+              Nothing ->
+                (error . unlines)
+                  [ "Expecting to be able to produce sort representation",
+                    "for defining it."
+                    ]
+              Just value -> return value
+    referenceCheckSort _ =
+      error "Unimplemented: sort with arguments."
+    referenceCheckSymbol SymbolReference {getSymbolReference} =
+      case Map.lookup getSymbolReference symbols of
+        Nothing ->
+          (error . unlines)
+            [ "All references should be resolved before transforming",
+              "to smt declarations."
+              ]
+        Just Symbol {smtFromSortArgs} ->
+          case smtFromSortArgs Map.empty [] of
+            Nothing ->
+              (error . unlines)
+                [ "Expecting to be able to produce symbol",
+                  "representation for defining it."
+                  ]
+            Just (SMT.Atom name) -> return name
+            Just _ ->
+              error
+                "Unable to understand symbol representation."
 
 removeBrokenReferences :: UnresolvedDeclarations -> UnresolvedDeclarations
-removeBrokenReferences declarations@Declarations { sorts, symbols } =
-    if not (shouldContinue afterOneStep)
+removeBrokenReferences declarations@Declarations {sorts, symbols} =
+  if not (shouldContinue afterOneStep)
     then afterOneStep
     else removeBrokenReferences afterOneStep
   where
     afterOneStep :: UnresolvedDeclarations
     afterOneStep =
-        resolveDeclarations (referenceCheckResolvers declarations) declarations
-
+      resolveDeclarations (referenceCheckResolvers declarations) declarations
     shouldContinue :: UnresolvedDeclarations -> Bool
-    shouldContinue Declarations { sorts = newSorts, symbols = newSymbols } =
-        case (sortComparison, symbolComparison) of
-            (LT, _) -> error "Unexpected increase in sort count"
-            (_, LT) -> error "Unexpected increase in symbol count"
-            (EQ, EQ) -> False
-            (_, _) -> True
+    shouldContinue Declarations {sorts = newSorts, symbols = newSymbols} =
+      case (sortComparison, symbolComparison) of
+        (LT, _) -> error "Unexpected increase in sort count"
+        (_, LT) -> error "Unexpected increase in symbol count"
+        (EQ, EQ) -> False
+        (_, _) -> True
       where
         sortComparison = compare (Map.size sorts) (Map.size newSorts)
         symbolComparison = compare (Map.size symbols) (Map.size newSymbols)
 
 referenceCheckResolvers
-    :: UnresolvedDeclarations
-    -> Resolvers SortReference SymbolReference Encodable
+  :: UnresolvedDeclarations
+  -> Resolvers SortReference SymbolReference Encodable
 referenceCheckResolvers Declarations {sorts, symbols} =
-    Resolvers
-        { sortResolver = referenceCheckSort
-        , symbolResolver = referenceCheckSymbol
-        , nameResolver = id
-        }
+  Resolvers
+    { sortResolver = referenceCheckSort,
+      symbolResolver = referenceCheckSymbol,
+      nameResolver = id
+      }
   where
     referenceCheckSort
-        reference@(SortReference
-            (Kore.SortActualSort Kore.SortActual
-                { sortActualName
-                , sortActualSorts = []
-                }
-            )
-        )
-      = traceMaybe D_SMT_referenceCheckSort [debugArg "reference" reference]
-        $ do
+      reference@( SortReference
+                    ( Kore.SortActualSort
+                        Kore.SortActual
+                          { sortActualName,
+                            sortActualSorts = []
+                            }
+                      )
+                  ) =
+        traceMaybe D_SMT_referenceCheckSort [debugArg "reference" reference]
+          $ do
             _ <- Map.lookup sortActualName sorts
             return reference
     referenceCheckSort reference =
-        traceMaybe D_SMT_referenceCheckSort [debugArg "reference" reference]
+      traceMaybe D_SMT_referenceCheckSort [debugArg "reference" reference]
         Nothing
-
     referenceCheckSymbol reference@SymbolReference {getSymbolReference} =
-        traceMaybe D_SMT_referenceCheckSymbol [debugArg "reference" reference]
+      traceMaybe D_SMT_referenceCheckSymbol [debugArg "reference" reference]
         $ do
-            _ <- Map.lookup getSymbolReference symbols
-            return reference
+          _ <- Map.lookup getSymbolReference symbols
+          return reference
 
 resolveDeclarations
-    :: (Show sort, Show symbol, Show name)
-    => Resolvers sort symbol name
-    -> UnresolvedDeclarations
-    -> Declarations sort symbol name
+  :: (Show sort, Show symbol, Show name)
+  => Resolvers sort symbol name
+  -> UnresolvedDeclarations
+  -> Declarations sort symbol name
 resolveDeclarations
-    resolvers
-    Declarations { sorts, symbols }
-  =
+  resolvers
+  Declarations {sorts, symbols} =
     Declarations
-        { sorts = Map.mapMaybe (resolveSort resolvers) sorts
-        , symbols = Map.mapMaybe (resolveSymbol resolvers) symbols
+      { sorts = Map.mapMaybe (resolveSort resolvers) sorts,
+        symbols = Map.mapMaybe (resolveSymbol resolvers) symbols
         }
 
 resolveSort
-    :: (Show sort, Show symbol, Show name)
-    => Resolvers sort symbol name
-    -> UnresolvedSort
-    -> Maybe (Sort sort symbol name)
+  :: (Show sort, Show symbol, Show name)
+  => Resolvers sort symbol name
+  -> UnresolvedSort
+  -> Maybe (Sort sort symbol name)
 resolveSort
-    resolvers
-    Sort { smtFromSortArgs, declaration }
-  = traceMaybe D_SMT_resolveSort [debugArg "declaration" declaration]
-    $ do
-    newDeclaration <- resolveKoreSortDeclaration resolvers declaration
-    return Sort
-        { smtFromSortArgs = smtFromSortArgs
-        , declaration = newDeclaration
-        }
+  resolvers
+  Sort {smtFromSortArgs, declaration} =
+    traceMaybe D_SMT_resolveSort [debugArg "declaration" declaration]
+      $ do
+        newDeclaration <- resolveKoreSortDeclaration resolvers declaration
+        return Sort
+          { smtFromSortArgs = smtFromSortArgs,
+            declaration = newDeclaration
+            }
 
 resolveKoreSortDeclaration
-    :: Resolvers sort symbol name
-    -> UnresolvedKoreSortDeclaration
-    -> Maybe (KoreSortDeclaration sort symbol name)
+  :: Resolvers sort symbol name
+  -> UnresolvedKoreSortDeclaration
+  -> Maybe (KoreSortDeclaration sort symbol name)
 resolveKoreSortDeclaration resolvers (SortDeclarationDataType declaration) =
-    SortDeclarationDataType
-        <$> resolveDataTypeDeclaration resolvers declaration
+  SortDeclarationDataType
+    <$> resolveDataTypeDeclaration resolvers declaration
 resolveKoreSortDeclaration resolvers (SortDeclarationSort declaration) =
-    return
-        (SortDeclarationSort
-            (resolveSortDeclaration resolvers declaration)
-        )
-resolveKoreSortDeclaration
-    Resolvers {nameResolver} (SortDeclaredIndirectly name)
-  =
-    Just (SortDeclaredIndirectly (nameResolver name))
+  return
+    ( SortDeclarationSort
+        (resolveSortDeclaration resolvers declaration)
+      )
+resolveKoreSortDeclaration Resolvers {nameResolver} (SortDeclaredIndirectly name) =
+  Just (SortDeclaredIndirectly (nameResolver name))
 
 resolveDataTypeDeclaration
-    :: Resolvers sort symbol name
-    -> UnresolvedDataTypeDeclaration
-    -> Maybe (SMT.DataTypeDeclaration sort symbol name)
+  :: Resolvers sort symbol name
+  -> UnresolvedDataTypeDeclaration
+  -> Maybe (SMT.DataTypeDeclaration sort symbol name)
 resolveDataTypeDeclaration
-    resolvers@Resolvers { nameResolver }
-    SMT.DataTypeDeclaration { name, typeArguments, constructors }
-  = do
-    newConstructors <- mapM (resolveConstructor resolvers) constructors
-    return SMT.DataTypeDeclaration
-        { name = nameResolver name
-        , typeArguments = map nameResolver typeArguments
-        , constructors = newConstructors
-        }
+  resolvers@Resolvers {nameResolver}
+  SMT.DataTypeDeclaration {name, typeArguments, constructors} =
+    do
+      newConstructors <- mapM (resolveConstructor resolvers) constructors
+      return SMT.DataTypeDeclaration
+        { name = nameResolver name,
+          typeArguments = map nameResolver typeArguments,
+          constructors = newConstructors
+          }
 
 resolveConstructor
-    :: Resolvers sort symbol name
-    -> UnresolvedConstructor
-    -> Maybe (SMT.Constructor sort symbol name)
+  :: Resolvers sort symbol name
+  -> UnresolvedConstructor
+  -> Maybe (SMT.Constructor sort symbol name)
 resolveConstructor
-    resolvers@Resolvers { symbolResolver }
-    SMT.Constructor { name, arguments }
-  = do
-    newName <- symbolResolver name
-    newArguments <- mapM (resolveConstructorArgument resolvers) arguments
-    return SMT.Constructor
-        { name = newName
-        , arguments = newArguments
-        }
+  resolvers@Resolvers {symbolResolver}
+  SMT.Constructor {name, arguments} =
+    do
+      newName <- symbolResolver name
+      newArguments <- mapM (resolveConstructorArgument resolvers) arguments
+      return SMT.Constructor
+        { name = newName,
+          arguments = newArguments
+          }
 
 resolveConstructorArgument
-    :: Resolvers sort symbol name
-    -> UnresolvedConstructorArgument
-    -> Maybe (SMT.ConstructorArgument sort name)
+  :: Resolvers sort symbol name
+  -> UnresolvedConstructorArgument
+  -> Maybe (SMT.ConstructorArgument sort name)
 resolveConstructorArgument
-    Resolvers { sortResolver, nameResolver }
-    SMT.ConstructorArgument { name, argType }
-  = do
-    newArgType <- sortResolver argType
-    return SMT.ConstructorArgument
-        { name = nameResolver name
-        , argType = newArgType
-        }
+  Resolvers {sortResolver, nameResolver}
+  SMT.ConstructorArgument {name, argType} =
+    do
+      newArgType <- sortResolver argType
+      return SMT.ConstructorArgument
+        { name = nameResolver name,
+          argType = newArgType
+          }
 
 resolveSortDeclaration
-    :: Resolvers sort symbol name
-    -> UnresolvedSortDeclaration
-    -> SMT.SortDeclaration name
+  :: Resolvers sort symbol name
+  -> UnresolvedSortDeclaration
+  -> SMT.SortDeclaration name
 resolveSortDeclaration
-    Resolvers { nameResolver }
-    SMT.SortDeclaration { name, arity }
-  =
-    SMT.SortDeclaration { name = nameResolver name, arity }
+  Resolvers {nameResolver}
+  SMT.SortDeclaration {name, arity} =
+    SMT.SortDeclaration {name = nameResolver name, arity}
 
 resolveSymbol
-    :: (Show sort, Show name)
-    => Resolvers sort symbol name
-    -> UnresolvedSymbol
-    -> Maybe (Symbol sort name)
+  :: (Show sort, Show name)
+  => Resolvers sort symbol name
+  -> UnresolvedSymbol
+  -> Maybe (Symbol sort name)
 resolveSymbol
-    resolvers
-    Symbol { smtFromSortArgs, declaration }
-  = traceMaybe D_SMT_resolveSymbol [debugArg "declaration" declaration] $ do
-    newDeclaration <- resolveKoreSymbolDeclaration resolvers declaration
-    return Symbol
-        { smtFromSortArgs = smtFromSortArgs
-        , declaration = newDeclaration
-        }
+  resolvers
+  Symbol {smtFromSortArgs, declaration} =
+    traceMaybe D_SMT_resolveSymbol [debugArg "declaration" declaration] $ do
+      newDeclaration <- resolveKoreSymbolDeclaration resolvers declaration
+      return Symbol
+        { smtFromSortArgs = smtFromSortArgs,
+          declaration = newDeclaration
+          }
 
 resolveKoreSymbolDeclaration
-    :: Resolvers sort symbol name
-    -> UnresolvedKoreSymbolDeclaration
-    -> Maybe (KoreSymbolDeclaration sort name)
+  :: Resolvers sort symbol name
+  -> UnresolvedKoreSymbolDeclaration
+  -> Maybe (KoreSymbolDeclaration sort name)
 resolveKoreSymbolDeclaration resolvers (SymbolDeclaredDirectly declaration) =
-    SymbolDeclaredDirectly <$> resolveFunctionDeclaration resolvers declaration
+  SymbolDeclaredDirectly <$> resolveFunctionDeclaration resolvers declaration
 resolveKoreSymbolDeclaration
-    Resolvers {sortResolver, nameResolver}
-    (SymbolDeclaredIndirectly IndirectSymbolDeclaration {name, sorts})
-  = do
-    newSorts <- mapM sortResolver sorts
-    return $ SymbolDeclaredIndirectly IndirectSymbolDeclaration
-        { name = nameResolver name
-        , sorts = newSorts
-        }
+  Resolvers {sortResolver, nameResolver}
+  (SymbolDeclaredIndirectly IndirectSymbolDeclaration {name, sorts}) =
+    do
+      newSorts <- mapM sortResolver sorts
+      return
+        $ SymbolDeclaredIndirectly IndirectSymbolDeclaration
+            { name = nameResolver name,
+              sorts = newSorts
+              }
 
 resolveFunctionDeclaration
-    :: Resolvers sort symbol name
-    -> UnresolvedFunctionDeclaration
-    -> Maybe (SMT.FunctionDeclaration sort name)
+  :: Resolvers sort symbol name
+  -> UnresolvedFunctionDeclaration
+  -> Maybe (SMT.FunctionDeclaration sort name)
 resolveFunctionDeclaration
-    Resolvers { sortResolver, nameResolver }
-    SMT.FunctionDeclaration { name, inputSorts, resultSort }
-  = do
-    newInputSorts <- mapM sortResolver inputSorts
-    newResultSort <- sortResolver resultSort
-    return SMT.FunctionDeclaration
-        { name = nameResolver name
-        , inputSorts = newInputSorts
-        , resultSort = newResultSort
-        }
+  Resolvers {sortResolver, nameResolver}
+  SMT.FunctionDeclaration {name, inputSorts, resultSort} =
+    do
+      newInputSorts <- mapM sortResolver inputSorts
+      newResultSort <- sortResolver resultSort
+      return SMT.FunctionDeclaration
+        { name = nameResolver name,
+          inputSorts = newInputSorts,
+          resultSort = newResultSort
+          }

--- a/kore/src/Kore/Step/SMT/Representation/Sorts.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Sorts.hs
@@ -5,83 +5,110 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 -}
-
 module Kore.Step.SMT.Representation.Sorts
-    ( buildRepresentations
-    ) where
+  ( buildRepresentations
+    )
+where
 
-import           Control.Monad
-                 ( when, zipWithM )
+import Control.Monad
+  ( when,
+    zipWithM
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-                 ( mapMaybe )
+import Data.Maybe
+  ( mapMaybe
+    )
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-
 import qualified Kore.Attribute.Axiom as Attribute
-                 ( Axiom )
+  ( Axiom
+    )
 import qualified Kore.Attribute.Axiom as Attribute.Axiom
-                 ( constructor )
+  ( constructor
+    )
 import qualified Kore.Attribute.Axiom.Constructor as Axiom.Constructor
-import           Kore.Attribute.Hook
-                 ( Hook (Hook) )
+import Kore.Attribute.Hook
+  ( Hook (Hook)
+    )
 import qualified Kore.Attribute.Hook as Hook
-import           Kore.Attribute.Smtlib
-                 ( applySExpr )
-import           Kore.Attribute.Smtlib.Smtlib
-                 ( Smtlib (Smtlib) )
+import Kore.Attribute.Smtlib
+  ( applySExpr
+    )
+import Kore.Attribute.Smtlib.Smtlib
+  ( Smtlib (Smtlib)
+    )
 import qualified Kore.Attribute.Smtlib.Smtlib as Smtlib
 import qualified Kore.Attribute.Sort as Attribute
-                 ( Sort )
+  ( Sort
+    )
 import qualified Kore.Attribute.Sort as Attribute.Sort
 import qualified Kore.Builtin.Bool as Bool
 import qualified Kore.Builtin.Int as Int
-import           Kore.IndexedModule.IndexedModule
-                 ( VerifiedModule, recursiveIndexedModuleAxioms,
-                 recursiveIndexedModuleSortDescriptions )
-import           Kore.Internal.TermLike
-import           Kore.Sort
-                 ( Sort (SortActualSort), SortActual (SortActual) )
+import Kore.IndexedModule.IndexedModule
+  ( VerifiedModule,
+    recursiveIndexedModuleAxioms,
+    recursiveIndexedModuleSortDescriptions
+    )
+import Kore.Internal.TermLike
+import Kore.Sort
+  ( Sort (SortActualSort),
+    SortActual (SortActual)
+    )
 import qualified Kore.Sort as SortActual
-                 ( SortActual (..) )
+  ( SortActual (..)
+    )
 import qualified Kore.Step.SMT.AST as AST
-import           Kore.Syntax.Id
-                 ( Id )
-import           Kore.Syntax.Sentence
-                 ( SentenceAxiom (SentenceAxiom), SentenceSort (SentenceSort) )
+import Kore.Syntax.Id
+  ( Id
+    )
+import Kore.Syntax.Sentence
+  ( SentenceAxiom (SentenceAxiom),
+    SentenceSort (SentenceSort)
+    )
 import qualified Kore.Syntax.Sentence as SentenceSort
-                 ( SentenceSort (..) )
+  ( SentenceSort (..)
+    )
 import qualified Kore.Syntax.Sentence as SentenceAxiom
-                 ( SentenceAxiom (..) )
-import           Kore.Unparser
-                 ( unparseToString )
+  ( SentenceAxiom (..)
+    )
+import Kore.Unparser
+  ( unparseToString
+    )
 import qualified Kore.Verified as Verified
 import qualified SMT
-                 ( Constructor (Constructor),
-                 ConstructorArgument (ConstructorArgument),
-                 DataTypeDeclaration (DataTypeDeclaration), SExpr (Atom, List),
-                 SortDeclaration (SortDeclaration), nameFromSExpr, showSExpr,
-                 tBool, tInt )
+  ( Constructor (Constructor),
+    ConstructorArgument (ConstructorArgument),
+    DataTypeDeclaration (DataTypeDeclaration),
+    SExpr (Atom, List),
+    SortDeclaration (SortDeclaration),
+    nameFromSExpr,
+    showSExpr,
+    tBool,
+    tInt
+    )
 import qualified SMT as SMT.DataTypeDeclaration
-                 ( DataTypeDeclaration (..) )
+  ( DataTypeDeclaration (..)
+    )
 import qualified SMT as SMT.SortDeclaration
-                 ( SortDeclaration (..) )
+  ( SortDeclaration (..)
+    )
 import qualified SMT as SMT.ConstructorArgument
-                 ( ConstructorArgument (..) )
+  ( ConstructorArgument (..)
+    )
 import qualified SMT as SMT.Constructor
-                 ( Constructor (..) )
-
+  ( Constructor (..)
+    )
 
 translateSort
-    :: Map.Map Id AST.SmtSort
-    -> Sort
-    -> Maybe SMT.SExpr
+  :: Map.Map Id AST.SmtSort
+  -> Sort
+  -> Maybe SMT.SExpr
 translateSort
-    sorts
-    (SortActualSort SortActual { sortActualName, sortActualSorts })
-  = do
-    AST.Sort { smtFromSortArgs } <- Map.lookup sortActualName sorts
-    smtFromSortArgs sorts sortActualSorts
+  sorts
+  (SortActualSort SortActual {sortActualName, sortActualSorts}) =
+    do
+      AST.Sort {smtFromSortArgs} <- Map.lookup sortActualName sorts
+      smtFromSortArgs sorts sortActualSorts
 translateSort _ _ = Nothing
 
 {-| Builds smt representations for sorts in the given module.
@@ -91,306 +118,297 @@ May ignore sorts that we don't handle yet (e.g. parameterized sorts).
 All references to other sorts and symbols are left unresolved.
 -}
 buildRepresentations
-    :: forall symbolAttribute
-    .  VerifiedModule symbolAttribute Attribute.Axiom
-    -> AST.UnresolvedDeclarations
+  :: forall symbolAttribute. VerifiedModule symbolAttribute Attribute.Axiom
+  -> AST.UnresolvedDeclarations
 buildRepresentations indexedModule =
-    builtinAndSmtLibDeclarations
-    `AST.mergePreferFirst`
-        listToDeclarations (parseNoJunkAxioms builtinAndSmtLibSorts)
-    `AST.mergePreferFirst`
-        listToDeclarations simpleSortDeclarations
+  builtinAndSmtLibDeclarations
+    `AST.mergePreferFirst` listToDeclarations (parseNoJunkAxioms builtinAndSmtLibSorts)
+    `AST.mergePreferFirst` listToDeclarations simpleSortDeclarations
   where
     listToDeclarations
-        :: [(Id, AST.UnresolvedSort)] -> AST.UnresolvedDeclarations
+      :: [(Id, AST.UnresolvedSort)] -> AST.UnresolvedDeclarations
     listToDeclarations list =
-        AST.Declarations
-            { sorts = Map.fromList list
-            , symbols = Map.empty
-            }
-
+      AST.Declarations
+        { sorts = Map.fromList list,
+          symbols = Map.empty
+          }
     builtinAndSmtLibDeclarations :: AST.UnresolvedDeclarations
     builtinAndSmtLibDeclarations =
-        listToDeclarations builtinSortDeclarations
-        `AST.mergePreferFirst`
-            listToDeclarations smtlibSortDeclarations
-
+      listToDeclarations builtinSortDeclarations
+        `AST.mergePreferFirst` listToDeclarations smtlibSortDeclarations
     builtinAndSmtLibSorts :: Set.Set Id
     builtinAndSmtLibSorts = Map.keysSet sorts
       where
         AST.Declarations {sorts} = builtinAndSmtLibDeclarations
-
     parseNoJunkAxioms
-        :: Set.Set Id
-        -> [(Id, AST.UnresolvedSort)]
+      :: Set.Set Id
+      -> [(Id, AST.UnresolvedSort)]
     parseNoJunkAxioms blacklist =
-        filter
-            (not . (`Set.member` blacklist) . fst)
-            (mapMaybe
-                parseNoJunkAxiom
-                (recursiveIndexedModuleAxioms indexedModule)
-            )
-
+      filter
+        (not . (`Set.member` blacklist) . fst)
+        ( mapMaybe
+            parseNoJunkAxiom
+            (recursiveIndexedModuleAxioms indexedModule)
+          )
     builtinSortDeclarations :: [(Id, AST.UnresolvedSort)]
     builtinSortDeclarations =
-        extractDefinitionsFromSentences builtinSortDeclaration
-
+      extractDefinitionsFromSentences builtinSortDeclaration
     smtlibSortDeclarations :: [(Id, AST.UnresolvedSort)]
     smtlibSortDeclarations =
-        extractDefinitionsFromSentences smtlibSortDeclaration
-
+      extractDefinitionsFromSentences smtlibSortDeclaration
     simpleSortDeclarations :: [(Id, AST.UnresolvedSort)]
     simpleSortDeclarations =
-        extractDefinitionsFromSentences simpleSortDeclaration
-
+      extractDefinitionsFromSentences simpleSortDeclaration
     extractDefinitionsFromSentences
-        ::  (   ( Attribute.Sort
-                , Verified.SentenceSort
-                )
-            -> Maybe (Id, AST.UnresolvedSort)
-            )
-        -> [(Id, AST.UnresolvedSort)]
+      :: ( ( Attribute.Sort,
+             Verified.SentenceSort
+             )
+           -> Maybe (Id, AST.UnresolvedSort)
+           )
+      -> [(Id, AST.UnresolvedSort)]
     extractDefinitionsFromSentences definitionExtractor =
-        mapMaybe
-            definitionExtractor
-            (Map.elems $ recursiveIndexedModuleSortDescriptions indexedModule)
+      mapMaybe
+        definitionExtractor
+        (Map.elems $ recursiveIndexedModuleSortDescriptions indexedModule)
 
 builtinSortDeclaration
-    ::  ( Attribute.Sort
-        , Verified.SentenceSort
-        )
-    -> Maybe (Id, AST.UnresolvedSort)
-builtinSortDeclaration
-    (attributes, SentenceSort { sentenceSortName })
-  = do
-    smtRepresentation <- case getHook of
+  :: ( Attribute.Sort,
+       Verified.SentenceSort
+       )
+  -> Maybe (Id, AST.UnresolvedSort)
+builtinSortDeclaration (attributes, SentenceSort {sentenceSortName}) =
+  do
+    smtRepresentation <-
+      case getHook of
         Just name
-            | name == Int.sort -> return SMT.tInt
-            | name == Bool.sort -> return SMT.tBool
+          | name == Int.sort -> return SMT.tInt
+          | name == Bool.sort -> return SMT.tBool
         _ -> Nothing
     return
-        ( sentenceSortName
-        , AST.Sort
-            { smtFromSortArgs = emptySortArgsToSmt smtRepresentation
-            , declaration =
-                AST.SortDeclaredIndirectly
-                    (AST.AlreadyEncoded (SMT.nameFromSExpr smtRepresentation))
+      ( sentenceSortName,
+        AST.Sort
+          { smtFromSortArgs = emptySortArgsToSmt smtRepresentation,
+            declaration =
+              AST.SortDeclaredIndirectly
+                (AST.AlreadyEncoded (SMT.nameFromSExpr smtRepresentation))
             }
         )
   where
     Hook {getHook} = Attribute.Sort.hook attributes
 
 smtlibSortDeclaration
-    ::  ( Attribute.Sort
-        , Verified.SentenceSort
-        )
-    -> Maybe (Id, AST.UnresolvedSort)
-smtlibSortDeclaration
-    (attributes, SentenceSort { sentenceSortName })
-  = do
+  :: ( Attribute.Sort,
+       Verified.SentenceSort
+       )
+  -> Maybe (Id, AST.UnresolvedSort)
+smtlibSortDeclaration (attributes, SentenceSort {sentenceSortName}) =
+  do
     smtRepresentation@(SMT.List (SMT.Atom smtName : sortArgs)) <- getSmtlib
     return
-        ( sentenceSortName
-        , AST.Sort
-            { smtFromSortArgs = applyToArgs smtRepresentation
-            , declaration = AST.SortDeclarationSort
-                SMT.SortDeclaration
-                    { name = AST.AlreadyEncoded smtName
-                    , arity = length sortArgs
-                    }
+      ( sentenceSortName,
+        AST.Sort
+          { smtFromSortArgs = applyToArgs smtRepresentation,
+            declaration =
+              AST.SortDeclarationSort SMT.SortDeclaration
+                { name = AST.AlreadyEncoded smtName,
+                  arity = length sortArgs
+                  }
             }
         )
   where
     applyToArgs
-        :: SMT.SExpr
-        -> Map.Map Id AST.SmtSort
-        -> [Sort]
-        -> Maybe SMT.SExpr
+      :: SMT.SExpr
+      -> Map.Map Id AST.SmtSort
+      -> [Sort]
+      -> Maybe SMT.SExpr
     applyToArgs sExpr definitions children = do
-        children' <- mapM (translateSort definitions) children
-        return $ applySExpr sExpr children'
-    Smtlib { getSmtlib } = Attribute.Sort.smtlib attributes
+      children' <- mapM (translateSort definitions) children
+      return $ applySExpr sExpr children'
+    Smtlib {getSmtlib} = Attribute.Sort.smtlib attributes
 
 simpleSortDeclaration
-    ::  ( Attribute.Sort
-        , Verified.SentenceSort
-        )
-    -> Maybe (Id, AST.UnresolvedSort)
+  :: ( Attribute.Sort,
+       Verified.SentenceSort
+       )
+  -> Maybe (Id, AST.UnresolvedSort)
 simpleSortDeclaration
-    ( _attribute
-    , SentenceSort
-        { sentenceSortName
-        , sentenceSortParameters = []
+  ( _attribute,
+    SentenceSort
+      { sentenceSortName,
+        sentenceSortParameters = []
         }
-    )
-  = Just
-        ( sentenceSortName
-        , AST.Sort
-            { smtFromSortArgs =
-                emptySortArgsToSmt (SMT.Atom $ AST.encode encodedName)
-            , declaration = AST.SortDeclarationSort
-                SMT.SortDeclaration
-                    { name = encodedName
-                    , arity = 0
-                    }
+    ) =
+    Just
+      ( sentenceSortName,
+        AST.Sort
+          { smtFromSortArgs =
+              emptySortArgsToSmt (SMT.Atom $ AST.encode encodedName),
+            declaration =
+              AST.SortDeclarationSort SMT.SortDeclaration
+                { name = encodedName,
+                  arity = 0
+                  }
             }
         )
-  where
-    encodedName = AST.encodable sentenceSortName
+    where
+      encodedName = AST.encodable sentenceSortName
 simpleSortDeclaration _ = Nothing
 
 emptySortArgsToSmt
-    :: SMT.SExpr
-    -> Map.Map Id AST.SmtSort
-    -> [Sort]
-    -> Maybe SMT.SExpr
+  :: SMT.SExpr
+  -> Map.Map Id AST.SmtSort
+  -> [Sort]
+  -> Maybe SMT.SExpr
 emptySortArgsToSmt representation _ [] = Just representation
-emptySortArgsToSmt representation _ args = (error . unlines)
-    [ "Sorts with arguments not supported yet."
-    , "representation=" ++ SMT.showSExpr representation
-    , "args = " ++ show (fmap unparseToString args)
-    ]
+emptySortArgsToSmt representation _ args =
+  (error . unlines)
+    [ "Sorts with arguments not supported yet.",
+      "representation=" ++ SMT.showSExpr representation,
+      "args = " ++ show (fmap unparseToString args)
+      ]
 
 parseNoJunkAxiom
-    ::  ( Attribute.Axiom
-        , Verified.SentenceAxiom
-        )
-    -> Maybe (Id, AST.UnresolvedSort)
+  :: ( Attribute.Axiom,
+       Verified.SentenceAxiom
+       )
+  -> Maybe (Id, AST.UnresolvedSort)
 parseNoJunkAxiom (attributes, SentenceAxiom {sentenceAxiomPattern})
-  | Axiom.Constructor.isConstructor (Attribute.Axiom.constructor attributes)
-  = parseNoJunkPattern sentenceAxiomPattern
+  | Axiom.Constructor.isConstructor (Attribute.Axiom.constructor attributes) =
+    parseNoJunkPattern sentenceAxiomPattern
   | otherwise = Nothing
 
 parseNoJunkPattern
-    :: TermLike Variable
-    -> Maybe (Id , AST.UnresolvedSort)
-parseNoJunkPattern patt = do  -- Maybe
-    (name, sortBuilder, constructors) <- parseNoJunkPatternHelper patt
-    -- We currently have invalid axioms like
-    -- axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
-    -- We could use them to prove anything we want and skip all the pain of
-    -- doing actual proofs, but it seems that we should pretend that
-    -- all is fine and look the other way when we encounter one of these
-    -- inconsistent things.
-    -- TODO (virgil): Transform this check into an assertion.
-    when (null constructors) Nothing
-    return (name, sortBuilder constructors)
+  :: TermLike Variable
+  -> Maybe (Id, AST.UnresolvedSort)
+parseNoJunkPattern patt = do
+  -- Maybe
+  (name, sortBuilder, constructors) <- parseNoJunkPatternHelper patt
+  -- We currently have invalid axioms like
+  -- axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
+  -- We could use them to prove anything we want and skip all the pain of
+  -- doing actual proofs, but it seems that we should pretend that
+  -- all is fine and look the other way when we encounter one of these
+  -- inconsistent things.
+  -- TODO (virgil): Transform this check into an assertion.
+  when (null constructors) Nothing
+  return (name, sortBuilder constructors)
 
 parseNoJunkPatternHelper
-    :: TermLike Variable
-    ->  Maybe
-        ( Id
-        , [AST.UnresolvedConstructor] -> AST.UnresolvedSort
-        , [AST.UnresolvedConstructor]
-        )
+  :: TermLike Variable
+  -> Maybe
+       ( Id,
+         [AST.UnresolvedConstructor] -> AST.UnresolvedSort,
+         [AST.UnresolvedConstructor]
+         )
 parseNoJunkPatternHelper
-    (Bottom_
-        (SortActualSort SortActual
-            { sortActualName, sortActualSorts = [] }
+  ( Bottom_
+      ( SortActualSort
+          SortActual
+            { sortActualName,
+              sortActualSorts = []
+              }
         )
-    )
-  = Just (sortActualName, fromConstructors, [])
-  where
-    encodedName = AST.encodable sortActualName
-    fromConstructors :: [AST.UnresolvedConstructor] -> AST.UnresolvedSort
-    fromConstructors constructors =
+    ) =
+    Just (sortActualName, fromConstructors, [])
+    where
+      encodedName = AST.encodable sortActualName
+      fromConstructors :: [AST.UnresolvedConstructor] -> AST.UnresolvedSort
+      fromConstructors constructors =
         AST.Sort
-            { smtFromSortArgs =
-                emptySortArgsToSmt (SMT.Atom $ AST.encode encodedName)
-            , declaration = AST.SortDeclarationDataType
-                SMT.DataTypeDeclaration
-                    { name = encodedName
-                    , typeArguments = []
-                    , constructors = constructors
-                    }
+          { smtFromSortArgs =
+              emptySortArgsToSmt (SMT.Atom $ AST.encode encodedName),
+            declaration =
+              AST.SortDeclarationDataType SMT.DataTypeDeclaration
+                { name = encodedName,
+                  typeArguments = [],
+                  constructors = constructors
+                  }
             }
-parseNoJunkPatternHelper (Or_ _ first second) = do  -- Maybe
-    (name, sortBuilder, constructors) <- parseNoJunkPatternHelper second
-    constructor <- parseSMTConstructor first
-    return (name, sortBuilder, constructor : constructors)
+parseNoJunkPatternHelper (Or_ _ first second) = do
+  -- Maybe
+  (name, sortBuilder, constructors) <- parseNoJunkPatternHelper second
+  constructor <- parseSMTConstructor first
+  return (name, sortBuilder, constructor : constructors)
 parseNoJunkPatternHelper _ = Nothing
 
 parseSMTConstructor :: TermLike Variable -> Maybe AST.UnresolvedConstructor
 parseSMTConstructor patt =
-    case parsedPatt of
-        App_ symbol children -> do
-            childVariables <-
-                checkOnlyQuantifiedVariablesOnce quantifiedVariables children
-            buildConstructor symbol childVariables
-        _ -> Nothing
+  case parsedPatt of
+    App_ symbol children -> do
+      childVariables <-
+        checkOnlyQuantifiedVariablesOnce quantifiedVariables children
+      buildConstructor symbol childVariables
+    _ -> Nothing
   where
     (quantifiedVariables, parsedPatt) = parseExists patt
-
     parseExists
-        :: TermLike Variable
-        -> (Set.Set (ElementVariable Variable), TermLike Variable)
+      :: TermLike Variable
+      -> (Set.Set (ElementVariable Variable), TermLike Variable)
     parseExists (Exists_ _ variable child) =
-        (Set.insert variable childVars, unquantifiedPatt)
+      (Set.insert variable childVars, unquantifiedPatt)
       where
         (childVars, unquantifiedPatt) = parseExists child
     parseExists unquantifiedPatt = (Set.empty, unquantifiedPatt)
-
     checkOnlyQuantifiedVariablesOnce
-        :: Set.Set (ElementVariable Variable)
-        -> [TermLike Variable]
-        -> Maybe [ElementVariable Variable]
+      :: Set.Set (ElementVariable Variable)
+      -> [TermLike Variable]
+      -> Maybe [ElementVariable Variable]
     checkOnlyQuantifiedVariablesOnce
-        allowedVars
-        []
-      | Set.null allowedVars = Just []
-      | otherwise = Nothing
+      allowedVars
+      []
+        | Set.null allowedVars = Just []
+        | otherwise = Nothing
     checkOnlyQuantifiedVariablesOnce
-        allowedVars
-        (patt0 : patts)
-      = case patt0 of
-        ElemVar_ var ->
+      allowedVars
+      (patt0 : patts) =
+        case patt0 of
+          ElemVar_ var ->
             if var `Set.member` allowedVars
-                then do
-                    vars <-
-                        checkOnlyQuantifiedVariablesOnce
-                            (Set.delete var allowedVars)
-                            patts
-                    return (var : vars)
-                else Nothing
-        _ -> Nothing
-
+              then do
+                vars <-
+                  checkOnlyQuantifiedVariablesOnce
+                    (Set.delete var allowedVars)
+                    patts
+                return (var : vars)
+              else Nothing
+          _ -> Nothing
     buildConstructor
-        :: Symbol
-        -> [ElementVariable Variable]
-        -> Maybe AST.UnresolvedConstructor
+      :: Symbol
+      -> [ElementVariable Variable]
+      -> Maybe AST.UnresolvedConstructor
     buildConstructor
-        Symbol { symbolConstructor, symbolParams = [] }
-        childVariables
-      = do -- Maybe monad
-        args <- zipWithM (parseVariableSort encodedName) [1..] childVariables
-        return SMT.Constructor
-            { name = AST.SymbolReference symbolConstructor
-            , arguments = args
-            }
-      where
-        encodedName = AST.encodable symbolConstructor
-
+      Symbol {symbolConstructor, symbolParams = []}
+      childVariables =
+        do
+          -- Maybe monad
+          args <- zipWithM (parseVariableSort encodedName) [1 ..] childVariables
+          return SMT.Constructor
+            { name = AST.SymbolReference symbolConstructor,
+              arguments = args
+              }
+        where
+          encodedName = AST.encodable symbolConstructor
     -- TODO(virgil): Also handle parameterized sorts.
     buildConstructor _ _ = Nothing
-
     parseVariableSort
-        :: AST.Encodable
-        -> Integer
-        -> ElementVariable Variable
-        -> Maybe AST.UnresolvedConstructorArgument
+      :: AST.Encodable
+      -> Integer
+      -> ElementVariable Variable
+      -> Maybe AST.UnresolvedConstructorArgument
     parseVariableSort
-        constructorName
-        index
-        (ElementVariable Variable
+      constructorName
+      index
+      ( ElementVariable
+          Variable
             { variableSort =
                 sort@(SortActualSort SortActual {sortActualSorts = []})
-            }
-        )
-      = Just SMT.ConstructorArgument
-            { name =
-                AST.appendToEncoding
-                    constructorName
-                    ((Text.pack . show) index)
-            , argType = AST.SortReference sort
+              }
+        ) =
+        Just SMT.ConstructorArgument
+          { name =
+              AST.appendToEncoding
+                constructorName
+                ((Text.pack . show) index),
+            argType = AST.SortReference sort
             }
     parseVariableSort _ _ _ = Nothing

--- a/kore/src/Kore/Step/SMT/Resolvers.hs
+++ b/kore/src/Kore/Step/SMT/Resolvers.hs
@@ -7,22 +7,29 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Step.SMT.Resolvers
-    (translateSymbol) where
+  ( translateSymbol
+    )
+where
 
 import qualified Data.Map as Map
-import           Data.Reflection
-                 ( Given, given )
-
+import Data.Reflection
+  ( Given,
+    given
+    )
 import qualified Kore.Attribute.Symbol as Attribute
-import           Kore.IndexedModule.MetadataTools
-                 ( MetadataTools (MetadataTools), SmtMetadataTools )
+import Kore.IndexedModule.MetadataTools
+  ( MetadataTools (MetadataTools),
+    SmtMetadataTools
+    )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
-                 ( MetadataTools (smtData) )
-import           Kore.Internal.Symbol
+  ( MetadataTools (smtData)
+    )
+import Kore.Internal.Symbol
 import qualified Kore.Step.SMT.AST as AST
-                 ( Declarations (Declarations), Symbol (Symbol) )
+  ( Declarations (Declarations),
+    Symbol (Symbol)
+    )
 import qualified Kore.Step.SMT.AST as AST.DoNotUse
 import qualified SMT
 
@@ -30,14 +37,13 @@ import qualified SMT
 the given SmtMetadataTools.
 -}
 translateSymbol
-    :: Given (SmtMetadataTools Attribute.Symbol)
-    => Symbol
-    -> Maybe SMT.SExpr
-translateSymbol Symbol { symbolConstructor, symbolParams } = do
-    AST.Symbol { smtFromSortArgs } <- Map.lookup symbolConstructor symbols
-    smtFromSortArgs sorts symbolParams
+  :: Given (SmtMetadataTools Attribute.Symbol)
+  => Symbol
+  -> Maybe SMT.SExpr
+translateSymbol Symbol {symbolConstructor, symbolParams} = do
+  AST.Symbol {smtFromSortArgs} <- Map.lookup symbolConstructor symbols
+  smtFromSortArgs sorts symbolParams
   where
     MetadataTools {smtData = AST.Declarations {sorts, symbols}} = tools
-
     tools :: SmtMetadataTools Attribute.Symbol
     tools = given

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -7,47 +7,55 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Step.SMT.Translate
-    ( translatePredicate
-    , Translator
-    , VarContext
-    , evalTranslator
-    , runTranslator
-    ) where
+  ( translatePredicate,
+    Translator,
+    VarContext,
+    evalTranslator,
+    runTranslator
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Control.Error
-                 ( MaybeT )
-import           Control.Monad.Counter
-                 ( CounterT, evalCounterT )
-import           Control.Monad.Except
-import           Control.Monad.Morph as Morph
-import           Control.Monad.State.Strict
-                 ( StateT, evalStateT )
+import Control.Error
+  ( MaybeT
+    )
+import Control.Monad.Counter
+  ( CounterT,
+    evalCounterT
+    )
+import Control.Monad.Except
+import Control.Monad.Morph as Morph
+import Control.Monad.State.Strict
+  ( StateT,
+    evalStateT
+    )
 import qualified Control.Monad.State.Strict as State
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Reflection
-
-import           Kore.Attribute.Hook
-import           Kore.Attribute.Smtlib
+import Data.Reflection
+import Kore.Attribute.Hook
+import Kore.Attribute.Smtlib
 import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Int as Builtin.Int
-import           Kore.IndexedModule.MetadataTools
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-import           Kore.Step.SMT.Resolvers
-                 ( translateSymbol )
-import           Kore.Unparser
-import           SMT
-                 ( SExpr (..) )
+import Kore.IndexedModule.MetadataTools
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+import Kore.Step.SMT.Resolvers
+  ( translateSymbol
+    )
+import Kore.Unparser
+import SMT
+  ( SExpr (..)
+    )
 import qualified SMT
 
 -- ----------------------------------------------------------------
@@ -63,192 +71,184 @@ the predicate from being sent to SMT.
 
  -}
 translatePredicate
-    :: forall p variable m .
-        ( Ord variable
-        , Unparse variable
-        , Given (SmtMetadataTools Attribute.Symbol)
-        , p ~ TermLike variable
-        , Monad m
-        )
-    => (SExpr -> p -> Translator m p SExpr)
-    -> Predicate variable
-    -> Translator m p SExpr
+  :: forall p variable m. ( Ord variable,
+                            Unparse variable,
+                            Given (SmtMetadataTools Attribute.Symbol),
+                            p ~ TermLike variable,
+                            Monad m
+                            )
+  => (SExpr -> p -> Translator m p SExpr)
+  -> Predicate variable
+  -> Translator m p SExpr
 translatePredicate translateUninterpreted predicate =
-    translatePredicatePattern $ unwrapPredicate predicate
+  translatePredicatePattern $ unwrapPredicate predicate
   where
     translatePredicatePattern
-        :: TermLike variable
-        -> Translator m (TermLike variable) SExpr
+      :: TermLike variable
+      -> Translator m (TermLike variable) SExpr
     translatePredicatePattern pat =
-        case Cofree.tailF (Recursive.project pat) of
-            EvaluatedF child -> translatePredicatePattern (getEvaluated child)
-            -- Logical connectives: translate as connectives
-            AndF and' -> translatePredicateAnd and'
-            BottomF _ -> return (SMT.bool False)
-            EqualsF eq ->
-                -- Equality of predicates and builtins can be translated to
-                -- equality in the SMT solver, but other patterns must remain
-                -- uninterpreted.
-                    translatePredicateEquals eq
-                <|> translateUninterpreted SMT.tBool pat
-            IffF iff -> translatePredicateIff iff
-            ImpliesF implies -> translatePredicateImplies implies
-            NotF not' -> translatePredicateNot not'
-            OrF or' -> translatePredicateOr or'
-            TopF _ -> return (SMT.bool True)
-
-            -- Uninterpreted: translate as variables
-            CeilF _ -> translateUninterpreted SMT.tBool pat
-            ExistsF _ -> translateUninterpreted SMT.tBool pat
-            FloorF _ -> translateUninterpreted SMT.tBool pat
-            ForallF _ -> translateUninterpreted SMT.tBool pat
-            InF _ -> translateUninterpreted SMT.tBool pat
-
-            -- Invalid: no translation, should not occur in predicates
-            MuF _ -> empty
-            NuF _ -> empty
-            ApplySymbolF _ -> empty
-            ApplyAliasF _ -> empty
-            BuiltinF _ -> empty
-            DomainValueF _ -> empty
-            NextF _ -> empty
-            RewritesF _ -> empty
-            VariableF _ -> empty
-            StringLiteralF _ -> empty
-            CharLiteralF _ -> empty
-            InhabitantF _ -> empty
-
-    translatePredicateAnd And { andFirst, andSecond } =
-        SMT.and
-            <$> translatePredicatePattern andFirst
-            <*> translatePredicatePattern andSecond
-
+      case Cofree.tailF (Recursive.project pat) of
+        EvaluatedF child -> translatePredicatePattern (getEvaluated child)
+        -- Logical connectives: translate as connectives
+        AndF and' -> translatePredicateAnd and'
+        BottomF _ -> return (SMT.bool False)
+        EqualsF eq ->
+          -- Equality of predicates and builtins can be translated to
+          -- equality in the SMT solver, but other patterns must remain
+          -- uninterpreted.
+          translatePredicateEquals eq
+            <|> translateUninterpreted SMT.tBool pat
+        IffF iff -> translatePredicateIff iff
+        ImpliesF implies -> translatePredicateImplies implies
+        NotF not' -> translatePredicateNot not'
+        OrF or' -> translatePredicateOr or'
+        TopF _ -> return (SMT.bool True)
+        -- Uninterpreted: translate as variables
+        CeilF _ -> translateUninterpreted SMT.tBool pat
+        ExistsF _ -> translateUninterpreted SMT.tBool pat
+        FloorF _ -> translateUninterpreted SMT.tBool pat
+        ForallF _ -> translateUninterpreted SMT.tBool pat
+        InF _ -> translateUninterpreted SMT.tBool pat
+        -- Invalid: no translation, should not occur in predicates
+        MuF _ -> empty
+        NuF _ -> empty
+        ApplySymbolF _ -> empty
+        ApplyAliasF _ -> empty
+        BuiltinF _ -> empty
+        DomainValueF _ -> empty
+        NextF _ -> empty
+        RewritesF _ -> empty
+        VariableF _ -> empty
+        StringLiteralF _ -> empty
+        CharLiteralF _ -> empty
+        InhabitantF _ -> empty
+    translatePredicateAnd And {andFirst, andSecond} =
+      SMT.and
+        <$> translatePredicatePattern andFirst
+        <*> translatePredicatePattern andSecond
     translatePredicateEquals
-        Equals
-            { equalsOperandSort
-            , equalsFirst
-            , equalsSecond
-            }
-      =
+      Equals
+        { equalsOperandSort,
+          equalsFirst,
+          equalsSecond
+          } =
         SMT.eq
-            <$> translatePredicateEqualsChild equalsFirst
-            <*> translatePredicateEqualsChild equalsSecond
-      where
-        translatePredicateEqualsChild child =
+          <$> translatePredicateEqualsChild equalsFirst
+          <*> translatePredicateEqualsChild equalsSecond
+        where
+          translatePredicateEqualsChild child =
             -- Attempt to translate patterns in builtin sorts, or failing that,
             -- as predicates.
             (<|>)
-                (translatePattern equalsOperandSort child)
-                (translatePredicatePattern child)
-
-    translatePredicateIff Iff { iffFirst, iffSecond } =
-        iff
-            <$> translatePredicatePattern iffFirst
-            <*> translatePredicatePattern iffSecond
+              (translatePattern equalsOperandSort child)
+              (translatePredicatePattern child)
+    translatePredicateIff Iff {iffFirst, iffSecond} =
+      iff
+        <$> translatePredicatePattern iffFirst
+        <*> translatePredicatePattern iffSecond
       where
         iff a b = SMT.and (SMT.implies a b) (SMT.implies b a)
-
-    translatePredicateImplies Implies { impliesFirst, impliesSecond } =
-        SMT.implies
-            <$> translatePredicatePattern impliesFirst
-            <*> translatePredicatePattern impliesSecond
-
-    translatePredicateNot Not { notChild } =
-        SMT.not <$> translatePredicatePattern notChild
-
-    translatePredicateOr Or { orFirst, orSecond } =
-        SMT.or
-            <$> translatePredicatePattern orFirst
-            <*> translatePredicatePattern orSecond
-
+    translatePredicateImplies Implies {impliesFirst, impliesSecond} =
+      SMT.implies
+        <$> translatePredicatePattern impliesFirst
+        <*> translatePredicatePattern impliesSecond
+    translatePredicateNot Not {notChild} =
+      SMT.not <$> translatePredicatePattern notChild
+    translatePredicateOr Or {orFirst, orSecond} =
+      SMT.or
+        <$> translatePredicatePattern orFirst
+        <*> translatePredicatePattern orSecond
     -- | Translate a functional pattern in the builtin Int sort for SMT.
     translateInt
-        ::  ( Given (SmtMetadataTools Attribute.Symbol)
-            , Ord variable
-            , p ~ TermLike variable
-            )
-        => p
-        -> Translator m p SExpr
+      :: ( Given (SmtMetadataTools Attribute.Symbol),
+           Ord variable,
+           p ~ TermLike variable
+           )
+      => p
+      -> Translator m p SExpr
     translateInt pat =
-        case Cofree.tailF (Recursive.project pat) of
-            VariableF _ -> translateUninterpreted SMT.tInt pat
-            BuiltinF dv ->
-                return $ SMT.int $ Builtin.Int.extractIntDomainValue
-                    "while translating dv to SMT.int" dv
-            ApplySymbolF app ->
-                (<|>)
-                    (translateApplication app)
-                    (translateUninterpreted SMT.tInt pat)
-            _ -> empty
-
+      case Cofree.tailF (Recursive.project pat) of
+        VariableF _ -> translateUninterpreted SMT.tInt pat
+        BuiltinF dv ->
+          return $ SMT.int
+            $ Builtin.Int.extractIntDomainValue
+                "while translating dv to SMT.int"
+                dv
+        ApplySymbolF app ->
+          (<|>)
+            (translateApplication app)
+            (translateUninterpreted SMT.tInt pat)
+        _ -> empty
     -- | Translate a functional pattern in the builtin Bool sort for SMT.
     translateBool
-        ::  ( Given (SmtMetadataTools Attribute.Symbol)
-            , Ord variable
-            , p ~ TermLike variable
-            )
-        => p
-        -> Translator m p SExpr
+      :: ( Given (SmtMetadataTools Attribute.Symbol),
+           Ord variable,
+           p ~ TermLike variable
+           )
+      => p
+      -> Translator m p SExpr
     translateBool pat =
-        case Cofree.tailF (Recursive.project pat) of
-            VariableF _ -> translateUninterpreted SMT.tBool pat
-            BuiltinF dv ->
-                return $ SMT.bool $ Builtin.Bool.extractBoolDomainValue
-                    "while translating dv to SMT.bool" dv
-            NotF Not { notChild } ->
-                -- \not is equivalent to BOOL.not for functional patterns.
-                -- The following is safe because non-functional patterns
-                -- will fail to translate.
-                SMT.not <$> translateBool notChild
-            ApplySymbolF app ->
-                (<|>)
-                    (translateApplication app)
-                    (translateUninterpreted SMT.tBool pat)
-            _ -> empty
-
+      case Cofree.tailF (Recursive.project pat) of
+        VariableF _ -> translateUninterpreted SMT.tBool pat
+        BuiltinF dv ->
+          return $ SMT.bool
+            $ Builtin.Bool.extractBoolDomainValue
+                "while translating dv to SMT.bool"
+                dv
+        NotF Not {notChild} ->
+          -- \not is equivalent to BOOL.not for functional patterns.
+          -- The following is safe because non-functional patterns
+          -- will fail to translate.
+          SMT.not <$> translateBool notChild
+        ApplySymbolF app ->
+          (<|>)
+            (translateApplication app)
+            (translateUninterpreted SMT.tBool pat)
+        _ -> empty
     translateApplication
-        ::  ( Given (SmtMetadataTools Attribute.Symbol)
-            , Ord variable
-            , p ~ TermLike variable
-            )
-        => Application Symbol p
-        -> Translator m p SExpr
+      :: ( Given (SmtMetadataTools Attribute.Symbol),
+           Ord variable,
+           p ~ TermLike variable
+           )
+      => Application Symbol p
+      -> Translator m p SExpr
     translateApplication
-        Application
-            { applicationSymbolOrAlias
-            , applicationChildren
-            }
-      = do
-        sexpr <- case translateSymbol applicationSymbolOrAlias of
-            Nothing -> empty  -- The symbol was not declared, give up.
-            Just sexpr -> return sexpr
-        children <- zipWithM translatePattern
-            applicationChildrenSorts
-            applicationChildren
-        return $ shortenSExpr (applySExpr sexpr children)
-      where
-        applicationChildrenSorts = termLikeSort <$> applicationChildren
-
+      Application
+        { applicationSymbolOrAlias,
+          applicationChildren
+          } =
+        do
+          sexpr <-
+            case translateSymbol applicationSymbolOrAlias of
+              Nothing -> empty -- The symbol was not declared, give up.
+              Just sexpr -> return sexpr
+          children <-
+            zipWithM translatePattern
+              applicationChildrenSorts
+              applicationChildren
+          return $ shortenSExpr (applySExpr sexpr children)
+        where
+          applicationChildrenSorts = termLikeSort <$> applicationChildren
     translatePattern
-        ::  ( Given (SmtMetadataTools Attribute.Symbol)
-            , p ~ TermLike variable
-            )
-        => Sort
-        -> p
-        -> Translator m p SExpr
+      :: ( Given (SmtMetadataTools Attribute.Symbol),
+           p ~ TermLike variable
+           )
+      => Sort
+      -> p
+      -> Translator m p SExpr
     translatePattern sort pat =
-        case getHook of
-            Just builtinSort
-              | builtinSort == Builtin.Bool.sort -> translateBool pat
-              | builtinSort == Builtin.Int.sort -> translateInt pat
-            _ -> case Cofree.tailF $ Recursive.project pat of
-                    ApplySymbolF app -> translateApplication app
-                    _ -> empty
+      case getHook of
+        Just builtinSort
+          | builtinSort == Builtin.Bool.sort -> translateBool pat
+          | builtinSort == Builtin.Int.sort -> translateInt pat
+        _ -> case Cofree.tailF $ Recursive.project pat of
+          ApplySymbolF app -> translateApplication app
+          _ -> empty
       where
         tools :: SmtMetadataTools Attribute.Symbol
         tools = given
-        Attribute.Sort { hook = Hook { getHook } } =
-            sortAttributes tools sort
+        Attribute.Sort {hook = Hook {getHook}} =
+          sortAttributes tools sort
 
 -- ----------------------------------------------------------------
 -- Translator
@@ -257,19 +257,20 @@ type VarContext p = Map p (SExpr, SExpr)
 type Translator m p = MaybeT (StateT (VarContext p) (CounterT m))
 
 evalTranslator
-    :: Ord p
-    => Monad m
-    => Translator m p a
-    -> MaybeT m a
+  :: Ord p
+  => Monad m
+  => Translator m p a
+  -> MaybeT m a
 evalTranslator = Morph.hoist (evalCounterT . flip evalStateT Map.empty)
 
 runTranslator
-    :: Ord p
-    => Monad m
-    => Translator m p a
-    -> MaybeT m (a, VarContext p)
+  :: Ord p
+  => Monad m
+  => Translator m p a
+  -> MaybeT m (a, VarContext p)
 runTranslator = evalTranslator . includeState
-  where includeState comp = do
-            comp' <- comp
-            state <- State.get
-            pure (comp', state)
+  where
+    includeState comp = do
+      comp' <- comp
+      state <- State.get
+      pure (comp', state)

--- a/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -8,52 +8,60 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.AndPredicates
-    ( simplifyEvaluatedMultiPredicate
-    ) where
+  ( simplifyEvaluatedMultiPredicate
+    )
+where
 
 import qualified Data.Foldable as Foldable
-
-import           Kore.Internal.MultiAnd
-                 ( MultiAnd )
+import Kore.Internal.MultiAnd
+  ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
-                 ( extractPatterns )
-import           Kore.Internal.MultiOr
-                 ( MultiOr )
+  ( extractPatterns
+    )
+import Kore.Internal.MultiOr
+  ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( fullCrossProduct, mergeAll )
-import           Kore.Internal.OrPredicate
-                 ( OrPredicate )
-import           Kore.Internal.Pattern
-                 ( Predicate )
-import           Kore.Step.Simplification.Data
-                 ( BranchT, MonadSimplify )
+  ( fullCrossProduct,
+    mergeAll
+    )
+import Kore.Internal.OrPredicate
+  ( OrPredicate
+    )
+import Kore.Internal.Pattern
+  ( Predicate
+    )
+import Kore.Step.Simplification.Data
+  ( BranchT,
+    MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
+  ( gather
+    )
 import qualified Kore.Step.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 simplifyEvaluatedMultiPredicate
-    :: forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
-    => MultiAnd (OrPredicate variable)
-    -> simplifier (OrPredicate variable)
+  :: forall variable simplifier. ( SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => MultiAnd (OrPredicate variable)
+  -> simplifier (OrPredicate variable)
 simplifyEvaluatedMultiPredicate predicates = do
-    let
-        crossProduct :: MultiOr [Predicate variable]
-        crossProduct =
-            MultiOr.fullCrossProduct
-                (MultiAnd.extractPatterns predicates)
-    orResults <- BranchT.gather (traverse andPredicates crossProduct)
-    return (MultiOr.mergeAll orResults)
+  let crossProduct :: MultiOr [Predicate variable]
+      crossProduct =
+        MultiOr.fullCrossProduct
+          (MultiAnd.extractPatterns predicates)
+  orResults <- BranchT.gather (traverse andPredicates crossProduct)
+  return (MultiOr.mergeAll orResults)
   where
     andPredicates
-        :: [Predicate variable]
-        -> BranchT simplifier (Predicate variable)
+      :: [Predicate variable]
+      -> BranchT simplifier (Predicate variable)
     andPredicates predicates' =
-        Substitution.normalize (Foldable.fold predicates')
+      Substitution.normalize (Foldable.fold predicates')

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -8,24 +8,30 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.AndTerms
-    ( simplifySortInjections
-    , termAnd
-    , termEquals
-    , termUnification
-    , SortInjectionMatch (..)
-    , SortInjectionSimplification (..)
-    , TermSimplifier
-    , TermTransformationOld
-    , cannotUnifyDistinctDomainValues
-    ) where
+  ( simplifySortInjections,
+    termAnd,
+    termEquals,
+    termUnification,
+    SortInjectionMatch (..),
+    SortInjectionSimplification (..),
+    TermSimplifier,
+    TermTransformationOld,
+    cannotUnifyDistinctDomainValues
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.Error
-                 ( MaybeT (..), fromMaybe, mapMaybeT )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.Error
+  ( MaybeT (..),
+    fromMaybe,
+    mapMaybeT
+    )
 import qualified Control.Error as Error
-import           Control.Exception
-                 ( assert )
+import Control.Exception
+  ( assert
+    )
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans as Monad.Trans
 import qualified Data.Foldable as Foldable
@@ -34,60 +40,75 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified GHC.Stack as GHC
-import           Prelude hiding
-                 ( concat )
-
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.List as Builtin.List
 import qualified Kore.Builtin.Map as Builtin.Map
 import qualified Kore.Builtin.Set as Builtin.Set
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.IndexedModule.MetadataTools
-                 ( SmtMetadataTools )
+import Kore.IndexedModule.MetadataTools
+  ( SmtMetadataTools
+    )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
-                 ( MetadataTools (..) )
+  ( MetadataTools (..)
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPredicate
-                 ( OrPredicate )
+import Kore.Internal.OrPredicate
+  ( OrPredicate
+    )
 import qualified Kore.Internal.OrPredicate as OrPredicate
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate as Predicate
+import Kore.Internal.Predicate as Predicate
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Logger as Logger
-import           Kore.Predicate.Predicate
-                 ( pattern PredicateTrue, makeEqualsPredicate,
-                 makeNotPredicate, makeTruePredicate )
-import           Kore.Step.PatternAttributes
-                 ( isConstructorLikeTop )
-import           Kore.Step.Simplification.Data as Simplifier
-import qualified Kore.Step.Simplification.Data as SimplificationType
-                 ( SimplificationType (..) )
-import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather, scatter )
-import           Kore.Step.Substitution
-                 ( PredicateMerger,
-                 createLiftedPredicatesAndSubstitutionsMerger,
-                 createPredicatesAndSubstitutionsMergerExcept )
-import           Kore.TopBottom
-import           Kore.Unification.Error
-                 ( unsupportedPatterns )
-import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unification.Unify as Unify
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
-
+import Kore.Predicate.Predicate
+  ( makeEqualsPredicate,
+    makeNotPredicate,
+    makeTruePredicate,
+    pattern PredicateTrue
+    )
+import Kore.Step.PatternAttributes
+  ( isConstructorLikeTop
+    )
 import {-# SOURCE #-} qualified Kore.Step.Simplification.Ceil as Ceil
-                 ( makeEvaluateTerm )
+  ( makeEvaluateTerm
+    )
+import Kore.Step.Simplification.Data as Simplifier
+import qualified Kore.Step.Simplification.Data as SimplificationType
+  ( SimplificationType (..)
+    )
+import qualified Kore.Step.Simplification.Data as BranchT
+  ( gather,
+    scatter
+    )
+import Kore.Step.Substitution
+  ( PredicateMerger,
+    createLiftedPredicatesAndSubstitutionsMerger,
+    createPredicatesAndSubstitutionsMergerExcept
+    )
+import Kore.TopBottom
+import Kore.Unification.Error
+  ( unsupportedPatterns
+    )
+import qualified Kore.Unification.Substitution as Substitution
+import Kore.Unification.Unify as Unify
+import Kore.Unparser
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
+import Prelude hiding
+  ( concat
+    )
 
 data SimplificationTarget = AndT | EqualsT | BothT
 
-type TermSimplifier variable m =
-    TermLike variable -> TermLike variable -> m (Pattern variable)
+type TermSimplifier variable m
+  = TermLike variable -> TermLike variable -> m (Pattern variable)
 
 {- | Simplify an equality relation of two patterns.
 
@@ -101,98 +122,94 @@ See also: 'termAnd'
 
  -}
 termEquals
-    ::  ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT simplifier (OrPredicate variable)
+  :: ( FreshVariable variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT simplifier (OrPredicate variable)
 termEquals first second = MaybeT $ do
-    maybeResults <- BranchT.gather $ runMaybeT $ termEqualsAnd first second
-    case sequence maybeResults of
-        Nothing -> return Nothing
-        Just results -> return $ Just $
-            MultiOr.make (map Predicate.eraseConditionalTerm results)
+  maybeResults <- BranchT.gather $ runMaybeT $ termEqualsAnd first second
+  case sequence maybeResults of
+    Nothing -> return Nothing
+    Just results ->
+      return $ Just
+        $ MultiOr.make (map Predicate.eraseConditionalTerm results)
 
 termEqualsAnd
-    ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT (BranchT simplifier) (Pattern variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT (BranchT simplifier) (Pattern variable)
 termEqualsAnd
-    p1
-    p2
-  = MaybeT
-    $   either missingCase BranchT.scatter
-        =<< (runUnifierT . runMaybeT) (maybeTermEqualsWorker p1 p2)
-  where
-    missingCase = const (return Nothing)
-
-    maybeTermEqualsWorker
-        :: forall unifier
-        .   ( MonadUnify unifier
-            , Logger.WithLog Logger.LogMessage unifier
-            )
+  p1
+  p2 =
+    MaybeT
+      $ either missingCase BranchT.scatter
+      =<< (runUnifierT . runMaybeT) (maybeTermEqualsWorker p1 p2)
+    where
+      missingCase = const (return Nothing)
+      maybeTermEqualsWorker
+        :: forall unifier. ( MonadUnify unifier,
+                             Logger.WithLog Logger.LogMessage unifier
+                             )
         => TermLike variable
         -> TermLike variable
         -> MaybeT unifier (Pattern variable)
-    maybeTermEqualsWorker =
+      maybeTermEqualsWorker =
         maybeTermEquals
-            createPredicatesAndSubstitutionsMergerExcept
-            termEqualsAndWorker
-
-    termEqualsAndWorker
-        :: forall unifier
-        .   ( MonadUnify unifier
-            , Logger.WithLog Logger.LogMessage unifier
-            )
+          createPredicatesAndSubstitutionsMergerExcept
+          termEqualsAndWorker
+      termEqualsAndWorker
+        :: forall unifier. ( MonadUnify unifier,
+                             Logger.WithLog Logger.LogMessage unifier
+                             )
         => TermLike variable
         -> TermLike variable
         -> unifier (Pattern variable)
-    termEqualsAndWorker first second =
+      termEqualsAndWorker first second =
         either ignoreErrors scatterResults
-        =<< (runUnifierT . runMaybeT) (maybeTermEqualsWorker first second)
-      where
-        ignoreErrors _ = return equalsPredicate
-        scatterResults =
+          =<< (runUnifierT . runMaybeT) (maybeTermEqualsWorker first second)
+        where
+          ignoreErrors _ = return equalsPredicate
+          scatterResults =
             maybe
-                (return equalsPredicate) -- default if no results
-                (alternate . BranchT.scatter)
-            . sequence
-        equalsPredicate =
+              (return equalsPredicate) -- default if no results
+              (alternate . BranchT.scatter)
+              . sequence
+          equalsPredicate =
             Conditional
-                { term = mkTop_
-                , predicate = makeEqualsPredicate first second
-                , substitution = mempty
+              { term = mkTop_,
+                predicate = makeEqualsPredicate first second,
+                substitution = mempty
                 }
 
 maybeTermEquals
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => GHC.HasCallStack
-    => PredicateMerger variable unifier
-    -> TermSimplifier variable unifier
-    -- ^ Used to simplify subterm "and".
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       MonadUnify unifier,
+       Logger.WithLog Logger.LogMessage unifier
+       )
+  => GHC.HasCallStack
+  => PredicateMerger variable unifier
+  -> TermSimplifier variable unifier
+  -- ^ Used to simplify subterm "and".
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 maybeTermEquals = maybeTransformTerm equalsFunctions
 
 {- | Unify two terms without discarding the terms.
@@ -210,43 +227,41 @@ the special cases handled by this.
 -- NOTE (hs-boot): Please update the AndTerms.hs-boot file when changing the
 -- signature.
 termUnification
-    ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> unifier (Pattern variable)
+  :: forall variable unifier. ( FreshVariable variable,
+                                Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Logger.WithLog Logger.LogMessage unifier
+                                )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> unifier (Pattern variable)
 termUnification =
-    termUnificationWorker
+  termUnificationWorker
   where
     termUnificationWorker
-        :: TermLike variable
-        -> TermLike variable
-        -> unifier (Pattern variable)
+      :: TermLike variable
+      -> TermLike variable
+      -> unifier (Pattern variable)
     termUnificationWorker pat1 pat2 = do
-        let
-            maybeTermUnification :: MaybeT unifier (Pattern variable)
-            maybeTermUnification =
-                maybeTermAnd
-                    createPredicatesAndSubstitutionsMergerExcept
-                    termUnificationWorker
-                    pat1
-                    pat2
-            unsupportedPatternsError =
-                throwUnificationError
-                    (unsupportedPatterns
-                        "Unknown unification case."
-                        pat1
-                        pat2
-                    )
-        Error.maybeT unsupportedPatternsError pure maybeTermUnification
+      let maybeTermUnification :: MaybeT unifier (Pattern variable)
+          maybeTermUnification =
+            maybeTermAnd
+              createPredicatesAndSubstitutionsMergerExcept
+              termUnificationWorker
+              pat1
+              pat2
+          unsupportedPatternsError =
+            throwUnificationError
+              ( unsupportedPatterns
+                  "Unknown unification case."
+                  pat1
+                  pat2
+                )
+      Error.maybeT unsupportedPatternsError pure maybeTermUnification
 
 {- | Simplify the conjunction (@\\and@) of two terms.
 
@@ -260,183 +275,183 @@ See also: 'termUnification'
 -- NOTE (hs-boot): Please update AndTerms.hs-boot file when changing the
 -- signature.
 termAnd
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> BranchT simplifier (Pattern variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   SortedVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> BranchT simplifier (Pattern variable)
 termAnd p1 p2 =
-    either (const andTerm) BranchT.scatter
+  either (const andTerm) BranchT.scatter
     =<< (Monad.Trans.lift . runUnifierT) (termAndWorker p1 p2)
   where
     andTerm = return $ Pattern.fromTermLike (mkAnd p1 p2)
     termAndWorker
-        ::  ( MonadUnify unifier
-            , Logger.WithLog Logger.LogMessage unifier
-            )
-        => TermLike variable
-        -> TermLike variable
-        -> unifier (Pattern variable)
+      :: ( MonadUnify unifier,
+           Logger.WithLog Logger.LogMessage unifier
+           )
+      => TermLike variable
+      -> TermLike variable
+      -> unifier (Pattern variable)
     termAndWorker first second = do
-        let maybeTermAnd' =
-                maybeTermAnd
-                    createLiftedPredicatesAndSubstitutionsMerger
-                    termAndWorker
-                    first
-                    second
-        patt <- runMaybeT maybeTermAnd'
-        return $ fromMaybe andPattern patt
+      let maybeTermAnd' =
+            maybeTermAnd
+              createLiftedPredicatesAndSubstitutionsMerger
+              termAndWorker
+              first
+              second
+      patt <- runMaybeT maybeTermAnd'
+      return $ fromMaybe andPattern patt
       where
         andPattern = Pattern.fromTermLike (mkAnd first second)
 
 maybeTermAnd
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => GHC.HasCallStack
-    => PredicateMerger variable unifier
-    -> TermSimplifier variable unifier
-    -- ^ Used to simplify subterm "and".
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       MonadUnify unifier,
+       Logger.WithLog Logger.LogMessage unifier
+       )
+  => GHC.HasCallStack
+  => PredicateMerger variable unifier
+  -> TermSimplifier variable unifier
+  -- ^ Used to simplify subterm "and".
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 maybeTermAnd = maybeTransformTerm andFunctions
 
 andFunctions
-    ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        , GHC.HasCallStack
-        )
-    => [TermTransformationOld variable unifier]
+  :: forall variable unifier. ( FreshVariable variable,
+                                Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Logger.WithLog Logger.LogMessage unifier,
+                                GHC.HasCallStack
+                                )
+  => [TermTransformationOld variable unifier]
 andFunctions =
-    map (forAnd . snd) (filter appliesToAnd andEqualsFunctions)
+  map (forAnd . snd) (filter appliesToAnd andEqualsFunctions)
   where
     appliesToAnd :: (SimplificationTarget, a) -> Bool
     appliesToAnd (AndT, _) = True
     appliesToAnd (EqualsT, _) = False
     appliesToAnd (BothT, _) = True
-
     forAnd
-        :: TermTransformation variable unifier
-        -> TermTransformationOld variable unifier
+      :: TermTransformation variable unifier
+      -> TermTransformationOld variable unifier
     forAnd f = f SimplificationType.And
 
 equalsFunctions
-    ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        , GHC.HasCallStack
-        )
-    => [TermTransformationOld variable unifier]
+  :: forall variable unifier. ( FreshVariable variable,
+                                Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Logger.WithLog Logger.LogMessage unifier,
+                                GHC.HasCallStack
+                                )
+  => [TermTransformationOld variable unifier]
 equalsFunctions =
-    map (forEquals . snd) (filter appliesToEquals andEqualsFunctions)
+  map (forEquals . snd) (filter appliesToEquals andEqualsFunctions)
   where
     appliesToEquals :: (SimplificationTarget, a) -> Bool
     appliesToEquals (AndT, _) = False
     appliesToEquals (EqualsT, _) = True
     appliesToEquals (BothT, _) = True
-
     forEquals
-        :: TermTransformation variable unifier
-        -> TermTransformationOld variable unifier
+      :: TermTransformation variable unifier
+      -> TermTransformationOld variable unifier
     forEquals f = f SimplificationType.Equals
 
 andEqualsFunctions
-    ::  forall variable unifier
-    .   ( Eq variable
-        , FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        , GHC.HasCallStack
-        )
-    => [(SimplificationTarget, TermTransformation variable unifier)]
-andEqualsFunctions = fmap mapEqualsFunctions
-    [ (AndT,    \_ _ _ -> boolAnd, "boolAnd")
-    , (BothT,   \_ _ _ -> equalAndEquals, "equalAndEquals")
-    , (EqualsT, \_ _ _ -> bottomTermEquals Predicate.topTODO, "bottomTermEquals")
-    , (EqualsT, \_ _ _ -> termBottomEquals Predicate.topTODO, "termBottomEquals")
-    , (BothT,   \t _ _ -> variableFunctionAndEquals Predicate.topTODO t, "variableFunctionAndEquals")
-    , (BothT,   \t _ _ -> functionVariableAndEquals Predicate.topTODO t, "functionVariableAndEquals")
-    , (BothT,   \_ _ s -> equalInjectiveHeadsAndEquals s, "equalInjectiveHeadsAndEquals")
-    , (BothT,   \_ _ s -> sortInjectionAndEqualsAssumesDifferentHeads s, "sortInjectionAndEqualsAssumesDifferentHeads")
-    , (BothT,   \_ _ _ -> constructorSortInjectionAndEquals, "constructorSortInjectionAndEquals")
-    , (BothT,   \_ _ _ -> constructorAndEqualsAssumesDifferentHeads, "constructorAndEqualsAssumesDifferentHeads")
-    , (BothT,   \_ _ s -> Builtin.Map.unifyEquals s, "Builtin.Map.unifyEquals")
-    , (BothT,   \_ _ s -> Builtin.Set.unifyEquals s, "Builtin.Set.unifyEquals")
-    , (BothT,   \t _ s -> Builtin.List.unifyEquals t s, "Builtin.List.unifyEquals")
-    , (BothT,   \_ _ _ -> domainValueAndConstructorErrors, "domainValueAndConstructorErrors")
-    , (BothT,   \_ _ _ -> domainValueAndEqualsAssumesDifferent, "domainValueAndEqualsAssumesDifferent")
-    , (BothT,   \_ _ _ -> stringLiteralAndEqualsAssumesDifferent, "stringLiteralAndEqualsAssumesDifferent")
-    , (BothT,   \_ _ _ -> charLiteralAndEqualsAssumesDifferent, "charLiteralAndEqualsAssumesDifferent")
-    , (AndT,    \_ _ _ t1 t2 -> Error.hoistMaybe $ functionAnd t1 t2, "functionAnd")
-    ]
+  :: forall variable unifier. ( Eq variable,
+                                FreshVariable variable,
+                                Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Logger.WithLog Logger.LogMessage unifier,
+                                GHC.HasCallStack
+                                )
+  => [(SimplificationTarget, TermTransformation variable unifier)]
+andEqualsFunctions =
+  fmap mapEqualsFunctions
+    [ (AndT, \_ _ _ -> boolAnd, "boolAnd"),
+      (BothT, \_ _ _ -> equalAndEquals, "equalAndEquals"),
+      (EqualsT, \_ _ _ -> bottomTermEquals Predicate.topTODO, "bottomTermEquals"),
+      (EqualsT, \_ _ _ -> termBottomEquals Predicate.topTODO, "termBottomEquals"),
+      (BothT, \t _ _ -> variableFunctionAndEquals Predicate.topTODO t, "variableFunctionAndEquals"),
+      (BothT, \t _ _ -> functionVariableAndEquals Predicate.topTODO t, "functionVariableAndEquals"),
+      (BothT, \_ _ s -> equalInjectiveHeadsAndEquals s, "equalInjectiveHeadsAndEquals"),
+      (BothT, \_ _ s -> sortInjectionAndEqualsAssumesDifferentHeads s, "sortInjectionAndEqualsAssumesDifferentHeads"),
+      (BothT, \_ _ _ -> constructorSortInjectionAndEquals, "constructorSortInjectionAndEquals"),
+      (BothT, \_ _ _ -> constructorAndEqualsAssumesDifferentHeads, "constructorAndEqualsAssumesDifferentHeads"),
+      (BothT, \_ _ s -> Builtin.Map.unifyEquals s, "Builtin.Map.unifyEquals"),
+      (BothT, \_ _ s -> Builtin.Set.unifyEquals s, "Builtin.Set.unifyEquals"),
+      (BothT, \t _ s -> Builtin.List.unifyEquals t s, "Builtin.List.unifyEquals"),
+      (BothT, \_ _ _ -> domainValueAndConstructorErrors, "domainValueAndConstructorErrors"),
+      (BothT, \_ _ _ -> domainValueAndEqualsAssumesDifferent, "domainValueAndEqualsAssumesDifferent"),
+      (BothT, \_ _ _ -> stringLiteralAndEqualsAssumesDifferent, "stringLiteralAndEqualsAssumesDifferent"),
+      (BothT, \_ _ _ -> charLiteralAndEqualsAssumesDifferent, "charLiteralAndEqualsAssumesDifferent"),
+      (AndT, \_ _ _ t1 t2 -> Error.hoistMaybe $ functionAnd t1 t2, "functionAnd")
+      ]
   where
     mapEqualsFunctions (target, termTransform, name) =
-        (target, logTT name termTransform)
-
+      (target, logTT name termTransform)
     logTT
-        :: String
-        -> TermTransformation variable unifier
-        -> TermTransformation variable unifier
+      :: String
+      -> TermTransformation variable unifier
+      -> TermTransformation variable unifier
     logTT fnName termTransformation sType pm ts t1 t2 =
-        mapMaybeT (\getResult -> do
+      mapMaybeT
+        ( \getResult -> do
             mresult <- getResult
             case mresult of
-                Nothing -> do
-                    Logger.withLogScope (Logger.Scope "AndTerms")
-                        . Logger.logDebug . Text.pack . show
-                        $ Pretty.hsep
-                            [ "Evaluator"
-                            , Pretty.pretty fnName
-                            , "does not apply."
-                            ]
-                    return mresult
-                Just result -> do
-                    Logger.withLogScope (Logger.Scope "AndTerms")
-                        . Logger.logDebug . Text.pack . show
-                        $ Pretty.vsep
-                            [ Pretty.hsep
-                                [ "Evaluator"
-                                , Pretty.pretty fnName
+              Nothing -> do
+                Logger.withLogScope (Logger.Scope "AndTerms")
+                  . Logger.logDebug
+                  . Text.pack
+                  . show
+                  $ Pretty.hsep
+                      [ "Evaluator",
+                        Pretty.pretty fnName,
+                        "does not apply."
+                        ]
+                return mresult
+              Just result -> do
+                Logger.withLogScope (Logger.Scope "AndTerms")
+                  . Logger.logDebug
+                  . Text.pack
+                  . show
+                  $ Pretty.vsep
+                      [ Pretty.hsep
+                          [ "Evaluator",
+                            Pretty.pretty fnName
+                            ],
+                        Pretty.indent 4
+                          $ Pretty.vsep
+                              [ "First:",
+                                Pretty.indent 4 $ unparse t1,
+                                "Second:",
+                                Pretty.indent 4 $ unparse t2,
+                                "Result:",
+                                Pretty.indent 4 $ unparse result
                                 ]
-                            , Pretty.indent 4 $ Pretty.vsep
-                                [ "First:"
-                                , Pretty.indent 4 $ unparse t1
-                                , "Second:"
-                                , Pretty.indent 4 $ unparse t2
-                                , "Result:"
-                                , Pretty.indent 4 $ unparse result
-                                ]
-                            ]
-                    return mresult
-            )
-            $ termTransformation sType pm ts t1 t2
+                        ]
+                return mresult
+          )
+        $ termTransformation sType pm ts t1 t2
 
 {- | Construct the conjunction or unification of two terms.
 
@@ -451,91 +466,94 @@ All the @TermTransformationOld@s and similar functions defined in this module
 call 'empty' unless given patterns matching their unification case.
 
  -}
-type TermTransformation variable unifier =
-       SimplificationType
-    -> PredicateMerger variable unifier
-    -> TermSimplifier variable unifier
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+type TermTransformation variable unifier
+  = SimplificationType
+  -> PredicateMerger variable unifier
+  -> TermSimplifier variable unifier
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 
-type TermTransformationOld variable unifier =
-       PredicateMerger variable unifier
-    -> TermSimplifier variable unifier
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+type TermTransformationOld variable unifier
+  = PredicateMerger variable unifier
+  -> TermSimplifier variable unifier
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 
 maybeTransformTerm
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Ord variable
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => [TermTransformationOld variable unifier]
-    -> PredicateMerger variable unifier
-    -> TermSimplifier variable unifier
-    -- ^ Used to simplify subterm pairs.
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       Ord variable,
+       Ord variable,
+       Ord variable,
+       Show variable,
+       SortedVariable variable,
+       MonadUnify unifier
+       )
+  => GHC.HasCallStack
+  => [TermTransformationOld variable unifier]
+  -> PredicateMerger variable unifier
+  -> TermSimplifier variable unifier
+  -- ^ Used to simplify subterm pairs.
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 maybeTransformTerm
-    topTransformers
-    predicateMerger
-    childTransformers
-    first
-    second
-  = do
-    Foldable.asum
-        (map
-            (\f -> f
-                predicateMerger
-                childTransformers
-                first
-                second
-            )
+  topTransformers
+  predicateMerger
+  childTransformers
+  first
+  second =
+    do
+      Foldable.asum
+        ( map
+            ( \f ->
+                f
+                  predicateMerger
+                  childTransformers
+                  first
+                  second
+              )
             topTransformers
-        )
+          )
 
 -- | Simplify the conjunction of terms where one is a predicate.
 boolAnd
-    :: MonadUnify unifier
-    => (Ord variable, SortedVariable variable, Unparse variable)
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: MonadUnify unifier
+  => (Ord variable, SortedVariable variable, Unparse variable)
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 boolAnd first second
-  | isBottom first  = do
+  | isBottom first =
+    do
       explainBoolAndBottom first second
       return (Pattern.fromTermLike first)
-  | isTop first     = return (Pattern.fromTermLike second)
-  | isBottom second = do
+  | isTop first = return (Pattern.fromTermLike second)
+  | isBottom second =
+    do
       explainBoolAndBottom first second
       return (Pattern.fromTermLike second)
-  | isTop second    = return (Pattern.fromTermLike first)
-  | otherwise       = empty
+  | isTop second = return (Pattern.fromTermLike first)
+  | otherwise = empty
 
 explainBoolAndBottom
-    :: MonadUnify unifier
-    => SortedVariable variable
-    => Unparse variable
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier ()
+  :: MonadUnify unifier
+  => SortedVariable variable
+  => Unparse variable
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier ()
 explainBoolAndBottom term1 term2 =
-    Monad.Trans.lift $ explainBottom "Cannot unify bottom." term1 term2
+  Monad.Trans.lift $ explainBottom "Cannot unify bottom." term1 term2
 
 -- | Unify two identical ('==') patterns.
 equalAndEquals
-    :: (Ord variable, SortedVariable variable)
-    => Monad unifier
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: (Ord variable, SortedVariable variable)
+  => Monad unifier
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 equalAndEquals first second
   | first == second =
     return (Pattern.fromTermLike first)
@@ -543,42 +561,44 @@ equalAndEquals _ _ = empty
 
 -- | Unify two patterns where the first is @\\bottom@.
 bottomTermEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => Predicate variable
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadUnify unifier,
+       Logger.WithLog Logger.LogMessage unifier
+       )
+  => Predicate variable
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 bottomTermEquals
-    predicate
-    first@(Bottom_ _)
-    second
-  = Monad.Trans.lift $ do -- MonadUnify
-    secondCeil <- Ceil.makeEvaluateTerm predicate second
-
-    case MultiOr.extractPatterns secondCeil of
+  predicate
+  first@(Bottom_ _)
+  second =
+    Monad.Trans.lift $ do
+      -- MonadUnify
+      secondCeil <- Ceil.makeEvaluateTerm predicate second
+      case MultiOr.extractPatterns secondCeil of
         [] -> return Pattern.top
-        [ Conditional { predicate = PredicateTrue, substitution } ]
-          | substitution == mempty -> do
-            explainBottom
+        [Conditional {predicate = PredicateTrue, substitution}]
+          | substitution == mempty ->
+            do
+              explainBottom
                 "Cannot unify bottom with non-bottom pattern."
                 first
                 second
-            empty
+              empty
         _ ->
-            return  Conditional
-                { term = mkTop_
-                , predicate =
-                    makeNotPredicate
-                    $ OrPredicate.toPredicate
-                    $ Predicate.toPredicate <$> secondCeil
-                , substitution = mempty
-                }
+          return Conditional
+            { term = mkTop_,
+              predicate =
+                makeNotPredicate
+                  $ OrPredicate.toPredicate
+                  $ Predicate.toPredicate
+                  <$> secondCeil,
+              substitution = mempty
+              }
 bottomTermEquals _ _ _ = empty
 
 {- | Unify two patterns where the second is @\\bottom@.
@@ -587,17 +607,17 @@ See also: 'bottomTermEquals'
 
  -}
 termBottomEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => Predicate variable
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadUnify unifier,
+       Logger.WithLog Logger.LogMessage unifier
+       )
+  => Predicate variable
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 termBottomEquals predicate first second = bottomTermEquals predicate second first
 
 {- | Unify a variable with a function pattern.
@@ -606,60 +626,61 @@ See also: 'isFunctionPattern'
 
  -}
 variableFunctionAndEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        , Logger.WithLog Logger.LogMessage unifier
-        )
-    => GHC.HasCallStack
-    => Predicate variable
-    -> SimplificationType
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadUnify unifier,
+       Logger.WithLog Logger.LogMessage unifier
+       )
+  => GHC.HasCallStack
+  => Predicate variable
+  -> SimplificationType
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 variableFunctionAndEquals
-    _
-    SimplificationType.And
-    first@(ElemVar_ v1)
-    second@(ElemVar_ v2)
-  =
+  _
+  SimplificationType.And
+  first@(ElemVar_ v1)
+  second@(ElemVar_ v2) =
     return Conditional
-        { term = if v2 > v1 then second else first
-        , predicate = makeTruePredicate
-        , substitution =
-            Substitution.wrap
-                [ if v2 > v1 then (ElemVar v1, second) else (ElemVar v2, first)
-                ]
+      { term = if v2 > v1 then second else first,
+        predicate = makeTruePredicate,
+        substitution =
+          Substitution.wrap
+            [ if v2 > v1 then (ElemVar v1, second) else (ElemVar v2, first)
+              ]
         }
 variableFunctionAndEquals
-    configurationPredicate
-    simplificationType
-    first@(ElemVar_ v)
-    second
-  | isFunctionPattern second = Monad.Trans.lift $ do -- MonadUnify
-    predicate <-
-        case simplificationType of -- Simplifier
+  configurationPredicate
+  simplificationType
+  first@(ElemVar_ v)
+  second
+    | isFunctionPattern second =
+      Monad.Trans.lift $ do
+        -- MonadUnify
+        predicate <-
+          case simplificationType of -- Simplifier
             SimplificationType.And ->
-                -- Ceil predicate not needed since 'second' being bottom
-                -- will make the entire term bottom. However, one must
-                -- be careful to not just drop the term.
-                return Predicate.top
+              -- Ceil predicate not needed since 'second' being bottom
+              -- will make the entire term bottom. However, one must
+              -- be careful to not just drop the term.
+              return Predicate.top
             SimplificationType.Equals -> do
-                resultOr <- Ceil.makeEvaluateTerm configurationPredicate second
-                case MultiOr.extractPatterns resultOr of
-                    [] -> do
-                        explainBottom
-                           "Unification of variable and bottom \
+              resultOr <- Ceil.makeEvaluateTerm configurationPredicate second
+              case MultiOr.extractPatterns resultOr of
+                [] -> do
+                  explainBottom
+                    "Unification of variable and bottom \
                            \when attempting to simplify equals."
-                           first
-                           second
-                        empty
-                    resultPredicates -> Unify.scatter resultPredicates
-    let result =
-            predicate <> Predicate.fromSingleSubstitution (ElemVar v, second)
-    return (Pattern.withCondition second result)
+                    first
+                    second
+                  empty
+                resultPredicates -> Unify.scatter resultPredicates
+        let result =
+              predicate <> Predicate.fromSingleSubstitution (ElemVar v, second)
+        return (Pattern.withCondition second result)
 variableFunctionAndEquals _ _ _ _ = empty
 
 {- | Unify a function pattern with a variable.
@@ -668,20 +689,20 @@ See also: 'variableFunctionAndEquals'
 
  -}
 functionVariableAndEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => Predicate variable
-    -> SimplificationType
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadUnify unifier
+       )
+  => GHC.HasCallStack
+  => Predicate variable
+  -> SimplificationType
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 functionVariableAndEquals predicate simplificationType first second =
-    variableFunctionAndEquals predicate simplificationType second first
+  variableFunctionAndEquals predicate simplificationType second first
 
 {- | Unify two application patterns with equal, injective heads.
 
@@ -692,32 +713,31 @@ See also: 'Attribute.isInjective', 'Attribute.isSortInjection',
 
  -}
 equalInjectiveHeadsAndEquals
-    ::  ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => TermSimplifier variable unifier
-    -- ^ Used to simplify subterm "and".
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: ( FreshVariable variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       MonadUnify unifier
+       )
+  => GHC.HasCallStack
+  => TermSimplifier variable unifier
+  -- ^ Used to simplify subterm "and".
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 equalInjectiveHeadsAndEquals
-    termMerger
-    (App_ firstHead firstChildren)
-    (App_ secondHead secondChildren)
-  | isFirstInjective && isSecondInjective && firstHead == secondHead =
-    Monad.Trans.lift $ do
+  termMerger
+  (App_ firstHead firstChildren)
+  (App_ secondHead secondChildren)
+    | isFirstInjective && isSecondInjective && firstHead == secondHead =
+      Monad.Trans.lift $ do
         children <- Monad.zipWithM termMerger firstChildren secondChildren
         let merged = Foldable.foldMap Pattern.withoutTerm children
             term = mkApplySymbol firstHead (Pattern.term <$> children)
         return (Pattern.withCondition term merged)
-  where
-    isFirstInjective = Symbol.isInjective firstHead
-    isSecondInjective = Symbol.isInjective secondHead
-
+    where
+      isFirstInjective = Symbol.isInjective firstHead
+      isSecondInjective = Symbol.isInjective secondHead
 equalInjectiveHeadsAndEquals _ _ _ = Error.nothing
 
 {- | Simplify the conjunction of two sort injections.
@@ -738,61 +758,60 @@ when @src1@ is a subsort of @src2@.
 
  -}
 sortInjectionAndEqualsAssumesDifferentHeads
-    ::  forall variable unifier
-    .   ( Ord variable
-        , SortedVariable variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => TermSimplifier variable unifier
-    -> TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier (Pattern variable)
+  :: forall variable unifier. ( Ord variable,
+                                SortedVariable variable,
+                                Unparse variable,
+                                MonadUnify unifier
+                                )
+  => GHC.HasCallStack
+  => TermSimplifier variable unifier
+  -> TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier (Pattern variable)
 sortInjectionAndEqualsAssumesDifferentHeads termMerger first second = do
-    tools <- Simplifier.askMetadataTools
-    case simplifySortInjections tools first second of
-        Nothing ->
-            Monad.Trans.lift
-                $ throwUnificationError
-                $ unsupportedPatterns
-                    "Unimplemented sort injection unification"
-                    first
-                    second
-        Just NotInjection -> empty
-        Just NotMatching -> Monad.Trans.lift $ do
-            explainBottom
-                "Unification of sort injections failed due to mismatch. \
+  tools <- Simplifier.askMetadataTools
+  case simplifySortInjections tools first second of
+    Nothing ->
+      Monad.Trans.lift
+        $ throwUnificationError
+        $ unsupportedPatterns
+            "Unimplemented sort injection unification"
+            first
+            second
+    Just NotInjection -> empty
+    Just NotMatching -> Monad.Trans.lift $ do
+      explainBottom
+        "Unification of sort injections failed due to mismatch. \
                 \This can happen either because one of them is a constructor \
                 \or because their sort intersection is empty."
-                first
-                second
-            empty
-        Just (Matching sortInjectionMatch) -> Monad.Trans.lift $ do
-            merged <- termMerger firstChild secondChild
-            if Pattern.isBottom merged
-                then do
-                    explainBottom
-                        "Unification of sort injections failed when \
+        first
+        second
+      empty
+    Just (Matching sortInjectionMatch) -> Monad.Trans.lift $ do
+      merged <- termMerger firstChild secondChild
+      if Pattern.isBottom merged
+        then do
+          explainBottom
+            "Unification of sort injections failed when \
                         \merging application children: \
                         \the result is bottom."
-                        first
-                        second
-                    empty
-                else do
-                    return $ applyInjection injectionHead <$> merged
-          where
-            SortInjectionMatch { firstChild, secondChild } = sortInjectionMatch
-            SortInjectionMatch { injectionHead } = sortInjectionMatch
+            first
+            second
+          empty
+        else do
+          return $ applyInjection injectionHead <$> merged
+      where
+        SortInjectionMatch {firstChild, secondChild} = sortInjectionMatch
+        SortInjectionMatch {injectionHead} = sortInjectionMatch
   where
     applyInjection injectionHead term = mkApplySymbol injectionHead [term]
 
-data SortInjectionMatch variable =
-    SortInjectionMatch
-        { injectionHead :: !Symbol
-        , sort :: !Sort
-        , firstChild :: !(TermLike variable)
-        , secondChild :: !(TermLike variable)
+data SortInjectionMatch variable
+  = SortInjectionMatch
+      { injectionHead :: !Symbol,
+        sort :: !Sort,
+        firstChild :: !(TermLike variable),
+        secondChild :: !(TermLike variable)
         }
 
 data SortInjectionSimplification variable
@@ -801,104 +820,94 @@ data SortInjectionSimplification variable
   | Matching !(SortInjectionMatch variable)
 
 simplifySortInjections
-    :: forall variable
-    .  (Ord variable, SortedVariable variable, Unparse variable)
-    => GHC.HasCallStack
-    => SmtMetadataTools Attribute.Symbol
-    -> TermLike variable
-    -> TermLike variable
-    -> Maybe (SortInjectionSimplification variable)
+  :: forall variable. (Ord variable, SortedVariable variable, Unparse variable)
+  => GHC.HasCallStack
+  => SmtMetadataTools Attribute.Symbol
+  -> TermLike variable
+  -> TermLike variable
+  -> Maybe (SortInjectionSimplification variable)
 simplifySortInjections
-    tools
-    (App_
-        firstHead@Symbol
-            { symbolConstructor = firstConstructor
-            , symbolParams = [firstOrigin, firstDestination]
-            }
-        [firstChild])
-    (App_
-        secondHead@Symbol
-            { symbolConstructor = secondConstructor
-            , symbolParams = [secondOrigin, secondDestination]
-            }
-        [secondChild]
+  tools
+  ( App_
+      firstHead@Symbol
+        { symbolConstructor = firstConstructor,
+          symbolParams = [firstOrigin, firstDestination]
+          }
+      [firstChild]
     )
-  | isFirstSortInjection && isSecondSortInjection =
-    assert (firstHead /= secondHead)
-    $ assert (firstDestination == secondDestination)
-    $ assert (firstConstructor == secondConstructor)
-    $ case () of
-        _
-          | firstOrigin `isSubsortOf` secondOrigin -> Just mergeFirstIntoSecond
-
-          | secondOrigin `isSubsortOf` firstOrigin -> Just mergeSecondIntoFirst
-
-          | isFirstConstructorLike || isSecondConstructorLike
-            -> Just NotMatching
-
-          | Set.null sortIntersection -> Just NotMatching
-
-          | otherwise -> Nothing
-  where
-    subsorts = MetadataTools.subsorts tools
-
-    isFirstSortInjection = Symbol.isSortInjection firstHead
-    isSecondSortInjection = Symbol.isSortInjection firstHead
-
-    isSubsortOf = MetadataTools.isSubsortOf tools
-
-    isConstructorLike = isConstructorLikeTop tools . Recursive.project
-    isFirstConstructorLike = isConstructorLike firstChild
-    isSecondConstructorLike = isConstructorLike secondChild
-
-    {- |
-        Merge the terms inside a sort injection,
-
-        \inj{src1, dst}(a) ∧ \inj{src2, dst}(b)
-        ===
-        \inj{src2, dst}(\inj{src1, src2}(a) ∧ b)
-
-        when src1 is a subsort of src2.
-     -}
-    mergeFirstIntoSecond ::  SortInjectionSimplification variable
-    mergeFirstIntoSecond =
+  ( App_
+      secondHead@Symbol
+        { symbolConstructor = secondConstructor,
+          symbolParams = [secondOrigin, secondDestination]
+          }
+      [secondChild]
+    )
+    | isFirstSortInjection && isSecondSortInjection =
+      assert (firstHead /= secondHead)
+        $ assert (firstDestination == secondDestination)
+        $ assert (firstConstructor == secondConstructor)
+        $ case () of
+          _
+            | firstOrigin `isSubsortOf` secondOrigin -> Just mergeFirstIntoSecond
+            | secondOrigin `isSubsortOf` firstOrigin -> Just mergeSecondIntoFirst
+            | isFirstConstructorLike || isSecondConstructorLike ->
+              Just NotMatching
+            | Set.null sortIntersection -> Just NotMatching
+            | otherwise -> Nothing
+    where
+      subsorts = MetadataTools.subsorts tools
+      isFirstSortInjection = Symbol.isSortInjection firstHead
+      isSecondSortInjection = Symbol.isSortInjection firstHead
+      isSubsortOf = MetadataTools.isSubsortOf tools
+      isConstructorLike = isConstructorLikeTop tools . Recursive.project
+      isFirstConstructorLike = isConstructorLike firstChild
+      isSecondConstructorLike = isConstructorLike secondChild
+      {- |
+          Merge the terms inside a sort injection,
+      
+          \inj{src1, dst}(a) ∧ \inj{src2, dst}(b)
+          ===
+          \inj{src2, dst}(\inj{src1, src2}(a) ∧ b)
+      
+          when src1 is a subsort of src2.
+       -}
+      mergeFirstIntoSecond :: SortInjectionSimplification variable
+      mergeFirstIntoSecond =
         Matching SortInjectionMatch
-            { injectionHead = secondHead
-            , sort = firstDestination
-            , firstChild = sortInjection firstOrigin secondOrigin firstChild
-            , secondChild = secondChild
+          { injectionHead = secondHead,
+            sort = firstDestination,
+            firstChild = sortInjection firstOrigin secondOrigin firstChild,
+            secondChild = secondChild
             }
-
-    {- |
-        Merge the terms inside a sort injection,
-
-        \inj{src1, dst}(a) ∧ \inj{src2, dst}(b)
-        ===
-        \inj{src1, dst}(a ∧ \inj{src2, src1}(b))
-
-        when src2 is a subsort of src1.
-     -}
-    mergeSecondIntoFirst :: SortInjectionSimplification variable
-    mergeSecondIntoFirst =
+      {- |
+          Merge the terms inside a sort injection,
+      
+          \inj{src1, dst}(a) ∧ \inj{src2, dst}(b)
+          ===
+          \inj{src1, dst}(a ∧ \inj{src2, src1}(b))
+      
+          when src2 is a subsort of src1.
+       -}
+      mergeSecondIntoFirst :: SortInjectionSimplification variable
+      mergeSecondIntoFirst =
         Matching SortInjectionMatch
-            { injectionHead = firstHead
-            , sort = firstDestination
-            , firstChild = firstChild
-            , secondChild = sortInjection secondOrigin firstOrigin secondChild
+          { injectionHead = firstHead,
+            sort = firstDestination,
+            firstChild = firstChild,
+            secondChild = sortInjection secondOrigin firstOrigin secondChild
             }
-
-    sortInjection
+      sortInjection
         :: Sort
         -> Sort
         -> TermLike variable
         -> TermLike variable
-    sortInjection originSort destinationSort term =
+      sortInjection originSort destinationSort term =
         mkApplySymbol
-            (Symbol.coerceSortInjection firstHead originSort destinationSort)
-            [term]
-    firstSubsorts = subsorts firstOrigin
-    secondSubsorts = subsorts secondOrigin
-    sortIntersection = Set.intersection firstSubsorts secondSubsorts
+          (Symbol.coerceSortInjection firstHead originSort destinationSort)
+          [term]
+      firstSubsorts = subsorts firstOrigin
+      secondSubsorts = subsorts secondOrigin
+      sortIntersection = Set.intersection firstSubsorts secondSubsorts
 simplifySortInjections _ _ _ = Just NotInjection
 
 {- | Unify a constructor application pattern with a sort injection pattern.
@@ -908,31 +917,31 @@ returns @\\bottom@.
 
  -}
 constructorSortInjectionAndEquals
-    ::  ( Eq variable
-        , SortedVariable variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: ( Eq variable,
+       SortedVariable variable,
+       Unparse variable,
+       MonadUnify unifier
+       )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 constructorSortInjectionAndEquals
-    first@(App_ firstHead _)
-    second@(App_ secondHead _)
-  | isConstructorSortInjection =
-    assert (firstHead /= secondHead) $ Monad.Trans.lift $ do
+  first@(App_ firstHead _)
+  second@(App_ secondHead _)
+    | isConstructorSortInjection =
+      assert (firstHead /= secondHead) $ Monad.Trans.lift $ do
         explainBottom
-            "Cannot unify constructors with sort injections."
-            first
-            second
+          "Cannot unify constructors with sort injections."
+          first
+          second
         empty
-  where
-    -- Are we asked to unify a constructor with a sort injection?
-    isConstructorSortInjection =
+    where
+      -- Are we asked to unify a constructor with a sort injection?
+      isConstructorSortInjection =
         (||)
-            (Symbol.isConstructor   firstHead && Symbol.isSortInjection secondHead)
-            (Symbol.isSortInjection firstHead && Symbol.isConstructor   secondHead)
+          (Symbol.isConstructor firstHead && Symbol.isSortInjection secondHead)
+          (Symbol.isSortInjection firstHead && Symbol.isConstructor secondHead)
 constructorSortInjectionAndEquals _ _ = empty
 
 {-| Unify two constructor application patterns.
@@ -942,26 +951,26 @@ to be different; therefore their conjunction is @\\bottom@.
 
  -}
 constructorAndEqualsAssumesDifferentHeads
-    ::  ( Eq variable
-        , SortedVariable variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: ( Eq variable,
+       SortedVariable variable,
+       Unparse variable,
+       MonadUnify unifier
+       )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 constructorAndEqualsAssumesDifferentHeads
-    first@(App_ firstHead _)
-    second@(App_ secondHead _)
-  | Symbol.isConstructor firstHead
-  , Symbol.isConstructor secondHead =
-    assert (firstHead /= secondHead) $ Monad.Trans.lift $ do
+  first@(App_ firstHead _)
+  second@(App_ secondHead _)
+    | Symbol.isConstructor firstHead,
+      Symbol.isConstructor secondHead =
+      assert (firstHead /= secondHead) $ Monad.Trans.lift $ do
         explainBottom
-            "Cannot unify different constructors or incompatible \
+          "Cannot unify different constructors or incompatible \
             \sort injections."
-            first
-            second
+          first
+          second
         empty
 constructorAndEqualsAssumesDifferentHeads _ _ = empty
 
@@ -973,48 +982,56 @@ sort with constructors.
 
 -}
 domainValueAndConstructorErrors
-    :: (Eq variable, Unparse variable, SortedVariable variable)
-    => Monad unifier
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: (Eq variable, Unparse variable, SortedVariable variable)
+  => Monad unifier
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 domainValueAndConstructorErrors
-    term1@(DV_ _ _)
-    term2@(App_ secondHead _)
+  term1@(DV_ _ _)
+  term2@(App_ secondHead _)
     | Symbol.isConstructor secondHead =
-      error (unlines [ "Cannot handle DomainValue and Constructor:"
-                     , unparseToString term1
-                     , unparseToString term2
-                     ]
-            )
+      error
+        ( unlines
+            [ "Cannot handle DomainValue and Constructor:",
+              unparseToString term1,
+              unparseToString term2
+              ]
+          )
 domainValueAndConstructorErrors
-    term1@(Builtin_ _)
-    term2@(App_ secondHead _)
+  term1@(Builtin_ _)
+  term2@(App_ secondHead _)
     | Symbol.isConstructor secondHead =
-      error (unlines [ "Cannot handle builtin and Constructor:"
-                     , unparseToString term1
-                     , unparseToString term2
-                     ]
-            )
+      error
+        ( unlines
+            [ "Cannot handle builtin and Constructor:",
+              unparseToString term1,
+              unparseToString term2
+              ]
+          )
 domainValueAndConstructorErrors
-    term1@(App_ firstHead _)
-    term2@(DV_ _ _)
+  term1@(App_ firstHead _)
+  term2@(DV_ _ _)
     | Symbol.isConstructor firstHead =
-      error (unlines [ "Cannot handle Constructor and DomainValue:"
-                     , unparseToString term1
-                     , unparseToString term2
-                     ]
-            )
+      error
+        ( unlines
+            [ "Cannot handle Constructor and DomainValue:",
+              unparseToString term1,
+              unparseToString term2
+              ]
+          )
 domainValueAndConstructorErrors
-    term1@(App_ firstHead _)
-    term2@(Builtin_ _)
+  term1@(App_ firstHead _)
+  term2@(Builtin_ _)
     | Symbol.isConstructor firstHead =
-      error (unlines [ "Cannot handle Constructor and builtin:"
-                     , unparseToString term1
-                     , unparseToString term2
-                     ]
-            )
+      error
+        ( unlines
+            [ "Cannot handle Constructor and builtin:",
+              unparseToString term1,
+              unparseToString term2
+              ]
+          )
 domainValueAndConstructorErrors _ _ = empty
 
 {- | Unify two domain values.
@@ -1028,51 +1045,51 @@ See also: 'equalAndEquals'
 -- TODO (thomas.tuegel): This unification case assumes that \dv is injective,
 -- but it is not.
 domainValueAndEqualsAssumesDifferent
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
-    => MonadUnify unifier
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: Eq variable
+  => SortedVariable variable
+  => Unparse variable
+  => MonadUnify unifier
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 domainValueAndEqualsAssumesDifferent
-    first@(DV_ _ _)
-    second@(DV_ _ _)
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(DV_ _ _)
+  second@(DV_ _ _) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
-    first@(Builtin_ (Domain.BuiltinBool _))
-    second@(Builtin_ (Domain.BuiltinBool _))
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(Builtin_ (Domain.BuiltinBool _))
+  second@(Builtin_ (Domain.BuiltinBool _)) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
-    first@(Builtin_ (Domain.BuiltinInt _))
-    second@(Builtin_ (Domain.BuiltinInt _))
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(Builtin_ (Domain.BuiltinInt _))
+  second@(Builtin_ (Domain.BuiltinInt _)) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
-    first@(Builtin_ (Domain.BuiltinString _))
-    second@(Builtin_ (Domain.BuiltinString _))
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(Builtin_ (Domain.BuiltinString _))
+  second@(Builtin_ (Domain.BuiltinString _)) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent _ _ = empty
 
 cannotUnifyDistinctDomainValues :: Pretty.Doc ()
 cannotUnifyDistinctDomainValues = "Cannot unify distinct domain values."
 
 cannotUnifyDomainValues
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
-    => MonadUnify unifier
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> unifier a
+  :: Eq variable
+  => SortedVariable variable
+  => Unparse variable
+  => MonadUnify unifier
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> unifier a
 cannotUnifyDomainValues first second =
-    assert (first /= second) $ do
-        explainBottom
-            cannotUnifyDistinctDomainValues
-            first
-            second
-        empty
+  assert (first /= second) $ do
+    explainBottom
+      cannotUnifyDistinctDomainValues
+      first
+      second
+    empty
 
 {-| Unify two literal strings.
 
@@ -1083,18 +1100,18 @@ See also: 'equalAndEquals'
 
  -}
 stringLiteralAndEqualsAssumesDifferent
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
-    => MonadUnify unifier
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: Eq variable
+  => SortedVariable variable
+  => Unparse variable
+  => MonadUnify unifier
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 stringLiteralAndEqualsAssumesDifferent
-    first@(StringLiteral_ _)
-    second@(StringLiteral_ _)
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(StringLiteral_ _)
+  second@(StringLiteral_ _) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 stringLiteralAndEqualsAssumesDifferent _ _ = empty
 
 {-| Unify two literal characters.
@@ -1106,18 +1123,18 @@ See also: 'equalAndEquals'
 
  -}
 charLiteralAndEqualsAssumesDifferent
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
-    => MonadUnify unifier
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> MaybeT unifier a
+  :: Eq variable
+  => SortedVariable variable
+  => Unparse variable
+  => MonadUnify unifier
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> MaybeT unifier a
 charLiteralAndEqualsAssumesDifferent
-    first@(CharLiteral_ _)
-    second@(CharLiteral_ _)
-  = Monad.Trans.lift $ cannotUnifyDomainValues first second
+  first@(CharLiteral_ _)
+  second@(CharLiteral_ _) =
+    Monad.Trans.lift $ cannotUnifyDomainValues first second
 charLiteralAndEqualsAssumesDifferent _ _ = empty
 
 {- | Unify any two function patterns.
@@ -1126,25 +1143,26 @@ The function patterns are unified by creating an @\\equals@ predicate.
 
 -}
 functionAnd
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => GHC.HasCallStack
-    => TermLike variable
-    -> TermLike variable
-    -> Maybe (Pattern variable)
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => GHC.HasCallStack
+  => TermLike variable
+  -> TermLike variable
+  -> Maybe (Pattern variable)
 functionAnd
-    first
-    second
-  | isFunctionPattern first, isFunctionPattern second =
-    return Conditional
-        { term = first  -- different for Equals
-        -- Ceil predicate not needed since first being
-        -- bottom will make the entire term bottom. However,
-        -- one must be careful to not just drop the term.
-        , predicate = makeEqualsPredicate first second
-        , substitution = mempty
-        }
-  | otherwise = empty
+  first
+  second
+    | isFunctionPattern first,
+      isFunctionPattern second =
+      return Conditional
+        { term = first, -- different for Equals
+            -- Ceil predicate not needed since first being
+            -- bottom will make the entire term bottom. However,
+            -- one must be careful to not just drop the term.
+          predicate = makeEqualsPredicate first second,
+          substitution = mempty
+          }
+    | otherwise = empty

--- a/kore/src/Kore/Step/Simplification/Application.hs
+++ b/kore/src/Kore/Step/Simplification/Application.hs
@@ -8,32 +8,41 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Application
-    ( simplify
-    , Application (..)
-    ) where
+  ( simplify,
+    Application (..)
+    )
+where
 
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( fullCrossProduct, mergeAll )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+  ( fullCrossProduct,
+    mergeAll
+    )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
-import           Kore.Step.Function.Evaluator
-                 ( evaluateApplication )
-import           Kore.Step.Simplification.Data as Simplifier
+import Kore.Internal.Predicate as Predicate
+import Kore.Internal.TermLike
+import Kore.Step.Function.Evaluator
+  ( evaluateApplication
+    )
+import Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
-import           Kore.Step.Substitution
-                 ( mergePredicatesAndSubstitutions )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( gather
+    )
+import Kore.Step.Substitution
+  ( mergePredicatesAndSubstitutions
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
-type ExpandedApplication variable =
-    Conditional variable (Application Symbol (TermLike variable))
+type ExpandedApplication variable
+  = Conditional variable (Application Symbol (TermLike variable))
 
 {-|'simplify' simplifies an 'Application' of 'OrPattern'.
 
@@ -46,97 +55,96 @@ predicates ans substitutions, applying functions on the Application(terms),
 then merging everything into an Pattern.
 -}
 simplify
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Predicate variable
-    -> Application Symbol (OrPattern variable)
-    -> simplifier (OrPattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => Predicate variable
+  -> Application Symbol (OrPattern variable)
+  -> simplifier (OrPattern variable)
 simplify predicate application = do
-    evaluated <-
-        traverse
-            (makeAndEvaluateApplications predicate symbol)
-            -- The "Propagation Or" inference rule together with
-            -- "Propagation Bottom" for the case when a child or is empty.
-            (MultiOr.fullCrossProduct children)
-    return (OrPattern.flatten evaluated)
+  evaluated <-
+    traverse
+      (makeAndEvaluateApplications predicate symbol)
+      -- The "Propagation Or" inference rule together with
+      -- "Propagation Bottom" for the case when a child or is empty.
+      (MultiOr.fullCrossProduct children)
+  return (OrPattern.flatten evaluated)
   where
     Application
-        { applicationSymbolOrAlias = symbol
-        , applicationChildren = children
-        }
-      = application
+      { applicationSymbolOrAlias = symbol,
+        applicationChildren = children
+        } =
+        application
 
 makeAndEvaluateApplications
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    =>  Predicate variable
-    ->  Symbol
-    -> [Pattern variable]
-    -> simplifier (OrPattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => Predicate variable
+  -> Symbol
+  -> [Pattern variable]
+  -> simplifier (OrPattern variable)
 makeAndEvaluateApplications predicate symbol children =
-    makeAndEvaluateSymbolApplications predicate symbol children
+  makeAndEvaluateSymbolApplications predicate symbol children
 
 makeAndEvaluateSymbolApplications
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Predicate variable
-    -> Symbol
-    -> [Pattern variable]
-    -> simplifier (OrPattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => Predicate variable
+  -> Symbol
+  -> [Pattern variable]
+  -> simplifier (OrPattern variable)
 makeAndEvaluateSymbolApplications predicate symbol children = do
-    expandedApplications <-
-        BranchT.gather $ makeExpandedApplication symbol children
-    orResults <- traverse (evaluateApplicationFunction predicate) expandedApplications
-    return (MultiOr.mergeAll orResults)
+  expandedApplications <-
+    BranchT.gather $ makeExpandedApplication symbol children
+  orResults <- traverse (evaluateApplicationFunction predicate) expandedApplications
+  return (MultiOr.mergeAll orResults)
 
 evaluateApplicationFunction
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Predicate variable
-    -- ^ The predicate from the configuration
-    -> ExpandedApplication variable
-    -- ^ The pattern to be evaluated
-    -> simplifier (OrPattern variable)
-evaluateApplicationFunction configurationPredicate Conditional { term, predicate, substitution } =
-    evaluateApplication
-        configurationPredicate
-        Conditional { term = (), predicate, substitution }
-        term
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => Predicate variable
+  -- ^ The predicate from the configuration
+  -> ExpandedApplication variable
+  -- ^ The pattern to be evaluated
+  -> simplifier (OrPattern variable)
+evaluateApplicationFunction configurationPredicate Conditional {term, predicate, substitution} =
+  evaluateApplication
+    configurationPredicate Conditional {term = (), predicate, substitution}
+    term
 
 makeExpandedApplication
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
-    => Symbol
-    -> [Pattern variable]
-    -> BranchT simplifier (ExpandedApplication variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier
+       )
+  => Symbol
+  -> [Pattern variable]
+  -> BranchT simplifier (ExpandedApplication variable)
 makeExpandedApplication symbol children = do
-    merged <-
-        mergePredicatesAndSubstitutions
-            (map Pattern.predicate children)
-            (map Pattern.substitution children)
-    let term =
-            Application
-                { applicationSymbolOrAlias = symbol
-                , applicationChildren = Pattern.term <$> children
-                }
-    return $ Pattern.withCondition term merged
+  merged <-
+    mergePredicatesAndSubstitutions
+      (map Pattern.predicate children)
+      (map Pattern.substitution children)
+  let term =
+        Application
+          { applicationSymbolOrAlias = symbol,
+            applicationChildren = Pattern.term <$> children
+            }
+  return $ Pattern.withCondition term merged

--- a/kore/src/Kore/Step/Simplification/Bottom.hs
+++ b/kore/src/Kore/Step/Simplification/Bottom.hs
@@ -8,14 +8,16 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Bottom
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Sort
-import           Kore.Syntax.Bottom
+import Kore.Sort
+import Kore.Syntax.Bottom
 
 {-| simplifies a Bottom pattern, which means returning an always-false or.
 -}

--- a/kore/src/Kore/Step/Simplification/Builtin.hs
+++ b/kore/src/Kore/Step/Simplification/Builtin.hs
@@ -4,123 +4,128 @@ License     : NCSA
 
  -}
 module Kore.Step.Simplification.Builtin
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
 import qualified Control.Lens as Lens
-import           Data.Functor.Compose
-import           Data.Generics.Product
-import           Data.Maybe
-
+import Data.Functor.Compose
+import Data.Generics.Product
+import Data.Maybe
 import qualified Kore.Builtin.AssociativeCommutative as Builtin
-import           Kore.Domain.Builtin
-                 ( InternalMap, InternalSet )
+import Kore.Domain.Builtin
+  ( InternalMap,
+    InternalSet
+    )
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.Internal.Conditional
-                 ( Conditional )
+import Kore.Internal.Conditional
+  ( Conditional
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( makeFalsePredicate )
-import           Kore.Unparser
+import Kore.Internal.MultiOr as MultiOr
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+  ( makeFalsePredicate
+    )
+import Kore.Unparser
 
 {-| 'simplify' simplifies a 'DomainValue' pattern, which means returning
 an or containing a term made of that value.
 -}
 simplify
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => Builtin (OrPattern variable)
-    -> OrPattern variable
+  => Builtin (OrPattern variable)
+  -> OrPattern variable
 simplify builtin =
-    MultiOr.filterOr $ do
-        child <- simplifyBuiltin builtin
-        return (mkBuiltin <$> child)
+  MultiOr.filterOr $ do
+    child <- simplifyBuiltin builtin
+    return (mkBuiltin <$> child)
 
 simplifyBuiltin
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => Builtin (OrPattern variable)
-    -> MultiOr (Conditional variable (Builtin (TermLike variable)))
+  => Builtin (OrPattern variable)
+  -> MultiOr (Conditional variable (Builtin (TermLike variable)))
 simplifyBuiltin =
-    \case
-        Domain.BuiltinMap map' -> simplifyInternalMap map'
-        Domain.BuiltinList list' -> simplifyInternalList list'
-        Domain.BuiltinSet set' -> simplifyInternalSet set'
-        Domain.BuiltinInt int -> (return . pure) (Domain.BuiltinInt int)
-        Domain.BuiltinBool bool -> (return . pure) (Domain.BuiltinBool bool)
-        Domain.BuiltinString string ->
-            (return . pure) (Domain.BuiltinString string)
+  \case
+    Domain.BuiltinMap map' -> simplifyInternalMap map'
+    Domain.BuiltinList list' -> simplifyInternalList list'
+    Domain.BuiltinSet set' -> simplifyInternalSet set'
+    Domain.BuiltinInt int -> (return . pure) (Domain.BuiltinInt int)
+    Domain.BuiltinBool bool -> (return . pure) (Domain.BuiltinBool bool)
+    Domain.BuiltinString string ->
+      (return . pure) (Domain.BuiltinString string)
 
 simplifyInternal
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , Traversable t
-        )
-    => (t (TermLike variable) -> Maybe (t (TermLike variable)))
-    -> t (OrPattern variable)
-    -> MultiOr (Conditional variable (t (TermLike variable)))
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       Traversable t
+       )
+  => (t (TermLike variable) -> Maybe (t (TermLike variable)))
+  -> t (OrPattern variable)
+  -> MultiOr (Conditional variable (t (TermLike variable)))
 simplifyInternal normalizer tOrPattern = do
-    conditional <- getCompose $ traverse Compose tOrPattern
-    let bottom = conditional `Conditional.andPredicate` makeFalsePredicate
-        normalized = fromMaybe bottom $ traverse normalizer conditional
-    return normalized
+  conditional <- getCompose $ traverse Compose tOrPattern
+  let bottom = conditional `Conditional.andPredicate` makeFalsePredicate
+      normalized = fromMaybe bottom $ traverse normalizer conditional
+  return normalized
 
 simplifyInternalMap
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Domain.InternalMap (TermLike Concrete) (OrPattern variable)
-    -> MultiOr (Conditional variable (Builtin (TermLike variable)))
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Domain.InternalMap (TermLike Concrete) (OrPattern variable)
+  -> MultiOr (Conditional variable (Builtin (TermLike variable)))
 simplifyInternalMap =
-    (fmap . fmap) Domain.BuiltinMap
+  (fmap . fmap) Domain.BuiltinMap
     . simplifyInternal normalizeInternalMap
 
 normalizeInternalMap
-    :: Ord variable
-    => InternalMap (TermLike Concrete) (TermLike variable)
-    -> Maybe (InternalMap (TermLike Concrete) (TermLike variable))
+  :: Ord variable
+  => InternalMap (TermLike Concrete) (TermLike variable)
+  -> Maybe (InternalMap (TermLike Concrete) (TermLike variable))
 normalizeInternalMap =
-    Lens.traverseOf (field @"builtinAcChild") Builtin.renormalize
+  Lens.traverseOf (field @"builtinAcChild") Builtin.renormalize
 
 simplifyInternalSet
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Domain.InternalSet (TermLike Concrete) (OrPattern variable)
-    -> MultiOr (Conditional variable (Builtin (TermLike variable)))
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Domain.InternalSet (TermLike Concrete) (OrPattern variable)
+  -> MultiOr (Conditional variable (Builtin (TermLike variable)))
 simplifyInternalSet =
-    (fmap . fmap) Domain.BuiltinSet
+  (fmap . fmap) Domain.BuiltinSet
     . simplifyInternal normalizeInternalSet
 
 normalizeInternalSet
-    :: Ord variable
-    => InternalSet (TermLike Concrete) (TermLike variable)
-    -> Maybe (InternalSet (TermLike Concrete) (TermLike variable))
+  :: Ord variable
+  => InternalSet (TermLike Concrete) (TermLike variable)
+  -> Maybe (InternalSet (TermLike Concrete) (TermLike variable))
 normalizeInternalSet =
-    Lens.traverseOf (field @"builtinAcChild") Builtin.renormalize
+  Lens.traverseOf (field @"builtinAcChild") Builtin.renormalize
 
 simplifyInternalList
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Domain.InternalList (OrPattern variable)
-    -> MultiOr (Conditional variable (Builtin (TermLike variable)))
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
+       )
+  => Domain.InternalList (OrPattern variable)
+  -> MultiOr (Conditional variable (Builtin (TermLike variable)))
 simplifyInternalList = (fmap . fmap) Domain.BuiltinList . simplifyInternal pure

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -8,55 +8,68 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Ceil
-    ( simplify
-    , makeEvaluate
-    , makeEvaluateTerm
-    , simplifyEvaluated
-    , Ceil (..)
-    ) where
+  ( simplify,
+    makeEvaluate,
+    makeEvaluateTerm,
+    simplifyEvaluated,
+    Ceil (..)
+    )
+where
 
 import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.List as List
 import qualified Data.Map as Map
-import           Data.Maybe
-                 ( fromMaybe )
-
+import Data.Maybe
+  ( fromMaybe
+    )
 import qualified Kore.Attribute.Symbol as Attribute.Symbol
-                 ( isTotal )
+  ( isTotal
+    )
 import qualified Kore.Domain.Builtin as Domain
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiAnd as MultiAnd
-                 ( make )
+  ( make
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.OrPredicate
-                 ( OrPredicate )
+import Kore.Internal.OrPredicate
+  ( OrPredicate
+    )
 import qualified Kore.Internal.OrPredicate as OrPredicate
-import           Kore.Internal.Pattern
-                 ( Pattern )
+import Kore.Internal.Pattern
+  ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Logger
-                 ( LogMessage, WithLog )
-import           Kore.Predicate.Predicate
-                 ( makeCeilPredicate, makeTruePredicate )
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
+import Kore.Predicate.Predicate
+  ( makeCeilPredicate,
+    makeTruePredicate
+    )
 import qualified Kore.Step.Function.Evaluator as Axiom
-                 ( evaluatePattern )
+  ( evaluatePattern
+    )
 import qualified Kore.Step.Simplification.AndPredicates as And
-import           Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Equals as Equals
 import qualified Kore.Step.Simplification.Not as Not
-import           Kore.TopBottom
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.TopBottom
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 {-| Simplify a 'Ceil' of 'OrPattern'.
 
@@ -67,16 +80,16 @@ A ceil(or) is equal to or(ceil). We also take into account that
 * ceil transforms terms into predicates
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => Predicate.Predicate variable
-    -> Ceil Sort (OrPattern variable)
-    -> simplifier (OrPattern variable)
-simplify predicate Ceil { ceilChild = child } = simplifyEvaluated predicate child
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => Predicate.Predicate variable
+  -> Ceil Sort (OrPattern variable)
+  -> simplifier (OrPattern variable)
+simplify predicate Ceil {ceilChild = child} = simplifyEvaluated predicate child
 
 {-| 'simplifyEvaluated' evaluates a ceil given its child, see 'simplify'
 for details.
@@ -95,64 +108,65 @@ carry around.
 
 -}
 simplifyEvaluated
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate.Predicate variable
-    -> OrPattern variable
-    -> simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate.Predicate variable
+  -> OrPattern variable
+  -> simplifier (OrPattern variable)
 simplifyEvaluated predicate child =
-    MultiOr.flatten <$> traverse (makeEvaluate predicate) child
+  MultiOr.flatten <$> traverse (makeEvaluate predicate) child
 
 {-| Evaluates a ceil given its child as an Pattern, see 'simplify'
 for details.
 -}
 makeEvaluate
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate.Predicate variable
-    -> Pattern variable
-    -> simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate.Predicate variable
+  -> Pattern variable
+  -> simplifier (OrPattern variable)
 makeEvaluate predicate child
-  | Pattern.isTop    child = return OrPattern.top
+  | Pattern.isTop child = return OrPattern.top
   | Pattern.isBottom child = return OrPattern.bottom
-  | otherwise              = makeEvaluateNonBoolCeil predicate child
+  | otherwise = makeEvaluateNonBoolCeil predicate child
 
 makeEvaluateNonBoolCeil
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate.Predicate variable
-    -> Pattern variable
-    -> simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Predicate.Predicate variable
+  -> Pattern variable
+  -> simplifier (OrPattern variable)
 makeEvaluateNonBoolCeil predicate patt@Conditional {term}
   | isTop term = return $ OrPattern.fromPattern patt
-  | otherwise = do
-    termCeil <- makeEvaluateTerm predicate term
-    result <-
+  | otherwise =
+    do
+      termCeil <- makeEvaluateTerm predicate term
+      result <-
         And.simplifyEvaluatedMultiPredicate
-            (MultiAnd.make
-                [ MultiOr.make [Predicate.eraseConditionalTerm patt]
-                , termCeil
+          ( MultiAnd.make
+              [ MultiOr.make [Predicate.eraseConditionalTerm patt],
+                termCeil
                 ]
             )
-    return (fmap Pattern.fromPredicate result)
+      return (fmap Pattern.fromPredicate result)
 
 -- TODO: Ceil(function) should be an and of all the function's conditions, both
 -- implicit and explicit.
@@ -161,231 +175,223 @@ makeEvaluateNonBoolCeil predicate patt@Conditional {term}
 -- NOTE (hs-boot): Please update Ceil.hs-boot file when changing the
 -- signature.
 makeEvaluateTerm
-    ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate.Predicate variable
-    -> TermLike variable
-    -> simplifier (OrPredicate variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier,
+                                   WithLog LogMessage simplifier
+                                   )
+  => Predicate.Predicate variable
+  -> TermLike variable
+  -> simplifier (OrPredicate variable)
 makeEvaluateTerm configurationPredicate term@(Recursive.project -> _ :< projected) =
-    makeEvaluateTermWorker
+  makeEvaluateTermWorker
   where
     makeEvaluateTermWorker
-      | isTop term            = return OrPredicate.top
-      | isBottom term         = return OrPredicate.bottom
+      | isTop term = return OrPredicate.top
+      | isBottom term = return OrPredicate.bottom
       | isDefinedPattern term = return OrPredicate.top
-
-      | ApplySymbolF app <- projected
-      , let Application { applicationSymbolOrAlias = patternHead } = app
-      , let headAttributes = symbolAttributes patternHead
-      , Attribute.Symbol.isTotal headAttributes = do
-            let Application { applicationChildren = children } = app
-            simplifiedChildren <- mapM (makeEvaluateTerm configurationPredicate) children
-            let ceils = simplifiedChildren
-            And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
-
+      | ApplySymbolF app <- projected,
+        let Application {applicationSymbolOrAlias = patternHead} = app,
+        let headAttributes = symbolAttributes patternHead,
+        Attribute.Symbol.isTotal headAttributes =
+        do
+          let Application {applicationChildren = children} = app
+          simplifiedChildren <- mapM (makeEvaluateTerm configurationPredicate) children
+          let ceils = simplifiedChildren
+          And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
       | BuiltinF child <- projected = makeEvaluateBuiltin configurationPredicate child
-
-      | otherwise = do
-            substitutionSimplifier <- Simplifier.askSimplifierPredicate
-            simplifier <- Simplifier.askSimplifierTermLike
-            axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
-            evaluation <- Axiom.evaluatePattern
-                substitutionSimplifier
-                simplifier
-                axiomIdToEvaluator
-                configurationPredicate
-                Conditional
-                    { term = ()
-                    , predicate = makeTruePredicate
-                    , substitution = mempty
-                    }
-                (mkCeil_ term)
-                (OrPattern.fromPattern Conditional
-                    { term = mkTop_
-                    , predicate = makeCeilPredicate term
-                    , substitution = mempty
+      | otherwise =
+        do
+          substitutionSimplifier <- Simplifier.askSimplifierPredicate
+          simplifier <- Simplifier.askSimplifierTermLike
+          axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
+          evaluation <-
+            Axiom.evaluatePattern
+              substitutionSimplifier
+              simplifier
+              axiomIdToEvaluator
+              configurationPredicate Conditional
+              { term = (),
+                predicate = makeTruePredicate,
+                substitution = mempty
+                }
+              (mkCeil_ term)
+              ( OrPattern.fromPattern Conditional
+                  { term = mkTop_,
+                    predicate = makeCeilPredicate term,
+                    substitution = mempty
                     }
                 )
-            return (fmap toPredicate evaluation)
-
+          return (fmap toPredicate evaluation)
     toPredicate Conditional {term = Top_ _, predicate, substitution} =
-        Conditional {term = (), predicate, substitution}
+      Conditional {term = (), predicate, substitution}
     toPredicate patt =
-        error
-            (  "Ceil simplification is expected to result ai a predicate, but"
-            ++ " got (" ++ show patt ++ ")."
+      error
+        ( "Ceil simplification is expected to result ai a predicate, but"
+            ++ " got ("
+            ++ show patt
+            ++ ")."
             ++ " The most likely cases are: evaluating predicate symbols, "
             ++ " and predicate symbols are currently unrecognized as such, "
             ++ "and programming errors."
-            )
+          )
 
 {-| Evaluates the ceil of a domain value.
 -}
 makeEvaluateBuiltin
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Predicate.Predicate variable
-    -> Builtin (TermLike variable)
-    -> simplifier (OrPredicate variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Unparse variable,
+                                   Show variable,
+                                   MonadSimplify simplifier,
+                                   WithLog LogMessage simplifier
+                                   )
+  => Predicate.Predicate variable
+  -> Builtin (TermLike variable)
+  -> simplifier (OrPredicate variable)
 makeEvaluateBuiltin
-    predicate
-    patt@(Domain.BuiltinMap Domain.InternalAc
-        {builtinAcChild}
-    )
-  =
+  predicate
+  patt@( Domain.BuiltinMap
+           Domain.InternalAc
+             { builtinAcChild
+               }
+         ) =
     fromMaybe
-        (return unsimplified)
-        (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
-  where
-    unsimplified =
+      (return unsimplified)
+      (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
+    where
+      unsimplified =
         OrPredicate.fromPredicate
-            (Predicate.fromPredicate
-                (makeCeilPredicate (mkBuiltin patt))
+          ( Predicate.fromPredicate
+              (makeCeilPredicate (mkBuiltin patt))
             )
 makeEvaluateBuiltin predicate (Domain.BuiltinList l) = do
-    children <- mapM (makeEvaluateTerm predicate) (Foldable.toList l)
-    let
-        ceils :: [OrPredicate variable]
-        ceils = children
-    And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
+  children <- mapM (makeEvaluateTerm predicate) (Foldable.toList l)
+  let ceils :: [OrPredicate variable]
+      ceils = children
+  And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
 makeEvaluateBuiltin
-    predicate
-    patt@(Domain.BuiltinSet Domain.InternalAc
-        {builtinAcChild}
-    )
-  =
+  predicate
+  patt@( Domain.BuiltinSet
+           Domain.InternalAc
+             { builtinAcChild
+               }
+         ) =
     fromMaybe
-        (return unsimplified)
-        (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
-  where
-    unsimplified =
+      (return unsimplified)
+      (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
+    where
+      unsimplified =
         OrPredicate.fromPredicate
-            (Predicate.fromPredicate
-                (makeCeilPredicate (mkBuiltin patt))
+          ( Predicate.fromPredicate
+              (makeCeilPredicate (mkBuiltin patt))
             )
 makeEvaluateBuiltin _ (Domain.BuiltinBool _) = return OrPredicate.top
 makeEvaluateBuiltin _ (Domain.BuiltinInt _) = return OrPredicate.top
 makeEvaluateBuiltin _ (Domain.BuiltinString _) = return OrPredicate.top
 
 makeEvaluateNormalizedAc
-    :: forall normalized variable simplifier
-    .   ( FreshVariable variable
-        , MonadSimplify simplifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Traversable (Domain.Value normalized)
-        , Unparse variable
-        , Domain.AcWrapper normalized
-        )
-    =>  Predicate.Predicate variable
-    ->  Domain.NormalizedAc
-            normalized
-            (TermLike Concrete)
-            (TermLike variable)
-    -> Maybe (simplifier (OrPredicate variable))
+  :: forall normalized variable simplifier. ( FreshVariable variable,
+                                              MonadSimplify simplifier,
+                                              Ord variable,
+                                              Show variable,
+                                              SortedVariable variable,
+                                              Traversable (Domain.Value normalized),
+                                              Unparse variable,
+                                              Domain.AcWrapper normalized
+                                              )
+  => Predicate.Predicate variable
+  -> Domain.NormalizedAc
+       normalized
+       (TermLike Concrete)
+       (TermLike variable)
+  -> Maybe (simplifier (OrPredicate variable))
 makeEvaluateNormalizedAc
-    configurationPredicate
-    Domain.NormalizedAc
-        { elementsWithVariables
-        , concreteElements
-        , opaque = []
-        }
-  = Just $ do
-    variableKeyConditions <- mapM (makeEvaluateTerm configurationPredicate) variableKeys
-    variableValueConditions <- evaluateValues variableValues
-    concreteValueConditions <- evaluateValues concreteValues
-
-    elementsWithVariablesDistinct <-
+  configurationPredicate
+  Domain.NormalizedAc
+    { elementsWithVariables,
+      concreteElements,
+      opaque = []
+      } =
+    Just $ do
+      variableKeyConditions <- mapM (makeEvaluateTerm configurationPredicate) variableKeys
+      variableValueConditions <- evaluateValues variableValues
+      concreteValueConditions <- evaluateValues concreteValues
+      elementsWithVariablesDistinct <-
         evaluateDistinct variableKeys concreteKeys
-    let allConditions :: [OrPredicate variable]
-        allConditions =
+      let allConditions :: [OrPredicate variable]
+          allConditions =
             concreteValueConditions
-            ++ variableValueConditions
-            ++ variableKeyConditions
-            ++ elementsWithVariablesDistinct
-    And.simplifyEvaluatedMultiPredicate (MultiAnd.make allConditions)
-  where
-    concreteElementsList
-        ::  [   ( TermLike variable
-                , Domain.Value normalized (TermLike variable)
-                )
-            ]
-    concreteElementsList =
+              ++ variableValueConditions
+              ++ variableKeyConditions
+              ++ elementsWithVariablesDistinct
+      And.simplifyEvaluatedMultiPredicate (MultiAnd.make allConditions)
+    where
+      concreteElementsList
+        :: [ ( TermLike variable,
+               Domain.Value normalized (TermLike variable)
+               )
+             ]
+      concreteElementsList =
         map
-            (\(a, b) -> (TermLike.fromConcrete a, b))
-            (Map.toList concreteElements)
-    (variableKeys, variableValues) =
+          (\(a, b) -> (TermLike.fromConcrete a, b))
+          (Map.toList concreteElements)
+      (variableKeys, variableValues) =
         unzip (Domain.unwrapElement <$> elementsWithVariables)
-    (concreteKeys, concreteValues) = unzip concreteElementsList
-
-    evaluateDistinct
+      (concreteKeys, concreteValues) = unzip concreteElementsList
+      evaluateDistinct
         :: [TermLike variable]
         -> [TermLike variable]
         -> simplifier [OrPredicate variable]
-    evaluateDistinct [] _ = return []
-    evaluateDistinct (variableTerm : variableTerms) concreteTerms = do
+      evaluateDistinct [] _ = return []
+      evaluateDistinct (variableTerm : variableTerms) concreteTerms = do
         equalities <-
-            mapM
-                (flip (Equals.makeEvaluateTermsToPredicate variableTerm) configurationPredicate)
-                -- TODO(virgil): consider eliminating these repeated
-                -- concatenations.
-                (variableTerms ++ concreteTerms)
+          mapM
+            (flip (Equals.makeEvaluateTermsToPredicate variableTerm) configurationPredicate)
+            -- TODO(virgil): consider eliminating these repeated
+            -- concatenations.
+            (variableTerms ++ concreteTerms)
         let negateEquality
-                :: OrPredicate variable -> Predicate.Predicate variable
+              :: OrPredicate variable -> Predicate.Predicate variable
             negateEquality orPredicate =
-                mergeAnd
-                    (map
-                        Not.makeEvaluatePredicate
-                        (Foldable.toList orPredicate)
-                    )
+              mergeAnd
+                ( map
+                    Not.makeEvaluatePredicate
+                    (Foldable.toList orPredicate)
+                  )
         let negations =
-                map (OrPredicate.fromPredicate . negateEquality) equalities
-
+              map (OrPredicate.fromPredicate . negateEquality) equalities
         remainingConditions <-
-            evaluateDistinct variableTerms concreteTerms
+          evaluateDistinct variableTerms concreteTerms
         return (negations ++ remainingConditions)
-
-    evaluateValues
+      evaluateValues
         :: [Domain.Value normalized (TermLike variable)]
         -> simplifier [OrPredicate variable]
-    evaluateValues elements = do
+      evaluateValues elements = do
         wrapped <- evaluateWrappers elements
         let unwrapped = map Foldable.toList wrapped
         return (concat unwrapped)
-      where
-        evaluateWrapper
+        where
+          evaluateWrapper
             :: Domain.Value normalized (TermLike variable)
             -> simplifier (Domain.Value normalized (OrPredicate variable))
-        evaluateWrapper = traverse (makeEvaluateTerm configurationPredicate)
-
-        evaluateWrappers
+          evaluateWrapper = traverse (makeEvaluateTerm configurationPredicate)
+          evaluateWrappers
             :: [Domain.Value normalized (TermLike variable)]
             -> simplifier [Domain.Value normalized (OrPredicate variable)]
-        evaluateWrappers = traverse evaluateWrapper
-
-    mergeAnd :: [Predicate.Predicate variable] -> Predicate.Predicate variable
-    mergeAnd [] = Predicate.top
-    mergeAnd (predicate : predicates) =
+          evaluateWrappers = traverse evaluateWrapper
+      mergeAnd :: [Predicate.Predicate variable] -> Predicate.Predicate variable
+      mergeAnd [] = Predicate.top
+      mergeAnd (predicate : predicates) =
         List.foldl' Conditional.andCondition predicate predicates
 makeEvaluateNormalizedAc
-    configurationPredicate
-    Domain.NormalizedAc
-        { elementsWithVariables = []
-        , concreteElements
-        , opaque = [opaqueAc]
-        }
-  | Map.null concreteElements = Just $ makeEvaluateTerm configurationPredicate opaqueAc
-makeEvaluateNormalizedAc _  _ = Nothing
+  configurationPredicate
+  Domain.NormalizedAc
+    { elementsWithVariables = [],
+      concreteElements,
+      opaque = [opaqueAc]
+      }
+    | Map.null concreteElements = Just $ makeEvaluateTerm configurationPredicate opaqueAc
+makeEvaluateNormalizedAc _ _ = Nothing

--- a/kore/src/Kore/Step/Simplification/CharLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/CharLiteral.hs
@@ -8,21 +8,23 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.CharLiteral
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 
 {-| 'simplify' simplifies a 'CharLiteral' pattern, which means returning
 an or containing a term made of that literal.
 -}
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => CharLiteral
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => CharLiteral
+  -> OrPattern variable
 simplify (CharLiteral char) =
-    OrPattern.fromPattern $ Pattern.fromTermLike $ mkCharLiteral char
+  OrPattern.fromPattern $ Pattern.fromTermLike $ mkCharLiteral char

--- a/kore/src/Kore/Step/Simplification/DomainValue.hs
+++ b/kore/src/Kore/Step/Simplification/DomainValue.hs
@@ -8,14 +8,17 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.DomainValue
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
 import Kore.Internal.Conditional
-       ( Conditional )
+  ( Conditional
+    )
 import Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrPattern
-       ( OrPattern )
+  ( OrPattern
+    )
 import Kore.Internal.TermLike
 import Kore.Unparser
 
@@ -23,26 +26,26 @@ import Kore.Unparser
 an or containing a term made of that value.
 -}
 simplify
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => DomainValue Sort (OrPattern variable)
-    -> OrPattern variable
+  => DomainValue Sort (OrPattern variable)
+  -> OrPattern variable
 simplify builtin =
-    MultiOr.filterOr $ do
-        child <- simplifyDomainValue builtin
-        return (mkDomainValue <$> child)
+  MultiOr.filterOr $ do
+    child <- simplifyDomainValue builtin
+    return (mkDomainValue <$> child)
 
 simplifyDomainValue
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => DomainValue Sort (OrPattern variable)
-    -> MultiOr (Conditional variable (DomainValue Sort (TermLike variable)))
+  => DomainValue Sort (OrPattern variable)
+  -> MultiOr (Conditional variable (DomainValue Sort (TermLike variable)))
 simplifyDomainValue _ext = do
-    _ext <- sequence _ext
-    return (sequenceA _ext)
+  _ext <- sequence _ext
+  return (sequenceA _ext)

--- a/kore/src/Kore/Step/Simplification/Floor.hs
+++ b/kore/src/Kore/Step/Simplification/Floor.hs
@@ -8,20 +8,25 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Floor
-    ( simplify
-    , makeEvaluateFloor
-    ) where
+  ( simplify,
+    makeEvaluateFloor
+    )
+where
 
 import qualified Kore.Internal.MultiOr as MultiOr
-                 ( extractPatterns )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+  ( extractPatterns
+    )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( makeAndPredicate, makeFloorPredicate )
-import           Kore.Unparser
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+  ( makeAndPredicate,
+    makeFloorPredicate
+    )
+import Kore.Unparser
 
 {-| 'simplify' simplifies a 'Floor' of 'OrPattern'.
 
@@ -35,15 +40,15 @@ However, we don't take into account things like
 floor(a and b) = floor(a) and floor(b).
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , Ord variable
-        )
-    => Floor Sort (OrPattern variable)
-    -> OrPattern variable
-simplify Floor { floorChild = child } =
-    simplifyEvaluatedFloor child
+  :: ( SortedVariable variable,
+       Unparse variable,
+       Show variable,
+       Ord variable
+       )
+  => Floor Sort (OrPattern variable)
+  -> OrPattern variable
+simplify Floor {floorChild = child} =
+  simplifyEvaluatedFloor child
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 
@@ -59,54 +64,52 @@ to carry around.
 
 -}
 simplifyEvaluatedFloor
-    ::  ( SortedVariable variable
-        , Show variable
-        , Ord variable
-        , Unparse variable
-        )
-    => OrPattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Show variable,
+       Ord variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> OrPattern variable
 simplifyEvaluatedFloor child =
-    case MultiOr.extractPatterns child of
-        [childP] -> makeEvaluateFloor childP
-        _ ->
-            makeEvaluateFloor
-                (OrPattern.toPattern child)
+  case MultiOr.extractPatterns child of
+    [childP] -> makeEvaluateFloor childP
+    _ ->
+      makeEvaluateFloor
+        (OrPattern.toPattern child)
 
 {-| 'makeEvaluateFloor' simplifies a 'Floor' of 'Pattern'.
 
 See 'simplify' for details.
 -}
 makeEvaluateFloor
-    ::  ( SortedVariable variable
-        , Show variable
-        , Ord variable
-        , Unparse variable
-        )
-    => Pattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Show variable,
+       Ord variable,
+       Unparse variable
+       )
+  => Pattern variable
+  -> OrPattern variable
 makeEvaluateFloor child
-  | Pattern.isTop child    = OrPattern.top
+  | Pattern.isTop child = OrPattern.top
   | Pattern.isBottom child = OrPattern.bottom
-  | otherwise              = makeEvaluateNonBoolFloor child
+  | otherwise = makeEvaluateNonBoolFloor child
 
 makeEvaluateNonBoolFloor
-    ::  ( SortedVariable variable
-        , Show variable
-        , Ord variable
-        , Unparse variable
-        )
-    => Pattern variable
-    -> OrPattern variable
-makeEvaluateNonBoolFloor patt@Conditional { term = Top_ _ } =
-    OrPattern.fromPattern patt
+  :: ( SortedVariable variable,
+       Show variable,
+       Ord variable,
+       Unparse variable
+       )
+  => Pattern variable
+  -> OrPattern variable
+makeEvaluateNonBoolFloor patt@Conditional {term = Top_ _} =
+  OrPattern.fromPattern patt
 -- TODO(virgil): Also evaluate functional patterns to bottom for non-singleton
 -- sorts, and maybe other cases also
-makeEvaluateNonBoolFloor
-    Conditional {term, predicate, substitution}
-  =
-    OrPattern.fromPattern Conditional
-        { term = mkTop_
-        , predicate = makeAndPredicate (makeFloorPredicate term) predicate
-        , substitution = substitution
-        }
+makeEvaluateNonBoolFloor Conditional {term, predicate, substitution} =
+  OrPattern.fromPattern Conditional
+    { term = mkTop_,
+      predicate = makeAndPredicate (makeFloorPredicate term) predicate,
+      substitution = substitution
+      }

--- a/kore/src/Kore/Step/Simplification/Forall.hs
+++ b/kore/src/Kore/Step/Simplification/Forall.hs
@@ -8,16 +8,18 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Forall
-    ( simplify
-    , makeEvaluate
-    ) where
+  ( simplify,
+    makeEvaluate
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Unparser
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import Kore.Unparser
 
 -- TODO: Move Forall up in the other simplifiers or something similar. Note
 -- that it messes up top/bottom testing so moving it up must be done
@@ -37,17 +39,15 @@ For this reason, we don't even try to see if the variable actually occurs in
 the pattern except for the top/bottom cases.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Forall Sort variable (OrPattern variable)
-    -> OrPattern variable
-simplify
-    Forall { forallVariable, forallChild }
-  =
-    simplifyEvaluated forallVariable forallChild
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Forall Sort variable (OrPattern variable)
+  -> OrPattern variable
+simplify Forall {forallVariable, forallChild} =
+  simplifyEvaluated forallVariable forallChild
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 
@@ -63,34 +63,34 @@ even more useful to carry around.
 
 -}
 simplifyEvaluated
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => ElementVariable variable
-    -> OrPattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => ElementVariable variable
+  -> OrPattern variable
+  -> OrPattern variable
 simplifyEvaluated variable simplified
-  | OrPattern.isTrue simplified  = simplified
+  | OrPattern.isTrue simplified = simplified
   | OrPattern.isFalse simplified = simplified
-  | otherwise                    = makeEvaluate variable <$> simplified
+  | otherwise = makeEvaluate variable <$> simplified
 
 {-| evaluates an 'Forall' given its two 'Pattern' children.
 
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => ElementVariable variable
-    -> Pattern variable
-    -> Pattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => ElementVariable variable
+  -> Pattern variable
+  -> Pattern variable
 makeEvaluate variable patt
-  | Pattern.isTop patt    = Pattern.top
+  | Pattern.isTop patt = Pattern.top
   | Pattern.isBottom patt = Pattern.bottom
   | otherwise =
     Pattern.fromTermLike $ mkForall variable $ Pattern.toTermLike patt

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -8,23 +8,29 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.In
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate as Predicate
-                 ( topTODO )
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( makeInPredicate )
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate as Predicate
+  ( topTODO
+    )
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+  ( makeInPredicate
+    )
 import qualified Kore.Step.Simplification.Ceil as Ceil
-                 ( makeEvaluate, simplifyEvaluated )
-import           Kore.Step.Simplification.Data
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( makeEvaluate,
+    simplifyEvaluated
+    )
+import Kore.Step.Simplification.Data
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 {-|'simplify' simplifies an 'In' pattern with 'OrPattern'
 children.
@@ -39,16 +45,16 @@ Right now this uses the following simplifications:
 TODO(virgil): It does not have yet a special case for children with top terms.
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => In Sort (OrPattern variable)
-    -> simplifier (OrPattern variable)
-simplify In { inContainedChild = first, inContainingChild = second } =
-    simplifyEvaluatedIn first second
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => In Sort (OrPattern variable)
+  -> simplifier (OrPattern variable)
+simplify In {inContainedChild = first, inContainingChild = second} =
+  simplifyEvaluatedIn first second
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 
@@ -64,36 +70,33 @@ carry around.
 
 -}
 simplifyEvaluatedIn
-    :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => OrPattern variable
-    -> OrPattern variable
-    -> simplifier (OrPattern variable)
+  :: forall variable simplifier. ( FreshVariable variable,
+                                   SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   MonadSimplify simplifier
+                                   )
+  => OrPattern variable
+  -> OrPattern variable
+  -> simplifier (OrPattern variable)
 simplifyEvaluatedIn first second
-  | OrPattern.isFalse first  = return OrPattern.bottom
+  | OrPattern.isFalse first = return OrPattern.bottom
   | OrPattern.isFalse second = return OrPattern.bottom
-
   | OrPattern.isTrue first = Ceil.simplifyEvaluated Predicate.topTODO second
   | OrPattern.isTrue second = Ceil.simplifyEvaluated Predicate.topTODO first
-
   | otherwise =
     OrPattern.flatten <$> sequence (makeEvaluateIn <$> first <*> second)
 
 makeEvaluateIn
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    => Pattern variable
-    -> Pattern variable
-    -> simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => Pattern variable
+  -> Pattern variable
+  -> simplifier (OrPattern variable)
 makeEvaluateIn first second
   | Pattern.isTop first = Ceil.makeEvaluate Predicate.topTODO second
   | Pattern.isTop second = Ceil.makeEvaluate Predicate.topTODO first
@@ -101,21 +104,21 @@ makeEvaluateIn first second
   | otherwise = return $ makeEvaluateNonBoolIn first second
 
 makeEvaluateNonBoolIn
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Pattern variable
-    -> Pattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Pattern variable
+  -> Pattern variable
+  -> OrPattern variable
 makeEvaluateNonBoolIn patt1 patt2 =
-    OrPattern.fromPattern Conditional
-        { term = mkTop_
-        , predicate =
-            makeInPredicate
-                -- TODO: Wrap in 'contained' and 'container'.
-                (Pattern.toTermLike patt1)
-                (Pattern.toTermLike patt2)
-        , substitution = mempty
-        }
+  OrPattern.fromPattern Conditional
+    { term = mkTop_,
+      predicate =
+        makeInPredicate
+          -- TODO: Wrap in 'contained' and 'container'.
+          (Pattern.toTermLike patt1)
+          (Pattern.toTermLike patt2),
+      substitution = mempty
+      }

--- a/kore/src/Kore/Step/Simplification/Inhabitant.hs
+++ b/kore/src/Kore/Step/Simplification/Inhabitant.hs
@@ -4,19 +4,21 @@ Description : Tools for Inhabitant pattern simplification.
 Copyright   : (c) Runtime Verification, 2018
 -}
 module Kore.Step.Simplification.Inhabitant
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 
 {-| 'simplify' simplifies a 'StringLiteral' pattern, which means returning
 an or containing a term made of that literal.
 -}
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => Inhabitant (OrPattern variable)
-    -> OrPattern variable
-simplify Inhabitant { inhSort } = OrPattern.fromTermLike $ mkInhabitant inhSort
+  :: (Ord variable, SortedVariable variable)
+  => Inhabitant (OrPattern variable)
+  -> OrPattern variable
+simplify Inhabitant {inhSort} = OrPattern.fromTermLike $ mkInhabitant inhSort

--- a/kore/src/Kore/Step/Simplification/Mu.hs
+++ b/kore/src/Kore/Step/Simplification/Mu.hs
@@ -3,12 +3,14 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 -}
 module Kore.Step.Simplification.Mu
-    ( simplify
-    , makeEvaluate
-    ) where
+  ( simplify,
+    makeEvaluate
+    )
+where
 
 import Kore.Internal.OrPattern
-       ( OrPattern )
+  ( OrPattern
+    )
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike
 import Kore.Unparser
@@ -17,29 +19,28 @@ import Kore.Unparser
 child.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Mu variable (OrPattern variable)
-    -> OrPattern variable
-simplify
-    Mu { muVariable, muChild }
-  = makeEvaluate muVariable <$> muChild
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Mu variable (OrPattern variable)
+  -> OrPattern variable
+simplify Mu {muVariable, muChild} =
+  makeEvaluate muVariable <$> muChild
 
 {-| evaluates a 'Mu' given its two 'Pattern' children.
 
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => SetVariable variable
-    -> Pattern variable
-    -> Pattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => SetVariable variable
+  -> Pattern variable
+  -> Pattern variable
 makeEvaluate variable patt =
-    Pattern.fromTermLike $ mkMu variable $ Pattern.toTermLike patt
+  Pattern.fromTermLike $ mkMu variable $ Pattern.toTermLike patt

--- a/kore/src/Kore/Step/Simplification/Next.hs
+++ b/kore/src/Kore/Step/Simplification/Next.hs
@@ -8,15 +8,17 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Next
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Unparser
+import Kore.Internal.TermLike
+import Kore.Unparser
 
 -- TODO: Move Next up in the other simplifiers or something similar. Note
 -- that it messes up top/bottom testing so moving it up must be done
@@ -27,25 +29,25 @@ child.
 Right now this does not do any actual simplification.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Next Sort (OrPattern variable)
-    -> OrPattern variable
-simplify Next { nextChild = child } = simplifyEvaluated child
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Next Sort (OrPattern variable)
+  -> OrPattern variable
+simplify Next {nextChild = child} = simplifyEvaluated child
 
 simplifyEvaluated
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => OrPattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> OrPattern variable
 simplifyEvaluated simplified =
-    OrPattern.fromTermLike
+  OrPattern.fromTermLike
     $ mkNext
     $ Pattern.toTermLike
     $ OrPattern.toPattern simplified

--- a/kore/src/Kore/Step/Simplification/Nu.hs
+++ b/kore/src/Kore/Step/Simplification/Nu.hs
@@ -3,12 +3,14 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 -}
 module Kore.Step.Simplification.Nu
-    ( simplify
-    , makeEvaluate
-    ) where
+  ( simplify,
+    makeEvaluate
+    )
+where
 
 import Kore.Internal.OrPattern
-       ( OrPattern )
+  ( OrPattern
+    )
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike
 import Kore.Unparser
@@ -17,29 +19,28 @@ import Kore.Unparser
 child.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Nu variable (OrPattern variable)
-    -> OrPattern variable
-simplify
-    Nu { nuVariable, nuChild }
-  = makeEvaluate nuVariable <$> nuChild
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Nu variable (OrPattern variable)
+  -> OrPattern variable
+simplify Nu {nuVariable, nuChild} =
+  makeEvaluate nuVariable <$> nuChild
 
 {-| evaluates a 'Nu' given its two 'Pattern' children.
 
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => SetVariable variable
-    -> Pattern variable
-    -> Pattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => SetVariable variable
+  -> Pattern variable
+  -> Pattern variable
 makeEvaluate variable patt =
-    Pattern.fromTermLike $ mkNu variable $ Pattern.toTermLike patt
+  Pattern.fromTermLike $ mkNu variable $ Pattern.toTermLike patt

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -4,36 +4,45 @@ License     : NCSA
 
 -}
 module Kore.Step.Simplification.OrPattern
-    ( simplifyPredicatesWithSmt
-    ) where
+  ( simplifyPredicatesWithSmt
+    )
+where
 
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
-import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
-import qualified Kore.Step.Simplification.Pattern as Pattern
-                 ( simplifyPredicate )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
-                 ( filterMultiOr )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( filterMultiOr
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
+import qualified Kore.Step.Simplification.Data as BranchT
+  ( gather
+    )
+import qualified Kore.Step.Simplification.Pattern as Pattern
+  ( simplifyPredicate
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 simplifyPredicatesWithSmt
-    ::  ( FreshVariable variable
-        , MonadSimplify simplifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => OrPattern variable -> simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       MonadSimplify simplifier,
+       Ord variable,
+       Show variable,
+       SortedVariable variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> simplifier (OrPattern variable)
 simplifyPredicatesWithSmt unsimplified = do
-    simplifiedOrs <- traverse
-        (BranchT.gather . Pattern.simplifyPredicate)
-        (MultiOr.extractPatterns unsimplified)
-    SMT.Evaluator.filterMultiOr (MultiOr.make (concat simplifiedOrs))
+  simplifiedOrs <-
+    traverse
+      (BranchT.gather . Pattern.simplifyPredicate)
+      (MultiOr.extractPatterns unsimplified)
+  SMT.Evaluator.filterMultiOr (MultiOr.make (concat simplifiedOrs))

--- a/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -4,98 +4,110 @@ License     : NCSA
 
 -}
 module Kore.Step.Simplification.Pattern
-    ( simplifyAndRemoveTopExists
-    , simplify
-    , simplifyPredicate
-    ) where
+  ( simplifyAndRemoveTopExists,
+    simplify,
+    simplifyPredicate
+    )
+where
 
 import qualified Control.Monad.Trans.Class as Monad.Trans
-
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
-import           Kore.Internal.Pattern
-                 ( Conditional (..), Pattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
+import Kore.Internal.Pattern
+  ( Conditional (..),
+    Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-                 ( pattern Exists_ )
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+import Kore.Internal.TermLike
+  ( pattern Exists_
+    )
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Step.Condition.Evaluator as Predicate
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Merging.Pattern as Pattern
-import           Kore.Step.Simplification.Data
-                 ( BranchT, MonadSimplify )
+import Kore.Step.Simplification.Data
+  ( BranchT,
+    MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather )
-import           Kore.Step.Substitution
-                 ( mergePredicatesAndSubstitutions )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( gather
+    )
+import Kore.Step.Substitution
+  ( mergePredicatesAndSubstitutions
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 simplifyAndRemoveTopExists
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Pattern variable
-    -> simplifier (OrPattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Pattern variable
+  -> simplifier (OrPattern variable)
 simplifyAndRemoveTopExists patt = do
-    simplified <- simplify patt
-    return (removeTopExists <$> simplified)
+  simplified <- simplify patt
+  return (removeTopExists <$> simplified)
   where
     removeTopExists :: Pattern variable -> Pattern variable
-    removeTopExists p@Conditional{ term = Exists_ _ _ quantified } =
-        removeTopExists p {term = quantified}
+    removeTopExists p@Conditional {term = Exists_ _ _ quantified} =
+      removeTopExists p {term = quantified}
     removeTopExists p = p
 
 {-| Simplifies an 'Pattern', returning an 'OrPattern'.
 -}
 simplify
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Pattern variable
-    -> simplifier (OrPattern variable)
-simplify pattern'@Conditional { term } = do
-    simplifiedTerm <- Simplifier.simplifyTerm term
-    orPatterns <-
-        BranchT.gather
-        $ traverse
-            (Pattern.mergeWithPredicate $ Pattern.withoutTerm pattern')
-            simplifiedTerm
-    return (MultiOr.mergeAll orPatterns)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Pattern variable
+  -> simplifier (OrPattern variable)
+simplify pattern'@Conditional {term} = do
+  simplifiedTerm <- Simplifier.simplifyTerm term
+  orPatterns <-
+    BranchT.gather
+      $ traverse
+          (Pattern.mergeWithPredicate $ Pattern.withoutTerm pattern')
+          simplifiedTerm
+  return (MultiOr.mergeAll orPatterns)
 
 {-| Simplifies the predicate inside an 'Pattern'.
 -}
 simplifyPredicate
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        , WithLog LogMessage simplifier
-        )
-    => Pattern variable
-    -- ^ The condition to be evaluated.
-    -> BranchT simplifier (Pattern variable)
+  :: ( Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       MonadSimplify simplifier,
+       WithLog LogMessage simplifier
+       )
+  => Pattern variable
+  -- ^ The condition to be evaluated.
+  -> BranchT simplifier (Pattern variable)
 simplifyPredicate Conditional {term, predicate, substitution} = do
-    evaluated <- Monad.Trans.lift $ Predicate.simplify predicate
-    let Conditional { predicate = evaluatedPredicate } = evaluated
-        Conditional { substitution = evaluatedSubstitution } = evaluated
-    merged <-
-        mergePredicatesAndSubstitutions
-            [evaluatedPredicate]
-            [substitution, evaluatedSubstitution]
-    -- TODO(virgil): Do I need to re-evaluate the predicate?
-    return $ Pattern.withCondition term merged
+  evaluated <- Monad.Trans.lift $ Predicate.simplify predicate
+  let Conditional {predicate = evaluatedPredicate} = evaluated
+      Conditional {substitution = evaluatedSubstitution} = evaluated
+  merged <-
+    mergePredicatesAndSubstitutions
+      [evaluatedPredicate]
+      [substitution, evaluatedSubstitution]
+  -- TODO(virgil): Do I need to re-evaluate the predicate?
+  return $ Pattern.withCondition term merged

--- a/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -8,15 +8,17 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Rewrites
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Unparser
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import Kore.Unparser
 
 {- | Simplify a 'Rewrites' pattern with a 'OrPattern' child.
 
@@ -25,19 +27,18 @@ Right now this does not do any actual simplification.
 TODO(virgil): Should I even bother to simplify Rewrites? Maybe to implies+next?
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Rewrites Sort (OrPattern variable)
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Rewrites Sort (OrPattern variable)
+  -> OrPattern variable
 simplify
-    Rewrites
-        { rewritesFirst = first
-        , rewritesSecond = second
-        }
-  =
+  Rewrites
+    { rewritesFirst = first,
+      rewritesSecond = second
+      } =
     simplifyEvaluatedRewrites first second
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
@@ -54,30 +55,30 @@ will make it even more useful to carry around.
 
 -}
 simplifyEvaluatedRewrites
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => OrPattern variable
-    -> OrPattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => OrPattern variable
+  -> OrPattern variable
+  -> OrPattern variable
 simplifyEvaluatedRewrites first second =
-    makeEvaluateRewrites
-        (OrPattern.toPattern first)
-        (OrPattern.toPattern second)
+  makeEvaluateRewrites
+    (OrPattern.toPattern first)
+    (OrPattern.toPattern second)
 
 makeEvaluateRewrites
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        )
-    => Pattern variable
-    -> Pattern variable
-    -> OrPattern variable
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable
+       )
+  => Pattern variable
+  -> Pattern variable
+  -> OrPattern variable
 makeEvaluateRewrites first second =
-    OrPattern.fromTermLike
+  OrPattern.fromTermLike
     $ mkRewrites
         (Pattern.toTermLike first)
         (Pattern.toTermLike second)

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -3,37 +3,44 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
 module Kore.Step.Simplification.Rule
-    ( simplifyRulePattern
-    , simplifyRewriteRule
-    , simplifyEqualityRule
-    , simplifyFunctionAxioms
-    ) where
+  ( simplifyRulePattern,
+    simplifyRewriteRule,
+    simplifyEqualityRule,
+    simplifyFunctionAxioms
+    )
+where
 
 import Data.Map
-       ( Map )
-
-import           Kore.Internal.Conditional
-                 ( Conditional (..) )
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+  ( Map
+    )
+import Kore.Internal.Conditional
+  ( Conditional (..)
+    )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-                 ( TermLike )
+import Kore.Internal.TermLike
+  ( TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Predicate.Predicate
-                 ( pattern PredicateTrue )
-import           Kore.Step.Rule
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+import Kore.Predicate.Predicate
+  ( pattern PredicateTrue
+    )
+import Kore.Step.Rule
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Pattern as Pattern
 import qualified Kore.Step.Simplification.Predicate as Predicate
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
+import Kore.Unparser
+  ( Unparse
+    )
+import Kore.Variables.Fresh
 
 {- | Simplify a 'Map' of 'EqualityRule's using only matching logic rules.
 
@@ -41,28 +48,28 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyFunctionAxioms
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  Map identifier [EqualityRule variable]
-    ->  simplifier (Map identifier [EqualityRule variable])
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => Map identifier [EqualityRule variable]
+  -> simplifier (Map identifier [EqualityRule variable])
 simplifyFunctionAxioms =
-    (traverse . traverse) simplifyEqualityRule
+  (traverse . traverse) simplifyEqualityRule
 
 simplifyEqualityRule
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  EqualityRule variable
-    ->  simplifier (EqualityRule variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => EqualityRule variable
+  -> simplifier (EqualityRule variable)
 simplifyEqualityRule (EqualityRule rule) =
-    EqualityRule <$> simplifyRulePattern rule
+  EqualityRule <$> simplifyRulePattern rule
 
 {- | Simplify a 'Rule' using only matching logic rules.
 
@@ -70,16 +77,16 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyRewriteRule
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  RewriteRule variable
-    ->  simplifier (RewriteRule variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => RewriteRule variable
+  -> simplifier (RewriteRule variable)
 simplifyRewriteRule (RewriteRule rule) =
-    RewriteRule <$> simplifyRulePattern rule
+  RewriteRule <$> simplifyRulePattern rule
 
 {- | Simplify a 'RulePattern' using only matching logic rules.
 
@@ -88,57 +95,58 @@ narrowly-defined criteria.
 
  -}
 simplifyRulePattern
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  RulePattern variable
-    ->  simplifier (RulePattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => RulePattern variable
+  -> simplifier (RulePattern variable)
 simplifyRulePattern rule = do
-    let RulePattern { left } = rule
-    simplifiedLeft <- simplifyPattern left
-    case OrPattern.toPatterns simplifiedLeft of
-        [ Conditional { term, predicate, substitution } ]
-          | PredicateTrue <- predicate -> do
-            let subst = Substitution.toMap substitution
-                left' = TermLike.substitute subst term
-                right' = TermLike.substitute subst right
-                  where
-                    RulePattern { right } = rule
-                requires' = TermLike.substitute subst <$> requires
-                  where
-                    RulePattern { requires } = rule
-                ensures' = TermLike.substitute subst <$> ensures
-                  where
-                    RulePattern { ensures } = rule
-                RulePattern { attributes } = rule
-            return RulePattern
-                { left = left'
-                , right = right'
-                , requires = requires'
-                , ensures = ensures'
-                , attributes = attributes
-                }
-        _ ->
-            -- Unable to simplify the given rule pattern, so we return the
-            -- original pattern in the hope that we can do something with it
-            -- later.
-            return rule
+  let RulePattern {left} = rule
+  simplifiedLeft <- simplifyPattern left
+  case OrPattern.toPatterns simplifiedLeft of
+    [Conditional {term, predicate, substitution}]
+      | PredicateTrue <- predicate ->
+        do
+          let subst = Substitution.toMap substitution
+              left' = TermLike.substitute subst term
+              right' = TermLike.substitute subst right
+                where
+                  RulePattern {right} = rule
+              requires' = TermLike.substitute subst <$> requires
+                where
+                  RulePattern {requires} = rule
+              ensures' = TermLike.substitute subst <$> ensures
+                where
+                  RulePattern {ensures} = rule
+              RulePattern {attributes} = rule
+          return RulePattern
+            { left = left',
+              right = right',
+              requires = requires',
+              ensures = ensures',
+              attributes = attributes
+              }
+    _ ->
+      -- Unable to simplify the given rule pattern, so we return the
+      -- original pattern in the hope that we can do something with it
+      -- later.
+      return rule
 
 -- | Simplify a 'TermLike' using only matching logic rules.
 simplifyPattern
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  TermLike variable
-    ->  simplifier (OrPattern variable)
+  :: ( FreshVariable variable,
+       SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       MonadSimplify simplifier
+       )
+  => TermLike variable
+  -> simplifier (OrPattern variable)
 simplifyPattern termLike =
-    Simplifier.localSimplifierTermLike (const Simplifier.create)
+  Simplifier.localSimplifierTermLike (const Simplifier.create)
     $ Simplifier.localSimplifierPredicate (const Predicate.create)
     $ Simplifier.localSimplifierAxioms (const mempty)
     $ Pattern.simplify (Pattern.fromTermLike termLike)

--- a/kore/src/Kore/Step/Simplification/SetVariable.hs
+++ b/kore/src/Kore/Step/Simplification/SetVariable.hs
@@ -8,19 +8,21 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.SetVariable
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 
 {-| 'simplify' simplifies a 'Variable' pattern, which means returning
 an or containing a term made of that variable.
 -}
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => SetVariable variable
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => SetVariable variable
+  -> OrPattern variable
 simplify setVar = OrPattern.fromTermLike $ mkSetVar setVar

--- a/kore/src/Kore/Step/Simplification/Simplifier.hs
+++ b/kore/src/Kore/Step/Simplification/Simplifier.hs
@@ -7,14 +7,15 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Step.Simplification.Simplifier
-    ( create
-    ) where
+  ( create
+    )
+where
 
-import           Kore.Step.Simplification.Data
+import Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.TermLike as TermLike
-                 ( simplifyToOr )
+  ( simplifyToOr
+    )
 
 create :: TermLikeSimplifier
 create = termLikeSimplifier TermLike.simplifyToOr

--- a/kore/src/Kore/Step/Simplification/StringLiteral.hs
+++ b/kore/src/Kore/Step/Simplification/StringLiteral.hs
@@ -8,20 +8,22 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.StringLiteral
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.TermLike
+import Kore.Internal.TermLike
 
 {-| 'simplify' simplifies a 'StringLiteral' pattern, which means returning
 an or containing a term made of that literal.
 -}
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => StringLiteral
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => StringLiteral
+  -> OrPattern variable
 simplify (StringLiteral str) =
-    OrPattern.fromTermLike $ mkStringLiteral str
+  OrPattern.fromTermLike $ mkStringLiteral str

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -4,72 +4,98 @@ License     : NCSA
 
 -}
 module Kore.Step.Simplification.TermLike
-    ( simplify
-    , simplifyToOr
-    , simplifyInternal
-    ) where
+  ( simplify,
+    simplifyToOr,
+    simplifyInternal
+    )
+where
 
-import           Data.Functor.Const
+import Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
-
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate as Predicate
-                 ( topTODO )
-import           Kore.Internal.TermLike
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate as Predicate
+  ( topTODO
+    )
+import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.And as And
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Application as Application
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Bottom as Bottom
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Builtin as Builtin
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Ceil as Ceil
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.CharLiteral as CharLiteral
-                 ( simplify )
-import           Kore.Step.Simplification.Data
+  ( simplify
+    )
+import Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.DomainValue as DomainValue
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Equals as Equals
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Exists as Exists
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Floor as Floor
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Forall as Forall
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Iff as Iff
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Implies as Implies
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.In as In
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Inhabitant as Inhabitant
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Mu as Mu
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Next as Next
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Not as Not
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Nu as Nu
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Or as Or
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Rewrites as Rewrites
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.StringLiteral as StringLiteral
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Top as Top
-                 ( simplify )
+  ( simplify
+    )
 import qualified Kore.Step.Simplification.Variable as Variable
-                 ( simplify )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
+  ( simplify
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
 
 -- TODO(virgil): Add a Simplifiable class and make all pattern types
 -- instances of that.
@@ -77,85 +103,83 @@ import           Kore.Variables.Fresh
 {-|'simplify' simplifies a `TermLike`, returning a 'Pattern'.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Show variable
-        , Ord variable
-        , Unparse variable
-        , FreshVariable variable
-        )
-    => TermLike variable
-    -> Simplifier (Pattern variable)
+  :: ( SortedVariable variable,
+       Show variable,
+       Ord variable,
+       Unparse variable,
+       FreshVariable variable
+       )
+  => TermLike variable
+  -> Simplifier (Pattern variable)
 simplify patt = do
-    orPatt <- simplifyToOr patt
-    return (OrPattern.toPattern orPatt)
+  orPatt <- simplifyToOr patt
+  return (OrPattern.toPattern orPatt)
 
 {-|'simplifyToOr' simplifies a TermLike variable, returning an
 'OrPattern'.
 -}
 simplifyToOr
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
-    => TermLike variable
-    -> simplifier (OrPattern variable)
+  :: ( SortedVariable variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       MonadSimplify simplifier
+       )
+  => TermLike variable
+  -> simplifier (OrPattern variable)
 simplifyToOr =
-    localSimplifierTermLike (const simplifier) . simplifyInternal
+  localSimplifierTermLike (const simplifier) . simplifyInternal
   where
     simplifier = termLikeSimplifier simplifyToOr
 
 simplifyInternal
-    ::  forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
-    => TermLike variable
-    -> simplifier (OrPattern variable)
+  :: forall variable simplifier. ( SortedVariable variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => TermLike variable
+  -> simplifier (OrPattern variable)
 simplifyInternal = simplifyInternalWorker
   where
     simplifyChildren
-        :: Traversable t
-        => t (TermLike variable)
-        -> simplifier (t (OrPattern variable))
+      :: Traversable t
+      => t (TermLike variable)
+      -> simplifier (t (OrPattern variable))
     simplifyChildren = traverse simplifyInternalWorker
-
     simplifyInternalWorker termLike =
-        let doNotSimplify = return (OrPattern.fromTermLike termLike)
-            (_ :< termLikeF) = Recursive.project termLike
-        in case termLikeF of
+      let doNotSimplify = return (OrPattern.fromTermLike termLike)
+          (_ :< termLikeF) = Recursive.project termLike
+       in case termLikeF of
             -- Unimplemented cases
             ApplyAliasF _ -> doNotSimplify
             -- Do not simplify evaluated patterns.
-            EvaluatedF  _ -> doNotSimplify
+            EvaluatedF _ -> doNotSimplify
             --
             AndF andF ->
-                And.simplify =<< simplifyChildren andF
+              And.simplify =<< simplifyChildren andF
             ApplySymbolF applySymbolF ->
-                Application.simplify Predicate.topTODO =<< simplifyChildren applySymbolF
+              Application.simplify Predicate.topTODO =<< simplifyChildren applySymbolF
             CeilF ceilF ->
-                Ceil.simplify Predicate.topTODO =<< simplifyChildren ceilF
+              Ceil.simplify Predicate.topTODO =<< simplifyChildren ceilF
             EqualsF equalsF ->
-                Equals.simplify Predicate.topTODO =<< simplifyChildren equalsF
+              Equals.simplify Predicate.topTODO =<< simplifyChildren equalsF
             ExistsF existsF ->
-                Exists.simplify =<< simplifyChildren existsF
+              Exists.simplify =<< simplifyChildren existsF
             IffF iffF ->
-                Iff.simplify =<< simplifyChildren iffF
+              Iff.simplify =<< simplifyChildren iffF
             ImpliesF impliesF ->
-                Implies.simplify =<< simplifyChildren impliesF
+              Implies.simplify =<< simplifyChildren impliesF
             InF inF ->
-                In.simplify =<< simplifyChildren inF
+              In.simplify =<< simplifyChildren inF
             NotF notF ->
-                Not.simplify =<< simplifyChildren notF
+              Not.simplify =<< simplifyChildren notF
             --
             BottomF bottomF -> Bottom.simplify <$> simplifyChildren bottomF
             BuiltinF builtinF -> Builtin.simplify <$> simplifyChildren builtinF
             DomainValueF domainValueF ->
-                DomainValue.simplify <$> simplifyChildren domainValueF
+              DomainValue.simplify <$> simplifyChildren domainValueF
             FloorF floorF -> Floor.simplify <$> simplifyChildren floorF
             ForallF forallF -> Forall.simplify <$> simplifyChildren forallF
             InhabitantF inhF -> Inhabitant.simplify <$> simplifyChildren inhF
@@ -165,12 +189,12 @@ simplifyInternal = simplifyInternalWorker
             NextF nextF -> Next.simplify <$> simplifyChildren nextF
             OrF orF -> Or.simplify <$> simplifyChildren orF
             RewritesF rewritesF ->
-                Rewrites.simplify <$> simplifyChildren rewritesF
+              Rewrites.simplify <$> simplifyChildren rewritesF
             TopF topF -> Top.simplify <$> simplifyChildren topF
             --
             StringLiteralF stringLiteralF ->
-                return $ StringLiteral.simplify (getConst stringLiteralF)
+              return $ StringLiteral.simplify (getConst stringLiteralF)
             CharLiteralF charLiteralF ->
-                return $ CharLiteral.simplify (getConst charLiteralF)
+              return $ CharLiteral.simplify (getConst charLiteralF)
             VariableF variableF ->
-                return $ Variable.simplify (getConst variableF)
+              return $ Variable.simplify (getConst variableF)

--- a/kore/src/Kore/Step/Simplification/Top.hs
+++ b/kore/src/Kore/Step/Simplification/Top.hs
@@ -8,21 +8,23 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Top
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Sort
-import           Kore.Syntax.Top
-import           Kore.Syntax.Variable
+import Kore.Sort
+import Kore.Syntax.Top
+import Kore.Syntax.Variable
 
 {-| simplifies a Top pattern, which means returning an always-true or.
 -}
 -- TODO (virgil): Preserve pattern sorts under simplification.
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => Top Sort child
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => Top Sort child
+  -> OrPattern variable
 simplify _ = OrPattern.top

--- a/kore/src/Kore/Step/Simplification/Variable.hs
+++ b/kore/src/Kore/Step/Simplification/Variable.hs
@@ -8,20 +8,22 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Simplification.Variable
-    ( simplify
-    ) where
+  ( simplify
+    )
+where
 
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.TermLike
-import           Kore.Variables.UnifiedVariable
+import Kore.Internal.TermLike
+import Kore.Variables.UnifiedVariable
 
 {-| 'simplify' simplifies a 'Variable' pattern, which means returning
 an or containing a term made of that variable.
 -}
 simplify
-    :: (Ord variable, SortedVariable variable)
-    => UnifiedVariable variable
-    -> OrPattern variable
+  :: (Ord variable, SortedVariable variable)
+  => UnifiedVariable variable
+  -> OrPattern variable
 simplify var = OrPattern.fromTermLike $ mkVar var

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -6,36 +6,36 @@ Direct interface to rule application (step-wise execution).
 See "Kore.Step" for the high-level strategy-based interface.
 
  -}
-
 module Kore.Step.Step
-    ( RulePattern
-    , UnificationProcedure (..)
-    , UnifiedRule
-    , withoutUnification
-    , Results
-    , Step.remainders
-    , Step.results
-    , Result
-    , isNarrowingResult
-    , Step.appliedRule
-    , Step.result
-    , Step.gatherResults
-    , Step.withoutRemainders
-    , checkSubstitutionCoverage
-    , unifyRule
-    , unifyRules
-    , applyInitialConditions
-    , finalizeAppliedRule
-    , unwrapRule
-    , finalizeRulesParallel
-    , applyRulesParallel
-    , applyRewriteRulesParallel
-    , finalizeRulesSequence
-    , applyRulesSequence
-    , applyRewriteRulesSequence
-    , toConfigurationVariables
-    , toAxiomVariables
-    ) where
+  ( RulePattern,
+    UnificationProcedure (..),
+    UnifiedRule,
+    withoutUnification,
+    Results,
+    Step.remainders,
+    Step.results,
+    Result,
+    isNarrowingResult,
+    Step.appliedRule,
+    Step.result,
+    Step.gatherResults,
+    Step.withoutRemainders,
+    checkSubstitutionCoverage,
+    unifyRule,
+    unifyRules,
+    applyInitialConditions,
+    finalizeAppliedRule,
+    unwrapRule,
+    finalizeRulesParallel,
+    applyRulesParallel,
+    applyRewriteRulesParallel,
+    finalizeRulesSequence,
+    applyRulesSequence,
+    applyRewriteRulesSequence,
+    toConfigurationVariables,
+    toAxiomVariables
+    )
+where
 
 import qualified Control.Monad as Monad
 import qualified Control.Monad.State.Strict as State
@@ -44,64 +44,76 @@ import qualified Data.Foldable as Foldable
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import           Kore.Internal.Conditional
-                 ( Conditional (Conditional) )
+import Kore.Internal.Conditional
+  ( Conditional (Conditional)
+    )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+  ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.OrPredicate
-                 ( OrPredicate )
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Predicate )
+import Kore.Internal.OrPredicate
+  ( OrPredicate
+    )
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate
+  ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike as TermLike
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+import Kore.Internal.TermLike as TermLike
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Logger as Log
 import qualified Kore.Step.Remainder as Remainder
 import qualified Kore.Step.Result as Step
-import           Kore.Step.Rule
-                 ( RewriteRule (..), RulePattern (RulePattern) )
+import Kore.Step.Rule
+  ( RewriteRule (..),
+    RulePattern (RulePattern)
+    )
 import qualified Kore.Step.Rule as Rule
 import qualified Kore.Step.Rule as RulePattern
 import qualified Kore.Step.Substitution as Substitution
 import qualified Kore.TopBottom as TopBottom
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-                 ( gather, scatter )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-import           Kore.Variables.Target
-                 ( Target )
+  ( gather,
+    scatter
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
+import Kore.Variables.Target
+  ( Target
+    )
 import qualified Kore.Variables.Target as Target
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable, foldMapVariable )
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable,
+    foldMapVariable
+    )
 
 -- | Wraps functions such as 'unificationProcedure' and
 -- 'Kore.Step.Axiom.Matcher.matchAsUnification' to be used in
 -- 'stepWithRule'.
-
-newtype UnificationProcedure =
-    UnificationProcedure
-        ( forall variable unifier
-        .   ( SortedVariable variable
-            , Ord variable
-            , Show variable
-            , Unparse variable
-            , FreshVariable variable
-            , MonadUnify unifier
-            )
+newtype UnificationProcedure
+  = UnificationProcedure
+      ( forall variable unifier. ( SortedVariable variable,
+                                   Ord variable,
+                                   Show variable,
+                                   Unparse variable,
+                                   FreshVariable variable,
+                                   MonadUnify unifier
+                                   )
         => TermLike variable
         -> TermLike variable
         -> unifier (Predicate variable)
@@ -118,11 +130,11 @@ type UnifiedRule variable = Conditional variable (RulePattern variable)
 withoutUnification :: UnifiedRule variable -> RulePattern variable
 withoutUnification = Conditional.term
 
-type Result variable =
-    Step.Result (UnifiedRule (Target variable)) (Pattern variable)
+type Result variable
+  = Step.Result (UnifiedRule (Target variable)) (Pattern variable)
 
-type Results variable =
-    Step.Results (UnifiedRule (Target variable)) (Pattern variable)
+type Results variable
+  = Step.Results (UnifiedRule (Target variable)) (Pattern variable)
 
 {- | Is the result a symbolic rewrite, i.e. a narrowing result?
 
@@ -131,56 +143,52 @@ from the left-hand side of the rule.
 
  -}
 isNarrowingResult :: Ord variable => Result variable -> Bool
-isNarrowingResult Step.Result { appliedRule } =
-    (not . Set.null) (wouldNarrowWith appliedRule)
+isNarrowingResult Step.Result {appliedRule} =
+  (not . Set.null) (wouldNarrowWith appliedRule)
 
 {- | Unwrap the variables in a 'RulePattern'.
  -}
 unwrapRule
-    :: Ord variable
-    => RulePattern (Target variable) -> RulePattern variable
+  :: Ord variable
+  => RulePattern (Target variable)
+  -> RulePattern variable
 unwrapRule = Rule.mapVariables Target.unwrapVariable
 
 {- | Remove axiom variables from the substitution and unwrap all variables.
  -}
 unwrapAndQuantifyConfiguration
-    :: forall variable
-    .   ( Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => Pattern (Target variable)
-    -> Pattern variable
-unwrapAndQuantifyConfiguration config@Conditional { substitution } =
-    if List.null targetVariables
+  :: forall variable. ( Ord variable,
+                        Show variable,
+                        SortedVariable variable,
+                        Unparse variable
+                        )
+  => Pattern (Target variable)
+  -> Pattern variable
+unwrapAndQuantifyConfiguration config@Conditional {substitution} =
+  if List.null targetVariables
     then unwrappedConfig
     else
-        Pattern.fromTermLike
-            (List.foldl'
-                quantify
-                (Pattern.toTermLike unwrappedConfig)
-                targetVariables
-            )
+      Pattern.fromTermLike
+        ( List.foldl'
+            quantify
+            (Pattern.toTermLike unwrappedConfig)
+            targetVariables
+          )
   where
     substitution' =
-        Substitution.filter (foldMapVariable Target.isNonTarget)
-            substitution
-
+      Substitution.filter (foldMapVariable Target.isNonTarget)
+        substitution
     configWithNewSubst :: Pattern (Target variable)
-    configWithNewSubst = config { Pattern.substitution = substitution' }
-
+    configWithNewSubst = config {Pattern.substitution = substitution'}
     unwrappedConfig :: Pattern variable
     unwrappedConfig =
-        Pattern.mapVariables Target.unwrapVariable configWithNewSubst
-
+      Pattern.mapVariables Target.unwrapVariable configWithNewSubst
     targetVariables :: [ElementVariable variable]
     targetVariables =
-        map (fmap Target.unwrapVariable)
+      map (fmap Target.unwrapVariable)
         . filter (Target.isTarget . getElementVariable)
         . Pattern.freeElementVariables
         $ configWithNewSubst
-
     quantify :: TermLike variable -> ElementVariable variable -> TermLike variable
     quantify = flip mkExists
 
@@ -198,65 +206,60 @@ unification. The substitution is not applied to the renamed rule.
 
  -}
 unifyRule
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => UnificationProcedure
-    -> Pattern variable
-    -- ^ Initial configuration
-    -> RulePattern variable
-    -- ^ Rule
-    -> unifier (UnifiedRule variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => UnificationProcedure
+  -> Pattern variable
+  -- ^ Initial configuration
+  -> RulePattern variable
+  -- ^ Rule
+  -> unifier (UnifiedRule variable)
 unifyRule
-    (UnificationProcedure unifyPatterns)
-    initial@Conditional { term = initialTerm }
-    rule
-  = do
-    -- Rename free axiom variables to avoid free variables from the initial
-    -- configuration.
-    let
-        configVariables = Pattern.freeVariables initial
-        (_, rule') = RulePattern.refreshRulePattern configVariables rule
-    -- Unify the left-hand side of the rule with the term of the initial
-    -- configuration.
-    let
-        RulePattern { left = ruleLeft } = rule'
-    unification <- unifyPatterns ruleLeft initialTerm
-    -- Combine the unification solution with the rule's requirement clause.
-    let
-        RulePattern { requires = ruleRequires } = rule'
-        requires' = Predicate.fromPredicate ruleRequires
-    unification' <- Substitution.normalizeExcept (unification <> requires')
-    return (rule' `Conditional.withCondition` unification')
+  (UnificationProcedure unifyPatterns)
+  initial@Conditional {term = initialTerm}
+  rule =
+    do
+      -- Rename free axiom variables to avoid free variables from the initial
+      -- configuration.
+      let configVariables = Pattern.freeVariables initial
+          (_, rule') = RulePattern.refreshRulePattern configVariables rule
+      -- Unify the left-hand side of the rule with the term of the initial
+      -- configuration.
+      let RulePattern {left = ruleLeft} = rule'
+      unification <- unifyPatterns ruleLeft initialTerm
+      -- Combine the unification solution with the rule's requirement clause.
+      let RulePattern {requires = ruleRequires} = rule'
+          requires' = Predicate.fromPredicate ruleRequires
+      unification' <- Substitution.normalizeExcept (unification <> requires')
+      return (rule' `Conditional.withCondition` unification')
 
 unifyRules
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => UnificationProcedure
-    -> Pattern (Target variable)
-    -- ^ Initial configuration
-    -> [RulePattern (Target variable)]
-    -- ^ Rule
-    -> unifier [UnifiedRule (Target variable)]
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => UnificationProcedure
+  -> Pattern (Target variable)
+  -- ^ Initial configuration
+  -> [RulePattern (Target variable)]
+  -- ^ Rule
+  -> unifier [UnifiedRule (Target variable)]
 unifyRules unificationProcedure initial rules =
-    Monad.Unify.gather $ do
-        rule <- Monad.Unify.scatter rules
-        unified <- unifyRule unificationProcedure initial rule
-        checkSubstitutionCoverage initial unified
-        return unified
+  Monad.Unify.gather $ do
+    rule <- Monad.Unify.scatter rules
+    unified <- unifyRule unificationProcedure initial rule
+    checkSubstitutionCoverage initial unified
+    return unified
 
 {- | Apply the initial conditions to the results of rule unification.
 
@@ -264,34 +267,33 @@ The rule is considered to apply if the result is not @\\bottom@.
 
  -}
 applyInitialConditions
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => Predicate variable
-    -- ^ Initial conditions
-    -> Predicate variable
-    -- ^ Unification conditions
-    -> unifier (OrPredicate variable)
-    -- TODO(virgil): This should take advantage of the unifier's branching and
-    -- not return an Or.
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => Predicate variable
+  -- ^ Initial conditions
+  -> Predicate variable
+  -- ^ Unification conditions
+  -> unifier (OrPredicate variable)
+-- TODO(virgil): This should take advantage of the unifier's branching and
+-- not return an Or.
 applyInitialConditions initial unification = do
-    -- Combine the initial conditions and the unification conditions.
-    -- The axiom requires clause is included in the unification conditions.
-    applied <-
-        Monad.liftM MultiOr.make
-        $ Monad.Unify.gather
-        $ Substitution.normalizeExcept (initial <> unification)
-    -- If 'applied' is \bottom, the rule is considered to not apply and
-    -- no result is returned. If the result is \bottom after this check,
-    -- then the rule is considered to apply with a \bottom result.
-    TopBottom.guardAgainstBottom applied
-    return applied
+  -- Combine the initial conditions and the unification conditions.
+  -- The axiom requires clause is included in the unification conditions.
+  applied <-
+    Monad.liftM MultiOr.make
+      $ Monad.Unify.gather
+      $ Substitution.normalizeExcept (initial <> unification)
+  -- If 'applied' is \bottom, the rule is considered to not apply and
+  -- no result is returned. If the result is \bottom after this check,
+  -- then the rule is considered to apply with a \bottom result.
+  TopBottom.guardAgainstBottom applied
+  return applied
 
 {- | Produce the final configurations of an applied rule.
 
@@ -306,171 +308,167 @@ See also: 'applyInitialConditions'
 
  -}
 finalizeAppliedRule
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => RulePattern variable
-    -- ^ Applied rule
-    -> OrPredicate variable
-    -- ^ Conditions of applied rule
-    -> unifier (OrPattern variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => RulePattern variable
+  -- ^ Applied rule
+  -> OrPredicate variable
+  -- ^ Conditions of applied rule
+  -> unifier (OrPattern variable)
 finalizeAppliedRule renamedRule appliedConditions =
-    Monad.liftM OrPattern.fromPatterns . Monad.Unify.gather
-    $ finalizeAppliedRuleWorker =<< Monad.Unify.scatter appliedConditions
+  Monad.liftM OrPattern.fromPatterns . Monad.Unify.gather
+    $ finalizeAppliedRuleWorker
+    =<< Monad.Unify.scatter appliedConditions
   where
     finalizeAppliedRuleWorker appliedCondition = do
-        -- Combine the initial conditions, the unification conditions, and the
-        -- axiom ensures clause. The axiom requires clause is included by
-        -- unifyRule.
-        let
-            RulePattern { ensures } = renamedRule
-            ensuresCondition = Predicate.fromPredicate ensures
-        finalCondition <- normalize (appliedCondition <> ensuresCondition)
-        -- Apply the normalized substitution to the right-hand side of the
-        -- axiom.
-        let
-            Conditional { substitution } = finalCondition
-            substitution' = Substitution.toMap substitution
-            RulePattern { right = finalTerm } = renamedRule
-            finalTerm' = TermLike.substitute substitution' finalTerm
-        return finalCondition { Pattern.term = finalTerm' }
-
+      -- Combine the initial conditions, the unification conditions, and the
+      -- axiom ensures clause. The axiom requires clause is included by
+      -- unifyRule.
+      let RulePattern {ensures} = renamedRule
+          ensuresCondition = Predicate.fromPredicate ensures
+      finalCondition <- normalize (appliedCondition <> ensuresCondition)
+      -- Apply the normalized substitution to the right-hand side of the
+      -- axiom.
+      let Conditional {substitution} = finalCondition
+          substitution' = Substitution.toMap substitution
+          RulePattern {right = finalTerm} = renamedRule
+          finalTerm' = TermLike.substitute substitution' finalTerm
+      return finalCondition {Pattern.term = finalTerm'}
     normalize = Substitution.normalizeExcept
 
 {- | Apply the remainder predicate to the given initial configuration.
 
  -}
 applyRemainder
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => Pattern variable
-    -- ^ Initial configuration
-    -> Predicate variable
-    -- ^ Remainder
-    -> unifier (Pattern variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => Pattern variable
+  -- ^ Initial configuration
+  -> Predicate variable
+  -- ^ Remainder
+  -> unifier (Pattern variable)
 applyRemainder initial remainder = do
-    let final = initial `Conditional.andCondition` remainder
-        finalCondition = Conditional.withoutTerm final
-        Conditional { Conditional.term = finalTerm } = final
-    normalizedCondition <- Substitution.normalizeExcept finalCondition
-    return normalizedCondition { Conditional.term = finalTerm }
+  let final = initial `Conditional.andCondition` remainder
+      finalCondition = Conditional.withoutTerm final
+      Conditional {Conditional.term = finalTerm} = final
+  normalizedCondition <- Substitution.normalizeExcept finalCondition
+  return normalizedCondition {Conditional.term = finalTerm}
 
 toAxiomVariables
-    :: Ord variable
-    => RulePattern variable
-    -> RulePattern (Target variable)
+  :: Ord variable
+  => RulePattern variable
+  -> RulePattern (Target variable)
 toAxiomVariables = RulePattern.mapVariables Target.Target
 
 toConfigurationVariables
-    :: Ord variable
-    => Pattern variable
-    -> Pattern (Target variable)
+  :: Ord variable
+  => Pattern variable
+  -> Pattern (Target variable)
 toConfigurationVariables = Pattern.mapVariables Target.NonTarget
 
 finalizeRule
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , Log.WithLog Log.LogMessage unifier
-        , MonadUnify unifier
-        )
-    => Predicate (Target variable)
-    -- ^ Initial conditions
-    -> UnifiedRule (Target variable)
-    -- ^ Rewriting axiom
-    -> unifier [Result variable]
-    -- TODO (virgil): This is broken, it should take advantage of the unifier's
-    -- branching and not return a list.
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       SortedVariable variable,
+       Log.WithLog Log.LogMessage unifier,
+       MonadUnify unifier
+       )
+  => Predicate (Target variable)
+  -- ^ Initial conditions
+  -> UnifiedRule (Target variable)
+  -- ^ Rewriting axiom
+  -> unifier [Result variable]
+-- TODO (virgil): This is broken, it should take advantage of the unifier's
+-- branching and not return a list.
 finalizeRule initialCondition unifiedRule =
-    Log.withLogScope "finalizeRule" $ Monad.Unify.gather $ do
-        let unificationCondition = Conditional.withoutTerm unifiedRule
-        applied <- applyInitialConditions initialCondition unificationCondition
-        let renamedRule = Conditional.term unifiedRule
-        final <- finalizeAppliedRule renamedRule applied
-        let result = unwrapAndQuantifyConfiguration <$> final
-        return Step.Result { appliedRule = unifiedRule, result }
+  Log.withLogScope "finalizeRule" $ Monad.Unify.gather $ do
+    let unificationCondition = Conditional.withoutTerm unifiedRule
+    applied <- applyInitialConditions initialCondition unificationCondition
+    let renamedRule = Conditional.term unifiedRule
+    final <- finalizeAppliedRule renamedRule applied
+    let result = unwrapAndQuantifyConfiguration <$> final
+    return Step.Result {appliedRule = unifiedRule, result}
 
 finalizeRulesParallel
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Log.WithLog Log.LogMessage unifier
-        )
-    => Pattern (Target variable)
-    -> [UnifiedRule (Target variable)]
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Log.WithLog Log.LogMessage unifier
+                                )
+  => Pattern (Target variable)
+  -> [UnifiedRule (Target variable)]
+  -> unifier (Results variable)
 finalizeRulesParallel initial unifiedRules = do
-    let initialCondition = Conditional.withoutTerm initial
-    results <-
-        Foldable.fold <$> traverse (finalizeRule initialCondition) unifiedRules
-    let unifications = MultiOr.make (Conditional.withoutTerm <$> unifiedRules)
-        remainder = Predicate.fromPredicate (Remainder.remainder' unifications)
-    remainders' <- Monad.Unify.gather $ applyRemainder initial remainder
-    return Step.Results
-        { results = Seq.fromList results
-        , remainders =
-            OrPattern.fromPatterns
-            $ Pattern.mapVariables Target.unwrapVariable <$> remainders'
-        }
+  let initialCondition = Conditional.withoutTerm initial
+  results <-
+    Foldable.fold <$> traverse (finalizeRule initialCondition) unifiedRules
+  let unifications = MultiOr.make (Conditional.withoutTerm <$> unifiedRules)
+      remainder = Predicate.fromPredicate (Remainder.remainder' unifications)
+  remainders' <- Monad.Unify.gather $ applyRemainder initial remainder
+  return Step.Results
+    { results = Seq.fromList results,
+      remainders =
+        OrPattern.fromPatterns
+          $ Pattern.mapVariables Target.unwrapVariable
+          <$> remainders'
+      }
 
 finalizeRulesSequence
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , MonadUnify unifier
-        , Log.WithLog Log.LogMessage unifier
-        )
-    => Pattern (Target variable)
-    -> [UnifiedRule (Target variable)]
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                MonadUnify unifier,
+                                Log.WithLog Log.LogMessage unifier
+                                )
+  => Pattern (Target variable)
+  -> [UnifiedRule (Target variable)]
+  -> unifier (Results variable)
 finalizeRulesSequence initial unifiedRules = do
-    (results, remainder) <-
-        State.runStateT
-            (traverse finalizeRuleSequence' unifiedRules)
-            (Conditional.withoutTerm initial)
-    remainders' <- Monad.Unify.gather $ applyRemainder initial remainder
-    return Step.Results
-        { results = Seq.fromList $ Foldable.fold results
-        , remainders =
-            OrPattern.fromPatterns
-            $ Pattern.mapVariables Target.unwrapVariable <$> remainders'
-        }
+  (results, remainder) <-
+    State.runStateT
+      (traverse finalizeRuleSequence' unifiedRules)
+      (Conditional.withoutTerm initial)
+  remainders' <- Monad.Unify.gather $ applyRemainder initial remainder
+  return Step.Results
+    { results = Seq.fromList $ Foldable.fold results,
+      remainders =
+        OrPattern.fromPatterns
+          $ Pattern.mapVariables Target.unwrapVariable
+          <$> remainders'
+      }
   where
     finalizeRuleSequence'
-        :: UnifiedRule (Target variable)
-        -> State.StateT (Predicate (Target variable)) unifier [Result variable]
+      :: UnifiedRule (Target variable)
+      -> State.StateT (Predicate (Target variable)) unifier [Result variable]
     finalizeRuleSequence' unifiedRule = do
-        remainder <- State.get
-        results <- Monad.Trans.lift $ finalizeRule remainder unifiedRule
-        let unification = Conditional.withoutTerm unifiedRule
-            remainder' =
-                Predicate.fromPredicate
-                $ Remainder.remainder'
-                $ MultiOr.singleton unification
-        State.put (remainder `Conditional.andCondition` remainder')
-        return results
+      remainder <- State.get
+      results <- Monad.Trans.lift $ finalizeRule remainder unifiedRule
+      let unification = Conditional.withoutTerm unifiedRule
+          remainder' =
+            Predicate.fromPredicate
+              $ Remainder.remainder'
+              $ MultiOr.singleton unification
+      State.put (remainder `Conditional.andCondition` remainder')
+      return results
 
 {- | Check that the final substitution covers the applied rule appropriately.
 
@@ -489,18 +487,17 @@ we added to the result.
 the axiom variables from the substitution and unwrap all the 'Target's.
 -}
 checkSubstitutionCoverage
-    ::  forall variable unifier
-    .   ( SortedVariable variable
-        , Ord     variable
-        , Show    variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
-    => Pattern (Target variable)
-    -- ^ Initial configuration
-    -> UnifiedRule (Target variable)
-    -- ^ Unified rule
-    -> unifier ()
+  :: forall variable unifier. ( SortedVariable variable,
+                                Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                MonadUnify unifier
+                                )
+  => Pattern (Target variable)
+  -- ^ Initial configuration
+  -> UnifiedRule (Target variable)
+  -- ^ Unified rule
+  -> unifier ()
 checkSubstitutionCoverage initial unified
   | isCoveringSubstitution || isSymbolic = return ()
   | otherwise =
@@ -509,46 +506,47 @@ checkSubstitutionCoverage initial unified
     -- initial configuration. This is a fatal error because it indicates
     -- something has gone horribly wrong.
     (error . show . Pretty.vsep)
-        [ "While applying axiom:"
-        , Pretty.indent 4 (Pretty.pretty axiom)
-        , "from the initial configuration:"
-        , Pretty.indent 4 (unparse initial)
-        , "with the unifier:"
-        , Pretty.indent 4 (unparse unifier)
-        , "Failed substitution coverage check!"
-        , "The substitution (above, in the unifier) \
-          \did not cover the axiom variables:"
-        , (Pretty.indent 4 . Pretty.sep)
-            (unparse <$> Set.toAscList uncovered)
-        , "in the left-hand side of the axiom."
+      [ "While applying axiom:",
+        Pretty.indent 4 (Pretty.pretty axiom),
+        "from the initial configuration:",
+        Pretty.indent 4 (unparse initial),
+        "with the unifier:",
+        Pretty.indent 4 (unparse unifier),
+        "Failed substitution coverage check!",
+        "The substitution (above, in the unifier) \
+          \did not cover the axiom variables:",
+        (Pretty.indent 4 . Pretty.sep)
+          (unparse <$> Set.toAscList uncovered),
+        "in the left-hand side of the axiom."
         ]
   where
-    Conditional { term = axiom } = unified
+    Conditional {term = axiom} = unified
     unifier :: Pattern (Target variable)
     unifier = mkTop_ <$ Conditional.withoutTerm unified
-    Conditional { substitution } = unified
+    Conditional {substitution} = unified
     substitutionVariables = Map.keysSet (Substitution.toMap substitution)
     uncovered = wouldNarrowWith unified
     isCoveringSubstitution = Set.null uncovered
     isSymbolic =
-        Foldable.any (foldMapVariable Target.isNonTarget)
-            substitutionVariables
+      Foldable.any (foldMapVariable Target.isNonTarget)
+        substitutionVariables
 
 {- | The 'Set' of variables that would be introduced by narrowing.
  -}
 -- TODO (thomas.tuegel): Unit tests
 wouldNarrowWith
-    :: Ord variable
-    => UnifiedRule variable -> Set (UnifiedVariable variable)
+  :: Ord variable
+  => UnifiedRule variable
+  -> Set (UnifiedVariable variable)
 wouldNarrowWith unified =
-    Set.difference leftAxiomVariables substitutionVariables
+  Set.difference leftAxiomVariables substitutionVariables
   where
     leftAxiomVariables =
-        FreeVariables.getFreeVariables $ TermLike.freeVariables leftAxiom
+      FreeVariables.getFreeVariables $ TermLike.freeVariables leftAxiom
       where
-        Conditional { term = axiom } = unified
-        RulePattern { left = leftAxiom } = axiom
-    Conditional { substitution } = unified
+        Conditional {term = axiom} = unified
+        RulePattern {left = leftAxiom} = axiom
+    Conditional {substitution} = unified
     substitutionVariables = Map.keysSet (Substitution.toMap substitution)
 
 {- | Apply the given rules to the initial configuration in parallel.
@@ -557,30 +555,28 @@ See also: 'applyRewriteRule'
 
  -}
 applyRulesParallel
-    ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , Log.WithLog Log.LogMessage unifier
-        , MonadUnify unifier
-        )
-    => UnificationProcedure
-    -> [RulePattern variable]
-    -- ^ Rewrite rules
-    -> Pattern variable
-    -- ^ Configuration being rewritten
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                Log.WithLog Log.LogMessage unifier,
+                                MonadUnify unifier
+                                )
+  => UnificationProcedure
+  -> [RulePattern variable]
+  -- ^ Rewrite rules
+  -> Pattern variable
+  -- ^ Configuration being rewritten
+  -> unifier (Results variable)
 applyRulesParallel
-    unificationProcedure
-    -- Wrap the rule and configuration so that unification prefers to substitute
-    -- axiom variables.
-    (map toAxiomVariables -> rules)
-    (toConfigurationVariables -> initial)
-  =
+  unificationProcedure
+  -- Wrap the rule and configuration so that unification prefers to substitute
+  -- axiom variables.
+  (map toAxiomVariables -> rules)
+  (toConfigurationVariables -> initial) =
     unifyRules unificationProcedure initial rules
-    >>= finalizeRulesParallel initial
+      >>= finalizeRulesParallel initial
 
 {- | Apply the given rewrite rules to the initial configuration in parallel.
 
@@ -588,23 +584,22 @@ See also: 'applyRewriteRule'
 
  -}
 applyRewriteRulesParallel
-    ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , Log.WithLog Log.LogMessage unifier
-        , MonadUnify unifier
-        )
-    => UnificationProcedure
-    -> [RewriteRule variable]
-    -- ^ Rewrite rules
-    -> Pattern variable
-    -- ^ Configuration being rewritten
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                Log.WithLog Log.LogMessage unifier,
+                                MonadUnify unifier
+                                )
+  => UnificationProcedure
+  -> [RewriteRule variable]
+  -- ^ Rewrite rules
+  -> Pattern variable
+  -- ^ Configuration being rewritten
+  -> unifier (Results variable)
 applyRewriteRulesParallel unificationProcedure rewriteRules =
-    applyRulesParallel unificationProcedure (getRewriteRule <$> rewriteRules)
+  applyRulesParallel unificationProcedure (getRewriteRule <$> rewriteRules)
 
 {- | Apply the given rewrite rules to the initial configuration in sequence.
 
@@ -612,30 +607,28 @@ See also: 'applyRewriteRule'
 
  -}
 applyRulesSequence
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , Log.WithLog Log.LogMessage unifier
-        , MonadUnify unifier
-        )
-    => UnificationProcedure
-    -> Pattern variable
-    -- ^ Configuration being rewritten
-    -> [RulePattern variable]
-    -- ^ Rewrite rules
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                Log.WithLog Log.LogMessage unifier,
+                                MonadUnify unifier
+                                )
+  => UnificationProcedure
+  -> Pattern variable
+  -- ^ Configuration being rewritten
+  -> [RulePattern variable]
+  -- ^ Rewrite rules
+  -> unifier (Results variable)
 applyRulesSequence
-    unificationProcedure
-    -- Wrap the rule and configuration so that unification prefers to substitute
-    -- axiom variables.
-    (toConfigurationVariables -> initial)
-    (map toAxiomVariables -> rules)
-  =
+  unificationProcedure
+  -- Wrap the rule and configuration so that unification prefers to substitute
+  -- axiom variables.
+  (toConfigurationVariables -> initial)
+  (map toAxiomVariables -> rules) =
     unifyRules unificationProcedure initial rules
-    >>= finalizeRulesSequence initial
+      >>= finalizeRulesSequence initial
 
 {- | Apply the given rewrite rules to the initial configuration in sequence.
 
@@ -643,23 +636,22 @@ See also: 'applyRewriteRulesParallel'
 
  -}
 applyRewriteRulesSequence
-    ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
-        , Log.WithLog Log.LogMessage unifier
-        , MonadUnify unifier
-        )
-    => UnificationProcedure
-    -> Pattern variable
-    -- ^ Configuration being rewritten
-    -> [RewriteRule variable]
-    -- ^ Rewrite rules
-    -> unifier (Results variable)
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                SortedVariable variable,
+                                Log.WithLog Log.LogMessage unifier,
+                                MonadUnify unifier
+                                )
+  => UnificationProcedure
+  -> Pattern variable
+  -- ^ Configuration being rewritten
+  -> [RewriteRule variable]
+  -- ^ Rewrite rules
+  -> unifier (Results variable)
 applyRewriteRulesSequence unificationProcedure initialConfig rewriteRules =
-    applyRulesSequence
-        unificationProcedure
-        initialConfig
-        (getRewriteRule <$> rewriteRules)
+  applyRulesSequence
+    unificationProcedure
+    initialConfig
+    (getRewriteRule <$> rewriteRules)

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -8,136 +8,142 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Step.Substitution
-    ( PredicateMerger (..)
-    , createLiftedPredicatesAndSubstitutionsMerger
-    , createPredicatesAndSubstitutionsMerger
-    , createPredicatesAndSubstitutionsMergerExcept
-    , mergePredicatesAndSubstitutions
-    , mergePredicatesAndSubstitutionsExcept
-    , normalize
-    , normalizeExcept
-    ) where
+  ( PredicateMerger (..),
+    createLiftedPredicatesAndSubstitutionsMerger,
+    createPredicatesAndSubstitutionsMerger,
+    createPredicatesAndSubstitutionsMergerExcept,
+    mergePredicatesAndSubstitutions,
+    mergePredicatesAndSubstitutionsExcept,
+    normalize,
+    normalizeExcept
+    )
+where
 
-import           Control.Monad.Except
-                 ( withExceptT )
+import Control.Monad.Except
+  ( withExceptT
+    )
 import qualified Control.Monad.Trans.Class as Monad.Trans
 import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
-import           GHC.Stack
-                 ( HasCallStack )
-
-import           Kore.Internal.Predicate
-                 ( Conditional (..), Predicate )
-import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Logger
-                 ( LogMessage, WithLog )
-import qualified Kore.Predicate.Predicate as Syntax
-                 ( Predicate )
-import qualified Kore.Predicate.Predicate as Syntax.Predicate
-import           Kore.Step.Simplification.Data as Simplifier
-import qualified Kore.Step.Simplification.Data as Branch
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import qualified Kore.TopBottom as TopBottom
-import           Kore.Unification.Error
-                 ( substitutionToUnifyOrSubError )
-import           Kore.Unification.Substitution
-                 ( Substitution )
-import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unification.SubstitutionNormalization
-                 ( normalizeSubstitution )
-import           Kore.Unification.UnifierImpl
-                 ( normalizeSubstitutionDuplication )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
-import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-
-newtype PredicateMerger variable m =
-    PredicateMerger
-    (  [Syntax.Predicate variable]
-    -> [Substitution variable]
-    -> m (Predicate variable)
+import GHC.Stack
+  ( HasCallStack
     )
+import Kore.Internal.Predicate
+  ( Conditional (..),
+    Predicate
+    )
+import qualified Kore.Internal.Predicate as Predicate
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+  ( Predicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax.Predicate
+import Kore.Step.Simplification.Data as Simplifier
+import qualified Kore.Step.Simplification.Data as Branch
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import qualified Kore.TopBottom as TopBottom
+import Kore.Unification.Error
+  ( substitutionToUnifyOrSubError
+    )
+import Kore.Unification.Substitution
+  ( Substitution
+    )
+import qualified Kore.Unification.Substitution as Substitution
+import Kore.Unification.SubstitutionNormalization
+  ( normalizeSubstitution
+    )
+import Kore.Unification.UnifierImpl
+  ( normalizeSubstitutionDuplication
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
+import qualified Kore.Unification.Unify as Monad.Unify
+import Kore.Unparser
+import Kore.Variables.Fresh
+
+newtype PredicateMerger variable m
+  = PredicateMerger
+      ( [Syntax.Predicate variable]
+        -> [Substitution variable]
+        -> m (Predicate variable)
+        )
 
 -- | Normalize the substitution and predicate of 'expanded'.
 normalize
-    :: forall variable term simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , MonadSimplify simplifier
-        )
-    => Conditional variable term
-    -> BranchT simplifier (Conditional variable term)
-normalize Conditional { term, predicate, substitution } = do
-    -- We collect all the results here because we should promote the
-    -- substitution to the predicate when there is an error on *any* branch.
-    results <-
-        Monad.Trans.lift
-        $ Monad.Unify.runUnifierT
-        $ normalizeExcept Conditional { term = (), predicate, substitution }
-    case results of
-        Right normal -> scatter (applyTerm <$> normal)
-        Left _ ->
-            return Conditional
-                { term
-                , predicate =
-                    Syntax.Predicate.makeAndPredicate predicate
-                    $ Syntax.Predicate.fromSubstitution substitution
-                , substitution = mempty
-                }
+  :: forall variable term simplifier. ( FreshVariable variable,
+                                        SortedVariable variable,
+                                        Unparse variable,
+                                        Show variable,
+                                        MonadSimplify simplifier
+                                        )
+  => Conditional variable term
+  -> BranchT simplifier (Conditional variable term)
+normalize Conditional {term, predicate, substitution} = do
+  -- We collect all the results here because we should promote the
+  -- substitution to the predicate when there is an error on *any* branch.
+  results <-
+    Monad.Trans.lift
+      $ Monad.Unify.runUnifierT
+      $ normalizeExcept Conditional {term = (), predicate, substitution}
+  case results of
+    Right normal -> scatter (applyTerm <$> normal)
+    Left _ ->
+      return Conditional
+        { term,
+          predicate =
+            Syntax.Predicate.makeAndPredicate predicate
+              $ Syntax.Predicate.fromSubstitution substitution,
+          substitution = mempty
+          }
   where
-    applyTerm predicated = predicated { term }
+    applyTerm predicated = predicated {term}
 
 normalizeExcept
-    ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => Predicate variable
-    -> unifier (Predicate variable)
-normalizeExcept Conditional { predicate, substitution } = do
-    predicateSimplifier <- Simplifier.askSimplifierPredicate
-    -- The intermediate steps do not need to be checked for \bottom because we
-    -- use guardAgainstBottom at the end.
-    deduplicated <- normalizeSubstitutionDuplication substitution
-    let
-        PredicateSimplifier simplifySubstitution = predicateSimplifier
-        Conditional { substitution = preDeduplicatedSubstitution } =
-            deduplicated
-        Conditional { predicate = deduplicatedPredicate } = deduplicated
-        -- The substitution is not fully normalized, but it is safe to convert
-        -- to a Map because it has been deduplicated.
-        deduplicatedSubstitution =
-            Map.fromList $ Substitution.unwrap preDeduplicatedSubstitution
-
-    normalized <- normalizeSubstitution' deduplicatedSubstitution
-    let
-        Conditional { substitution = normalizedSubstitution } = normalized
-        Conditional { predicate = normalizedPredicate } = normalized
-
-        mergedPredicate =
-            Syntax.Predicate.makeMultipleAndPredicate
-                [predicate, deduplicatedPredicate, normalizedPredicate]
-
-    TopBottom.guardAgainstBottom mergedPredicate
-    Branch.alternate $ simplifySubstitution Conditional
-            { term = ()
-            , predicate = mergedPredicate
-            , substitution = normalizedSubstitution
-            }
+  :: forall unifier variable. ( Ord variable,
+                                Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                FreshVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => Predicate variable
+  -> unifier (Predicate variable)
+normalizeExcept Conditional {predicate, substitution} = do
+  predicateSimplifier <- Simplifier.askSimplifierPredicate
+  -- The intermediate steps do not need to be checked for \bottom because we
+  -- use guardAgainstBottom at the end.
+  deduplicated <- normalizeSubstitutionDuplication substitution
+  let PredicateSimplifier simplifySubstitution = predicateSimplifier
+      Conditional {substitution = preDeduplicatedSubstitution} =
+        deduplicated
+      Conditional {predicate = deduplicatedPredicate} = deduplicated
+      -- The substitution is not fully normalized, but it is safe to convert
+      -- to a Map because it has been deduplicated.
+      deduplicatedSubstitution =
+        Map.fromList $ Substitution.unwrap preDeduplicatedSubstitution
+  normalized <- normalizeSubstitution' deduplicatedSubstitution
+  let Conditional {substitution = normalizedSubstitution} = normalized
+      Conditional {predicate = normalizedPredicate} = normalized
+      mergedPredicate =
+        Syntax.Predicate.makeMultipleAndPredicate
+          [predicate, deduplicatedPredicate, normalizedPredicate]
+  TopBottom.guardAgainstBottom mergedPredicate
+  Branch.alternate
+    $ simplifySubstitution Conditional
+        { term = (),
+          predicate = mergedPredicate,
+          substitution = normalizedSubstitution
+          }
   where
-
     normalizeSubstitution' =
-        Monad.Unify.lowerExceptT
+      Monad.Unify.lowerExceptT
         . withExceptT substitutionToUnifyOrSubError
         . normalizeSubstitution
 
@@ -151,135 +157,126 @@ predicates and redo the merge.
 hs-boot: Please remember to update the hs-boot file when changing the signature.
 -}
 mergePredicatesAndSubstitutions
-    ::  forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , Ord variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        , HasCallStack
-        , WithLog LogMessage simplifier
-        )
-    => [Syntax.Predicate variable]
-    -> [Substitution variable]
-    -> BranchT simplifier (Predicate variable)
+  :: forall variable simplifier. ( Show variable,
+                                   Unparse variable,
+                                   SortedVariable variable,
+                                   Ord variable,
+                                   FreshVariable variable,
+                                   MonadSimplify simplifier,
+                                   HasCallStack,
+                                   WithLog LogMessage simplifier
+                                   )
+  => [Syntax.Predicate variable]
+  -> [Substitution variable]
+  -> BranchT simplifier (Predicate variable)
 mergePredicatesAndSubstitutions predicates substitutions = do
-    result <-
-        (Monad.Trans.lift . Monad.Unify.runUnifierT)
-        (mergePredicatesAndSubstitutionsExcept predicates substitutions)
-    case result of
-        Left _ ->
-            let
-                mergedPredicate =
-                    Syntax.Predicate.makeMultipleAndPredicate
-                        (  predicates
-                        ++ map Syntax.Predicate.fromSubstitution substitutions
-                        )
-            in
-                return $ Predicate.fromPredicate mergedPredicate
-        Right r -> Branch.scatter r
+  result <-
+    (Monad.Trans.lift . Monad.Unify.runUnifierT)
+      (mergePredicatesAndSubstitutionsExcept predicates substitutions)
+  case result of
+    Left _ ->
+      let mergedPredicate =
+            Syntax.Predicate.makeMultipleAndPredicate
+              ( predicates
+                  ++ map Syntax.Predicate.fromSubstitution substitutions
+                )
+       in return $ Predicate.fromPredicate mergedPredicate
+    Right r -> Branch.scatter r
 
 mergePredicatesAndSubstitutionsExcept
-    ::  forall variable unifier
-    .   ( Show variable
-        , SortedVariable variable
-        , Ord variable
-        , Unparse variable
-        , FreshVariable variable
-        , HasCallStack
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => [Syntax.Predicate variable]
-    -> [Substitution variable]
-    -> unifier (Predicate variable)
+  :: forall variable unifier. ( Show variable,
+                                SortedVariable variable,
+                                Ord variable,
+                                Unparse variable,
+                                FreshVariable variable,
+                                HasCallStack,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => [Syntax.Predicate variable]
+  -> [Substitution variable]
+  -> unifier (Predicate variable)
 mergePredicatesAndSubstitutionsExcept predicates substitutions = do
-    let
-        mergedSubstitution = Foldable.fold substitutions
-        mergedPredicate = Syntax.Predicate.makeMultipleAndPredicate predicates
-    normalizeExcept
-        Conditional
-            { term = ()
-            , predicate = mergedPredicate
-            , substitution = mergedSubstitution
-            }
+  let mergedSubstitution = Foldable.fold substitutions
+      mergedPredicate = Syntax.Predicate.makeMultipleAndPredicate predicates
+  normalizeExcept Conditional
+    { term = (),
+      predicate = mergedPredicate,
+      substitution = mergedSubstitution
+      }
 
 {-| Creates a 'PredicateMerger' that returns errors on unifications it
 can't handle.
 -}
 createPredicatesAndSubstitutionsMergerExcept
-    ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => PredicateMerger variable unifier
+  :: forall variable unifier. ( Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                FreshVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => PredicateMerger variable unifier
 createPredicatesAndSubstitutionsMergerExcept =
-    PredicateMerger worker
+  PredicateMerger worker
   where
     worker
-        :: [Syntax.Predicate variable]
-        -> [Substitution variable]
-        -> unifier (Predicate variable)
+      :: [Syntax.Predicate variable]
+      -> [Substitution variable]
+      -> unifier (Predicate variable)
     worker predicates substitutions = do
-        let merged =
-                (Predicate.fromPredicate <$> predicates)
-                <> (Predicate.fromSubstitution <$> substitutions)
-        normalizeExcept (Foldable.fold merged)
+      let merged =
+            (Predicate.fromPredicate <$> predicates)
+              <> (Predicate.fromSubstitution <$> substitutions)
+      normalizeExcept (Foldable.fold merged)
 
 {-| Creates a 'PredicateMerger' that creates predicates for
 unifications it can't handle.
 -}
 createPredicatesAndSubstitutionsMerger
-    :: forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
-    => PredicateMerger variable (BranchT simplifier)
+  :: forall variable simplifier. ( Show variable,
+                                   Unparse variable,
+                                   SortedVariable variable,
+                                   FreshVariable variable,
+                                   MonadSimplify simplifier
+                                   )
+  => PredicateMerger variable (BranchT simplifier)
 createPredicatesAndSubstitutionsMerger =
-    PredicateMerger worker
+  PredicateMerger worker
   where
     worker
-        :: [Syntax.Predicate variable]
-        -> [Substitution variable]
-        -> BranchT simplifier (Predicate variable)
+      :: [Syntax.Predicate variable]
+      -> [Substitution variable]
+      -> BranchT simplifier (Predicate variable)
     worker predicates substitutions = do
-        let merged =
-                (Predicate.fromPredicate <$> predicates)
-                <> (Predicate.fromSubstitution <$> substitutions)
-        normalize (Foldable.fold merged)
+      let merged =
+            (Predicate.fromPredicate <$> predicates)
+              <> (Predicate.fromSubstitution <$> substitutions)
+      normalize (Foldable.fold merged)
 
 {-| Creates a 'PredicateMerger' that creates predicates for
 unifications it can't handle and whose result is in any monad transformer
 over the base monad.
 -}
 createLiftedPredicatesAndSubstitutionsMerger
-    ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , Ord variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => PredicateMerger variable unifier
+  :: forall variable unifier. ( Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                Ord variable,
+                                FreshVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => PredicateMerger variable unifier
 createLiftedPredicatesAndSubstitutionsMerger =
-    PredicateMerger worker
+  PredicateMerger worker
   where
     worker
-        :: [Syntax.Predicate variable]
-        -> [Substitution variable]
-        -> unifier (Predicate variable)
+      :: [Syntax.Predicate variable]
+      -> [Substitution variable]
+      -> unifier (Predicate variable)
     worker predicates substitutions = do
-        let merged =
-                (Predicate.fromPredicate <$> predicates)
-                <> (Predicate.fromSubstitution <$> substitutions)
-        normalizeExcept (Foldable.fold merged)
+      let merged =
+            (Predicate.fromPredicate <$> predicates)
+              <> (Predicate.fromSubstitution <$> substitutions)
+      normalizeExcept (Foldable.fold merged)

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -3,44 +3,52 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Step.Transition
-    ( TransitionT (..)
-    , runTransitionT
-    , tryTransitionT
-    , scatter
-    , addRule
-    , addRules
+  ( TransitionT (..),
+    runTransitionT,
+    tryTransitionT,
+    scatter,
+    addRule,
+    addRules,
     -- * Re-exports
-    , Seq
-    ) where
+    Seq
+    )
+where
 
-import           Control.Applicative
-import           Control.Monad.Except
-                 ( MonadError (..) )
+import Control.Applicative
+import Control.Monad.Except
+  ( MonadError (..)
+    )
 import qualified Control.Monad.Morph as Monad.Morph
-import           Control.Monad.Reader
+import Control.Monad.Reader
 import qualified Control.Monad.Trans as Monad.Trans
-import           Control.Monad.Trans.Accum
+import Control.Monad.Trans.Accum
 import qualified Control.Monad.Trans.Accum as Accum
 import qualified Data.Foldable as Foldable
-import           Data.Sequence
-                 ( Seq )
+import Data.Sequence
+  ( Seq
+    )
 import qualified Data.Sequence as Seq
-import           Data.Typeable
-                 ( Typeable )
-
-import           Kore.Logger
-                 ( WithLog (..) )
-import           Kore.Profiler.Data
-                 ( MonadProfiler )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify (..) )
-import           ListT
-                 ( ListT, mapListT )
+import Data.Typeable
+  ( Typeable
+    )
+import Kore.Logger
+  ( WithLog (..)
+    )
+import Kore.Profiler.Data
+  ( MonadProfiler
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify (..)
+    )
+import ListT
+  ( ListT,
+    mapListT
+    )
 import qualified ListT
-import           SMT
-                 ( MonadSMT (..) )
+import SMT
+  ( MonadSMT (..)
+    )
 
 {- | @TransitionT@ represents a transition between program states.
 
@@ -54,44 +62,46 @@ contain all the rules recorded before the branch, but each child keeps a
 separate record of applied rules after the branch.
 
  -}
-newtype TransitionT rule m a =
-    TransitionT { getTransitionT :: AccumT (Seq rule) (ListT m) a }
-    deriving
-        ( Alternative
-        , Applicative
-        , Functor
-        , Monad
-        , MonadIO
-        , MonadPlus
-        , Typeable
-        )
+newtype TransitionT rule m a
+  = TransitionT {getTransitionT :: AccumT (Seq rule) (ListT m) a}
+  deriving
+    ( Alternative,
+      Applicative,
+      Functor,
+      Monad,
+      MonadIO,
+      MonadPlus,
+      Typeable
+      )
 
 instance WithLog msg m => WithLog msg (TransitionT rule m) where
-    localLogAction locally =
-        mapTransitionT (localLogAction locally)
-    {-# INLINE localLogAction #-}
+  localLogAction locally =
+    mapTransitionT (localLogAction locally)
+  {-# INLINE localLogAction #-}
 
 instance MonadTrans (TransitionT rule) where
-    lift = TransitionT . Monad.Trans.lift . Monad.Trans.lift
-    {-# INLINE lift #-}
+  lift = TransitionT . Monad.Trans.lift . Monad.Trans.lift
+  {-# INLINE lift #-}
 
 instance MonadError e m => MonadError e (TransitionT rule m) where
-    throwError = Monad.Trans.lift . throwError
-    {-# INLINE throwError #-}
 
-    catchError action handler =
-        Monad.Trans.lift (catchError action' handler') >>= scatter
-      where
-        action' = runTransitionT action
-        handler' e = runTransitionT (handler e)
-    {-# INLINE catchError #-}
+  throwError = Monad.Trans.lift . throwError
+  {-# INLINE throwError #-}
+
+  catchError action handler =
+    Monad.Trans.lift (catchError action' handler') >>= scatter
+    where
+      action' = runTransitionT action
+      handler' e = runTransitionT (handler e)
+  {-# INLINE catchError #-}
 
 instance MonadReader e m => MonadReader e (TransitionT rule m) where
-    ask     = Monad.Trans.lift ask
-    {-# INLINE ask #-}
 
-    local f = TransitionT . Accum.mapAccumT (local f) . getTransitionT
-    {-# INLINE local #-}
+  ask = Monad.Trans.lift ask
+  {-# INLINE ask #-}
+
+  local f = TransitionT . Accum.mapAccumT (local f) . getTransitionT
+  {-# INLINE local #-}
 
 deriving instance MonadSMT m => MonadSMT (TransitionT rule m)
 
@@ -103,32 +113,32 @@ runTransitionT :: Monad m => TransitionT rule m a -> m [(a, Seq rule)]
 runTransitionT (TransitionT edge) = ListT.gather (runAccumT edge mempty)
 
 tryTransitionT
-    :: Monad m
-    => TransitionT rule m a
-    -> TransitionT rule m [(a, Seq rule)]
+  :: Monad m
+  => TransitionT rule m a
+  -> TransitionT rule m [(a, Seq rule)]
 tryTransitionT = Monad.Trans.lift . runTransitionT
 
 mapTransitionT
-    :: Monad m
-    => (forall x. m x -> m x)
-    -> TransitionT rule m a
-    -> TransitionT rule m a
+  :: Monad m
+  => (forall x. m x -> m x)
+  -> TransitionT rule m a
+  -> TransitionT rule m a
 mapTransitionT mapping =
-    TransitionT . mapAccumT (mapListT mapping) . getTransitionT
+  TransitionT . mapAccumT (mapListT mapping) . getTransitionT
 
 scatter :: Monad m => [(a, Seq rule)] -> TransitionT rule m a
 scatter edges = do
-    (a, rules) <- TransitionT (Monad.Trans.lift (ListT.scatter edges))
-    addRules rules
-    return a
+  (a, rules) <- TransitionT (Monad.Trans.lift (ListT.scatter edges))
+  addRules rules
+  return a
 
 {- | Record the application of a sequence of rules.
  -}
 addRules
-    :: (Monad m, Foldable f)
-    => f rule
-    -- ^ Sequence of applied rules
-    -> TransitionT rule m ()
+  :: (Monad m, Foldable f)
+  => f rule
+  -- ^ Sequence of applied rules
+  -> TransitionT rule m ()
 addRules = TransitionT . Accum.add . Seq.fromList . Foldable.toList
 
 {- | Record the application of a single rule.

--- a/kore/src/Kore/Substitute.hs
+++ b/kore/src/Kore/Substitute.hs
@@ -3,36 +3,42 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Substitute
-    ( substitute
-    ) where
+  ( substitute
+    )
+where
 
-import           Control.Applicative
+import Control.Applicative
 import qualified Data.Foldable as Foldable
-import           Data.Function
-                 ( (&) )
-import           Data.Functor.Foldable
-                 ( Corecursive, Recursive )
+import Data.Function
+  ( (&)
+    )
+import Data.Functor.Foldable
+  ( Corecursive,
+    Recursive
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Functor.Identity
-import           Data.Map.Strict
-                 ( Map )
+import Data.Functor.Identity
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Set
-                 ( Set )
+import Data.Maybe
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-
-import           Kore.Attribute.Pattern.FreeVariables
-                 ( FreeVariables )
+import Kore.Attribute.Pattern.FreeVariables
+  ( FreeVariables
+    )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import           Kore.Attribute.Synthetic
-import           Kore.Syntax
-import           Kore.Variables.Binding
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Attribute.Synthetic
+import Kore.Syntax
+import Kore.Variables.Binding
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 {- | Traverse the pattern from the top down and apply substitutions.
 
@@ -44,53 +50,51 @@ may appear in the right-hand side of any substitution, but this is not checked.
 
  -}
 substitute
-    ::  forall patternType patternBase attribute variable.
-        ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Corecursive patternType, Recursive patternType
-        , Functor patternBase
-        , CofreeF patternBase attribute ~ Base patternType
-        , Binding patternType
-        , VariableType patternType ~ UnifiedVariable variable
-        , Synthetic attribute patternBase
-        )
-    => (patternType -> FreeVariables variable)
-    -- ^ View into free variables of the pattern
-    -> Map (UnifiedVariable variable) patternType
-    -- ^ Substitution
-    -> patternType
-    -- ^ Original pattern
-    -> patternType
+  :: forall patternType patternBase attribute variable. ( FreshVariable variable,
+                                                          Ord variable,
+                                                          Show variable,
+                                                          SortedVariable variable,
+                                                          Corecursive patternType,
+                                                          Recursive patternType,
+                                                          Functor patternBase,
+                                                          CofreeF patternBase attribute ~ Base patternType,
+                                                          Binding patternType,
+                                                          VariableType patternType ~ UnifiedVariable variable,
+                                                          Synthetic attribute patternBase
+                                                          )
+  => (patternType -> FreeVariables variable)
+  -- ^ View into free variables of the pattern
+  -> Map (UnifiedVariable variable) patternType
+  -- ^ Substitution
+  -> patternType
+  -- ^ Original pattern
+  -> patternType
 substitute viewFreeVariables =
-    substituteWorker . Map.map Left
+  substituteWorker . Map.map Left
   where
     extractFreeVariables :: patternType -> Set (UnifiedVariable variable)
     extractFreeVariables =
-        FreeVariables.getFreeVariables . viewFreeVariables
-
+      FreeVariables.getFreeVariables . viewFreeVariables
     -- | Insert an optional variable renaming into the substitution.
     renaming
-        :: UnifiedVariable variable  -- ^ Original variable
-        -> Maybe (UnifiedVariable variable)  -- ^ Renamed variable
-        -> Map
-            (UnifiedVariable variable)
-            (Either patternType (UnifiedVariable variable))
-        -- ^ Substitution
-        -> Map
-            (UnifiedVariable variable)
-            (Either patternType (UnifiedVariable variable))
+      :: UnifiedVariable variable -- ^ Original variable
+      -> Maybe (UnifiedVariable variable) -- ^ Renamed variable
+      -> Map
+           (UnifiedVariable variable)
+           (Either patternType (UnifiedVariable variable))
+      -- ^ Substitution
+      -> Map
+           (UnifiedVariable variable)
+           (Either patternType (UnifiedVariable variable))
     renaming variable = maybe id (Map.insert variable . Right)
-
     substituteWorker
-        :: Map
-            (UnifiedVariable variable)
-            (Either patternType (UnifiedVariable variable))
-        -> patternType
-        -> patternType
+      :: Map
+           (UnifiedVariable variable)
+           (Either patternType (UnifiedVariable variable))
+      -> patternType
+      -> patternType
     substituteWorker subst termLike =
-        substituteNone <|> substituteBinder <|> substituteVariable
+      substituteNone <|> substituteBinder <|> substituteVariable
         & fromMaybe substituteDefault
       where
         -- | Special case: None of the targeted variables occurs in the pattern.
@@ -98,76 +102,66 @@ substitute viewFreeVariables =
         substituteNone :: Maybe patternType
         substituteNone
           | Map.null subst' = pure termLike
-          | otherwise       = empty
-
+          | otherwise = empty
         -- | Special case: The pattern is a binder.
         -- The bound variable may be renamed to avoid capturing free variables
         -- in the substitutions. The substitution (and renaming, if necessary)
         -- is carried out on the bound pattern.
         substituteBinder :: Maybe patternType
         substituteBinder =
-            runIdentity <$> matchWith traverseBinder worker termLike
+          runIdentity <$> matchWith traverseBinder worker termLike
           where
             worker
-                :: Binder (UnifiedVariable variable) patternType
-                -> Identity (Binder (UnifiedVariable variable) patternType)
-            worker Binder { binderVariable, binderChild } = do
-                let
-                    binderVariable' = avoidCapture binderVariable
-                    -- Rename the freshened bound variable in the subterms.
-                    subst'' = renaming binderVariable binderVariable' subst'
-                return Binder
-                    { binderVariable = fromMaybe binderVariable binderVariable'
-                    , binderChild = substituteWorker subst'' binderChild
-                    }
-
+              :: Binder (UnifiedVariable variable) patternType
+              -> Identity (Binder (UnifiedVariable variable) patternType)
+            worker Binder {binderVariable, binderChild} = do
+              let binderVariable' = avoidCapture binderVariable
+                  -- Rename the freshened bound variable in the subterms.
+                  subst'' = renaming binderVariable binderVariable' subst'
+              return Binder
+                { binderVariable = fromMaybe binderVariable binderVariable',
+                  binderChild = substituteWorker subst'' binderChild
+                  }
         -- | Special case: The pattern is a variable.
         -- Substitute or rename the variable, as required.
         substituteVariable :: Maybe patternType
         substituteVariable =
-            either id id <$> matchWith traverseVariable worker termLike
+          either id id <$> matchWith traverseVariable worker termLike
           where
             worker
-                :: UnifiedVariable variable
-                -> Either patternType (UnifiedVariable variable)
+              :: UnifiedVariable variable
+              -> Either patternType (UnifiedVariable variable)
             worker variable =
-                -- If the variable is not substituted or renamed, return the
-                -- original pattern.
-                fromMaybe
-                    (Left termLike)
-                    -- If the variable is renamed, 'Map.lookup' returns a
-                    -- 'Right' which @traverseVariable@ embeds into
-                    -- @patternType@. If the variable is substituted,
-                    -- 'Map.lookup' returns a 'Left' which is used directly as
-                    -- the result, exiting early from @traverseVariable@.
-                    (Map.lookup variable subst')
-
+              -- If the variable is not substituted or renamed, return the
+              -- original pattern.
+              fromMaybe
+                (Left termLike)
+                -- If the variable is renamed, 'Map.lookup' returns a
+                -- 'Right' which @traverseVariable@ embeds into
+                -- @patternType@. If the variable is substituted,
+                -- 'Map.lookup' returns a 'Left' which is used directly as
+                -- the result, exiting early from @traverseVariable@.
+                (Map.lookup variable subst')
         -- | Default case: Descend into sub-patterns and apply the substitution.
         substituteDefault =
-            synthesize termLikeHead'
+          synthesize termLikeHead'
           where
             _ :< termLikeHead = Recursive.project termLike
             termLikeHead' = substituteWorker subst' <$> termLikeHead
-
         freeVariables = extractFreeVariables termLike
-
         -- | The substitution applied to subterms, including only the free
         -- variables below the current node. Shadowed variables are
         -- automatically omitted.
         subst' = Map.intersection subst (Map.fromSet id freeVariables)
-
         -- | Free variables of the original pattern that are not targeted.
         originalVariables = Set.difference freeVariables (Map.keysSet subst')
-
         -- | Free variables of the resulting pattern.
         freeVariables' = Set.union originalVariables targetFreeVariables
           where
             -- | Free variables of the target substitutions.
             targetFreeVariables =
-                Foldable.foldl' Set.union Set.empty
-                    (either extractFreeVariables Set.singleton <$> subst')
-
+              Foldable.foldl' Set.union Set.empty
+                (either extractFreeVariables Set.singleton <$> subst')
         -- | Rename a bound variable, if needed.
         avoidCapture = refreshVariable freeVariables'
-
 {-# INLINE substitute #-}

--- a/kore/src/Kore/Syntax.hs
+++ b/kore/src/Kore/Syntax.hs
@@ -3,38 +3,38 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax
-    ( module Kore.Sort
-    , module Kore.Syntax.And
-    , module Kore.Syntax.Application
-    , module Kore.Syntax.Bottom
-    , module Kore.Syntax.Ceil
-    , module Kore.Syntax.CharLiteral
-    , module Kore.Syntax.DomainValue
-    , module Kore.Syntax.Equals
-    , module Kore.Syntax.Exists
-    , module Kore.Syntax.Floor
-    , module Kore.Syntax.Forall
-    , module Kore.Syntax.Iff
-    , module Kore.Syntax.Implies
-    , module Kore.Syntax.In
-    , module Kore.Syntax.Inhabitant
-    , module Kore.Syntax.Mu
-    , module Kore.Syntax.Next
-    , module Kore.Syntax.Not
-    , module Kore.Syntax.Nu
-    , module Kore.Syntax.Or
-    , PatternF (..)
-    , module Kore.Syntax.Pattern
-    , module Kore.Syntax.Rewrites
-    , module Kore.Syntax.ElementVariable
-    , module Kore.Syntax.SetVariable
-    , module Kore.Syntax.StringLiteral
-    , module Kore.Syntax.Top
-    , module Kore.Syntax.Variable
-    , Const (..)
-    ) where
+  ( module Kore.Sort,
+    module Kore.Syntax.And,
+    module Kore.Syntax.Application,
+    module Kore.Syntax.Bottom,
+    module Kore.Syntax.Ceil,
+    module Kore.Syntax.CharLiteral,
+    module Kore.Syntax.DomainValue,
+    module Kore.Syntax.Equals,
+    module Kore.Syntax.Exists,
+    module Kore.Syntax.Floor,
+    module Kore.Syntax.Forall,
+    module Kore.Syntax.Iff,
+    module Kore.Syntax.Implies,
+    module Kore.Syntax.In,
+    module Kore.Syntax.Inhabitant,
+    module Kore.Syntax.Mu,
+    module Kore.Syntax.Next,
+    module Kore.Syntax.Not,
+    module Kore.Syntax.Nu,
+    module Kore.Syntax.Or,
+    PatternF (..),
+    module Kore.Syntax.Pattern,
+    module Kore.Syntax.Rewrites,
+    module Kore.Syntax.ElementVariable,
+    module Kore.Syntax.SetVariable,
+    module Kore.Syntax.StringLiteral,
+    module Kore.Syntax.Top,
+    module Kore.Syntax.Variable,
+    Const (..)
+    )
+where
 
 import Kore.Sort
 import Kore.Syntax.And
@@ -60,7 +60,9 @@ import Kore.Syntax.Nu
 import Kore.Syntax.Or
 import Kore.Syntax.Pattern
 import Kore.Syntax.PatternF
-       ( Const (..), PatternF (..) )
+  ( Const (..),
+    PatternF (..)
+    )
 import Kore.Syntax.Rewrites
 import Kore.Syntax.SetVariable
 import Kore.Syntax.StringLiteral

--- a/kore/src/Kore/Syntax/And.hs
+++ b/kore/src/Kore/Syntax/And.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.And
-    ( And (..)
-    ) where
+  ( And (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,12 +31,13 @@ Section 9.1.4 (Patterns).
 
 This represents the 'andFirst ∧ andSecond' Matching Logic construct.
 -}
-data And sort child = And
-    { andSort   :: !sort
-    , andFirst  :: child
-    , andSecond :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data And sort child
+  = And
+      { andSort :: !sort,
+        andFirst :: child,
+        andSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (And sort child)
 
@@ -49,25 +50,28 @@ instance SOP.HasDatatypeInfo (And sort child)
 instance (Debug sort, Debug child) => Debug (And sort child)
 
 instance Unparse child => Unparse (And Sort child) where
-    unparse And { andSort, andFirst, andSecond } =
-        "\\and"
-        <> parameters [andSort]
-        <> arguments [andFirst, andSecond]
 
-    unparse2 And { andFirst, andSecond } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\and"
-            , unparse2 andFirst
-            , unparse2 andSecond
-            ])
+  unparse And {andSort, andFirst, andSecond} =
+    "\\and"
+      <> parameters [andSort]
+      <> arguments [andFirst, andSecond]
+
+  unparse2 And {andFirst, andSecond} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\and",
+            unparse2 andFirst,
+            unparse2 andSecond
+            ]
+        )
 
 instance Ord variable => Synthetic (FreeVariables variable) (And sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (And Sort) where
-    synthetic And { andSort, andFirst, andSecond } =
-        andSort
-        & seq (matchSort andSort andFirst)
-        . seq (matchSort andSort andSecond)
-    {-# INLINE synthetic #-}
+  synthetic And {andSort, andFirst, andSecond} =
+    andSort
+      & seq (matchSort andSort andFirst)
+      . seq (matchSort andSort andSecond)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Application.hs
+++ b/kore/src/Kore/Syntax/Application.hs
@@ -13,20 +13,20 @@ an AST term in a single data type (e.g. 'UnifiedSort' that can be either
 Please refer to Section 9 (The Kore Language) of the
 <http://github.com/kframework/kore/blob/master/docs/semantics-of-k.pdf Semantics of K>.
 -}
-
 module Kore.Syntax.Application
-    ( SymbolOrAlias (..)
-    , Application (..)
-    , mapHead
-    ) where
+  ( SymbolOrAlias (..),
+    Application (..),
+    mapHead
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Sort
 import Kore.Unparser
@@ -35,11 +35,12 @@ import Kore.Unparser
 @head@ syntactic category from the Semantics of K,
 Section 9.1.3 (Heads).
  -}
-data SymbolOrAlias = SymbolOrAlias
-    { symbolOrAliasConstructor :: !Id
-    , symbolOrAliasParams      :: ![Sort]
-    }
-    deriving (Show, Eq, Ord, GHC.Generic)
+data SymbolOrAlias
+  = SymbolOrAlias
+      { symbolOrAliasConstructor :: !Id,
+        symbolOrAliasParams :: ![Sort]
+        }
+  deriving (Show, Eq, Ord, GHC.Generic)
 
 instance Hashable SymbolOrAlias
 
@@ -52,26 +53,28 @@ instance SOP.HasDatatypeInfo SymbolOrAlias
 instance Debug SymbolOrAlias
 
 instance Unparse SymbolOrAlias where
-    unparse
-        SymbolOrAlias
-            { symbolOrAliasConstructor
-            , symbolOrAliasParams
-            }
-      =
-        unparse symbolOrAliasConstructor <> parameters symbolOrAliasParams
-    unparse2 SymbolOrAlias { symbolOrAliasConstructor } =
-        Pretty.parens $ Pretty.fillSep [ unparse2 symbolOrAliasConstructor ]
+
+  unparse
+    SymbolOrAlias
+      { symbolOrAliasConstructor,
+        symbolOrAliasParams
+        } =
+      unparse symbolOrAliasConstructor <> parameters symbolOrAliasParams
+
+  unparse2 SymbolOrAlias {symbolOrAliasConstructor} =
+    Pretty.parens $ Pretty.fillSep [unparse2 symbolOrAliasConstructor]
 
 {-|'Application' corresponds to the @head(pattern-list)@ branches of the
 @pattern@ syntactic category from the Semantics of K, Section 9.1.4 (Patterns).
 
 This represents the @σ(φ1, ..., φn)@ symbol patterns in Matching Logic.
 -}
-data Application head child = Application
-    { applicationSymbolOrAlias :: !head
-    , applicationChildren      :: [child]
-    }
-    deriving (Eq, Functor, Foldable, Ord, Traversable, GHC.Generic, Show)
+data Application head child
+  = Application
+      { applicationSymbolOrAlias :: !head,
+        applicationChildren :: [child]
+        }
+  deriving (Eq, Functor, Foldable, Ord, Traversable, GHC.Generic, Show)
 
 instance (Hashable head, Hashable child) => Hashable (Application head child)
 
@@ -84,22 +87,25 @@ instance SOP.HasDatatypeInfo (Application head child)
 instance (Debug head, Debug child) => Debug (Application head child)
 
 instance (Unparse head, Unparse child) => Unparse (Application head child) where
-    unparse Application { applicationSymbolOrAlias, applicationChildren } =
-        unparse applicationSymbolOrAlias <> arguments applicationChildren
 
-    unparse2 Application { applicationSymbolOrAlias, applicationChildren } =
-        case applicationChildren of
-            [] ->
-                Pretty.parens (unparse2 applicationSymbolOrAlias)
-            children ->
-                Pretty.parens (Pretty.fillSep
-                    [ unparse2 applicationSymbolOrAlias
-                    , arguments2 children
-                    ])
+  unparse Application {applicationSymbolOrAlias, applicationChildren} =
+    unparse applicationSymbolOrAlias <> arguments applicationChildren
+
+  unparse2 Application {applicationSymbolOrAlias, applicationChildren} =
+    case applicationChildren of
+      [] ->
+        Pretty.parens (unparse2 applicationSymbolOrAlias)
+      children ->
+        Pretty.parens
+          ( Pretty.fillSep
+              [ unparse2 applicationSymbolOrAlias,
+                arguments2 children
+                ]
+            )
 
 mapHead
-    :: (head1 -> head2)
-    -> Application head1 child
-    -> Application head2 child
+  :: (head1 -> head2)
+  -> Application head1 child
+  -> Application head2 child
 mapHead mapping app =
-    app { applicationSymbolOrAlias = mapping (applicationSymbolOrAlias app) }
+  app {applicationSymbolOrAlias = mapping (applicationSymbolOrAlias app)}

--- a/kore/src/Kore/Syntax/Bottom.hs
+++ b/kore/src/Kore/Syntax/Bottom.hs
@@ -3,17 +3,17 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Bottom
-    ( Bottom (..)
-    ) where
+  ( Bottom (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -26,8 +26,8 @@ category from the Semantics of K, Section 9.1.4 (Patterns).
 'bottomSort' is the sort of the result.
 
  -}
-newtype Bottom sort child = Bottom { bottomSort :: sort }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Traversable, Show)
+newtype Bottom sort child = Bottom {bottomSort :: sort}
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Traversable, Show)
 
 instance Hashable sort => Hashable (Bottom sort child)
 
@@ -40,14 +40,16 @@ instance SOP.HasDatatypeInfo (Bottom sort child)
 instance Debug sort => Debug (Bottom sort child)
 
 instance Unparse (Bottom Sort child) where
-    unparse Bottom { bottomSort } =
-        "\\bottom" <> parameters [bottomSort] <> noArguments
-    unparse2 _ = "\\bottom"
+
+  unparse Bottom {bottomSort} =
+    "\\bottom" <> parameters [bottomSort] <> noArguments
+
+  unparse2 _ = "\\bottom"
 
 instance Ord variable => Synthetic (FreeVariables variable) (Bottom sort) where
-    synthetic = const mempty
-    {-# INLINE synthetic #-}
+  synthetic = const mempty
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Bottom Sort) where
-    synthetic = bottomSort
-    {-# INLINE synthetic #-}
+  synthetic = bottomSort
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Ceil.hs
+++ b/kore/src/Kore/Syntax/Ceil.hs
@@ -3,19 +3,19 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Ceil
-    ( Ceil (..)
-    ) where
+  ( Ceil (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Function
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -32,12 +32,13 @@ Section 9.1.4 (Patterns).
 
 This represents the ⌈ceilPattern⌉ Matching Logic construct.
 -}
-data Ceil sort child = Ceil
-    { ceilOperandSort :: !sort
-    , ceilResultSort  :: !sort
-    , ceilChild       :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Traversable, Show)
+data Ceil sort child
+  = Ceil
+      { ceilOperandSort :: !sort,
+        ceilResultSort :: !sort,
+        ceilChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Traversable, Show)
 
 instance (Hashable sort, Hashable child) => Hashable (Ceil sort child)
 
@@ -50,20 +51,21 @@ instance SOP.HasDatatypeInfo (Ceil sort child)
 instance (Debug sort, Debug child) => Debug (Ceil sort child)
 
 instance Unparse child => Unparse (Ceil Sort child) where
-    unparse Ceil { ceilOperandSort, ceilResultSort, ceilChild } =
-        "\\ceil"
-        <> parameters [ceilOperandSort, ceilResultSort]
-        <> arguments [ceilChild]
 
-    unparse2 Ceil { ceilChild } =
-        Pretty.parens (Pretty.fillSep ["\\ceil", unparse2 ceilChild])
+  unparse Ceil {ceilOperandSort, ceilResultSort, ceilChild} =
+    "\\ceil"
+      <> parameters [ceilOperandSort, ceilResultSort]
+      <> arguments [ceilChild]
+
+  unparse2 Ceil {ceilChild} =
+    Pretty.parens (Pretty.fillSep ["\\ceil", unparse2 ceilChild])
 
 instance Ord variable => Synthetic (FreeVariables variable) (Ceil sort) where
-    synthetic = ceilChild
-    {-# INLINE synthetic #-}
+  synthetic = ceilChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Ceil Sort) where
-    synthetic Ceil { ceilOperandSort, ceilResultSort, ceilChild } =
-        ceilResultSort
-        & seq (matchSort ceilOperandSort ceilChild)
-    {-# INLINE synthetic #-}
+  synthetic Ceil {ceilOperandSort, ceilResultSort, ceilChild} =
+    ceilResultSort
+      & seq (matchSort ceilOperandSort ceilChild)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/CharLiteral.hs
+++ b/kore/src/Kore/Syntax/CharLiteral.hs
@@ -3,23 +3,25 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 
 -}
-
 module Kore.Syntax.CharLiteral
-    ( CharLiteral (..)
-    ) where
+  ( CharLiteral (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Functor.Const
-import           Data.Hashable
-import           Data.String
-                 ( fromString )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Functor.Const
+import Data.Hashable
+import Data.String
+  ( fromString
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
-       ( FreeVariables )
+  ( FreeVariables
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
@@ -28,8 +30,8 @@ import Kore.Unparser
 {-|'CharLiteral' corresponds to the @char@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype CharLiteral = CharLiteral { getCharLiteral :: Char }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype CharLiteral = CharLiteral {getCharLiteral :: Char}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable CharLiteral
 
@@ -42,14 +44,15 @@ instance SOP.HasDatatypeInfo CharLiteral
 instance Debug CharLiteral
 
 instance Unparse CharLiteral where
-    unparse = Pretty.squotes . fromString . escapeChar . getCharLiteral
-    unparse2 = unparse
 
-instance Ord variable => Synthetic (FreeVariables variable) (Const CharLiteral)
-  where
-    synthetic = const mempty
-    {-# INLINE synthetic #-}
+  unparse = Pretty.squotes . fromString . escapeChar . getCharLiteral
+
+  unparse2 = unparse
+
+instance Ord variable => Synthetic (FreeVariables variable) (Const CharLiteral) where
+  synthetic = const mempty
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Const CharLiteral) where
-    synthetic = const charMetaSort
-    {-# INLINE synthetic #-}
+  synthetic = const charMetaSort
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Definition.hs
+++ b/kore/src/Kore/Syntax/Definition.hs
@@ -4,28 +4,29 @@ License     : NCSA
 
 -}
 module Kore.Syntax.Definition
-    ( Definition (..)
+  ( Definition (..),
     -- * Type synonyms
-    , PureDefinition
-    , ParsedDefinition
+    PureDefinition,
+    ParsedDefinition,
     -- * Re-exports
-    , module Kore.Syntax.Sentence
-    ) where
+    module Kore.Syntax.Sentence
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-                 ( Hashable (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
+  ( Hashable (..)
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Attributes
 import Kore.Debug
 import Kore.Syntax.Module
 import Kore.Syntax.Sentence
 import Kore.Unparser
-
 
 {- | Currently, a 'Definition' consists of some 'Attributes' and a 'Module'
 
@@ -36,12 +37,12 @@ syntactic category from the Semantics of K, Section 9.1.6
 'definitionAttributes' corresponds to the first non-terminal of @definition@,
 while the remaining three are grouped into 'definitionModules'.
 -}
-data Definition (sentence :: *) =
-    Definition
-        { definitionAttributes :: !Attributes
-        , definitionModules    :: ![Module sentence]
+data Definition (sentence :: *)
+  = Definition
+      { definitionAttributes :: !Attributes,
+        definitionModules :: ![Module sentence]
         }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Show, Traversable)
+  deriving (Eq, Functor, Foldable, GHC.Generic, Show, Traversable)
 
 instance Hashable sentence => Hashable (Definition sentence)
 
@@ -54,13 +55,14 @@ instance SOP.HasDatatypeInfo (Definition sentence)
 instance Debug sentence => Debug (Definition sentence)
 
 instance Unparse sentence => Unparse (Definition sentence) where
-    unparse Definition { definitionAttributes, definitionModules } =
-        Pretty.vsep
-            (unparse definitionAttributes : map unparse definitionModules)
 
-    unparse2 Definition { definitionAttributes, definitionModules } =
-        Pretty.vsep
-            (unparse2 definitionAttributes : map unparse2 definitionModules)
+  unparse Definition {definitionAttributes, definitionModules} =
+    Pretty.vsep
+      (unparse definitionAttributes : map unparse definitionModules)
+
+  unparse2 Definition {definitionAttributes, definitionModules} =
+    Pretty.vsep
+      (unparse2 definitionAttributes : map unparse2 definitionModules)
 
 -- |'PureDefinition' is the pure (fixed-@level@) version of 'Definition'
 type PureDefinition = Definition PureSentence

--- a/kore/src/Kore/Syntax/DomainValue.hs
+++ b/kore/src/Kore/Syntax/DomainValue.hs
@@ -3,18 +3,18 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.DomainValue
-    ( DomainValue (..)
-    ) where
+  ( DomainValue (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Function
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Function
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,11 +31,12 @@ This represents the encoding of an object constant, e.g. we may use
 \dv{Int{}}{"123"} instead of a representation based on constructors,
 e.g. succesor(succesor(...succesor(0)...))
 -}
-data DomainValue sort child = DomainValue
-    { domainValueSort  :: !sort
-    , domainValueChild :: !child
-    }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+data DomainValue sort child
+  = DomainValue
+      { domainValueSort :: !sort,
+        domainValueChild :: !child
+        }
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (DomainValue sort child)
 
@@ -48,24 +49,26 @@ instance SOP.HasDatatypeInfo (DomainValue sort child)
 instance (Debug sort, Debug child) => Debug (DomainValue sort child)
 
 instance Unparse child => Unparse (DomainValue Sort child) where
-    unparse DomainValue { domainValueSort, domainValueChild } =
-        "\\dv"
-        <> parameters [domainValueSort]
-        <> arguments [domainValueChild]
-    unparse2 DomainValue { domainValueSort, domainValueChild } =
-        "\\dv"
-        <> parameters2 [domainValueSort]
-        <> arguments2 [domainValueChild]
+
+  unparse DomainValue {domainValueSort, domainValueChild} =
+    "\\dv"
+      <> parameters [domainValueSort]
+      <> arguments [domainValueChild]
+
+  unparse2 DomainValue {domainValueSort, domainValueChild} =
+    "\\dv"
+      <> parameters2 [domainValueSort]
+      <> arguments2 [domainValueChild]
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (DomainValue sort)
+  Ord variable
+  => Synthetic (FreeVariables variable) (DomainValue sort)
   where
-    synthetic = domainValueChild
-    {-# INLINE synthetic #-}
+  synthetic = domainValueChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (DomainValue Sort) where
-    synthetic DomainValue { domainValueSort, domainValueChild } =
-        domainValueSort
-        & seq (matchSort stringMetaSort domainValueChild)
-    {-# INLINE synthetic #-}
+  synthetic DomainValue {domainValueSort, domainValueChild} =
+    domainValueSort
+      & seq (matchSort stringMetaSort domainValueChild)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/ElementVariable.hs
+++ b/kore/src/Kore/Syntax/ElementVariable.hs
@@ -3,24 +3,24 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.ElementVariable
-    ( ElementVariable (..)
-    ) where
+  ( ElementVariable (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Unparser
 
 -- | Element (singleton) Kore variables
 newtype ElementVariable variable
-    = ElementVariable { getElementVariable :: variable }
-    deriving (Eq, GHC.Generic, Ord, Show, Functor, Foldable, Traversable)
+  = ElementVariable {getElementVariable :: variable}
+  deriving (Eq, GHC.Generic, Ord, Show, Functor, Foldable, Traversable)
 
 instance Hashable variable => Hashable (ElementVariable variable)
 
@@ -33,6 +33,7 @@ instance SOP.HasDatatypeInfo (ElementVariable variable)
 instance Debug variable => Debug (ElementVariable variable)
 
 instance Unparse variable => Unparse (ElementVariable variable) where
-    unparse = unparse . getElementVariable
-    unparse2 = unparse2 . getElementVariable
 
+  unparse = unparse . getElementVariable
+
+  unparse2 = unparse2 . getElementVariable

--- a/kore/src/Kore/Syntax/Equals.hs
+++ b/kore/src/Kore/Syntax/Equals.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Equals
-    ( Equals (..)
-    ) where
+  ( Equals (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -32,13 +32,14 @@ Section 9.1.4 (Patterns).
 'equalsResultSort' is the sort of the result.
 
 -}
-data Equals sort child = Equals
-    { equalsOperandSort :: !sort
-    , equalsResultSort  :: !sort
-    , equalsFirst       :: child
-    , equalsSecond      :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Equals sort child
+  = Equals
+      { equalsOperandSort :: !sort,
+        equalsResultSort :: !sort,
+        equalsFirst :: child,
+        equalsSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Equals sort child)
 
@@ -51,39 +52,41 @@ instance SOP.HasDatatypeInfo (Equals sort child)
 instance (Debug sort, Debug child) => Debug (Equals sort child)
 
 instance Unparse child => Unparse (Equals Sort child) where
-    unparse
-        Equals
-            { equalsOperandSort
-            , equalsResultSort
-            , equalsFirst
-            , equalsSecond
-            }
-      =
-        "\\equals"
+
+  unparse
+    Equals
+      { equalsOperandSort,
+        equalsResultSort,
+        equalsFirst,
+        equalsSecond
+        } =
+      "\\equals"
         <> parameters [equalsOperandSort, equalsResultSort]
         <> arguments [equalsFirst, equalsSecond]
 
-    unparse2
-        Equals
-            { equalsFirst
-            , equalsSecond
-            }
-      = Pretty.parens (Pretty.fillSep
-            [ "\\equals"
-            , unparse2 equalsFirst
-            , unparse2 equalsSecond
-            ])
+  unparse2
+    Equals
+      { equalsFirst,
+        equalsSecond
+        } =
+      Pretty.parens
+        ( Pretty.fillSep
+            [ "\\equals",
+              unparse2 equalsFirst,
+              unparse2 equalsSecond
+              ]
+          )
 
 instance Ord variable => Synthetic (FreeVariables variable) (Equals sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Equals Sort) where
-    synthetic equals =
-        equalsResultSort
-        & seq (matchSort equalsOperandSort equalsFirst)
-        . seq (matchSort equalsOperandSort equalsSecond)
-      where
-        Equals { equalsOperandSort, equalsResultSort } = equals
-        Equals { equalsFirst, equalsSecond } = equals
-    {-# INLINE synthetic #-}
+  synthetic equals =
+    equalsResultSort
+      & seq (matchSort equalsOperandSort equalsFirst)
+      . seq (matchSort equalsOperandSort equalsSecond)
+    where
+      Equals {equalsOperandSort, equalsResultSort} = equals
+      Equals {equalsFirst, equalsSecond} = equals
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Exists.hs
+++ b/kore/src/Kore/Syntax/Exists.hs
@@ -3,18 +3,18 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Exists
-    ( Exists (..)
-    ) where
+  ( Exists (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,54 +31,58 @@ Section 9.1.4 (Patterns).
 'existsSort' is both the sort of the operands and the sort of the result.
 
 -}
-data Exists sort variable child = Exists
-    { existsSort     :: !sort
-    , existsVariable :: !(ElementVariable variable)
-    , existsChild    :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Exists sort variable child
+  = Exists
+      { existsSort :: !sort,
+        existsVariable :: !(ElementVariable variable),
+        existsChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance
-    (Hashable sort, Hashable variable, Hashable child) =>
-    Hashable (Exists sort variable child)
+  (Hashable sort, Hashable variable, Hashable child)
+  => Hashable (Exists sort variable child)
 
 instance
-    (NFData sort, NFData variable, NFData child) =>
-    NFData (Exists sort variable child)
+  (NFData sort, NFData variable, NFData child)
+  => NFData (Exists sort variable child)
 
 instance SOP.Generic (Exists sort variable child)
 
 instance SOP.HasDatatypeInfo (Exists sort variable child)
 
 instance
-    (Debug sort, Debug variable, Debug child) =>
-    Debug (Exists sort variable child)
+  (Debug sort, Debug variable, Debug child)
+  => Debug (Exists sort variable child)
 
 instance
-    (SortedVariable variable, Unparse variable, Unparse child) =>
-    Unparse (Exists Sort variable child)
+  (SortedVariable variable, Unparse variable, Unparse child)
+  => Unparse (Exists Sort variable child)
   where
-    unparse Exists { existsSort, existsVariable, existsChild } =
-        "\\exists"
-        <> parameters [existsSort]
-        <> arguments' [unparse existsVariable, unparse existsChild]
 
-    unparse2 Exists { existsVariable, existsChild } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\exists"
-            , unparse2SortedVariable (getElementVariable existsVariable)
-            , unparse2 existsChild
-            ])
+  unparse Exists {existsSort, existsVariable, existsChild} =
+    "\\exists"
+      <> parameters [existsSort]
+      <> arguments' [unparse existsVariable, unparse existsChild]
+
+  unparse2 Exists {existsVariable, existsChild} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\exists",
+            unparse2SortedVariable (getElementVariable existsVariable),
+            unparse2 existsChild
+            ]
+        )
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Exists sort variable)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Exists sort variable)
   where
-    synthetic Exists { existsVariable, existsChild } =
-        bindVariable (ElemVar existsVariable) existsChild
-    {-# INLINE synthetic #-}
+  synthetic Exists {existsVariable, existsChild} =
+    bindVariable (ElemVar existsVariable) existsChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Exists Sort variable) where
-    synthetic Exists { existsSort, existsChild } =
-        existsSort `matchSort` existsChild
-    {-# INLINE synthetic #-}
+  synthetic Exists {existsSort, existsChild} =
+    existsSort `matchSort` existsChild
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Floor.hs
+++ b/kore/src/Kore/Syntax/Floor.hs
@@ -3,19 +3,19 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Floor
-    ( Floor (..)
-    ) where
+  ( Floor (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Function
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,12 +31,13 @@ Section 9.1.4 (Patterns).
 'floorResultSort' is the sort of the result.
 
 -}
-data Floor sort child = Floor
-    { floorOperandSort :: !sort
-    , floorResultSort  :: !sort
-    , floorChild       :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Floor sort child
+  = Floor
+      { floorOperandSort :: !sort,
+        floorResultSort :: !sort,
+        floorChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Floor sort child)
 
@@ -49,20 +50,21 @@ instance SOP.HasDatatypeInfo (Floor sort child)
 instance (Debug sort, Debug child) => Debug (Floor sort child)
 
 instance Unparse child => Unparse (Floor Sort child) where
-    unparse Floor { floorOperandSort, floorResultSort, floorChild } =
-        "\\floor"
-        <> parameters [floorOperandSort, floorResultSort]
-        <> arguments [floorChild]
 
-    unparse2 Floor { floorChild } =
-        Pretty.parens (Pretty.fillSep ["\\floor", unparse2 floorChild])
+  unparse Floor {floorOperandSort, floorResultSort, floorChild} =
+    "\\floor"
+      <> parameters [floorOperandSort, floorResultSort]
+      <> arguments [floorChild]
+
+  unparse2 Floor {floorChild} =
+    Pretty.parens (Pretty.fillSep ["\\floor", unparse2 floorChild])
 
 instance Ord variable => Synthetic (FreeVariables variable) (Floor sort) where
-    synthetic = floorChild
-    {-# INLINE synthetic #-}
+  synthetic = floorChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Floor Sort) where
-    synthetic Floor { floorOperandSort, floorResultSort, floorChild } =
-        floorResultSort
-        & seq (matchSort floorOperandSort floorChild)
-    {-# INLINE synthetic #-}
+  synthetic Floor {floorOperandSort, floorResultSort, floorChild} =
+    floorResultSort
+      & seq (matchSort floorOperandSort floorChild)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Forall.hs
+++ b/kore/src/Kore/Syntax/Forall.hs
@@ -3,18 +3,18 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Forall
-    ( Forall (..)
-    ) where
+  ( Forall (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,54 +31,58 @@ Section 9.1.4 (Patterns).
 'forallSort' is both the sort of the operands and the sort of the result.
 
 -}
-data Forall sort variable child = Forall
-    { forallSort     :: !sort
-    , forallVariable :: !(ElementVariable variable)
-    , forallChild    :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Forall sort variable child
+  = Forall
+      { forallSort :: !sort,
+        forallVariable :: !(ElementVariable variable),
+        forallChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance
-    (Hashable sort, Hashable variable, Hashable child) =>
-    Hashable (Forall sort variable child)
+  (Hashable sort, Hashable variable, Hashable child)
+  => Hashable (Forall sort variable child)
 
 instance
-    (NFData sort, NFData variable, NFData child) =>
-    NFData (Forall sort variable child)
+  (NFData sort, NFData variable, NFData child)
+  => NFData (Forall sort variable child)
 
 instance SOP.Generic (Forall sort variable child)
 
 instance SOP.HasDatatypeInfo (Forall sort variable child)
 
 instance
-    (Debug sort, Debug variable, Debug child) =>
-    Debug (Forall sort variable child)
+  (Debug sort, Debug variable, Debug child)
+  => Debug (Forall sort variable child)
 
 instance
-    (SortedVariable variable, Unparse variable, Unparse child) =>
-    Unparse (Forall Sort variable child)
+  (SortedVariable variable, Unparse variable, Unparse child)
+  => Unparse (Forall Sort variable child)
   where
-    unparse Forall { forallSort, forallVariable, forallChild } =
-        "\\forall"
-        <> parameters [forallSort]
-        <> arguments' [unparse forallVariable, unparse forallChild]
 
-    unparse2 Forall { forallVariable, forallChild } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\forall"
-            , unparse2SortedVariable (getElementVariable forallVariable)
-            , unparse2 forallChild
-            ])
+  unparse Forall {forallSort, forallVariable, forallChild} =
+    "\\forall"
+      <> parameters [forallSort]
+      <> arguments' [unparse forallVariable, unparse forallChild]
+
+  unparse2 Forall {forallVariable, forallChild} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\forall",
+            unparse2SortedVariable (getElementVariable forallVariable),
+            unparse2 forallChild
+            ]
+        )
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Forall sort variable)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Forall sort variable)
   where
-    synthetic Forall { forallVariable, forallChild } =
-        bindVariable (ElemVar forallVariable) forallChild
-    {-# INLINE synthetic #-}
+  synthetic Forall {forallVariable, forallChild} =
+    bindVariable (ElemVar forallVariable) forallChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Forall Sort variable) where
-    synthetic Forall { forallSort, forallChild } =
-        forallSort `matchSort` forallChild
-    {-# INLINE synthetic #-}
+  synthetic Forall {forallSort, forallChild} =
+    forallSort `matchSort` forallChild
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -6,31 +6,34 @@ Please refer to Section 9 (The Kore Language) of the
 <http://github.com/kframework/kore/blob/master/docs/semantics-of-k.pdf Semantics of K>.
 -}
 module Kore.Syntax.Id
-    (
-    -- * Identifiers
-      Id (..)
-    , getIdForError
-    , noLocationId
-    , implicitId
+  ( -- * Identifiers
+    Id (..),
+    getIdForError,
+    noLocationId,
+    implicitId,
     -- * Locations
-    , AstLocation (..)
-    , FileLocation (..)
-    , prettyPrintAstLocation
-    ) where
+    AstLocation (..),
+    FileLocation (..),
+    prettyPrintAstLocation
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Hashable
-                 ( Hashable )
-import           Data.String
-                 ( IsString (..) )
-import           Data.Text
-                 ( Text )
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Hashable
+  ( Hashable
+    )
+import Data.String
+  ( IsString (..)
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Unparser
 
@@ -40,20 +43,21 @@ import Kore.Unparser
 Section 9.1.1 (Lexicon).
 
  -}
-data Id = Id
-    { getId      :: !Text
-    , idLocation :: !AstLocation
-    }
-    deriving (Show, GHC.Generic)
+data Id
+  = Id
+      { getId :: !Text,
+        idLocation :: !AstLocation
+        }
+  deriving (Show, GHC.Generic)
 
 -- | 'Ord' ignores the 'AstLocation'
 instance Ord Id where
-    compare first@(Id _ _) second@(Id _ _) =
-        compare (getId first) (getId second)
+  compare first@(Id _ _) second@(Id _ _) =
+    compare (getId first) (getId second)
 
 -- | 'Eq' ignores the 'AstLocation'
 instance Eq Id where
-    first == second = compare first second == EQ
+  first == second = compare first second == EQ
 
 instance Hashable Id
 
@@ -66,11 +70,13 @@ instance SOP.HasDatatypeInfo Id
 instance Debug Id
 
 instance IsString Id where
-    fromString = noLocationId . fromString
+  fromString = noLocationId . fromString
 
 instance Unparse Id where
-    unparse = Pretty.pretty . getId
-    unparse2 = Pretty.pretty . getId
+
+  unparse = Pretty.pretty . getId
+
+  unparse2 = Pretty.pretty . getId
 
 {- | Create an 'Id' without location.
 
@@ -99,14 +105,14 @@ the kore parsing code and pretty printing code below would access
 the AstLocationFile branch.
 -}
 data AstLocation
-    = AstLocationNone
-    | AstLocationImplicit
-    | AstLocationGeneratedVariable
-    | AstLocationTest
-    | AstLocationFile FileLocation
-    | AstLocationUnknown
+  = AstLocationNone
+  | AstLocationImplicit
+  | AstLocationGeneratedVariable
+  | AstLocationTest
+  | AstLocationFile FileLocation
+  | AstLocationUnknown
     -- ^ This should not be used and should be eliminated in further releases
-    deriving (Eq, Show, GHC.Generic)
+  deriving (Eq, Show, GHC.Generic)
 
 instance Hashable AstLocation
 
@@ -125,28 +131,31 @@ prettyPrintAstLocation :: AstLocation -> Text
 prettyPrintAstLocation AstLocationNone = "<unknown location>"
 prettyPrintAstLocation AstLocationImplicit = "<implicitly defined entity>"
 prettyPrintAstLocation AstLocationGeneratedVariable =
-    "<variable generated internally>"
+  "<variable generated internally>"
 prettyPrintAstLocation AstLocationTest = "<test data>"
 prettyPrintAstLocation
-    (AstLocationFile FileLocation
-        { fileName = name
-        , line = line'
-        , column = column'
-        }
-    )
-  = Text.pack name <> " "
-    <> Text.pack (show line') <> ":"
-    <> Text.pack (show column')
+  ( AstLocationFile
+      FileLocation
+        { fileName = name,
+          line = line',
+          column = column'
+          }
+    ) =
+    Text.pack name <> " "
+      <> Text.pack (show line')
+      <> ":"
+      <> Text.pack (show column')
 prettyPrintAstLocation AstLocationUnknown = "<unknown location>"
 
 {-| 'FileLocation' represents a position in a source file.
 -}
-data FileLocation = FileLocation
-    { fileName :: FilePath
-    , line     :: Int
-    , column   :: Int
-    }
-    deriving (Eq, Show, GHC.Generic)
+data FileLocation
+  = FileLocation
+      { fileName :: FilePath,
+        line :: Int,
+        column :: Int
+        }
+  deriving (Eq, Show, GHC.Generic)
 
 instance Hashable FileLocation
 

--- a/kore/src/Kore/Syntax/Iff.hs
+++ b/kore/src/Kore/Syntax/Iff.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Iff
-    ( Iff (..)
-    ) where
+  ( Iff (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -30,12 +30,13 @@ Section 9.1.4 (Patterns).
 'iffSort' is both the sort of the operands and the sort of the result.
 
 -}
-data Iff sort child = Iff
-    { iffSort   :: !sort
-    , iffFirst  :: child
-    , iffSecond :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Iff sort child
+  = Iff
+      { iffSort :: !sort,
+        iffFirst :: child,
+        iffSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Iff sort child)
 
@@ -48,25 +49,28 @@ instance SOP.HasDatatypeInfo (Iff sort child)
 instance (Debug sort, Debug child) => Debug (Iff sort child)
 
 instance Unparse child => Unparse (Iff Sort child) where
-    unparse Iff { iffSort, iffFirst, iffSecond } =
-        "\\iff"
-        <> parameters [iffSort]
-        <> arguments [iffFirst, iffSecond]
 
-    unparse2 Iff { iffFirst, iffSecond } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\iff"
-            , unparse2 iffFirst
-            , unparse2 iffSecond
-            ])
+  unparse Iff {iffSort, iffFirst, iffSecond} =
+    "\\iff"
+      <> parameters [iffSort]
+      <> arguments [iffFirst, iffSecond]
+
+  unparse2 Iff {iffFirst, iffSecond} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\iff",
+            unparse2 iffFirst,
+            unparse2 iffSecond
+            ]
+        )
 
 instance Ord variable => Synthetic (FreeVariables variable) (Iff sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Iff Sort) where
-    synthetic Iff { iffSort, iffFirst, iffSecond } =
-        iffSort
-        & seq (matchSort iffSort iffFirst)
-        . seq (matchSort iffSort iffSecond)
-    {-# INLINE synthetic #-}
+  synthetic Iff {iffSort, iffFirst, iffSecond} =
+    iffSort
+      & seq (matchSort iffSort iffFirst)
+      . seq (matchSort iffSort iffSecond)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Implies.hs
+++ b/kore/src/Kore/Syntax/Implies.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Implies
-    ( Implies (..)
-    ) where
+  ( Implies (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -30,12 +30,13 @@ Section 9.1.4 (Patterns).
 'impliesSort' is both the sort of the operands and the sort of the result.
 
 -}
-data Implies sort child = Implies
-    { impliesSort   :: !sort
-    , impliesFirst  :: child
-    , impliesSecond :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Implies sort child
+  = Implies
+      { impliesSort :: !sort,
+        impliesFirst :: child,
+        impliesSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Implies sort child)
 
@@ -48,25 +49,28 @@ instance SOP.HasDatatypeInfo (Implies sort child)
 instance (Debug sort, Debug child) => Debug (Implies sort child)
 
 instance Unparse child => Unparse (Implies Sort child) where
-    unparse Implies { impliesSort, impliesFirst, impliesSecond } =
-        "\\implies"
-        <> parameters [impliesSort]
-        <> arguments [impliesFirst, impliesSecond]
 
-    unparse2 Implies { impliesFirst, impliesSecond } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\implies"
-            , unparse2 impliesFirst
-            , unparse2 impliesSecond
-            ])
+  unparse Implies {impliesSort, impliesFirst, impliesSecond} =
+    "\\implies"
+      <> parameters [impliesSort]
+      <> arguments [impliesFirst, impliesSecond]
+
+  unparse2 Implies {impliesFirst, impliesSecond} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\implies",
+            unparse2 impliesFirst,
+            unparse2 impliesSecond
+            ]
+        )
 
 instance Ord variable => Synthetic (FreeVariables variable) (Implies sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Implies Sort) where
-    synthetic Implies { impliesSort, impliesFirst, impliesSecond } =
-        impliesSort
-        & seq (matchSort impliesSort impliesFirst)
-        . seq (matchSort impliesSort impliesSecond)
-    {-# INLINE synthetic #-}
+  synthetic Implies {impliesSort, impliesFirst, impliesSecond} =
+    impliesSort
+      & seq (matchSort impliesSort impliesFirst)
+      . seq (matchSort impliesSort impliesSecond)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/In.hs
+++ b/kore/src/Kore/Syntax/In.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.In
-    ( In (..)
-    ) where
+  ( In (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -32,13 +32,14 @@ Section 9.1.4 (Patterns).
 'inResultSort' is the sort of the result.
 
 -}
-data In sort child = In
-    { inOperandSort     :: !sort
-    , inResultSort      :: !sort
-    , inContainedChild  :: child
-    , inContainingChild :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data In sort child
+  = In
+      { inOperandSort :: !sort,
+        inResultSort :: !sort,
+        inContainedChild :: child,
+        inContainingChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (In sort child)
 
@@ -51,39 +52,41 @@ instance SOP.HasDatatypeInfo (In sort child)
 instance (Debug sort, Debug child) => Debug (In sort child)
 
 instance Unparse child => Unparse (In Sort child) where
-    unparse
-        In
-            { inOperandSort
-            , inResultSort
-            , inContainedChild
-            , inContainingChild
-            }
-      =
-        "\\in"
+
+  unparse
+    In
+      { inOperandSort,
+        inResultSort,
+        inContainedChild,
+        inContainingChild
+        } =
+      "\\in"
         <> parameters [inOperandSort, inResultSort]
         <> arguments [inContainedChild, inContainingChild]
 
-    unparse2
-        In
-            { inContainedChild
-            , inContainingChild
-            }
-      = Pretty.parens (Pretty.fillSep
-            [ "\\in"
-            , unparse2 inContainedChild
-            , unparse2 inContainingChild
-            ])
+  unparse2
+    In
+      { inContainedChild,
+        inContainingChild
+        } =
+      Pretty.parens
+        ( Pretty.fillSep
+            [ "\\in",
+              unparse2 inContainedChild,
+              unparse2 inContainingChild
+              ]
+          )
 
 instance Ord variable => Synthetic (FreeVariables variable) (In sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (In Sort) where
-    synthetic in' =
-        inResultSort
-        & seq (matchSort inOperandSort inContainedChild)
-        . seq (matchSort inOperandSort inContainingChild)
-      where
-        In { inResultSort, inOperandSort } = in'
-        In { inContainedChild, inContainingChild } = in'
-    {-# INLINE synthetic #-}
+  synthetic in' =
+    inResultSort
+      & seq (matchSort inOperandSort inContainedChild)
+      . seq (matchSort inOperandSort inContainingChild)
+    where
+      In {inResultSort, inOperandSort} = in'
+      In {inContainedChild, inContainingChild} = in'
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Inhabitant.hs
+++ b/kore/src/Kore/Syntax/Inhabitant.hs
@@ -3,27 +3,28 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Inhabitant
-    ( Inhabitant (..)
-    ) where
+  ( Inhabitant (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
-       ( FreeVariables )
+  ( FreeVariables
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
 import Kore.Unparser
 
 -- | 'Inhabitant' symbolizes the inhabitants of a sort.
-data Inhabitant child = Inhabitant { inhSort :: !Sort }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+data Inhabitant child = Inhabitant {inhSort :: !Sort}
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable (Inhabitant child)
 
@@ -36,16 +37,18 @@ instance SOP.HasDatatypeInfo (Inhabitant child)
 instance Debug (Inhabitant child)
 
 instance Unparse (Inhabitant child) where
-    unparse = unparse . inhSort
-    unparse2 = unparse2 . inhSort
+
+  unparse = unparse . inhSort
+
+  unparse2 = unparse2 . inhSort
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) Inhabitant
+  Ord variable
+  => Synthetic (FreeVariables variable) Inhabitant
   where
-    synthetic = const mempty
-    {-# INLINE synthetic #-}
+  synthetic = const mempty
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort Inhabitant where
-    synthetic = inhSort
-    {-# INLINE synthetic #-}
+  synthetic = inhSort
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Module.hs
+++ b/kore/src/Kore/Syntax/Module.hs
@@ -4,26 +4,31 @@ License     : NCSA
 
 -}
 module Kore.Syntax.Module
-    ( ModuleName (..)
-    , getModuleNameForError
-    , Module (..)
-    ) where
+  ( ModuleName (..),
+    getModuleNameForError,
+    Module (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-                 ( Hashable (..) )
-import           Data.Maybe
-                 ( catMaybes )
-import           Data.String
-                 ( IsString )
-import           Data.Text
-                 ( Text )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
+  ( Hashable (..)
+    )
+import Data.Maybe
+  ( catMaybes
+    )
+import Data.String
+  ( IsString
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Attributes
 import Kore.Debug
 import Kore.Unparser
@@ -31,8 +36,8 @@ import Kore.Unparser
 {- | 'ModuleName' corresponds to the @module-name@ syntactic category
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 -}
-newtype ModuleName = ModuleName { getModuleName :: Text }
-    deriving (Eq, GHC.Generic, IsString, Ord, Show)
+newtype ModuleName = ModuleName {getModuleName :: Text}
+  deriving (Eq, GHC.Generic, IsString, Ord, Show)
 
 instance Hashable ModuleName
 
@@ -45,9 +50,10 @@ instance SOP.HasDatatypeInfo ModuleName
 instance Debug ModuleName
 
 instance Unparse ModuleName where
-    unparse = Pretty.pretty . getModuleName
-    unparse2 = Pretty.pretty . getModuleName
 
+  unparse = Pretty.pretty . getModuleName
+
+  unparse2 = Pretty.pretty . getModuleName
 
 getModuleNameForError :: ModuleName -> String
 getModuleNameForError = Text.unpack . getModuleName
@@ -59,13 +65,13 @@ They correspond to the second, third and forth non-terminals of the @definition@
 syntactic category from the Semantics of K, Section 9.1.6
 (Declaration and Definitions).
 -}
-data Module (sentence :: *) =
-    Module
-        { moduleName       :: !ModuleName
-        , moduleSentences  :: ![sentence]
-        , moduleAttributes :: !Attributes
+data Module (sentence :: *)
+  = Module
+      { moduleName :: !ModuleName,
+        moduleSentences :: ![sentence],
+        moduleAttributes :: !Attributes
         }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Show, Traversable)
+  deriving (Eq, Functor, Foldable, GHC.Generic, Show, Traversable)
 
 instance Hashable sentence => Hashable (Module sentence)
 
@@ -78,30 +84,27 @@ instance SOP.HasDatatypeInfo (Module sentence)
 instance Debug sentence => Debug (Module sentence)
 
 instance Unparse sentence => Unparse (Module sentence) where
-    unparse
-        Module { moduleName, moduleSentences, moduleAttributes }
-      =
-        (Pretty.vsep . catMaybes)
-            [ Just ("module" Pretty.<+> unparse moduleName)
-            , case moduleSentences of
-                [] -> Nothing
-                _ ->
-                    (Just . Pretty.indent 4 . Pretty.vsep)
-                        (unparse <$> moduleSentences)
-            , Just "endmodule"
-            , Just (unparse moduleAttributes)
-            ]
 
-    unparse2
-        Module { moduleName, moduleSentences, moduleAttributes }
-      =
-        (Pretty.vsep . catMaybes)
-            [ Just ("module" Pretty.<+> unparse2 moduleName)
-            , case moduleSentences of
-                [] -> Nothing
-                _ ->
-                    (Just . Pretty.indent 4 . Pretty.vsep)
-                        (unparse2 <$> moduleSentences)
-            , Just "endmodule"
-            , Just (unparse2 moduleAttributes)
-            ]
+  unparse Module {moduleName, moduleSentences, moduleAttributes} =
+    (Pretty.vsep . catMaybes)
+      [ Just ("module" Pretty.<+> unparse moduleName),
+        case moduleSentences of
+          [] -> Nothing
+          _ ->
+            (Just . Pretty.indent 4 . Pretty.vsep)
+              (unparse <$> moduleSentences),
+        Just "endmodule",
+        Just (unparse moduleAttributes)
+        ]
+
+  unparse2 Module {moduleName, moduleSentences, moduleAttributes} =
+    (Pretty.vsep . catMaybes)
+      [ Just ("module" Pretty.<+> unparse2 moduleName),
+        case moduleSentences of
+          [] -> Nothing
+          _ ->
+            (Just . Pretty.indent 4 . Pretty.vsep)
+              (unparse2 <$> moduleSentences),
+        Just "endmodule",
+        Just (unparse2 moduleAttributes)
+        ]

--- a/kore/src/Kore/Syntax/Mu.hs
+++ b/kore/src/Kore/Syntax/Mu.hs
@@ -3,19 +3,19 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Mu
-    ( Mu (..)
-    ) where
+  ( Mu (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Function
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,11 +31,12 @@ import Kore.Variables.UnifiedVariable
 The sort of the variable is the same as the sort of the result.
 
 -}
-data Mu variable child = Mu
-    { muVariable :: !(SetVariable variable)
-    , muChild    :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Mu variable child
+  = Mu
+      { muVariable :: !(SetVariable variable),
+        muChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable variable, Hashable child) => Hashable (Mu variable child)
 
@@ -48,33 +49,36 @@ instance SOP.HasDatatypeInfo (Mu variable child)
 instance (Debug variable, Debug child) => Debug (Mu variable child)
 
 instance
-    (SortedVariable variable, Unparse variable, Unparse child) =>
-    Unparse (Mu variable child)
+  (SortedVariable variable, Unparse variable, Unparse child)
+  => Unparse (Mu variable child)
   where
-    unparse Mu { muVariable, muChild } =
-        "\\mu"
-        <> parameters ([] :: [Sort])
-        <> arguments' [unparse muVariable, unparse muChild]
 
-    unparse2 Mu { muVariable, muChild } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\mu"
-            , unparse2SortedVariable (getSetVariable muVariable)
-            , unparse2 muChild
-            ])
+  unparse Mu {muVariable, muChild} =
+    "\\mu"
+      <> parameters ([] :: [Sort])
+      <> arguments' [unparse muVariable, unparse muChild]
+
+  unparse2 Mu {muVariable, muChild} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\mu",
+            unparse2SortedVariable (getSetVariable muVariable),
+            unparse2 muChild
+            ]
+        )
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Mu variable)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Mu variable)
   where
-    synthetic Mu { muVariable, muChild } =
-        bindVariable (SetVar muVariable) muChild
-    {-# INLINE synthetic #-}
+  synthetic Mu {muVariable, muChild} =
+    bindVariable (SetVar muVariable) muChild
+  {-# INLINE synthetic #-}
 
 instance SortedVariable variable => Synthetic Sort (Mu variable) where
-    synthetic Mu { muVariable, muChild } =
-        muSort
-        & seq (matchSort muSort muChild)
-      where
-        muSort = sortedVariableSort (getSetVariable muVariable)
-    {-# INLINE synthetic #-}
+  synthetic Mu {muVariable, muChild} =
+    muSort
+      & seq (matchSort muSort muChild)
+    where
+      muSort = sortedVariableSort (getSetVariable muVariable)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Next.hs
+++ b/kore/src/Kore/Syntax/Next.hs
@@ -3,18 +3,18 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Next
-    ( Next (..)
-    ) where
+  ( Next (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -27,11 +27,12 @@ syntactic category from the Semantics of K, Section 9.1.4 (Patterns).
 'nextSort' is both the sort of the operand and the sort of the result.
 
 -}
-data Next sort child = Next
-    { nextSort  :: !sort
-    , nextChild :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Next sort child
+  = Next
+      { nextSort :: !sort,
+        nextChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Next sort child)
 
@@ -44,19 +45,20 @@ instance SOP.HasDatatypeInfo (Next sort child)
 instance (Debug sort, Debug child) => Debug (Next sort child)
 
 instance Unparse child => Unparse (Next Sort child) where
-    unparse Next { nextSort, nextChild } =
-        "\\next"
-        <> parameters [nextSort]
-        <> arguments [nextChild]
 
-    unparse2 Next { nextChild } =
-        Pretty.parens (Pretty.fillSep ["\\next", unparse2 nextChild])
+  unparse Next {nextSort, nextChild} =
+    "\\next"
+      <> parameters [nextSort]
+      <> arguments [nextChild]
+
+  unparse2 Next {nextChild} =
+    Pretty.parens (Pretty.fillSep ["\\next", unparse2 nextChild])
 
 instance Ord variable => Synthetic (FreeVariables variable) (Next sort) where
-    synthetic = nextChild
-    {-# INLINE synthetic #-}
+  synthetic = nextChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Next Sort) where
-    synthetic Next { nextSort, nextChild } =
-        nextSort `matchSort` nextChild
-    {-# INLINE synthetic #-}
+  synthetic Next {nextSort, nextChild} =
+    nextSort `matchSort` nextChild
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Not.hs
+++ b/kore/src/Kore/Syntax/Not.hs
@@ -3,18 +3,18 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Not
-    ( Not (..)
-    ) where
+  ( Not (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -29,11 +29,12 @@ Section 9.1.4 (Patterns).
 'notSort' is both the sort of the operand and the sort of the result.
 
 -}
-data Not sort child = Not
-    { notSort  :: !sort
-    , notChild :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Not sort child
+  = Not
+      { notSort :: !sort,
+        notChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Not sort child)
 
@@ -46,23 +47,26 @@ instance SOP.HasDatatypeInfo (Not sort child)
 instance (Debug sort, Debug child) => Debug (Not sort child)
 
 instance Unparse child => Unparse (Not Sort child) where
-    unparse Not { notSort, notChild } =
-        "\\not"
-        <> parameters [notSort]
-        <> arguments [notChild]
 
-    unparse2 Not { notChild } =
-        Pretty.parens (Pretty.fillSep ["\\not", unparse2 notChild])
+  unparse Not {notSort, notChild} =
+    "\\not"
+      <> parameters [notSort]
+      <> arguments [notChild]
+
+  unparse2 Not {notChild} =
+    Pretty.parens (Pretty.fillSep ["\\not", unparse2 notChild])
 
 instance TopBottom child => TopBottom (Not sort child) where
-    isTop = isBottom . notChild
-    isBottom = isTop . notChild
+
+  isTop = isBottom . notChild
+
+  isBottom = isTop . notChild
 
 instance Ord variable => Synthetic (FreeVariables variable) (Not child) where
-    synthetic = notChild
-    {-# INLINE synthetic #-}
+  synthetic = notChild
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Not Sort) where
-    synthetic Not { notSort, notChild } =
-        notSort `matchSort` notChild
-    {-# INLINE synthetic #-}
+  synthetic Not {notSort, notChild} =
+    notSort `matchSort` notChild
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Nu.hs
+++ b/kore/src/Kore/Syntax/Nu.hs
@@ -3,19 +3,19 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Nu
-    ( Nu (..)
-    ) where
+  ( Nu (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Function
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -31,11 +31,12 @@ import Kore.Variables.UnifiedVariable
 The sort of the variable is the same as the sort of the result.
 
 -}
-data Nu variable child = Nu
-    { nuVariable :: !(SetVariable variable)
-    , nuChild    :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Nu variable child
+  = Nu
+      { nuVariable :: !(SetVariable variable),
+        nuChild :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable variable, Hashable child) => Hashable (Nu variable child)
 
@@ -48,33 +49,36 @@ instance SOP.HasDatatypeInfo (Nu variable child)
 instance (Debug variable, Debug child) => Debug (Nu variable child)
 
 instance
-    (SortedVariable variable, Unparse variable, Unparse child) =>
-    Unparse (Nu variable child)
+  (SortedVariable variable, Unparse variable, Unparse child)
+  => Unparse (Nu variable child)
   where
-    unparse Nu {nuVariable, nuChild } =
-        "\\nu"
-        <> parameters ([] :: [Sort])
-        <> arguments' [unparse nuVariable, unparse nuChild]
 
-    unparse2 Nu {nuVariable, nuChild } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\nu"
-            , unparse2SortedVariable (getSetVariable nuVariable)
-            , unparse2 nuChild
-            ])
+  unparse Nu {nuVariable, nuChild} =
+    "\\nu"
+      <> parameters ([] :: [Sort])
+      <> arguments' [unparse nuVariable, unparse nuChild]
+
+  unparse2 Nu {nuVariable, nuChild} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\nu",
+            unparse2SortedVariable (getSetVariable nuVariable),
+            unparse2 nuChild
+            ]
+        )
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Nu variable)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Nu variable)
   where
-    synthetic Nu { nuVariable, nuChild } =
-        bindVariable (SetVar nuVariable) nuChild
-    {-# INLINE synthetic #-}
+  synthetic Nu {nuVariable, nuChild} =
+    bindVariable (SetVar nuVariable) nuChild
+  {-# INLINE synthetic #-}
 
 instance SortedVariable variable => Synthetic Sort (Nu variable) where
-    synthetic Nu { nuVariable, nuChild } =
-        nuSort
-        & seq (matchSort nuSort nuChild)
-      where
-        nuSort = sortedVariableSort (getSetVariable nuVariable)
-    {-# INLINE synthetic #-}
+  synthetic Nu {nuVariable, nuChild} =
+    nuSort
+      & seq (matchSort nuSort nuChild)
+    where
+      nuSort = sortedVariableSort (getSetVariable nuVariable)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Or.hs
+++ b/kore/src/Kore/Syntax/Or.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Or
-    ( Or (..)
-    ) where
+  ( Or (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -30,12 +30,13 @@ Section 9.1.4 (Patterns).
 'orSort' is both the sort of the operands and the sort of the result.
 
 -}
-data Or sort child = Or
-    { orSort   :: !sort
-    , orFirst  :: child
-    , orSecond :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Or sort child
+  = Or
+      { orSort :: !sort,
+        orFirst :: child,
+        orSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Or sort child)
 
@@ -48,25 +49,28 @@ instance SOP.HasDatatypeInfo (Or sort child)
 instance (Debug sort, Debug child) => Debug (Or sort child)
 
 instance Unparse child => Unparse (Or Sort child) where
-    unparse Or { orSort, orFirst, orSecond } =
-        "\\or"
-        <> parameters [orSort]
-        <> arguments [orFirst, orSecond]
 
-    unparse2 Or { orFirst, orSecond } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\or"
-            , unparse2 orFirst
-            , unparse2 orSecond
-            ])
+  unparse Or {orSort, orFirst, orSecond} =
+    "\\or"
+      <> parameters [orSort]
+      <> arguments [orFirst, orSecond]
+
+  unparse2 Or {orFirst, orSecond} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\or",
+            unparse2 orFirst,
+            unparse2 orSecond
+            ]
+        )
 
 instance Ord variable => Synthetic (FreeVariables variable) (Or sort) where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Or Sort) where
-    synthetic Or { orSort, orFirst, orSecond } =
-        orSort
-        & seq (matchSort orSort orFirst)
-        . seq (matchSort orSort orSecond)
-    {-# INLINE synthetic #-}
+  synthetic Or {orSort, orFirst, orSecond} =
+    orSort
+      & seq (matchSort orSort orFirst)
+      . seq (matchSort orSort orSecond)
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Pattern.hs
+++ b/kore/src/Kore/Syntax/Pattern.hs
@@ -4,51 +4,65 @@ License     : NCSA
 
 -}
 module Kore.Syntax.Pattern
-    ( Pattern (..)
-    , asPattern
-    , fromPattern
-    , eraseAnnotations
-    , traverseVariables
-    , mapVariables
-    , asConcretePattern
-    , isConcrete
-    , fromConcretePattern
+  ( Pattern (..),
+    asPattern,
+    fromPattern,
+    eraseAnnotations,
+    traverseVariables,
+    mapVariables,
+    asConcretePattern,
+    isConcrete,
+    fromConcretePattern,
     -- * Re-exports
-    , Base, CofreeF (..)
-    , PatternF (..)
-    , Const (..)
-    , module Control.Comonad
-    ) where
+    Base,
+    CofreeF (..),
+    PatternF (..),
+    Const (..),
+    module Control.Comonad
+    )
+where
 
-import           Control.Comonad
-import           Control.Comonad.Trans.Cofree
-                 ( Cofree, CofreeF (..), ComonadCofree (..) )
+import Control.Comonad
+import Control.Comonad.Trans.Cofree
+  ( Cofree,
+    CofreeF (..),
+    ComonadCofree (..)
+    )
 import qualified Control.Comonad.Trans.Env as Env
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Bifunctor as Bifunctor
-import           Data.Functor.Compose
-                 ( Compose (..) )
-import           Data.Functor.Foldable
-                 ( Base, Corecursive, Recursive )
+import Data.Functor.Compose
+  ( Compose (..)
+    )
+import Data.Functor.Foldable
+  ( Base,
+    Corecursive,
+    Recursive
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Functor.Identity
-                 ( Identity (..) )
-import           Data.Hashable
-                 ( Hashable (..) )
-import           Data.Maybe
-import qualified Generics.SOP as SOP
+import Data.Functor.Identity
+  ( Identity (..)
+    )
+import Data.Hashable
+  ( Hashable (..)
+    )
+import Data.Maybe
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Debug
-import           Kore.Syntax.PatternF
-                 ( Const (..), PatternF (..) )
+import Kore.Debug
+import Kore.Syntax.PatternF
+  ( Const (..),
+    PatternF (..)
+    )
 import qualified Kore.Syntax.PatternF as PatternF
-import           Kore.Syntax.Variable
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unparser
+import Kore.Syntax.Variable
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unparser
 
 {- | The abstract syntax of Kore.
 
@@ -59,194 +73,202 @@ syntax tree. @Pattern@ is a 'Traversable' 'Comonad' over the type of
 annotations.
 
 -}
-newtype Pattern
+newtype
+  Pattern
     (variable :: *)
     (annotation :: *)
-  =
-    Pattern
-        { getPattern :: Cofree (PatternF variable) annotation }
-    deriving (Foldable, Functor, GHC.Generic, Traversable)
+  = Pattern
+      {getPattern :: Cofree (PatternF variable) annotation}
+  deriving (Foldable, Functor, GHC.Generic, Traversable)
 
 instance Eq variable => Eq (Pattern variable annotation) where
-    (==) = eqWorker
-      where
-        eqWorker
-            (Recursive.project -> _ :< pat1)
-            (Recursive.project -> _ :< pat2)
-          =
-            pat1 == pat2
-    {-# INLINE (==) #-}
+  (==) = eqWorker
+    where
+      eqWorker
+        (Recursive.project -> _ :< pat1)
+        (Recursive.project -> _ :< pat2) =
+          pat1 == pat2
+  {-# INLINE (==) #-}
 
 instance Ord variable => Ord (Pattern variable annotation) where
-    compare = compareWorker
-      where
-        compareWorker
-            (Recursive.project -> _ :< pat1)
-            (Recursive.project -> _ :< pat2)
-          =
-            compare pat1 pat2
-    {-# INLINE compare #-}
+  compare = compareWorker
+    where
+      compareWorker
+        (Recursive.project -> _ :< pat1)
+        (Recursive.project -> _ :< pat2) =
+          compare pat1 pat2
+  {-# INLINE compare #-}
 
 deriving instance
-    (Show annotation, Show variable) =>
-    Show (Pattern variable annotation)
+  (Show annotation, Show variable)
+  => Show (Pattern variable annotation)
 
 instance Hashable variable => Hashable (Pattern variable annotation) where
-    hashWithSalt salt (Recursive.project -> _ :< pat) = hashWithSalt salt pat
-    {-# INLINE hashWithSalt #-}
+  hashWithSalt salt (Recursive.project -> _ :< pat) = hashWithSalt salt pat
+  {-# INLINE hashWithSalt #-}
 
 instance
-    (NFData annotation, NFData variable) =>
-    NFData (Pattern variable annotation)
+  (NFData annotation, NFData variable)
+  => NFData (Pattern variable annotation)
   where
-    rnf (Recursive.project -> annotation :< pat) =
-        rnf annotation `seq` rnf pat
+  rnf (Recursive.project -> annotation :< pat) =
+    rnf annotation `seq` rnf pat
 
 instance SOP.Generic (Pattern variable annotation)
 
 instance SOP.HasDatatypeInfo (Pattern variable annotation)
 
 instance
-    (Debug annotation, Debug variable) =>
-    Debug (Pattern variable annotation)
+  (Debug annotation, Debug variable)
+  => Debug (Pattern variable annotation)
 
 instance
-    (SortedVariable variable, Unparse variable) =>
-    Unparse (Pattern variable annotation)
+  (SortedVariable variable, Unparse variable)
+  => Unparse (Pattern variable annotation)
   where
-    unparse (Recursive.project -> _ :< pat) = unparse pat
-    unparse2 (Recursive.project -> _ :< pat) = unparse2 pat
 
-type instance Base (Pattern variable annotation) =
+  unparse (Recursive.project -> _ :< pat) = unparse pat
+
+  unparse2 (Recursive.project -> _ :< pat) = unparse2 pat
+
+type instance
+  Base (Pattern variable annotation) =
     CofreeF (PatternF variable) annotation
 
 -- This instance implements all class functions for the Pattern newtype
 -- because the their implementations for the inner type may be specialized.
 instance Recursive (Pattern variable annotation) where
-    project = \(Pattern embedded) ->
-        case Recursive.project embedded of
-            Compose (Identity projected) -> Pattern <$> projected
-    {-# INLINE project #-}
 
-    -- This specialization is particularly important: The default implementation
-    -- of 'cata' in terms of 'project' would involve an extra call to 'fmap' at
-    -- every level of the tree due to the implementation of 'project' above.
-    cata alg = \(Pattern fixed) ->
-        Recursive.cata
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE cata #-}
+  project = \(Pattern embedded) ->
+    case Recursive.project embedded of
+      Compose (Identity projected) -> Pattern <$> projected
+  {-# INLINE project #-}
 
-    para alg = \(Pattern fixed) ->
-        Recursive.para
-            (\(Compose (Identity base)) ->
-                 alg (Bifunctor.first Pattern <$> base)
-            )
-            fixed
-    {-# INLINE para #-}
+  -- This specialization is particularly important: The default implementation
+  -- of 'cata' in terms of 'project' would involve an extra call to 'fmap' at
+  -- every level of the tree due to the implementation of 'project' above.
+  cata alg = \(Pattern fixed) ->
+    Recursive.cata
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE cata #-}
 
-    gpara dist alg = \(Pattern fixed) ->
-        Recursive.gpara
-            (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
-            (\(Compose (Identity base)) -> alg (Env.local Pattern <$> base))
-            fixed
-    {-# INLINE gpara #-}
+  para alg = \(Pattern fixed) ->
+    Recursive.para
+      ( \(Compose (Identity base)) ->
+          alg (Bifunctor.first Pattern <$> base)
+        )
+      fixed
+  {-# INLINE para #-}
 
-    prepro pre alg = \(Pattern fixed) ->
-        Recursive.prepro
-            (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE prepro #-}
+  gpara dist alg = \(Pattern fixed) ->
+    Recursive.gpara
+      (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
+      (\(Compose (Identity base)) -> alg (Env.local Pattern <$> base))
+      fixed
+  {-# INLINE gpara #-}
 
-    gprepro dist pre alg = \(Pattern fixed) ->
-        Recursive.gprepro
-            (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
-            (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
-            (\(Compose (Identity base)) -> alg base)
-            fixed
-    {-# INLINE gprepro #-}
+  prepro pre alg = \(Pattern fixed) ->
+    Recursive.prepro
+      (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE prepro #-}
+
+  gprepro dist pre alg = \(Pattern fixed) ->
+    Recursive.gprepro
+      (\(Compose (Identity base)) -> Compose . Identity <$> dist base)
+      (\(Compose (Identity base)) -> (Compose . Identity) (pre base))
+      (\(Compose (Identity base)) -> alg base)
+      fixed
+  {-# INLINE gprepro #-}
 
 -- This instance implements all class functions for the Pattern newtype
 -- because the their implementations for the inner type may be specialized.
 instance Corecursive (Pattern variable annotation) where
-    embed = \projected ->
-        (Pattern . Recursive.embed . Compose . Identity)
-            (getPattern <$> projected)
-    {-# INLINE embed #-}
 
-    ana coalg = Pattern . ana0
-      where
-        ana0 =
-            Recursive.ana (Compose . Identity . coalg)
-    {-# INLINE ana #-}
+  embed = \projected ->
+    (Pattern . Recursive.embed . Compose . Identity)
+      (getPattern <$> projected)
+  {-# INLINE embed #-}
 
-    apo coalg = Pattern . apo0
-      where
-        apo0 =
-            Recursive.apo
-                (\a ->
-                     (Compose . Identity)
-                        (Bifunctor.first getPattern <$> coalg a)
-                )
-    {-# INLINE apo #-}
+  ana coalg = Pattern . ana0
+    where
+      ana0 =
+        Recursive.ana (Compose . Identity . coalg)
+  {-# INLINE ana #-}
 
-    postpro post coalg = Pattern . postpro0
-      where
-        postpro0 =
-            Recursive.postpro
-                (\(Compose (Identity base)) -> (Compose . Identity) (post base))
-                (Compose . Identity . coalg)
-    {-# INLINE postpro #-}
+  apo coalg = Pattern . apo0
+    where
+      apo0 =
+        Recursive.apo
+          ( \a ->
+              (Compose . Identity)
+                (Bifunctor.first getPattern <$> coalg a)
+            )
+  {-# INLINE apo #-}
 
-    gpostpro dist post coalg = Pattern . gpostpro0
-      where
-        gpostpro0 =
-            Recursive.gpostpro
-                (Compose . Identity . dist . (<$>) (runIdentity . getCompose))
-                (\(Compose (Identity base)) -> (Compose . Identity) (post base))
-                (Compose . Identity . coalg)
-    {-# INLINE gpostpro #-}
+  postpro post coalg = Pattern . postpro0
+    where
+      postpro0 =
+        Recursive.postpro
+          (\(Compose (Identity base)) -> (Compose . Identity) (post base))
+          (Compose . Identity . coalg)
+  {-# INLINE postpro #-}
+
+  gpostpro dist post coalg = Pattern . gpostpro0
+    where
+      gpostpro0 =
+        Recursive.gpostpro
+          (Compose . Identity . dist . (<$>) (runIdentity . getCompose))
+          (\(Compose (Identity base)) -> (Compose . Identity) (post base))
+          (Compose . Identity . coalg)
+  {-# INLINE gpostpro #-}
 
 -- This instance implements all class functions for the Pattern newtype
 -- because the their implementations for the inner type may be specialized.
 instance Comonad (Pattern variable) where
-    extract = \(Pattern fixed) -> extract fixed
-    {-# INLINE extract #-}
-    duplicate = \(Pattern fixed) -> Pattern (extend Pattern fixed)
-    {-# INLINE duplicate #-}
-    extend extending = \(Pattern fixed) ->
-        Pattern (extend (extending . Pattern) fixed)
-    {-# INLINE extend #-}
+
+  extract = \(Pattern fixed) -> extract fixed
+  {-# INLINE extract #-}
+
+  duplicate = \(Pattern fixed) -> Pattern (extend Pattern fixed)
+  {-# INLINE duplicate #-}
+
+  extend extending = \(Pattern fixed) ->
+    Pattern (extend (extending . Pattern) fixed)
+  {-# INLINE extend #-}
 
 instance ComonadCofree (PatternF variable) (Pattern variable) where
-    unwrap = \(Pattern fixed) -> Pattern <$> unwrap fixed
-    {-# INLINE unwrap #-}
+  unwrap = \(Pattern fixed) -> Pattern <$> unwrap fixed
+  {-# INLINE unwrap #-}
 
 instance TopBottom (Pattern variable annotation) where
-    isTop (Recursive.project -> _ :< TopF _) = True
-    isTop _ = False
-    isBottom (Recursive.project -> _ :< BottomF _) = True
-    isBottom _ = False
+
+  isTop (Recursive.project -> _ :< TopF _) = True
+  isTop _ = False
+
+  isBottom (Recursive.project -> _ :< BottomF _) = True
+  isBottom _ = False
 
 fromPattern
-    :: Pattern variable annotation
-    -> Base
-        (Pattern variable annotation)
-        (Pattern variable annotation)
+  :: Pattern variable annotation
+  -> Base
+       (Pattern variable annotation)
+       (Pattern variable annotation)
 fromPattern = Recursive.project
 
 asPattern
-    :: Base
-        (Pattern variable annotation)
-        (Pattern variable annotation)
-    -> Pattern variable annotation
+  :: Base
+       (Pattern variable annotation)
+       (Pattern variable annotation)
+  -> Pattern variable annotation
 asPattern = Recursive.embed
 
 -- | Erase the annotations from any 'Pattern'.
 eraseAnnotations
-    :: Pattern variable erased
-    -> Pattern variable Attribute.Null
+  :: Pattern variable erased
+  -> Pattern variable Attribute.Null
 eraseAnnotations = (<$) Attribute.Null
 
 {- | Use the provided traversal to replace all variables in a 'Pattern'.
@@ -260,21 +282,20 @@ See also: 'mapVariables'
 
  -}
 traverseVariables
-    ::  forall m variable1 variable2 annotation.
-        Monad m
-    => (variable1 -> m variable2)
-    -> Pattern variable1 annotation
-    -> m (Pattern variable2 annotation)
+  :: forall m variable1 variable2 annotation. Monad m
+  => (variable1 -> m variable2)
+  -> Pattern variable1 annotation
+  -> m (Pattern variable2 annotation)
 traverseVariables traversing =
-    Recursive.fold traverseVariablesWorker
+  Recursive.fold traverseVariablesWorker
   where
     traverseVariablesWorker
-        :: Base
-            (Pattern variable1 annotation)
-            (m (Pattern variable2 annotation))
-        -> m (Pattern variable2 annotation)
+      :: Base
+           (Pattern variable1 annotation)
+           (m (Pattern variable2 annotation))
+      -> m (Pattern variable2 annotation)
     traverseVariablesWorker (a :< pat) =
-        reannotate <$> (PatternF.traverseVariables traversing =<< sequence pat)
+      reannotate <$> (PatternF.traverseVariables traversing =<< sequence pat)
       where
         reannotate pat' = Recursive.embed (a :< pat')
 
@@ -288,14 +309,14 @@ See also: 'traverseVariables'
 
  -}
 mapVariables
-    :: (variable1 -> variable2)
-    -> Pattern variable1 annotation
-    -> Pattern variable2 annotation
+  :: (variable1 -> variable2)
+  -> Pattern variable1 annotation
+  -> Pattern variable2 annotation
 mapVariables mapping =
-    Recursive.ana (mapVariablesWorker . Recursive.project)
+  Recursive.ana (mapVariablesWorker . Recursive.project)
   where
     mapVariablesWorker (a :< pat) =
-        a :< PatternF.mapVariables mapping pat
+      a :< PatternF.mapVariables mapping pat
 
 {- | Construct a 'ConcretePattern' from a 'Pattern'.
 
@@ -309,9 +330,10 @@ deciding if the result is @Nothing@ or @Just _@.
 
  -}
 asConcretePattern
-    :: Pattern variable annotation
-    -> Maybe (Pattern Concrete annotation)
-asConcretePattern = traverseVariables (\case { _ -> Nothing })
+  :: Pattern variable annotation
+  -> Maybe (Pattern Concrete annotation)
+asConcretePattern = traverseVariables (\case
+      _ -> Nothing)
 
 isConcrete :: Pattern variable annotation -> Bool
 isConcrete = isJust . asConcretePattern
@@ -326,6 +348,7 @@ composes with other tree transformations without allocating intermediates.
 
  -}
 fromConcretePattern
-    :: Pattern Concrete annotation
-    -> Pattern variable annotation
-fromConcretePattern = mapVariables (\case {})
+  :: Pattern Concrete annotation
+  -> Pattern variable annotation
+fromConcretePattern = mapVariables (\case
+    )

--- a/kore/src/Kore/Syntax/PatternF.hs
+++ b/kore/src/Kore/Syntax/PatternF.hs
@@ -3,29 +3,31 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.PatternF
-    ( PatternF (..)
-    , mapVariables
-    , traverseVariables
+  ( PatternF (..),
+    mapVariables,
+    traverseVariables,
     -- * Pure pattern heads
-    , groundHead
-    , constant
+    groundHead,
+    constant,
     -- * Re-exports
-    , Const (..)
-    ) where
+    Const (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Functor.Const
-import           Data.Functor.Identity
-                 ( Identity (..) )
-import           Data.Hashable
-import           Data.Text
-                 ( Text )
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Functor.Const
+import Data.Functor.Identity
+  ( Identity (..)
+    )
+import Data.Hashable
+import Data.Text
+  ( Text
+    )
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Sort
 import Kore.Syntax.And
@@ -58,30 +60,30 @@ import Kore.Variables.UnifiedVariable
 
 -}
 data PatternF variable child
-    = AndF           !(And Sort child)
-    | ApplicationF   !(Application SymbolOrAlias child)
-    | BottomF        !(Bottom Sort child)
-    | CeilF          !(Ceil Sort child)
-    | DomainValueF   !(DomainValue Sort child)
-    | EqualsF        !(Equals Sort child)
-    | ExistsF        !(Exists Sort variable child)
-    | FloorF         !(Floor Sort child)
-    | ForallF        !(Forall Sort variable child)
-    | IffF           !(Iff Sort child)
-    | ImpliesF       !(Implies Sort child)
-    | InF            !(In Sort child)
-    | MuF            !(Mu variable child)
-    | NextF          !(Next Sort child)
-    | NotF           !(Not Sort child)
-    | NuF            !(Nu variable child)
-    | OrF            !(Or Sort child)
-    | RewritesF      !(Rewrites Sort child)
-    | TopF           !(Top Sort child)
-    | InhabitantF    !(Inhabitant child)
-    | StringLiteralF !(Const StringLiteral child)
-    | CharLiteralF   !(Const CharLiteral child)
-    | VariableF      !(Const (UnifiedVariable variable) child)
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  = AndF !(And Sort child)
+  | ApplicationF !(Application SymbolOrAlias child)
+  | BottomF !(Bottom Sort child)
+  | CeilF !(Ceil Sort child)
+  | DomainValueF !(DomainValue Sort child)
+  | EqualsF !(Equals Sort child)
+  | ExistsF !(Exists Sort variable child)
+  | FloorF !(Floor Sort child)
+  | ForallF !(Forall Sort variable child)
+  | IffF !(Iff Sort child)
+  | ImpliesF !(Implies Sort child)
+  | InF !(In Sort child)
+  | MuF !(Mu variable child)
+  | NextF !(Next Sort child)
+  | NotF !(Not Sort child)
+  | NuF !(Nu variable child)
+  | OrF !(Or Sort child)
+  | RewritesF !(Rewrites Sort child)
+  | TopF !(Top Sort child)
+  | InhabitantF !(Inhabitant child)
+  | StringLiteralF !(Const StringLiteral child)
+  | CharLiteralF !(Const CharLiteral child)
+  | VariableF !(Const (UnifiedVariable variable) child)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance SOP.Generic (PatternF variable child)
 
@@ -90,17 +92,19 @@ instance SOP.HasDatatypeInfo (PatternF variable child)
 instance (Debug variable, Debug child) => Debug (PatternF variable child)
 
 instance
-    (Hashable child, Hashable variable) =>
-    Hashable (PatternF variable child)
+  (Hashable child, Hashable variable)
+  => Hashable (PatternF variable child)
 
 instance (NFData child, NFData variable) => NFData (PatternF variable child)
 
 instance
-    (SortedVariable variable, Unparse variable, Unparse child) =>
-    Unparse (PatternF variable child)
+  (SortedVariable variable, Unparse variable, Unparse child)
+  => Unparse (PatternF variable child)
   where
-    unparse = unparseGeneric
-    unparse2 = unparse2Generic
+
+  unparse = unparseGeneric
+
+  unparse2 = unparse2Generic
 
 {- | Use the provided mapping to replace all variables in a 'PatternF' head.
 
@@ -109,11 +113,11 @@ not injective!
 
 -}
 mapVariables
-    :: (variable1 -> variable2)
-    -> PatternF variable1 child
-    -> PatternF variable2 child
+  :: (variable1 -> variable2)
+  -> PatternF variable1 child
+  -> PatternF variable2 child
 mapVariables mapping =
-    runIdentity . traverseVariables (Identity . mapping)
+  runIdentity . traverseVariables (Identity . mapping)
 {-# INLINE mapVariables #-}
 
 {- | Use the provided traversal to replace all variables in a 'PatternF' head.
@@ -123,71 +127,72 @@ traversal is not injective!
 
 -}
 traverseVariables
-    :: Applicative f
-    => (variable1 -> f variable2)
-    -> PatternF variable1 child
-    -> f (PatternF variable2 child)
+  :: Applicative f
+  => (variable1 -> f variable2)
+  -> PatternF variable1 child
+  -> f (PatternF variable2 child)
 traverseVariables traversing =
-    \case
-        -- Non-trivial cases
-        ExistsF any0 -> ExistsF <$> traverseVariablesExists any0
-        ForallF all0 -> ForallF <$> traverseVariablesForall all0
-        MuF any0 -> MuF <$> traverseVariablesMu any0
-        NuF any0 -> NuF <$> traverseVariablesNu any0
-        VariableF variableF -> traverseVariable variableF
-        -- Trivial cases
-        AndF andP -> pure (AndF andP)
-        ApplicationF appP -> pure (ApplicationF appP)
-        BottomF botP -> pure (BottomF botP)
-        CeilF ceilP -> pure (CeilF ceilP)
-        DomainValueF dvP -> pure (DomainValueF dvP)
-        EqualsF eqP -> pure (EqualsF eqP)
-        FloorF flrP -> pure (FloorF flrP)
-        IffF iffP -> pure (IffF iffP)
-        ImpliesF impP -> pure (ImpliesF impP)
-        InF inP -> pure (InF inP)
-        NextF nxtP -> pure (NextF nxtP)
-        NotF notP -> pure (NotF notP)
-        OrF orP -> pure (OrF orP)
-        RewritesF rewP -> pure (RewritesF rewP)
-        StringLiteralF strP -> pure (StringLiteralF strP)
-        CharLiteralF charP -> pure (CharLiteralF charP)
-        TopF topP -> pure (TopF topP)
-        InhabitantF s -> pure (InhabitantF s)
+  \case
+    -- Non-trivial cases
+    ExistsF any0 -> ExistsF <$> traverseVariablesExists any0
+    ForallF all0 -> ForallF <$> traverseVariablesForall all0
+    MuF any0 -> MuF <$> traverseVariablesMu any0
+    NuF any0 -> NuF <$> traverseVariablesNu any0
+    VariableF variableF -> traverseVariable variableF
+    -- Trivial cases
+    AndF andP -> pure (AndF andP)
+    ApplicationF appP -> pure (ApplicationF appP)
+    BottomF botP -> pure (BottomF botP)
+    CeilF ceilP -> pure (CeilF ceilP)
+    DomainValueF dvP -> pure (DomainValueF dvP)
+    EqualsF eqP -> pure (EqualsF eqP)
+    FloorF flrP -> pure (FloorF flrP)
+    IffF iffP -> pure (IffF iffP)
+    ImpliesF impP -> pure (ImpliesF impP)
+    InF inP -> pure (InF inP)
+    NextF nxtP -> pure (NextF nxtP)
+    NotF notP -> pure (NotF notP)
+    OrF orP -> pure (OrF orP)
+    RewritesF rewP -> pure (RewritesF rewP)
+    StringLiteralF strP -> pure (StringLiteralF strP)
+    CharLiteralF charP -> pure (CharLiteralF charP)
+    TopF topP -> pure (TopF topP)
+    InhabitantF s -> pure (InhabitantF s)
   where
     traverseVariable (Const variable) =
-        VariableF . Const <$> traverse traversing variable
-    traverseVariablesExists Exists { existsSort, existsVariable, existsChild } =
-        Exists existsSort
+      VariableF . Const <$> traverse traversing variable
+    traverseVariablesExists Exists {existsSort, existsVariable, existsChild} =
+      Exists existsSort
         <$> traverse traversing existsVariable
         <*> pure existsChild
-    traverseVariablesForall Forall { forallSort, forallVariable, forallChild } =
-        Forall forallSort
+    traverseVariablesForall Forall {forallSort, forallVariable, forallChild} =
+      Forall forallSort
         <$> traverse traversing forallVariable
         <*> pure forallChild
-    traverseVariablesMu Mu { muVariable, muChild } =
-        Mu <$> traverse traversing muVariable <*> pure muChild
-    traverseVariablesNu Nu { nuVariable, nuChild } =
-        Nu <$> traverse traversing nuVariable <*> pure nuChild
+    traverseVariablesMu Mu {muVariable, muChild} =
+      Mu <$> traverse traversing muVariable <*> pure muChild
+    traverseVariablesNu Nu {nuVariable, nuChild} =
+      Nu <$> traverse traversing nuVariable <*> pure nuChild
 
 -- | Given an 'Id', 'groundHead' produces the head of an 'Application'
 -- corresponding to that argument.
 groundHead :: Text -> AstLocation -> SymbolOrAlias
 groundHead ctor location = SymbolOrAlias
-    { symbolOrAliasConstructor = Id
-        { getId = ctor
-        , idLocation = location
-        }
-    , symbolOrAliasParams = []
+  { symbolOrAliasConstructor = Id
+      { getId = ctor,
+        idLocation = location
+        },
+    symbolOrAliasParams = []
     }
 
 -- | Given a head and a list of children, produces an 'ApplicationF'
 --  applying the given head to the children
 apply :: SymbolOrAlias -> [child] -> PatternF variable child
-apply patternHead patterns = ApplicationF Application
-    { applicationSymbolOrAlias = patternHead
-    , applicationChildren = patterns
-    }
+apply patternHead patterns =
+  ApplicationF Application
+    { applicationSymbolOrAlias = patternHead,
+      applicationChildren = patterns
+      }
 
 -- |Applies the given head to the empty list of children to obtain a
 -- constant 'ApplicationF'

--- a/kore/src/Kore/Syntax/Rewrites.hs
+++ b/kore/src/Kore/Syntax/Rewrites.hs
@@ -3,20 +3,20 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Rewrites
-    ( Rewrites (..)
-    ) where
+  ( Rewrites (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
 import qualified Data.Foldable as Foldable
-import           Data.Function
-import           Data.Hashable
+import Data.Function
+import Data.Hashable
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -29,13 +29,13 @@ syntactic category from the Semantics of K, Section 9.1.4 (Patterns).
 'rewritesSort' is both the sort of the operands and the sort of the result.
 
 -}
-
-data Rewrites sort child = Rewrites
-    { rewritesSort   :: !sort
-    , rewritesFirst  :: child
-    , rewritesSecond :: child
-    }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+data Rewrites sort child
+  = Rewrites
+      { rewritesSort :: !sort,
+        rewritesFirst :: child,
+        rewritesSecond :: child
+        }
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance (Hashable sort, Hashable child) => Hashable (Rewrites sort child)
 
@@ -48,25 +48,27 @@ instance SOP.HasDatatypeInfo (Rewrites sort child)
 instance (Debug sort, Debug child) => Debug (Rewrites sort child)
 
 instance Unparse child => Unparse (Rewrites Sort child) where
-    unparse Rewrites { rewritesSort, rewritesFirst, rewritesSecond } =
-        "\\rewrites"
-        <> parameters [rewritesSort]
-        <> arguments [rewritesFirst, rewritesSecond]
 
-    unparse2 Rewrites { rewritesFirst, rewritesSecond } =
-        Pretty.parens (Pretty.fillSep
-            [ "\\rewrites"
-            , unparse2 rewritesFirst
-            , unparse2 rewritesSecond
-            ])
+  unparse Rewrites {rewritesSort, rewritesFirst, rewritesSecond} =
+    "\\rewrites"
+      <> parameters [rewritesSort]
+      <> arguments [rewritesFirst, rewritesSecond]
 
-instance Ord variable => Synthetic (FreeVariables variable) (Rewrites sort)
-  where
-    synthetic = Foldable.fold
-    {-# INLINE synthetic #-}
+  unparse2 Rewrites {rewritesFirst, rewritesSecond} =
+    Pretty.parens
+      ( Pretty.fillSep
+          [ "\\rewrites",
+            unparse2 rewritesFirst,
+            unparse2 rewritesSecond
+            ]
+        )
+
+instance Ord variable => Synthetic (FreeVariables variable) (Rewrites sort) where
+  synthetic = Foldable.fold
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Rewrites Sort) where
-    synthetic Rewrites { rewritesSort, rewritesFirst, rewritesSecond } =
-        rewritesSort
-        & seq (matchSort rewritesSort rewritesFirst)
-        . seq (matchSort rewritesSort rewritesSecond)
+  synthetic Rewrites {rewritesSort, rewritesFirst, rewritesSecond} =
+    rewritesSort
+      & seq (matchSort rewritesSort rewritesFirst)
+      . seq (matchSort rewritesSort rewritesSecond)

--- a/kore/src/Kore/Syntax/Sentence.hs
+++ b/kore/src/Kore/Syntax/Sentence.hs
@@ -3,70 +3,73 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Sentence
-    ( Symbol (..)
-    , groundSymbol
-    , Alias (..)
-    , SentenceAlias (..)
-    , SentenceSymbol (..)
-    , coerceSentenceSymbol
-    , SentenceImport (..)
-    , coerceSentenceImport
-    , SentenceSort (..)
-    , coerceSentenceSort
-    , SentenceAxiom (..)
-    , SentenceClaim (..)
-    , SentenceHook (..)
-    , coerceSentenceHook
-    , Sentence (..)
-    , sentenceAttributes
-    , eraseSentenceAnnotations
+  ( Symbol (..),
+    groundSymbol,
+    Alias (..),
+    SentenceAlias (..),
+    SentenceSymbol (..),
+    coerceSentenceSymbol,
+    SentenceImport (..),
+    coerceSentenceImport,
+    SentenceSort (..),
+    coerceSentenceSort,
+    SentenceAxiom (..),
+    SentenceClaim (..),
+    SentenceHook (..),
+    coerceSentenceHook,
+    Sentence (..),
+    sentenceAttributes,
+    eraseSentenceAnnotations,
     -- * Injections and projections
-    , AsSentence (..)
-    , SentenceSymbolOrAlias (..)
+    AsSentence (..),
+    SentenceSymbolOrAlias (..),
     -- * Type synonyms
-    , PureSentenceSymbol
-    , PureSentenceAlias
-    , PureSentenceImport
-    , PureSentenceAxiom
-    , PureSentenceHook
-    , PureSentence
-    , PureModule
-    , ParsedSentenceAlias
-    , ParsedSentenceSymbol
-    , ParsedSentenceImport
-    , ParsedSentenceAxiom
-    , ParsedSentenceSort
-    , ParsedSentenceHook
-    , ParsedSentence
-    , ParsedModule
+    PureSentenceSymbol,
+    PureSentenceAlias,
+    PureSentenceImport,
+    PureSentenceAxiom,
+    PureSentenceHook,
+    PureSentence,
+    PureModule,
+    ParsedSentenceAlias,
+    ParsedSentenceSymbol,
+    ParsedSentenceImport,
+    ParsedSentenceAxiom,
+    ParsedSentenceSort,
+    ParsedSentenceHook,
+    ParsedSentence,
+    ParsedModule,
     -- * Re-exports
-    , module Kore.Attribute.Attributes
-    , module Kore.Syntax.Module
-    ) where
+    module Kore.Attribute.Attributes,
+    module Kore.Syntax.Module
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Coerce
-import           Data.Hashable
-                 ( Hashable (..) )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Coerce
+import Data.Hashable
+  ( Hashable (..)
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
-import           Kore.Attribute.Attributes
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Attributes
 import qualified Kore.Attribute.Null as Attribute
-                 ( Null (..) )
-import           Kore.Debug
-import           Kore.Sort
-import           Kore.Syntax.Application
-import           Kore.Syntax.ElementVariable
-import           Kore.Syntax.Module
-import           Kore.Syntax.Pattern
-                 ( Pattern )
-import           Kore.Syntax.Variable
-import           Kore.Unparser
+  ( Null (..)
+    )
+import Kore.Debug
+import Kore.Sort
+import Kore.Syntax.Application
+import Kore.Syntax.ElementVariable
+import Kore.Syntax.Module
+import Kore.Syntax.Pattern
+  ( Pattern
+    )
+import Kore.Syntax.Variable
+import Kore.Unparser
 
 {- | @Symbol@ is the @head-constructor{sort-variable-list}@ part of the
 @symbol-declaration@ syntactic category from the Semantics of K, Section 9.1.6
@@ -75,11 +78,12 @@ import           Kore.Unparser
 See also: 'SymbolOrAlias'
 
  -}
-data Symbol = Symbol
-    { symbolConstructor :: !Id
-    , symbolParams      :: ![SortVariable]
-    }
-    deriving (Eq, GHC.Generic, Ord, Show)
+data Symbol
+  = Symbol
+      { symbolConstructor :: !Id,
+        symbolParams :: ![SortVariable]
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable Symbol
 
@@ -92,20 +96,20 @@ instance SOP.HasDatatypeInfo Symbol
 instance Debug Symbol
 
 instance Unparse Symbol where
-    unparse Symbol { symbolConstructor, symbolParams } =
-        unparse symbolConstructor
-        <> parameters symbolParams
 
-    unparse2 Symbol { symbolConstructor } =
-        unparse2 symbolConstructor
+  unparse Symbol {symbolConstructor, symbolParams} =
+    unparse symbolConstructor
+      <> parameters symbolParams
 
+  unparse2 Symbol {symbolConstructor} =
+    unparse2 symbolConstructor
 
 -- |Given an 'Id', 'groundSymbol' produces the unparameterized 'Symbol'
 -- corresponding to that argument.
 groundSymbol :: Id -> Symbol
 groundSymbol ctor = Symbol
-    { symbolConstructor = ctor
-    , symbolParams = []
+  { symbolConstructor = ctor,
+    symbolParams = []
     }
 
 {- | 'Alias' corresponds to the @head-constructor{sort-variable-list}@ part of
@@ -115,11 +119,12 @@ Semantics of K, Section 9.1.6 (Declaration and Definitions).
 See also: 'SymbolOrAlias'.
 
  -}
-data Alias = Alias
-    { aliasConstructor :: !Id
-    , aliasParams      :: ![SortVariable]
-    }
-    deriving (Eq, GHC.Generic, Ord, Show)
+data Alias
+  = Alias
+      { aliasConstructor :: !Id,
+        aliasParams :: ![SortVariable]
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable Alias
 
@@ -132,26 +137,28 @@ instance SOP.HasDatatypeInfo Alias
 instance Debug Alias
 
 instance Unparse Alias where
-    unparse Alias { aliasConstructor, aliasParams } =
-        unparse aliasConstructor <> parameters aliasParams
-    unparse2 Alias { aliasConstructor } =
-        unparse2 aliasConstructor
+
+  unparse Alias {aliasConstructor, aliasParams} =
+    unparse aliasConstructor <> parameters aliasParams
+
+  unparse2 Alias {aliasConstructor} =
+    unparse2 aliasConstructor
 
 {- | 'SentenceAlias' corresponds to the @alias-declaration@ and syntactic
 category from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 
 -}
-data SentenceAlias (patternType :: *) =
-    SentenceAlias
-        { sentenceAliasAlias        :: !Alias
-        , sentenceAliasSorts        :: ![Sort]
-        , sentenceAliasResultSort   :: !Sort
-        , sentenceAliasLeftPattern
-            :: !(Application SymbolOrAlias (ElementVariable Variable))
-        , sentenceAliasRightPattern :: !patternType
-        , sentenceAliasAttributes   :: !Attributes
+data SentenceAlias (patternType :: *)
+  = SentenceAlias
+      { sentenceAliasAlias :: !Alias,
+        sentenceAliasSorts :: ![Sort],
+        sentenceAliasResultSort :: !Sort,
+        sentenceAliasLeftPattern
+          :: !(Application SymbolOrAlias (ElementVariable Variable)),
+        sentenceAliasRightPattern :: !patternType,
+        sentenceAliasAttributes :: !Attributes
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable patternType => Hashable (SentenceAlias patternType)
 
@@ -164,62 +171,61 @@ instance SOP.HasDatatypeInfo (SentenceAlias patternType)
 instance Debug patternType => Debug (SentenceAlias patternType)
 
 instance Unparse patternType => Unparse (SentenceAlias patternType) where
-    unparse
-        SentenceAlias
-            { sentenceAliasAlias
-            , sentenceAliasSorts
-            , sentenceAliasResultSort
-            , sentenceAliasLeftPattern
-            , sentenceAliasRightPattern
-            , sentenceAliasAttributes
-            }
-      =
-        Pretty.fillSep
-            [ "alias"
-            , unparse sentenceAliasAlias <> arguments sentenceAliasSorts
-            , ":"
-            , unparse sentenceAliasResultSort
-            , "where"
-            , unparse sentenceAliasLeftPattern
-            , ":="
-            , unparse sentenceAliasRightPattern
-            , unparse sentenceAliasAttributes
-            ]
 
-    unparse2
-        SentenceAlias
-            { sentenceAliasAlias
-            , sentenceAliasSorts
-            , sentenceAliasResultSort
-            , sentenceAliasLeftPattern
-            , sentenceAliasRightPattern
-            , sentenceAliasAttributes
-            }
-      =
-        Pretty.fillSep
-            [ "alias"
-            , unparse2 sentenceAliasAlias <> arguments2 sentenceAliasSorts
-            , ":"
-            , unparse2 sentenceAliasResultSort
-            , "where"
-            , unparse2 sentenceAliasLeftPattern
-            , ":="
-            , unparse2 sentenceAliasRightPattern
-            , unparse2 sentenceAliasAttributes
-            ]
+  unparse
+    SentenceAlias
+      { sentenceAliasAlias,
+        sentenceAliasSorts,
+        sentenceAliasResultSort,
+        sentenceAliasLeftPattern,
+        sentenceAliasRightPattern,
+        sentenceAliasAttributes
+        } =
+      Pretty.fillSep
+        [ "alias",
+          unparse sentenceAliasAlias <> arguments sentenceAliasSorts,
+          ":",
+          unparse sentenceAliasResultSort,
+          "where",
+          unparse sentenceAliasLeftPattern,
+          ":=",
+          unparse sentenceAliasRightPattern,
+          unparse sentenceAliasAttributes
+          ]
+
+  unparse2
+    SentenceAlias
+      { sentenceAliasAlias,
+        sentenceAliasSorts,
+        sentenceAliasResultSort,
+        sentenceAliasLeftPattern,
+        sentenceAliasRightPattern,
+        sentenceAliasAttributes
+        } =
+      Pretty.fillSep
+        [ "alias",
+          unparse2 sentenceAliasAlias <> arguments2 sentenceAliasSorts,
+          ":",
+          unparse2 sentenceAliasResultSort,
+          "where",
+          unparse2 sentenceAliasLeftPattern,
+          ":=",
+          unparse2 sentenceAliasRightPattern,
+          unparse2 sentenceAliasAttributes
+          ]
 
 {- | 'SentenceSymbol' is the @symbol-declaration@ and syntactic category from
 the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 
 -}
-data SentenceSymbol (patternType :: *) =
-    SentenceSymbol
-        { sentenceSymbolSymbol     :: !Symbol
-        , sentenceSymbolSorts      :: ![Sort]
-        , sentenceSymbolResultSort :: !Sort
-        , sentenceSymbolAttributes :: !Attributes
+data SentenceSymbol (patternType :: *)
+  = SentenceSymbol
+      { sentenceSymbolSymbol :: !Symbol,
+        sentenceSymbolSorts :: ![Sort],
+        sentenceSymbolResultSort :: !Sort,
+        sentenceSymbolAttributes :: !Attributes
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable (SentenceSymbol patternType)
 
@@ -232,47 +238,53 @@ instance SOP.HasDatatypeInfo (SentenceSymbol patternType)
 instance Debug (SentenceSymbol patternType)
 
 instance Unparse (SentenceSymbol patternType) where
-    unparse
-        SentenceSymbol
-            { sentenceSymbolSymbol
-            , sentenceSymbolSorts
-            , sentenceSymbolResultSort
-            , sentenceSymbolAttributes
-            }
-      =
-        Pretty.fillSep
-            [ "symbol"
-            , unparse sentenceSymbolSymbol <> arguments sentenceSymbolSorts
-            , ":"
-            , unparse sentenceSymbolResultSort
-            , unparse sentenceSymbolAttributes
-            ]
 
-    unparse2
-        SentenceSymbol
-            { sentenceSymbolSymbol
-            , sentenceSymbolSorts
-            , sentenceSymbolResultSort
-            }
-      = Pretty.vsep
-            [ Pretty.fillSep [ "symbol", unparse2 sentenceSymbolSymbol ]
-            , Pretty.fillSep [ "axiom \\forall s Sorts"
-                             , Pretty.parens (Pretty.fillSep
-                                   [ "\\subset"
-                                   , Pretty.parens (Pretty.fillSep
-                                       [ unparse2 sentenceSymbolSymbol
-                                       , unparse2Inhabitant sentenceSymbolSorts
-                                       ])
-                                   , unparse2 sentenceSymbolResultSort
-                                   ])
-                             ]
-            ]
-          where unparse2Inhabitant ss =
-                  case ss of
-                      [] -> ""
-                      (s : rest) ->
-                        Pretty.parens (Pretty.fillSep ["\\inh", unparse2 s])
-                        <> unparse2Inhabitant rest
+  unparse
+    SentenceSymbol
+      { sentenceSymbolSymbol,
+        sentenceSymbolSorts,
+        sentenceSymbolResultSort,
+        sentenceSymbolAttributes
+        } =
+      Pretty.fillSep
+        [ "symbol",
+          unparse sentenceSymbolSymbol <> arguments sentenceSymbolSorts,
+          ":",
+          unparse sentenceSymbolResultSort,
+          unparse sentenceSymbolAttributes
+          ]
+
+  unparse2
+    SentenceSymbol
+      { sentenceSymbolSymbol,
+        sentenceSymbolSorts,
+        sentenceSymbolResultSort
+        } =
+      Pretty.vsep
+        [ Pretty.fillSep ["symbol", unparse2 sentenceSymbolSymbol],
+          Pretty.fillSep
+            [ "axiom \\forall s Sorts",
+              Pretty.parens
+                ( Pretty.fillSep
+                    [ "\\subset",
+                      Pretty.parens
+                        ( Pretty.fillSep
+                            [ unparse2 sentenceSymbolSymbol,
+                              unparse2Inhabitant sentenceSymbolSorts
+                              ]
+                          ),
+                      unparse2 sentenceSymbolResultSort
+                      ]
+                  )
+              ]
+          ]
+      where
+        unparse2Inhabitant ss =
+          case ss of
+            [] -> ""
+            (s : rest) ->
+              Pretty.parens (Pretty.fillSep ["\\inh", unparse2 s])
+                <> unparse2Inhabitant rest
 
 {- | Coerce the pattern type of a 'SentenceSymbol' to any other type.
 
@@ -293,12 +305,12 @@ from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 -- are phantom, every use of 'asSentence' for a 'SentenceImport' will require a
 -- type ascription. We should refactor the class so this is not necessary and
 -- remove the parameters.
-data SentenceImport (patternType :: *) =
-    SentenceImport
-        { sentenceImportModuleName :: !ModuleName
-        , sentenceImportAttributes :: !Attributes
+data SentenceImport (patternType :: *)
+  = SentenceImport
+      { sentenceImportModuleName :: !ModuleName,
+        sentenceImportAttributes :: !Attributes
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable (SentenceImport patternType)
 
@@ -311,21 +323,20 @@ instance SOP.HasDatatypeInfo (SentenceImport patternType)
 instance Debug (SentenceImport patternType)
 
 instance Unparse (SentenceImport patternType) where
-    unparse
-        SentenceImport { sentenceImportModuleName, sentenceImportAttributes }
-      =
-        Pretty.fillSep
-            [ "import", unparse sentenceImportModuleName
-            , unparse sentenceImportAttributes
-            ]
 
-    unparse2
-        SentenceImport { sentenceImportModuleName, sentenceImportAttributes }
-      =
-        Pretty.fillSep
-            [ "import", unparse2 sentenceImportModuleName
-            , unparse2 sentenceImportAttributes
-            ]
+  unparse SentenceImport {sentenceImportModuleName, sentenceImportAttributes} =
+    Pretty.fillSep
+      [ "import",
+        unparse sentenceImportModuleName,
+        unparse sentenceImportAttributes
+        ]
+
+  unparse2 SentenceImport {sentenceImportModuleName, sentenceImportAttributes} =
+    Pretty.fillSep
+      [ "import",
+        unparse2 sentenceImportModuleName,
+        unparse2 sentenceImportAttributes
+        ]
 
 {- | Coerce the pattern type of a 'SentenceImport' to any other type.
 
@@ -342,13 +353,13 @@ coerceSentenceImport = coerce
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 
  -}
-data SentenceSort (patternType :: *) =
-    SentenceSort
-        { sentenceSortName       :: !Id
-        , sentenceSortParameters :: ![SortVariable]
-        , sentenceSortAttributes :: !Attributes
+data SentenceSort (patternType :: *)
+  = SentenceSort
+      { sentenceSortName :: !Id,
+        sentenceSortParameters :: ![SortVariable],
+        sentenceSortAttributes :: !Attributes
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable (SentenceSort patternType)
 
@@ -361,39 +372,43 @@ instance SOP.HasDatatypeInfo (SentenceSort patternType)
 instance Debug (SentenceSort patternType)
 
 instance Unparse (SentenceSort patternType) where
-    unparse
-        SentenceSort
-            { sentenceSortName
-            , sentenceSortParameters
-            , sentenceSortAttributes
-            }
-      =
-        Pretty.fillSep
-            [ "sort"
-            , unparse sentenceSortName <> parameters sentenceSortParameters
-            , unparse sentenceSortAttributes
-            ]
 
-    unparse2
-        SentenceSort
-            { sentenceSortName
-            , sentenceSortParameters
-            }
-      = Pretty.vsep
-            [ Pretty.fillSep ["symbol", unparse2 sentenceSortName, "[sort]"]
-            , Pretty.fillSep ["axiom"
-                             , "\\subset"
-                             , Pretty.parens (Pretty.fillSep
-                                [ unparse2 sentenceSortName
-                                , printLbSortsRb (length sentenceSortParameters)
-                                ])
-                             , "Sorts"
-                             ]
-            ]
-      where printLbSortsRb n =
-              case n of
-                  0 -> ""
-                  m -> Pretty.fillSep["(\\inh Sorts)", printLbSortsRb (m - 1)]
+  unparse
+    SentenceSort
+      { sentenceSortName,
+        sentenceSortParameters,
+        sentenceSortAttributes
+        } =
+      Pretty.fillSep
+        [ "sort",
+          unparse sentenceSortName <> parameters sentenceSortParameters,
+          unparse sentenceSortAttributes
+          ]
+
+  unparse2
+    SentenceSort
+      { sentenceSortName,
+        sentenceSortParameters
+        } =
+      Pretty.vsep
+        [ Pretty.fillSep ["symbol", unparse2 sentenceSortName, "[sort]"],
+          Pretty.fillSep
+            [ "axiom",
+              "\\subset",
+              Pretty.parens
+                ( Pretty.fillSep
+                    [ unparse2 sentenceSortName,
+                      printLbSortsRb (length sentenceSortParameters)
+                      ]
+                  ),
+              "Sorts"
+              ]
+          ]
+      where
+        printLbSortsRb n =
+          case n of
+            0 -> ""
+            m -> Pretty.fillSep ["(\\inh Sorts)", printLbSortsRb (m - 1)]
 
 {- | Coerce the pattern type of a 'SentenceSort' to any other type.
 
@@ -410,13 +425,13 @@ coerceSentenceSort = coerce
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 
  -}
-data SentenceAxiom (patternType :: *) =
-    SentenceAxiom
-        { sentenceAxiomParameters :: ![SortVariable]
-        , sentenceAxiomPattern    :: !patternType
-        , sentenceAxiomAttributes :: !Attributes
+data SentenceAxiom (patternType :: *)
+  = SentenceAxiom
+      { sentenceAxiomParameters :: ![SortVariable],
+        sentenceAxiomPattern :: !patternType,
+        sentenceAxiomAttributes :: !Attributes
         }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable patternType => Hashable (SentenceAxiom patternType)
 
@@ -429,54 +444,54 @@ instance SOP.HasDatatypeInfo (SentenceAxiom patternType)
 instance Debug patternType => Debug (SentenceAxiom patternType)
 
 instance Unparse patternType => Unparse (SentenceAxiom patternType) where
-    unparse = unparseAxiom "axiom"
-    unparse2 = unparseAxiom2 "axiom"
+
+  unparse = unparseAxiom "axiom"
+
+  unparse2 = unparseAxiom2 "axiom"
 
 unparseAxiom
-    :: Unparse patternType
-    => Pretty.Doc ann
-    -> SentenceAxiom patternType
-    -> Pretty.Doc ann
+  :: Unparse patternType
+  => Pretty.Doc ann
+  -> SentenceAxiom patternType
+  -> Pretty.Doc ann
 unparseAxiom
-    label
-    SentenceAxiom
-        { sentenceAxiomParameters
-        , sentenceAxiomPattern
-        , sentenceAxiomAttributes
-        }
-  =
+  label
+  SentenceAxiom
+    { sentenceAxiomParameters,
+      sentenceAxiomPattern,
+      sentenceAxiomAttributes
+      } =
     Pretty.fillSep
-        [ label
-        , parameters sentenceAxiomParameters
-        , unparse sentenceAxiomPattern
-        , unparse sentenceAxiomAttributes
+      [ label,
+        parameters sentenceAxiomParameters,
+        unparse sentenceAxiomPattern,
+        unparse sentenceAxiomAttributes
         ]
 
 unparseAxiom2
-    :: Unparse patternType
-    => Pretty.Doc ann
-    -> SentenceAxiom patternType
-    -> Pretty.Doc ann
+  :: Unparse patternType
+  => Pretty.Doc ann
+  -> SentenceAxiom patternType
+  -> Pretty.Doc ann
 unparseAxiom2
-    label
-    SentenceAxiom
-        { sentenceAxiomPattern
-        , sentenceAxiomAttributes
-        }
-  =
+  label
+  SentenceAxiom
+    { sentenceAxiomPattern,
+      sentenceAxiomAttributes
+      } =
     Pretty.fillSep
-        [ label
-        , unparse2 sentenceAxiomPattern
-        , unparse2 sentenceAxiomAttributes
+      [ label,
+        unparse2 sentenceAxiomPattern,
+        unparse2 sentenceAxiomAttributes
         ]
 
 {- | 'SentenceClaim' corresponds to the @claim-declaration@ syntactic category
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
 
  -}
-newtype SentenceClaim (patternType :: *) =
-    SentenceClaim { getSentenceClaim :: SentenceAxiom patternType }
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+newtype SentenceClaim (patternType :: *)
+  = SentenceClaim {getSentenceClaim :: SentenceAxiom patternType}
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable patternType => Hashable (SentenceClaim patternType)
 
@@ -489,8 +504,10 @@ instance SOP.HasDatatypeInfo (SentenceClaim patternType)
 instance Debug patternType => Debug (SentenceClaim patternType)
 
 instance Unparse patternType => Unparse (SentenceClaim patternType) where
-    unparse = unparseAxiom "claim" . getSentenceClaim
-    unparse2 = unparseAxiom2 "claim" . getSentenceClaim
+
+  unparse = unparseAxiom "claim" . getSentenceClaim
+
+  unparse2 = unparseAxiom2 "claim" . getSentenceClaim
 
 {- | @SentenceHook@ corresponds to @hook-declaration@ syntactic category
 from the Semantics of K, Section 9.1.6 (Declaration and Definitions).
@@ -499,9 +516,9 @@ See also: 'SentenceSort', 'SentenceSymbol'
 
  -}
 data SentenceHook (patternType :: *)
-    = SentenceHookedSort !(SentenceSort patternType)
-    | SentenceHookedSymbol !(SentenceSymbol patternType)
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  = SentenceHookedSort !(SentenceSort patternType)
+  | SentenceHookedSymbol !(SentenceSymbol patternType)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable (SentenceHook patternType)
 
@@ -514,15 +531,16 @@ instance SOP.HasDatatypeInfo (SentenceHook patternType)
 instance Debug (SentenceHook patternType)
 
 instance Unparse (SentenceHook patternType) where
-    unparse =
-        \case
-            SentenceHookedSort a -> "hooked-" <> unparse a
-            SentenceHookedSymbol a -> "hooked-" <> unparse a
 
-    unparse2 =
-        \case
-            SentenceHookedSort a -> "hooked-" <> unparse2 a
-            SentenceHookedSymbol a -> "hooked-" <> unparse2 a
+  unparse =
+    \case
+      SentenceHookedSort a -> "hooked-" <> unparse a
+      SentenceHookedSymbol a -> "hooked-" <> unparse a
+
+  unparse2 =
+    \case
+      SentenceHookedSort a -> "hooked-" <> unparse2 a
+      SentenceHookedSymbol a -> "hooked-" <> unparse2 a
 
 {- | Coerce the pattern type of a 'SentenceHook' to any other type.
 
@@ -540,14 +558,14 @@ Section 9.1.6 (Declaration and Definitions).
 
 -}
 data Sentence (patternType :: *)
-    = SentenceAliasSentence  !(SentenceAlias patternType)
-    | SentenceSymbolSentence !(SentenceSymbol patternType)
-    | SentenceImportSentence !(SentenceImport patternType)
-    | SentenceAxiomSentence  !(SentenceAxiom patternType)
-    | SentenceClaimSentence  !(SentenceClaim patternType)
-    | SentenceSortSentence   !(SentenceSort patternType)
-    | SentenceHookSentence   !(SentenceHook patternType)
-    deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
+  = SentenceAliasSentence !(SentenceAlias patternType)
+  | SentenceSymbolSentence !(SentenceSymbol patternType)
+  | SentenceImportSentence !(SentenceImport patternType)
+  | SentenceAxiomSentence !(SentenceAxiom patternType)
+  | SentenceClaimSentence !(SentenceClaim patternType)
+  | SentenceSortSentence !(SentenceSort patternType)
+  | SentenceHookSentence !(SentenceHook patternType)
+  deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
 instance NFData patternType => NFData (Sentence patternType)
 
@@ -558,8 +576,10 @@ instance SOP.HasDatatypeInfo (Sentence patternType)
 instance Debug patternType => Debug (Sentence patternType)
 
 instance Unparse patternType => Unparse (Sentence patternType) where
-     unparse = unparseGeneric
-     unparse2 = unparse2Generic
+
+  unparse = unparseGeneric
+
+  unparse2 = unparse2Generic
 
 {- | The attributes associated with a sentence.
 
@@ -568,100 +588,119 @@ Every sentence type has attributes, so this operation is total.
  -}
 sentenceAttributes :: Sentence patternType -> Attributes
 sentenceAttributes =
-    \case
-        SentenceAliasSentence
-            SentenceAlias { sentenceAliasAttributes } ->
-                sentenceAliasAttributes
-        SentenceSymbolSentence
-            SentenceSymbol { sentenceSymbolAttributes } ->
-                sentenceSymbolAttributes
-        SentenceImportSentence
-            SentenceImport { sentenceImportAttributes } ->
-                sentenceImportAttributes
-        SentenceAxiomSentence
-            SentenceAxiom { sentenceAxiomAttributes } ->
-                sentenceAxiomAttributes
-        SentenceClaimSentence
-            (SentenceClaim SentenceAxiom { sentenceAxiomAttributes }) ->
-                sentenceAxiomAttributes
-        SentenceSortSentence
-            SentenceSort { sentenceSortAttributes } ->
-                sentenceSortAttributes
-        SentenceHookSentence sentence ->
-            case sentence of
-                SentenceHookedSort
-                    SentenceSort { sentenceSortAttributes } ->
-                        sentenceSortAttributes
-                SentenceHookedSymbol
-                    SentenceSymbol { sentenceSymbolAttributes } ->
-                        sentenceSymbolAttributes
+  \case
+    SentenceAliasSentence
+      SentenceAlias {sentenceAliasAttributes} ->
+        sentenceAliasAttributes
+    SentenceSymbolSentence
+      SentenceSymbol {sentenceSymbolAttributes} ->
+        sentenceSymbolAttributes
+    SentenceImportSentence
+      SentenceImport {sentenceImportAttributes} ->
+        sentenceImportAttributes
+    SentenceAxiomSentence
+      SentenceAxiom {sentenceAxiomAttributes} ->
+        sentenceAxiomAttributes
+    SentenceClaimSentence
+      (SentenceClaim SentenceAxiom {sentenceAxiomAttributes}) ->
+        sentenceAxiomAttributes
+    SentenceSortSentence
+      SentenceSort {sentenceSortAttributes} ->
+        sentenceSortAttributes
+    SentenceHookSentence sentence ->
+      case sentence of
+        SentenceHookedSort
+          SentenceSort {sentenceSortAttributes} ->
+            sentenceSortAttributes
+        SentenceHookedSymbol
+          SentenceSymbol {sentenceSymbolAttributes} ->
+            sentenceSymbolAttributes
 
 -- | Erase the pattern annotations within a 'Sentence'.
 eraseSentenceAnnotations
-    :: Sentence (Pattern variable erased)
-    -> Sentence (Pattern variable Attribute.Null)
+  :: Sentence (Pattern variable erased)
+  -> Sentence (Pattern variable Attribute.Null)
 eraseSentenceAnnotations sentence = (<$) Attribute.Null <$> sentence
 
 class AsSentence sentenceType where
-    asSentence :: sentenceType patternType -> Sentence patternType
+  asSentence :: sentenceType patternType -> Sentence patternType
 
 instance AsSentence SentenceAlias where
-    asSentence = SentenceAliasSentence
+  asSentence = SentenceAliasSentence
 
 instance AsSentence SentenceSymbol where
-    asSentence = SentenceSymbolSentence
+  asSentence = SentenceSymbolSentence
 
 instance AsSentence SentenceImport where
-    asSentence = SentenceImportSentence
+  asSentence = SentenceImportSentence
 
 instance AsSentence SentenceAxiom where
-    asSentence = SentenceAxiomSentence
+  asSentence = SentenceAxiomSentence
 
 instance AsSentence SentenceSort where
-    asSentence = SentenceSortSentence
+  asSentence = SentenceSortSentence
 
 instance AsSentence SentenceHook where
-    asSentence = SentenceHookSentence
+  asSentence = SentenceHookSentence
 
 class SentenceSymbolOrAlias (sentence :: * -> *) where
-    getSentenceSymbolOrAliasConstructor
-        :: sentence patternType -> Id
-    getSentenceSymbolOrAliasSortParams
-        :: sentence patternType -> [SortVariable]
-    getSentenceSymbolOrAliasArgumentSorts
-        :: sentence patternType -> [Sort]
-    getSentenceSymbolOrAliasResultSort
-        :: sentence patternType -> Sort
-    getSentenceSymbolOrAliasAttributes
-        :: sentence patternType -> Attributes
-    getSentenceSymbolOrAliasSentenceName
-        :: sentence patternType -> String
-    getSentenceSymbolOrAliasHead
-        :: sentence patternType
-        -> [Sort]
-        -> SymbolOrAlias
-    getSentenceSymbolOrAliasHead sentence sortParameters = SymbolOrAlias
-        { symbolOrAliasConstructor =
-            getSentenceSymbolOrAliasConstructor sentence
-        , symbolOrAliasParams = sortParameters
-        }
+
+  getSentenceSymbolOrAliasConstructor
+    :: sentence patternType -> Id
+
+  getSentenceSymbolOrAliasSortParams
+    :: sentence patternType -> [SortVariable]
+
+  getSentenceSymbolOrAliasArgumentSorts
+    :: sentence patternType -> [Sort]
+
+  getSentenceSymbolOrAliasResultSort
+    :: sentence patternType -> Sort
+
+  getSentenceSymbolOrAliasAttributes
+    :: sentence patternType -> Attributes
+
+  getSentenceSymbolOrAliasSentenceName
+    :: sentence patternType -> String
+
+  getSentenceSymbolOrAliasHead
+    :: sentence patternType
+    -> [Sort]
+    -> SymbolOrAlias
+  getSentenceSymbolOrAliasHead sentence sortParameters = SymbolOrAlias
+    { symbolOrAliasConstructor =
+        getSentenceSymbolOrAliasConstructor sentence,
+      symbolOrAliasParams = sortParameters
+      }
 
 instance SentenceSymbolOrAlias SentenceAlias where
-    getSentenceSymbolOrAliasConstructor = aliasConstructor . sentenceAliasAlias
-    getSentenceSymbolOrAliasSortParams = aliasParams . sentenceAliasAlias
-    getSentenceSymbolOrAliasArgumentSorts = sentenceAliasSorts
-    getSentenceSymbolOrAliasResultSort = sentenceAliasResultSort
-    getSentenceSymbolOrAliasAttributes = sentenceAliasAttributes
-    getSentenceSymbolOrAliasSentenceName _ = "alias"
+
+  getSentenceSymbolOrAliasConstructor = aliasConstructor . sentenceAliasAlias
+
+  getSentenceSymbolOrAliasSortParams = aliasParams . sentenceAliasAlias
+
+  getSentenceSymbolOrAliasArgumentSorts = sentenceAliasSorts
+
+  getSentenceSymbolOrAliasResultSort = sentenceAliasResultSort
+
+  getSentenceSymbolOrAliasAttributes = sentenceAliasAttributes
+
+  getSentenceSymbolOrAliasSentenceName _ = "alias"
 
 instance SentenceSymbolOrAlias SentenceSymbol where
-    getSentenceSymbolOrAliasConstructor =
-        symbolConstructor . sentenceSymbolSymbol
-    getSentenceSymbolOrAliasSortParams = symbolParams . sentenceSymbolSymbol
-    getSentenceSymbolOrAliasArgumentSorts = sentenceSymbolSorts
-    getSentenceSymbolOrAliasResultSort = sentenceSymbolResultSort
-    getSentenceSymbolOrAliasAttributes = sentenceSymbolAttributes
-    getSentenceSymbolOrAliasSentenceName _ = "symbol"
+
+  getSentenceSymbolOrAliasConstructor =
+    symbolConstructor . sentenceSymbolSymbol
+
+  getSentenceSymbolOrAliasSortParams = symbolParams . sentenceSymbolSymbol
+
+  getSentenceSymbolOrAliasArgumentSorts = sentenceSymbolSorts
+
+  getSentenceSymbolOrAliasResultSort = sentenceSymbolResultSort
+
+  getSentenceSymbolOrAliasAttributes = sentenceSymbolAttributes
+
+  getSentenceSymbolOrAliasSentenceName _ = "symbol"
 
 -- |'PureSentenceAxiom' is the pure (fixed-@level@) version of 'SentenceAxiom'
 type PureSentenceAxiom = SentenceAxiom ParsedPattern

--- a/kore/src/Kore/Syntax/SetVariable.hs
+++ b/kore/src/Kore/Syntax/SetVariable.hs
@@ -3,24 +3,24 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.SetVariable
-    ( SetVariable (..)
-    ) where
+  ( SetVariable (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Unparser
 
 -- | Applicative-Kore set variables
 newtype SetVariable variable
-    = SetVariable { getSetVariable :: variable }
-    deriving (Eq, GHC.Generic, Ord, Show, Functor, Foldable, Traversable)
+  = SetVariable {getSetVariable :: variable}
+  deriving (Eq, GHC.Generic, Ord, Show, Functor, Foldable, Traversable)
 
 instance Hashable variable => Hashable (SetVariable variable)
 
@@ -33,6 +33,7 @@ instance SOP.HasDatatypeInfo (SetVariable variable)
 instance Debug variable => Debug (SetVariable variable)
 
 instance Unparse variable => Unparse (SetVariable variable) where
-    unparse = unparse . getSetVariable
-    unparse2 = unparse2 . getSetVariable
 
+  unparse = unparse . getSetVariable
+
+  unparse2 = unparse2 . getSetVariable

--- a/kore/src/Kore/Syntax/StringLiteral.hs
+++ b/kore/src/Kore/Syntax/StringLiteral.hs
@@ -3,23 +3,25 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.StringLiteral
-    ( StringLiteral (..)
-    ) where
+  ( StringLiteral (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Functor.Const
-import           Data.Hashable
-import           Data.Text
-                 ( Text )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Functor.Const
+import Data.Hashable
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
-       ( FreeVariables )
+  ( FreeVariables
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
@@ -28,8 +30,8 @@ import Kore.Unparser
 {-|'StringLiteral' corresponds to the @string@ literal from the Semantics of K,
 Section 9.1.1 (Lexicon).
 -}
-newtype StringLiteral = StringLiteral { getStringLiteral :: Text }
-    deriving (Eq, GHC.Generic, Ord, Show)
+newtype StringLiteral = StringLiteral {getStringLiteral :: Text}
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable StringLiteral
 
@@ -42,16 +44,18 @@ instance SOP.HasDatatypeInfo StringLiteral
 instance Debug StringLiteral
 
 instance Unparse StringLiteral where
-    unparse = Pretty.dquotes . Pretty.pretty . escapeStringT . getStringLiteral
-    unparse2 = unparse
+
+  unparse = Pretty.dquotes . Pretty.pretty . escapeStringT . getStringLiteral
+
+  unparse2 = unparse
 
 instance
-    Ord variable =>
-    Synthetic (FreeVariables variable) (Const StringLiteral)
+  Ord variable
+  => Synthetic (FreeVariables variable) (Const StringLiteral)
   where
-    synthetic = const mempty
-    {-# INLINE synthetic #-}
+  synthetic = const mempty
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Const StringLiteral) where
-    synthetic = const stringMetaSort
-    {-# INLINE synthetic #-}
+  synthetic = const stringMetaSort
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Top.hs
+++ b/kore/src/Kore/Syntax/Top.hs
@@ -3,17 +3,17 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
 -}
-
 module Kore.Syntax.Top
-    ( Top (..)
-    ) where
+  ( Top (..)
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import qualified Generics.SOP as SOP
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
 import qualified GHC.Generics as GHC
-
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
 import Kore.Debug
@@ -27,8 +27,8 @@ Section 9.1.4 (Patterns).
 
 'topSort' is the sort of the result.
 -}
-newtype Top sort child = Top { topSort :: sort }
-    deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
+newtype Top sort child = Top {topSort :: sort}
+  deriving (Eq, Functor, Foldable, GHC.Generic, Ord, Show, Traversable)
 
 instance Hashable sort => Hashable (Top sort child)
 
@@ -41,14 +41,15 @@ instance SOP.HasDatatypeInfo (Top sort child)
 instance Debug sort => Debug (Top sort child)
 
 instance Unparse (Top Sort child) where
-    unparse Top { topSort } = "\\top" <> parameters [topSort] <> noArguments
 
-    unparse2 _ = "\\top"
+  unparse Top {topSort} = "\\top" <> parameters [topSort] <> noArguments
+
+  unparse2 _ = "\\top"
 
 instance Ord variable => Synthetic (FreeVariables variable) (Top sort) where
-    synthetic = const mempty
-    {-# INLINE synthetic #-}
+  synthetic = const mempty
+  {-# INLINE synthetic #-}
 
 instance Synthetic Sort (Top Sort) where
-    synthetic = topSort
-    {-# INLINE synthetic #-}
+  synthetic = topSort
+  {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Variable.hs
+++ b/kore/src/Kore/Syntax/Variable.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyDataDeriving #-}
+
 {- |
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
@@ -5,34 +7,33 @@ License     : NCSA
 Please refer to Section 9 (The Kore Language) of the
 <http://github.com/kframework/kore/blob/master/docs/semantics-of-k.pdf Semantics of K>.
 -}
-
-{-# LANGUAGE EmptyDataDeriving #-}
-
 module Kore.Syntax.Variable
-    ( Variable (..)
-    , isOriginalVariable
-    , illegalVariableCounter
-    , externalizeFreshVariable
-    , SortedVariable (..)
-    , unparse2SortedVariable
-    , Concrete
-    ) where
+  ( Variable (..),
+    isOriginalVariable,
+    illegalVariableCounter,
+    externalizeFreshVariable,
+    SortedVariable (..),
+    unparse2SortedVariable,
+    Concrete
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData (..) )
-import           Data.Hashable
-import           Data.Maybe
-                 ( isNothing )
+import Control.DeepSeq
+  ( NFData (..)
+    )
+import Data.Hashable
+import Data.Maybe
+  ( isNothing
+    )
+import Data.Sup
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-import           Numeric.Natural
-
-import Data.Sup
+import qualified Generics.SOP as SOP
 import Kore.Debug
 import Kore.Sort
 import Kore.Unparser
+import Numeric.Natural
 
 {-|'Variable' corresponds to the @variable@ syntactic category from the
 Semantics of K, Section 9.1.4 (Patterns).
@@ -47,12 +48,13 @@ Particularly, this is the type of variable in patterns returned by the parser.
 --
 -- This value of variableCounter may only be used in refreshVariable to pivot
 -- the set of variables that must not be captured.
-data Variable = Variable
-    { variableName :: !Id
-    , variableCounter :: !(Maybe (Sup Natural))
-    , variableSort :: !Sort
-    }
-    deriving (Eq, GHC.Generic, Ord, Show)
+data Variable
+  = Variable
+      { variableName :: !Id,
+        variableCounter :: !(Maybe (Sup Natural)),
+        variableSort :: !Sort
+        }
+  deriving (Eq, GHC.Generic, Ord, Show)
 
 instance Hashable Variable
 
@@ -65,26 +67,27 @@ instance SOP.HasDatatypeInfo Variable
 instance Debug Variable
 
 instance Unparse Variable where
-    unparse Variable { variableName, variableCounter, variableSort } =
-        unparse variableName
-        <> Pretty.pretty variableCounter
-        <> Pretty.colon
-        <> unparse variableSort
 
-    unparse2 Variable { variableName, variableCounter } =
-        unparse2 variableName
-        <> Pretty.pretty variableCounter
+  unparse Variable {variableName, variableCounter, variableSort} =
+    unparse variableName
+      <> Pretty.pretty variableCounter
+      <> Pretty.colon
+      <> unparse variableSort
+
+  unparse2 Variable {variableName, variableCounter} =
+    unparse2 variableName
+      <> Pretty.pretty variableCounter
 
 {- | Is the variable original (as opposed to generated)?
  -}
 isOriginalVariable :: Variable -> Bool
-isOriginalVariable Variable { variableCounter } = isNothing variableCounter
+isOriginalVariable Variable {variableCounter} = isNothing variableCounter
 
 {- | Error thrown when 'variableCounter' takes an illegal value.
  -}
 illegalVariableCounter :: a
 illegalVariableCounter =
-    error "Illegal use of Variable { variableCounter = Just Sup }"
+  error "Illegal use of Variable { variableCounter = Just Sup }"
 
 {- | Reset 'variableCounter' so that a 'Variable' may be unparsed.
 
@@ -93,21 +96,20 @@ illegalVariableCounter =
 
  -}
 externalizeFreshVariable :: Variable -> Variable
-externalizeFreshVariable variable@Variable { variableName, variableCounter } =
-    variable
-        { variableName = variableName'
-        , variableCounter = Nothing
-        }
+externalizeFreshVariable variable@Variable {variableName, variableCounter} =
+  variable
+    { variableName = variableName',
+      variableCounter = Nothing
+      }
   where
     variableName' =
-        variableName
-            { getId =
-                case variableCounter of
-                    Nothing -> getId variableName
-                    Just (Element n) -> getId variableName <> Text.pack (show n)
-                    Just Sup -> illegalVariableCounter
-            , idLocation = AstLocationGeneratedVariable
-            }
+      variableName
+        { getId = case variableCounter of
+            Nothing -> getId variableName
+            Just (Element n) -> getId variableName <> Text.pack (show n)
+            Just Sup -> illegalVariableCounter,
+          idLocation = AstLocationGeneratedVariable
+          }
 
 {- | 'SortedVariable' is a Kore variable with a known sort.
 
@@ -123,23 +125,28 @@ but the reverse is not required.
 
  -}
 class SortedVariable variable where
-    -- | The known 'Sort' of the given variable.
-    sortedVariableSort :: variable -> Sort
-    sortedVariableSort variable =
-        variableSort
-      where
-        Variable { variableSort } = toVariable variable
 
-    -- | Convert a variable from the parsed syntax of Kore.
-    fromVariable :: Variable -> variable
-    -- | Extract the parsed syntax of a Kore variable.
-    toVariable :: variable -> Variable
+  -- | The known 'Sort' of the given variable.
+  sortedVariableSort :: variable -> Sort
+  sortedVariableSort variable =
+    variableSort
+    where
+      Variable {variableSort} = toVariable variable
+
+  -- | Convert a variable from the parsed syntax of Kore.
+  fromVariable :: Variable -> variable
+
+  -- | Extract the parsed syntax of a Kore variable.
+  toVariable :: variable -> Variable
+
 -- TODO(traiansf): the 'SortedVariable' class mixes different concerns.
-
 instance SortedVariable Variable where
-    sortedVariableSort = variableSort
-    fromVariable = id
-    toVariable = id
+
+  sortedVariableSort = variableSort
+
+  fromVariable = id
+
+  toVariable = id
 
 {- | Unparse any 'SortedVariable' in an Applicative Kore binder.
 
@@ -150,11 +157,11 @@ variable for the latter case.
 
  -}
 unparse2SortedVariable
-    :: (SortedVariable variable, Unparse variable)
-    => variable
-    -> Pretty.Doc ann
+  :: (SortedVariable variable, Unparse variable)
+  => variable
+  -> Pretty.Doc ann
 unparse2SortedVariable variable =
-    unparse2 variable <> Pretty.colon <> unparse (sortedVariableSort variable)
+  unparse2 variable <> Pretty.colon <> unparse (sortedVariableSort variable)
 
 {- | @Concrete@ is a variable occuring in a concrete pattern.
 
@@ -165,7 +172,7 @@ See also: 'Data.Void.Void'
 
  -}
 data Concrete
-    deriving (Eq, GHC.Generic, Ord, Read, Show)
+  deriving (Eq, GHC.Generic, Ord, Read, Show)
 
 instance Hashable Concrete
 
@@ -178,10 +185,19 @@ instance SOP.HasDatatypeInfo Concrete
 instance Debug Concrete
 
 instance Unparse Concrete where
-    unparse = \case {}
-    unparse2 = \case {}
+
+  unparse = \case
+
+
+  unparse2 = \case
+
 
 instance SortedVariable Concrete where
-    sortedVariableSort = \case {}
-    toVariable = \case {}
-    fromVariable = error "Cannot construct a variable in a concrete term!"
+
+  sortedVariableSort = \case
+
+
+  toVariable = \case
+
+
+  fromVariable = error "Cannot construct a variable in a concrete term!"

--- a/kore/src/Kore/TopBottom.hs
+++ b/kore/src/Kore/TopBottom.hs
@@ -7,14 +7,15 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.TopBottom
-    ( TopBottom (..)
-    , guardAgainstBottom
-    ) where
+  ( TopBottom (..),
+    guardAgainstBottom
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+  ( Alternative (..)
+    )
 import qualified Control.Monad as Monad
 
 {-| Class for types whose values work as top, bottom, or something between.
@@ -30,14 +31,18 @@ Instances of 'TopBottom' must satisfy the following laws:
 
 -}
 class TopBottom term where
-    -- | Whether the term works as 'Top'.
-    isTop :: term -> Bool
-    -- | Whether the term works as 'Bottom'.
-    isBottom :: term -> Bool
+
+  -- | Whether the term works as 'Top'.
+  isTop :: term -> Bool
+
+  -- | Whether the term works as 'Bottom'.
+  isBottom :: term -> Bool
 
 instance TopBottom () where
-    isTop _ = True
-    isBottom _ = False
+
+  isTop _ = True
+
+  isBottom _ = False
 
 {- | Fail using 'empty' when @term@ is bottom.
 

--- a/kore/src/Kore/Unification/Error.hs
+++ b/kore/src/Kore/Unification/Error.hs
@@ -8,95 +8,102 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Unification.Error
-    ( SubstitutionError (..)
-    , UnificationError (..)
-    , UnificationOrSubstitutionError (..)
-    , substitutionToUnifyOrSubError
-    , unificationToUnifyOrSubError
-    , unsupportedPatterns
-    ) where
+  ( SubstitutionError (..),
+    UnificationError (..),
+    UnificationOrSubstitutionError (..),
+    substitutionToUnifyOrSubError,
+    unificationToUnifyOrSubError,
+    unsupportedPatterns
+    )
+where
 
-import           Data.Text.Prettyprint.Doc
-                 ( Pretty )
+import Data.Text.Prettyprint.Doc
+  ( Pretty
+    )
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
 import Kore.Internal.TermLike
-       ( TermLike )
+  ( TermLike
+    )
 import Kore.Sort
 import Kore.Syntax.Application
 import Kore.Syntax.Variable
 import Kore.Unparser
 import Kore.Variables.UnifiedVariable
-       ( UnifiedVariable (..) )
+  ( UnifiedVariable (..)
+    )
 
 -- | Hack sum-type to wrap unification and substitution errors
 data UnificationOrSubstitutionError
-    = UnificationError UnificationError
-    | SubstitutionError SubstitutionError
-    deriving Show
+  = UnificationError UnificationError
+  | SubstitutionError SubstitutionError
+  deriving (Show)
 
 instance Pretty UnificationOrSubstitutionError where
-    pretty (UnificationError  err) = Pretty.pretty err
-    pretty (SubstitutionError err) = Pretty.pretty err
+  pretty (UnificationError err) = Pretty.pretty err
+  pretty (SubstitutionError err) = Pretty.pretty err
 
 -- |'UnificationError' specifies various error cases encountered during
 -- unification
 newtype UnificationError = UnsupportedPatterns String
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 unsupportedPatterns
-    ::  ( SortedVariable variable
-        , Unparse variable
-        )
-    => String -> TermLike variable -> TermLike variable -> UnificationError
+  :: ( SortedVariable variable,
+       Unparse variable
+       )
+  => String
+  -> TermLike variable
+  -> TermLike variable
+  -> UnificationError
 unsupportedPatterns message first second =
-    UnsupportedPatterns $ unlines
-        [ message
-        , "first=" ++ unparseToString first
-        , "second=" ++ unparseToString second
-        ]
+  UnsupportedPatterns
+    $ unlines
+        [ message,
+          "first=" ++ unparseToString first,
+          "second=" ++ unparseToString second
+          ]
 
 instance Pretty UnificationError where
-    pretty (UnsupportedPatterns err) =
-        "Unsupported patterns: " <> Pretty.pretty err
+  pretty (UnsupportedPatterns err) =
+    "Unsupported patterns: " <> Pretty.pretty err
 
 -- |@ClashReason@ describes the head of a pattern involved in a clash.
 data ClashReason
-    = HeadClash SymbolOrAlias
-    | DomainValueClash String
-    | SortInjectionClash Sort Sort
-    deriving (Eq, Show)
+  = HeadClash SymbolOrAlias
+  | DomainValueClash String
+  | SortInjectionClash Sort Sort
+  deriving (Eq, Show)
 
 {-| 'SubstitutionError' specifies the various error cases related to
 substitutions.
 -}
-data SubstitutionError =
-    forall variable.
-    (Ord variable, Show variable, SortedVariable variable, Unparse variable) =>
-    NonCtorCircularVariableDependency [UnifiedVariable variable]
+data SubstitutionError
+  = forall variable. (Ord variable, Show variable, SortedVariable variable, Unparse variable)
+    => NonCtorCircularVariableDependency
+      [UnifiedVariable variable]
     -- ^ the circularity path may pass through non-constructors: maybe solvable.
 
 instance Show SubstitutionError where
-    showsPrec prec (NonCtorCircularVariableDependency variables) =
-        showParen (prec >= 10)
-        $ showString "NonCtorCircularVariableDependency "
-        . showList variables
+  showsPrec prec (NonCtorCircularVariableDependency variables) =
+    showParen (prec >= 10)
+      $ showString "NonCtorCircularVariableDependency "
+      . showList variables
 
 instance Pretty SubstitutionError where
-    pretty (NonCtorCircularVariableDependency vars) =
-        Pretty.vsep
-        ( "Non-constructor circular variable dependency:"
-        : (unparse <$> vars)
+  pretty (NonCtorCircularVariableDependency vars) =
+    Pretty.vsep
+      ( "Non-constructor circular variable dependency:"
+          : (unparse <$> vars)
         )
 
 -- Trivially promote substitution errors to sum-type errors
 substitutionToUnifyOrSubError
-    :: SubstitutionError
-    -> UnificationOrSubstitutionError
+  :: SubstitutionError
+  -> UnificationOrSubstitutionError
 substitutionToUnifyOrSubError = SubstitutionError
 
 -- Trivially promote unification errors to sum-type errors
 unificationToUnifyOrSubError
-    :: UnificationError
-    -> UnificationOrSubstitutionError
+  :: UnificationError
+  -> UnificationOrSubstitutionError
 unificationToUnifyOrSubError = UnificationError

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -8,82 +8,95 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Unification.Procedure
-    ( unificationProcedure
-    ) where
+  ( unificationProcedure
+    )
+where
 
-import           Control.Applicative
-                 ( empty )
+import Control.Applicative
+  ( empty
+    )
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
-
-import           Kore.Internal.Pattern
-                 ( Conditional (..) )
+import Kore.Internal.Pattern
+  ( Conditional (..)
+    )
 import qualified Kore.Internal.Pattern as Conditional
-import           Kore.Internal.Predicate as Predicate
-                 ( Predicate, topTODO )
-import           Kore.Internal.TermLike
+import Kore.Internal.Predicate as Predicate
+  ( Predicate,
+    topTODO
+    )
+import Kore.Internal.TermLike
 import qualified Kore.Logger as Logger
 import qualified Kore.Step.Merging.OrPattern as OrPattern
-import           Kore.Step.Simplification.AndTerms
-                 ( termUnification )
+import Kore.Step.Simplification.AndTerms
+  ( termUnification
+    )
 import qualified Kore.Step.Simplification.Ceil as Ceil
-                 ( makeEvaluateTerm )
+  ( makeEvaluateTerm
+    )
 import qualified Kore.Step.Simplification.Data as BranchT
-import           Kore.Step.Substitution
-                 ( createPredicatesAndSubstitutionsMerger )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unification.Unify
-                 ( MonadUnify )
+import Kore.Step.Substitution
+  ( createPredicatesAndSubstitutionsMerger
+    )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
 
 -- |'unificationProcedure' atempts to simplify @t1 = t2@, assuming @t1@ and @t2@
 -- are terms (functional patterns) to a substitution.
 -- If successful, it also produces a proof of how the substitution was obtained.
 -- If failing, it gives a 'UnificationError' reason for the failure.
 unificationProcedure
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        )
-    => TermLike variable
-    -> TermLike variable
-    -> unifier (Predicate variable)
-unificationProcedure  p1 p2
-  | p1Sort /= p2Sort = do
-    Monad.Unify.explainBottom
+  :: ( SortedVariable variable,
+       Ord variable,
+       Show variable,
+       Unparse variable,
+       FreshVariable variable,
+       MonadUnify unifier
+       )
+  => TermLike variable
+  -> TermLike variable
+  -> unifier (Predicate variable)
+unificationProcedure p1 p2
+  | p1Sort /= p2Sort =
+    do
+      Monad.Unify.explainBottom
         "Cannot unify different sorts."
         p1
         p2
-    empty
-  | otherwise = do
-    Logger.withLogScope (Logger.Scope "UnificationProcedure")
+      empty
+  | otherwise =
+    do
+      Logger.withLogScope (Logger.Scope "UnificationProcedure")
         . Logger.logDebug
         . Text.pack
         . show
         $ Pretty.vsep
-            [ "Attemptying to unify terms"
-            , Pretty.indent 4 $ unparse p1
-            , "with"
-            , Pretty.indent 4 $ unparse p2
-            ]
-    pat@Conditional { term } <- termUnification p1 p2
-    if Conditional.isBottom pat
+            [ "Attemptying to unify terms",
+              Pretty.indent 4 $ unparse p1,
+              "with",
+              Pretty.indent 4 $ unparse p2
+              ]
+      pat@Conditional {term} <- termUnification p1 p2
+      if Conditional.isBottom pat
         then empty
         else do
-            orCeil <- Ceil.makeEvaluateTerm Predicate.topTODO term
-            orResult <-
-                BranchT.alternate $ OrPattern.mergeWithPredicateAssumesEvaluated
-                    createPredicatesAndSubstitutionsMerger
-                    (Conditional.withoutTerm pat)
-                    orCeil
-            Monad.Unify.scatter orResult
+          orCeil <- Ceil.makeEvaluateTerm Predicate.topTODO term
+          orResult <-
+            BranchT.alternate
+              $ OrPattern.mergeWithPredicateAssumesEvaluated
+                  createPredicatesAndSubstitutionsMerger
+                  (Conditional.withoutTerm pat)
+                  orCeil
+          Monad.Unify.scatter orResult
   where
-      p1Sort = termLikeSort p1
-      p2Sort = termLikeSort p2
+    p1Sort = termLikeSort p1
+    p2Sort = termLikeSort p2

--- a/kore/src/Kore/Unification/Substitution.hs
+++ b/kore/src/Kore/Unification/Substitution.hs
@@ -7,60 +7,73 @@ Maintainer  : vladimir.ciobanu@runtimeverification.com
 Stability   : experimental
 Portability : portable
 -}
-
 module Kore.Unification.Substitution
-    ( Substitution
-    , unwrap
-    , toMap
-    , fromMap
-    , singleton
-    , wrap
-    , modify
-    , Kore.Unification.Substitution.mapVariables
-    , isNormalized
-    , null
-    , variables
-    , unsafeWrap
-    , Kore.Unification.Substitution.filter
-    , Kore.Unification.Substitution.freeVariables
-    , partition
-    , reverseIfRhsIsVar
-    ) where
+  ( Substitution,
+    unwrap,
+    toMap,
+    fromMap,
+    singleton,
+    wrap,
+    modify,
+    Kore.Unification.Substitution.mapVariables,
+    isNormalized,
+    null,
+    variables,
+    unsafeWrap,
+    Kore.Unification.Substitution.filter,
+    Kore.Unification.Substitution.freeVariables,
+    partition,
+    reverseIfRhsIsVar
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
+import Control.DeepSeq
+  ( NFData
+    )
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
-import           Data.Hashable
+import Data.Hashable
 import qualified Data.List as List
-import           Data.Map.Strict
-                 ( Map )
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-import           GHC.Stack
-                 ( HasCallStack )
-import           Prelude hiding
-                 ( null )
-
-import           Kore.Attribute.Pattern.FreeVariables
-import           Kore.Debug
-import           Kore.Internal.TermLike
-                 ( TermLike, pattern Var_, mkVar )
+import GHC.Stack
+  ( HasCallStack
+    )
+import qualified Generics.SOP as SOP
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Debug
+import Kore.Internal.TermLike
+  ( TermLike,
+    mkVar,
+    pattern Var_
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.TopBottom
-                 ( TopBottom (..) )
-import           Kore.Unparser
-                 ( Unparse, unparseToString )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Syntax.Variable
+  ( SortedVariable
+    )
+import Kore.TopBottom
+  ( TopBottom (..)
+    )
+import Kore.Unparser
+  ( Unparse,
+    unparseToString
+    )
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
+import Prelude hiding
+  ( null
+    )
 
 {- | @Substitution@ represents a collection @[xᵢ=φᵢ]@ of substitutions.
 
@@ -76,22 +89,22 @@ the collection, @xⱼ@ is unique among all @xᵢ@ and none of the @xᵢ@ (includ
 
  -}
 data Substitution variable
-    -- TODO (thomas.tuegel): Instead of a sum type, use a product containing the
+  = -- TODO (thomas.tuegel): Instead of a sum type, use a product containing the
     -- normalized and denormalized parts of the substitution together. That
     -- would enable us to keep more substitutions normalized in the Semigroup
     -- instance below.
-    = Substitution ![(UnifiedVariable variable, TermLike variable)]
-    | NormalizedSubstitution
-        !(Map (UnifiedVariable variable) (TermLike variable))
-    deriving GHC.Generic
+    Substitution ![(UnifiedVariable variable, TermLike variable)]
+  | NormalizedSubstitution
+      !(Map (UnifiedVariable variable) (TermLike variable))
+  deriving (GHC.Generic)
 
 -- | 'Eq' does not differentiate normalized and denormalized 'Substitution's.
 instance Ord variable => Eq (Substitution variable) where
-    (==) = Function.on (==) unwrap
+  (==) = Function.on (==) unwrap
 
 -- | 'Ord' does not differentiate normalized and denormalized 'Substitution's.
 instance Ord variable => Ord (Substitution variable) where
-    compare = Function.on compare unwrap
+  compare = Function.on compare unwrap
 
 instance SOP.Generic (Substitution variable)
 
@@ -104,32 +117,34 @@ deriving instance Show variable => Show (Substitution variable)
 instance NFData variable => NFData (Substitution variable)
 
 instance Hashable variable => Hashable (Substitution variable) where
-    hashWithSalt salt (Substitution denorm) =
-        salt `hashWithSalt` (0::Int) `hashWithSalt` denorm
-    hashWithSalt salt (NormalizedSubstitution norm) =
-        salt `hashWithSalt` (1::Int) `hashWithSalt` Map.toList norm
+  hashWithSalt salt (Substitution denorm) =
+    salt `hashWithSalt` (0 :: Int) `hashWithSalt` denorm
+  hashWithSalt salt (NormalizedSubstitution norm) =
+    salt `hashWithSalt` (1 :: Int) `hashWithSalt` Map.toList norm
 
 instance TopBottom (Substitution variable) where
-    isTop = null
-    isBottom _ = False
+
+  isTop = null
+
+  isBottom _ = False
 
 instance Ord variable => Semigroup (Substitution variable) where
-    a <> b
-      | null a, null b = mempty
-      | null a         = b
-      | null b         = a
-      | otherwise      = Substitution (unwrap a <> unwrap b)
+  a <> b
+    | null a, null b = mempty
+    | null a = b
+    | null b = a
+    | otherwise = Substitution (unwrap a <> unwrap b)
 
 instance Ord variable => Monoid (Substitution variable) where
-    mempty = NormalizedSubstitution mempty
+  mempty = NormalizedSubstitution mempty
 
 -- | Unwrap the 'Substitution' to its inner list of substitutions.
 unwrap
-    :: Ord variable
-    => Substitution variable
-    -> [(UnifiedVariable variable, TermLike variable)]
+  :: Ord variable
+  => Substitution variable
+  -> [(UnifiedVariable variable, TermLike variable)]
 unwrap (Substitution xs) = List.sortBy (Function.on compare fst) xs
-unwrap (NormalizedSubstitution xs)  = Map.toList xs
+unwrap (NormalizedSubstitution xs) = Map.toList xs
 
 {- | Convert a normalized substitution to a 'Map'.
 
@@ -140,17 +155,17 @@ See also: 'fromMap'
 
  -}
 toMap
-    :: (HasCallStack, Ord variable)
-    => Substitution variable
-    -> Map (UnifiedVariable variable) (TermLike variable)
+  :: (HasCallStack, Ord variable)
+  => Substitution variable
+  -> Map (UnifiedVariable variable) (TermLike variable)
 toMap (Substitution _) =
-    error "Cannot convert a denormalized substitution to a map!"
+  error "Cannot convert a denormalized substitution to a map!"
 toMap (NormalizedSubstitution norm) = norm
 
 fromMap
-    :: Ord variable
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> Substitution variable
+  :: Ord variable
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> Substitution variable
 fromMap = wrap . Map.toList
 
 {- | Construct substitution for a single variable.
@@ -159,10 +174,10 @@ The substitution is normalized if the variable does not occur free in the term.
 
  -}
 singleton
-    :: Ord variable
-    => UnifiedVariable variable
-    -> TermLike variable
-    -> Substitution variable
+  :: Ord variable
+  => UnifiedVariable variable
+  -> TermLike variable
+  -> Substitution variable
 singleton var termLike
   | TermLike.hasFreeVariable var termLike = Substitution [(var, termLike)]
   | otherwise =
@@ -171,58 +186,57 @@ singleton var termLike
 -- | Wrap the list of substitutions to an un-normalized substitution. Note that
 -- @wrap . unwrap@ is not @id@ because the normalization state is lost.
 wrap
-    :: [(UnifiedVariable variable, TermLike variable)]
-    -> Substitution variable
+  :: [(UnifiedVariable variable, TermLike variable)]
+  -> Substitution variable
 wrap [] = NormalizedSubstitution Map.empty
 wrap xs = Substitution xs
 
 -- | Wrap the list of substitutions to a normalized substitution. Do not use
 -- this unless you are sure you need it.
 unsafeWrap
-    :: Ord variable
-    => [(UnifiedVariable variable, TermLike variable)]
-    -> Substitution variable
+  :: Ord variable
+  => [(UnifiedVariable variable, TermLike variable)]
+  -> Substitution variable
 unsafeWrap = NormalizedSubstitution . Map.fromList
 
 -- | Maps a function over the inner representation of the 'Substitution'. The
 -- normalization status is reset to un-normalized.
 modify
-    :: Ord variable1
-    => ([(UnifiedVariable variable1, TermLike variable1)]
-            -> [(UnifiedVariable variable2, TermLike variable2)])
-    -> Substitution variable1
-    -> Substitution variable2
+  :: Ord variable1
+  => ( [(UnifiedVariable variable1, TermLike variable1)]
+       -> [(UnifiedVariable variable2, TermLike variable2)]
+       )
+  -> Substitution variable1
+  -> Substitution variable2
 modify f = wrap . f . unwrap
 
 -- | 'mapVariables' changes all the variables in the substitution
 -- with the given function.
 mapVariables
-    :: forall variableFrom variableTo
-    .  (Ord variableFrom, Ord variableTo)
-    => (variableFrom -> variableTo)
-    -> Substitution variableFrom
-    -> Substitution variableTo
+  :: forall variableFrom variableTo. (Ord variableFrom, Ord variableTo)
+  => (variableFrom -> variableTo)
+  -> Substitution variableFrom
+  -> Substitution variableTo
 mapVariables variableMapper =
-    modify (map (mapVariable variableMapper))
+  modify (map (mapVariable variableMapper))
   where
     mapVariable
-        :: (variableFrom -> variableTo)
-        -> (UnifiedVariable variableFrom, TermLike variableFrom)
-        -> (UnifiedVariable variableTo, TermLike variableTo)
+      :: (variableFrom -> variableTo)
+      -> (UnifiedVariable variableFrom, TermLike variableFrom)
+      -> (UnifiedVariable variableTo, TermLike variableTo)
     mapVariable
-        mapper
-        (substVariable, patt)
-      =
+      mapper
+      (substVariable, patt) =
         (mapper <$> substVariable, TermLike.mapVariables mapper patt)
 
 -- | Returns true iff the substitution is normalized.
 isNormalized :: Substitution variable -> Bool
-isNormalized (Substitution _)           = False
+isNormalized (Substitution _) = False
 isNormalized (NormalizedSubstitution _) = True
 
 -- | Returns true iff the substitution is empty.
 null :: Substitution variable -> Bool
-null (Substitution denorm)         = List.null denorm
+null (Substitution denorm) = List.null denorm
 null (NormalizedSubstitution norm) = Map.null norm
 
 -- | Returns the list of variables in the 'Substitution'.
@@ -231,12 +245,12 @@ variables = fmap fst . unwrap
 
 -- | Filter the variables of the 'Substitution'.
 filter
-    :: Ord variable
-    => (UnifiedVariable variable -> Bool)
-    -> Substitution variable
-    -> Substitution variable
+  :: Ord variable
+  => (UnifiedVariable variable -> Bool)
+  -> Substitution variable
+  -> Substitution variable
 filter filtering =
-    modify (Prelude.filter (filtering . fst))
+  modify (Prelude.filter (filtering . fst))
 
 {- | Return the pair of substitutions that do and do not satisfy the criterion.
 
@@ -244,106 +258,100 @@ The normalization state is preserved.
 
  -}
 partition
-    :: (UnifiedVariable variable -> TermLike variable -> Bool)
-    -> Substitution variable
-    -> (Substitution variable, Substitution variable)
+  :: (UnifiedVariable variable -> TermLike variable -> Bool)
+  -> Substitution variable
+  -> (Substitution variable, Substitution variable)
 partition criterion (Substitution substitution) =
-    let (true, false) = List.partition (uncurry criterion) substitution
-    in (Substitution true, Substitution false)
+  let (true, false) = List.partition (uncurry criterion) substitution
+   in (Substitution true, Substitution false)
 partition criterion (NormalizedSubstitution substitution) =
-    let (true, false) = Map.partitionWithKey criterion substitution
-    in (NormalizedSubstitution true, NormalizedSubstitution false)
+  let (true, false) = Map.partitionWithKey criterion substitution
+   in (NormalizedSubstitution true, NormalizedSubstitution false)
 
 {- | Reverses all `var = givenVar` assignments in the substitution and
 renormalizes, if needed.
 -}
 reverseIfRhsIsVar
-    :: forall variable
-    .   ( Eq variable
-        , FreshVariable variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => UnifiedVariable variable
-    -> Substitution variable
-    -> Substitution variable
+  :: forall variable. ( Eq variable,
+                        FreshVariable variable,
+                        Show variable,
+                        SortedVariable variable,
+                        Unparse variable
+                        )
+  => UnifiedVariable variable
+  -> Substitution variable
+  -> Substitution variable
 reverseIfRhsIsVar variable (Substitution substitution) =
-    Substitution (map (reversePairIfRhsVar variable) substitution)
+  Substitution (map (reversePairIfRhsVar variable) substitution)
   where
     reversePairIfRhsVar
-        :: UnifiedVariable variable
-        -> (UnifiedVariable variable, TermLike variable)
-        -> (UnifiedVariable variable, TermLike variable)
+      :: UnifiedVariable variable
+      -> (UnifiedVariable variable, TermLike variable)
+      -> (UnifiedVariable variable, TermLike variable)
     reversePairIfRhsVar var (substVar, Var_ substitutionVar)
       | var == substitutionVar =
-          (substitutionVar, mkVar substVar)
+        (substitutionVar, mkVar substVar)
     reversePairIfRhsVar _ original = original
 reverseIfRhsIsVar variable original@(NormalizedSubstitution substitution) =
-    case reversableVars of
-        [] -> original
-        (v:vs) ->
-            let
-                replacementVar :: UnifiedVariable variable
-                replacementVar = foldr max v vs
-
-                replacement :: TermLike variable
-                replacement = mkVar replacementVar
-
-                replacedSubstitution
-                    :: Map (UnifiedVariable variable) (TermLike variable)
-                replacedSubstitution =
-                    fmap
-                        (TermLike.substitute
-                            (Map.singleton variable replacement)
-                        )
-                        (assertNoneAreFreeVarsInRhs
-                            (Set.fromList reversableVars)
-                            (Map.delete replacementVar substitution)
-                        )
-            in
-                NormalizedSubstitution
-                    (Map.insert variable replacement replacedSubstitution)
+  case reversableVars of
+    [] -> original
+    (v : vs) ->
+      let replacementVar :: UnifiedVariable variable
+          replacementVar = foldr max v vs
+          replacement :: TermLike variable
+          replacement = mkVar replacementVar
+          replacedSubstitution
+            :: Map (UnifiedVariable variable) (TermLike variable)
+          replacedSubstitution =
+            fmap
+              ( TermLike.substitute
+                  (Map.singleton variable replacement)
+                )
+              ( assertNoneAreFreeVarsInRhs
+                  (Set.fromList reversableVars)
+                  (Map.delete replacementVar substitution)
+                )
+       in NormalizedSubstitution
+            (Map.insert variable replacement replacedSubstitution)
   where
     reversable :: [(UnifiedVariable variable, TermLike variable)]
     reversable = List.filter (rhsIsVar variable) (Map.toList substitution)
-
     reversableVars :: [UnifiedVariable variable]
     reversableVars = map fst reversable
-
     rhsIsVar :: UnifiedVariable variable -> (thing, TermLike variable) -> Bool
     rhsIsVar var (_, Var_ otherVar) = var == otherVar
     rhsIsVar _ _ = False
 
 assertNoneAreFreeVarsInRhs
-    ::  ( Ord variable
-        , SortedVariable variable
-        , Unparse variable
-        )
-    => Set (UnifiedVariable variable)
-    -> Map (UnifiedVariable variable) (TermLike variable)
-    -> Map (UnifiedVariable variable) (TermLike variable)
+  :: ( Ord variable,
+       SortedVariable variable,
+       Unparse variable
+       )
+  => Set (UnifiedVariable variable)
+  -> Map (UnifiedVariable variable) (TermLike variable)
+  -> Map (UnifiedVariable variable) (TermLike variable)
 assertNoneAreFreeVarsInRhs lhsVariables =
-    fmap assertNoneAreFree
+  fmap assertNoneAreFree
   where
     assertNoneAreFree patt =
-        if Set.null commonVars
+      if Set.null commonVars
         then patt
-        else (error . unlines)
-            [ "Unexpected lhs variable in rhs term "
-            , "in normalized substitution. While this can"
-            , "be a valid case sometimes, i.e. x=f(x),"
-            , "we don't handle that right now."
-            , "patt=" ++ unparseToString patt
-            , "commonVars="
+        else
+          (error . unlines)
+            [ "Unexpected lhs variable in rhs term ",
+              "in normalized substitution. While this can",
+              "be a valid case sometimes, i.e. x=f(x),",
+              "we don't handle that right now.",
+              "patt=" ++ unparseToString patt,
+              "commonVars="
                 ++ show
-                    ( unparseToString
-                    <$> Set.toList commonVars
-                    )
-            ]
+                     ( unparseToString
+                         <$> Set.toList commonVars
+                       )
+              ]
       where
         commonVars =
-            Set.intersection lhsVariables
+          Set.intersection lhsVariables
             $ getFreeVariables
             $ TermLike.freeVariables patt
 
@@ -354,10 +362,10 @@ the free variables are @variable@ and all the free variables of @term@.
 
  -}
 freeVariables
-    :: Ord variable
-    => Substitution variable
-    -> FreeVariables variable
+  :: Ord variable
+  => Substitution variable
+  -> FreeVariables variable
 freeVariables = Foldable.foldMap freeVariablesWorker . unwrap
   where
     freeVariablesWorker (x, t) =
-        freeVariable x <> TermLike.freeVariables t
+      freeVariable x <> TermLike.freeVariables t

--- a/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -9,43 +9,56 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Unification.SubstitutionNormalization
-    ( normalizeSubstitution
-    ) where
+  ( normalizeSubstitution
+    )
+where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Control.Monad.Except
-                 ( ExceptT (..), lift, throwError )
-import           Data.Functor.Const
-import           Data.Functor.Foldable
-                 ( Base )
+import Control.Monad.Except
+  ( ExceptT (..),
+    lift,
+    throwError
+    )
+import Data.Functor.Const
+import Data.Functor.Foldable
+  ( Base
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Map.Strict
-                 ( Map )
+import Data.Graph.TopologicalSort
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-                 ( mapMaybe )
-import           Data.Set
-                 ( Set )
+import Data.Maybe
+  ( mapMaybe
+    )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-
-import           Data.Graph.TopologicalSort
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import           Kore.Internal.Predicate
-                 ( Conditional (..), Predicate )
+import Kore.Internal.Predicate
+  ( Conditional (..),
+    Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
 import qualified Kore.Internal.Symbol as Symbol
-import           Kore.Internal.TermLike as TermLike
-import           Kore.Predicate.Predicate
-                 ( makeTruePredicate )
-import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
-import           Kore.Unification.Error
-                 ( SubstitutionError (..) )
+import Kore.Internal.TermLike as TermLike
+import Kore.Predicate.Predicate
+  ( makeTruePredicate
+    )
+import Kore.Step.Simplification.Data
+  ( MonadSimplify
+    )
+import Kore.Unification.Error
+  ( SubstitutionError (..)
+    )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
+import Kore.Unparser
+import Kore.Variables.Fresh
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 import qualified Kore.Variables.UnifiedVariable as UnifiedVariable
 
 data TopologicalSortResult variable
@@ -65,139 +78,132 @@ Returns an error when the substitution is not normalizable (i.e. it contains
 x = f(x) or something equivalent).
 -}
 normalizeSubstitution
-    ::  forall m variable
-     .  ( Ord variable
-        , MonadSimplify m
-        , FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        )
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> ExceptT SubstitutionError m (Predicate variable)
+  :: forall m variable. ( Ord variable,
+                          MonadSimplify m,
+                          FreshVariable variable,
+                          SortedVariable variable,
+                          Show variable,
+                          Unparse variable
+                          )
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> ExceptT SubstitutionError m (Predicate variable)
 normalizeSubstitution substitution = do
-    let
-        -- | Do a `topologicalSort` of variables using the `dependencies` Map.
-        -- Topological cycles with non-ctors are returned as Left errors.
-        -- Non-simplifiable cycles are returned as Right Nothing.
-        topologicalSortConverted
-            :: Either
-                SubstitutionError
-                (TopologicalSortResult (UnifiedVariable variable))
-        topologicalSortConverted =
-            case topologicalSort (Set.toList <$> allDependencies) of
-                Left (ToplogicalSortCycles vars) ->
-                    case nonSimplifiableSortResult of
-                        Left (ToplogicalSortCycles nonSimplifiableCycle)
-                          | all isVariable
-                              (mapMaybe
-                                  (`Map.lookup` substitution)
-                                  nonSimplifiableCycle
-                              ) ->
-                              error "Impossible: order on variables should prevent only-variable-cycles"
-                          | all UnifiedVariable.isSetVar nonSimplifiableCycle ->
-                              Right (SetCtorCycle nonSimplifiableCycle)
-                          | otherwise ->
-                              Right (MixedCtorCycle nonSimplifiableCycle)
-                        Right _ ->
-                            Left (NonCtorCircularVariableDependency vars)
-                Right result -> Right (Sorted result)
-          where
-            nonSimplifiableSortResult =
-                topologicalSort (Set.toList <$> nonSimplifiableDependencies)
-    case topologicalSortConverted of
-        Left err -> throwError err
-        Right (MixedCtorCycle _) -> return Predicate.bottom
-        Right (Sorted vars) -> lift $ normalizeSortedSubstitution' vars
-        Right (SetCtorCycle vars) -> normalizeSubstitution
-            $ Map.mapWithKey (makeRhsBottom (`elem` vars)) substitution
+  let -- | Do a `topologicalSort` of variables using the `dependencies` Map.
+      -- Topological cycles with non-ctors are returned as Left errors.
+      -- Non-simplifiable cycles are returned as Right Nothing.
+      topologicalSortConverted
+        :: Either
+             SubstitutionError
+             (TopologicalSortResult (UnifiedVariable variable))
+      topologicalSortConverted =
+        case topologicalSort (Set.toList <$> allDependencies) of
+          Left (ToplogicalSortCycles vars) ->
+            case nonSimplifiableSortResult of
+              Left (ToplogicalSortCycles nonSimplifiableCycle)
+                | all isVariable
+                    ( mapMaybe
+                        (`Map.lookup` substitution)
+                        nonSimplifiableCycle
+                      ) ->
+                  error "Impossible: order on variables should prevent only-variable-cycles"
+                | all UnifiedVariable.isSetVar nonSimplifiableCycle ->
+                  Right (SetCtorCycle nonSimplifiableCycle)
+                | otherwise ->
+                  Right (MixedCtorCycle nonSimplifiableCycle)
+              Right _ ->
+                Left (NonCtorCircularVariableDependency vars)
+          Right result -> Right (Sorted result)
+        where
+          nonSimplifiableSortResult =
+            topologicalSort (Set.toList <$> nonSimplifiableDependencies)
+  case topologicalSortConverted of
+    Left err -> throwError err
+    Right (MixedCtorCycle _) -> return Predicate.bottom
+    Right (Sorted vars) -> lift $ normalizeSortedSubstitution' vars
+    Right (SetCtorCycle vars) ->
+      normalizeSubstitution
+        $ Map.mapWithKey (makeRhsBottom (`elem` vars)) substitution
   where
     isVariable :: TermLike variable -> Bool
     isVariable term =
-        case Cofree.tailF (Recursive.project term) of
-            VariableF _ -> True
-            _ -> False
-
+      case Cofree.tailF (Recursive.project term) of
+        VariableF _ -> True
+        _ -> False
     interestingVariables :: Set (UnifiedVariable variable)
     interestingVariables = Map.keysSet substitution
-
     allDependencies
-        :: Map (UnifiedVariable variable) (Set (UnifiedVariable variable))
+      :: Map (UnifiedVariable variable) (Set (UnifiedVariable variable))
     allDependencies =
-        Map.mapWithKey
-            (getDependencies interestingVariables)
-            substitution
-
+      Map.mapWithKey
+        (getDependencies interestingVariables)
+        substitution
     nonSimplifiableDependencies
-        :: Map (UnifiedVariable variable) (Set (UnifiedVariable variable))
+      :: Map (UnifiedVariable variable) (Set (UnifiedVariable variable))
     nonSimplifiableDependencies =
-        Map.mapWithKey
-            (getNonSimplifiableDependencies interestingVariables)
-            substitution
-
+      Map.mapWithKey
+        (getNonSimplifiableDependencies interestingVariables)
+        substitution
     sortedSubstitution
-        :: [UnifiedVariable variable]
-        -> [(UnifiedVariable variable, TermLike variable)]
+      :: [UnifiedVariable variable]
+      -> [(UnifiedVariable variable, TermLike variable)]
     sortedSubstitution = fmap (variableToSubstitution substitution)
-
     normalizeSortedSubstitution'
-        :: [UnifiedVariable variable]
-        -> m (Predicate variable)
+      :: [UnifiedVariable variable]
+      -> m (Predicate variable)
     normalizeSortedSubstitution' s =
-        normalizeSortedSubstitution (sortedSubstitution s) mempty mempty
-
+      normalizeSortedSubstitution (sortedSubstitution s) mempty mempty
     makeRhsBottom
-        :: (UnifiedVariable variable -> Bool)
-        -> UnifiedVariable variable
-        -> TermLike variable
-        -> TermLike variable
+      :: (UnifiedVariable variable -> Bool)
+      -> UnifiedVariable variable
+      -> TermLike variable
+      -> TermLike variable
     makeRhsBottom test var rhs
-      | test var  = TermLike.mkBottom (termLikeSort rhs)
+      | test var = TermLike.mkBottom (termLikeSort rhs)
       | otherwise = rhs
 
 variableToSubstitution
-    :: (Ord variable, Show variable)
-    => Map (UnifiedVariable variable) (TermLike variable)
-    -> UnifiedVariable variable
-    -> (UnifiedVariable variable, TermLike variable)
+  :: (Ord variable, Show variable)
+  => Map (UnifiedVariable variable) (TermLike variable)
+  -> UnifiedVariable variable
+  -> (UnifiedVariable variable, TermLike variable)
 variableToSubstitution varToPattern var =
-    case Map.lookup var varToPattern of
-        Just patt -> (var, patt)
-        Nothing   -> error ("variable " ++ show var ++ " not found.")
+  case Map.lookup var varToPattern of
+    Just patt -> (var, patt)
+    Nothing -> error ("variable " ++ show var ++ " not found.")
 
 normalizeSortedSubstitution
-    ::  ( Ord variable
-        , Monad m
-        , FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        )
-    => [(UnifiedVariable variable, TermLike variable)]
-    -> [(UnifiedVariable variable, TermLike variable)]
-    -> [(UnifiedVariable variable, TermLike variable)]
-    -> m (Predicate variable)
+  :: ( Ord variable,
+       Monad m,
+       FreshVariable variable,
+       SortedVariable variable,
+       Show variable
+       )
+  => [(UnifiedVariable variable, TermLike variable)]
+  -> [(UnifiedVariable variable, TermLike variable)]
+  -> [(UnifiedVariable variable, TermLike variable)]
+  -> m (Predicate variable)
 normalizeSortedSubstitution [] result _ =
-    return Conditional
-        { term = ()
-        , predicate = makeTruePredicate
-        , substitution = Substitution.unsafeWrap result
-        }
+  return Conditional
+    { term = (),
+      predicate = makeTruePredicate,
+      substitution = Substitution.unsafeWrap result
+      }
 normalizeSortedSubstitution
-    ((var, varPattern) : unprocessed)
-    result
-    substitution
-  = case (var, Cofree.tailF (Recursive.project varPattern)) of
-        (UnifiedVariable.ElemVar _, BottomF _) -> return Predicate.bottom
-        (rvar, VariableF (Const var'))
-          | rvar == var' ->
-            normalizeSortedSubstitution unprocessed result substitution
-        _ -> let
-              substitutedVarPattern =
-                  TermLike.substitute (Map.fromList substitution) varPattern
-              in normalizeSortedSubstitution
-                  unprocessed
-                  ((var, substitutedVarPattern) : result)
-                  ((var, substitutedVarPattern) : substitution)
+  ((var, varPattern) : unprocessed)
+  result
+  substitution =
+    case (var, Cofree.tailF (Recursive.project varPattern)) of
+      (UnifiedVariable.ElemVar _, BottomF _) -> return Predicate.bottom
+      (rvar, VariableF (Const var'))
+        | rvar == var' ->
+          normalizeSortedSubstitution unprocessed result substitution
+      _ ->
+        let substitutedVarPattern =
+              TermLike.substitute (Map.fromList substitution) varPattern
+         in normalizeSortedSubstitution
+              unprocessed
+              ((var, substitutedVarPattern) : result)
+              ((var, substitutedVarPattern) : substitution)
 
 {- | Calculate the dependencies of a substitution.
 
@@ -206,15 +212,15 @@ normalizeSortedSubstitution
     pattern.
  -}
 getDependencies
-    :: (Ord variable, Show variable)
-    => Set (UnifiedVariable variable)  -- ^ interesting variables
-    -> UnifiedVariable variable  -- ^ substitution variable
-    -> TermLike variable  -- ^ substitution pattern
-    -> Set (UnifiedVariable variable)
+  :: (Ord variable, Show variable)
+  => Set (UnifiedVariable variable) -- ^ interesting variables
+  -> UnifiedVariable variable -- ^ substitution variable
+  -> TermLike variable -- ^ substitution pattern
+  -> Set (UnifiedVariable variable)
 getDependencies interesting var termLike =
-    case termLike of
-        Var_ v | v == var -> Set.empty
-        _ -> Set.intersection interesting freeVars
+  case termLike of
+    Var_ v | v == var -> Set.empty
+    _ -> Set.intersection interesting freeVars
   where
     freeVars = FreeVariables.getFreeVariables $ TermLike.freeVariables termLike
 
@@ -226,31 +232,31 @@ getDependencies interesting var termLike =
     pattern.
  -}
 getNonSimplifiableDependencies
-    ::  ( Ord variable
-        , Show variable
-        )
-    => Set (UnifiedVariable variable)  -- ^ interesting variables
-    -> UnifiedVariable variable  -- ^ substitution variable
-    -> TermLike variable  -- ^ substitution pattern
-    -> Set (UnifiedVariable variable)
+  :: ( Ord variable,
+       Show variable
+       )
+  => Set (UnifiedVariable variable) -- ^ interesting variables
+  -> UnifiedVariable variable -- ^ substitution variable
+  -> TermLike variable -- ^ substitution pattern
+  -> Set (UnifiedVariable variable)
 getNonSimplifiableDependencies interesting var termLike =
-    case termLike of
-        Var_ v | v == var -> Set.empty
-        _ -> Recursive.fold (nonSimplifiableAbove interesting) termLike
+  case termLike of
+    Var_ v | v == var -> Set.empty
+    _ -> Recursive.fold (nonSimplifiableAbove interesting) termLike
 
 nonSimplifiableAbove
-    :: forall variable. (Ord variable, Show variable)
-    => Set (UnifiedVariable variable)
-    -> Base (TermLike variable) (Set (UnifiedVariable variable))
-    -> Set (UnifiedVariable variable)
+  :: forall variable. (Ord variable, Show variable)
+  => Set (UnifiedVariable variable)
+  -> Base (TermLike variable) (Set (UnifiedVariable variable))
+  -> Set (UnifiedVariable variable)
 nonSimplifiableAbove interesting p =
-    case Cofree.tailF p of
-        VariableF (Const v)
-            | v `Set.member` interesting -> Set.singleton v
-        ApplySymbolF Application { applicationSymbolOrAlias }
-            | Symbol.isNonSimplifiable applicationSymbolOrAlias ->
-                dependencies
-        _ -> Set.empty
+  case Cofree.tailF p of
+    VariableF (Const v)
+      | v `Set.member` interesting -> Set.singleton v
+    ApplySymbolF Application {applicationSymbolOrAlias}
+      | Symbol.isNonSimplifiable applicationSymbolOrAlias ->
+        dependencies
+    _ -> Set.empty
   where
     dependencies :: Set (UnifiedVariable variable)
     dependencies = foldl Set.union Set.empty p

--- a/kore/src/Kore/Unification/Unifier.hs
+++ b/kore/src/Kore/Unification/Unifier.hs
@@ -9,11 +9,14 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Unification.Unifier
-    ( module UnifierImpl
-    , module Error
-    ) where
+  ( module UnifierImpl,
+    module Error
+    )
+where
 
 import Kore.Unification.Error as Error
-       ( UnificationError (..) )
+  ( UnificationError (..)
+    )
 import Kore.Unification.UnifierImpl as UnifierImpl
-       ( normalizeSubstitutionDuplication )
+  ( normalizeSubstitutionDuplication
+    )

--- a/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/kore/src/Kore/Unification/UnifierImpl.hs
@@ -11,89 +11,104 @@ Portability : portable
 module Kore.Unification.UnifierImpl where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import           Control.Monad
-                 ( foldM )
-import           Data.Function
-                 ( on )
+import Control.Monad
+  ( foldM
+    )
+import Data.Function
+  ( on
+    )
 import qualified Data.Functor.Foldable as Recursive
-import           Data.List
-                 ( foldl', groupBy, partition, sortBy )
-import           Data.List.NonEmpty
-                 ( NonEmpty (..) )
-
+import Data.List
+  ( foldl',
+    groupBy,
+    partition,
+    sortBy
+    )
+import Data.List.NonEmpty
+  ( NonEmpty (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.Predicate
-                 ( Conditional (..), Predicate )
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate
+  ( Conditional (..),
+    Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
-import           Kore.Logger
-                 ( LogMessage, WithLog )
+import Kore.Internal.TermLike
+import Kore.Logger
+  ( LogMessage,
+    WithLog
+    )
 import qualified Kore.Predicate.Predicate as Predicate
-                 ( isFalse, makeAndPredicate )
-import           Kore.Unification.Substitution
-                 ( Substitution )
-import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unification.Unify
-                 ( MonadUnify )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
-import           Kore.Variables.UnifiedVariable
-                 ( UnifiedVariable (..) )
-
+  ( isFalse,
+    makeAndPredicate
+    )
 import {-# SOURCE #-} Kore.Step.Simplification.AndTerms
-       ( termUnification )
+  ( termUnification
+    )
 import {-# SOURCE #-} Kore.Step.Substitution
-       ( mergePredicatesAndSubstitutionsExcept )
+  ( mergePredicatesAndSubstitutionsExcept
+    )
+import Kore.Unification.Substitution
+  ( Substitution
+    )
+import qualified Kore.Unification.Substitution as Substitution
+import Kore.Unification.Unify
+  ( MonadUnify
+    )
+import Kore.Unparser
+import Kore.Variables.Fresh
+  ( FreshVariable
+    )
+import Kore.Variables.UnifiedVariable
+  ( UnifiedVariable (..)
+    )
 
 simplifyAnds
-    ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => NonEmpty (TermLike variable)
-    -> unifier (Pattern variable)
+  :: forall variable unifier. ( Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                FreshVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => NonEmpty (TermLike variable)
+  -> unifier (Pattern variable)
 simplifyAnds patterns = do
-    let
-        simplifyAnds'
-            :: Pattern variable
-            -> TermLike variable
-            -> unifier (Pattern variable)
-        simplifyAnds' intermediate pat =
-            case Cofree.tailF (Recursive.project pat) of
-                AndF And { andFirst = lhs, andSecond = rhs } ->
-                    foldM simplifyAnds' intermediate [lhs, rhs]
-                _ -> do
-                    result <- termUnification (Pattern.term intermediate) pat
-                    predSubst <-
-                        mergePredicatesAndSubstitutionsExcept
-                            [ Pattern.predicate result
-                            , Pattern.predicate intermediate
-                            ]
-                            [ Pattern.substitution result
-                            , Pattern.substitution intermediate
-                            ]
-                    return Pattern.Conditional
-                        { term = Pattern.term result
-                        , predicate = Conditional.predicate predSubst
-                        , substitution = Conditional.substitution predSubst
-                        }
-    result <- foldM simplifyAnds' Pattern.top patterns
-    if Predicate.isFalse . Pattern.predicate $ result
-        then return Pattern.bottom
-        else return result
+  let simplifyAnds'
+        :: Pattern variable
+        -> TermLike variable
+        -> unifier (Pattern variable)
+      simplifyAnds' intermediate pat =
+        case Cofree.tailF (Recursive.project pat) of
+          AndF And {andFirst = lhs, andSecond = rhs} ->
+            foldM simplifyAnds' intermediate [lhs, rhs]
+          _ -> do
+            result <- termUnification (Pattern.term intermediate) pat
+            predSubst <-
+              mergePredicatesAndSubstitutionsExcept
+                [ Pattern.predicate result,
+                  Pattern.predicate intermediate
+                  ]
+                [ Pattern.substitution result,
+                  Pattern.substitution intermediate
+                  ]
+            return Pattern.Conditional
+              { term = Pattern.term result,
+                predicate = Conditional.predicate predSubst,
+                substitution = Conditional.substitution predSubst
+                }
+  result <- foldM simplifyAnds' Pattern.top patterns
+  if Predicate.isFalse . Pattern.predicate $ result
+    then return Pattern.bottom
+    else return result
 
 groupSubstitutionByVariable
-    :: (Ord variable, SortedVariable variable)
-    => [(UnifiedVariable variable, TermLike variable)]
-    -> [[(UnifiedVariable variable, TermLike variable)]]
+  :: (Ord variable, SortedVariable variable)
+  => [(UnifiedVariable variable, TermLike variable)]
+  -> [[(UnifiedVariable variable, TermLike variable)]]
 groupSubstitutionByVariable =
-    groupBy ((==) `on` fst) . sortBy (compare `on` fst) . map sortRenaming
+  groupBy ((==) `on` fst) . sortBy (compare `on` fst) . map sortRenaming
   where
     sortRenaming (var, Var_ var') | var' < var = (var', mkVar var)
     sortRenaming eq = eq
@@ -102,26 +117,26 @@ groupSubstitutionByVariable =
 -- x = ((t1 /\ t2) /\ (..)) /\ tn
 -- then recursively reducing that to finally get x = t /\ subst
 solveGroupedSubstitution
-    :: ( Show variable
-       , Unparse variable
-       , SortedVariable variable
-       , FreshVariable variable
-       , MonadUnify unifier
-       , WithLog LogMessage unifier
+  :: ( Show variable,
+       Unparse variable,
+       SortedVariable variable,
+       FreshVariable variable,
+       MonadUnify unifier,
+       WithLog LogMessage unifier
        )
-    => UnifiedVariable variable
-    -> NonEmpty (TermLike variable)
-    -> unifier (Predicate variable)
+  => UnifiedVariable variable
+  -> NonEmpty (TermLike variable)
+  -> unifier (Predicate variable)
 solveGroupedSubstitution var patterns = do
-    predSubst <- simplifyAnds patterns
-    return Conditional
-        { term = ()
-        , predicate = Pattern.predicate predSubst
-        , substitution = Substitution.wrap $ termAndSubstitution predSubst
-        }
+  predSubst <- simplifyAnds patterns
+  return Conditional
+    { term = (),
+      predicate = Pattern.predicate predSubst,
+      substitution = Substitution.wrap $ termAndSubstitution predSubst
+      }
   where
     termAndSubstitution s =
-        (var, Pattern.term s) : Substitution.unwrap (Pattern.substitution s)
+      (var, Pattern.term s) : Substitution.unwrap (Pattern.substitution s)
 
 -- |Takes a potentially non-normalized substitution,
 -- and if it contains multiple assignments to the same variable,
@@ -130,61 +145,61 @@ solveGroupedSubstitution var patterns = do
 -- `normalizeSubstitutionDuplication` recursively calls itself until it
 -- stabilizes.
 normalizeSubstitutionDuplication
-    :: forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        , WithLog LogMessage unifier
-        )
-    => Substitution variable
-    -> unifier (Predicate variable)
+  :: forall variable unifier. ( Show variable,
+                                Unparse variable,
+                                SortedVariable variable,
+                                FreshVariable variable,
+                                MonadUnify unifier,
+                                WithLog LogMessage unifier
+                                )
+  => Substitution variable
+  -> unifier (Predicate variable)
 normalizeSubstitutionDuplication subst
   | null nonSingletonSubstitutions || Substitution.isNormalized subst =
     return (Predicate.fromSubstitution subst)
-  | otherwise = do
-    predSubst <-
+  | otherwise =
+    do
+      predSubst <-
         mergePredicateList
-        <$> mapM (uncurry solveGroupedSubstitution) varAndSubstList
-    finalSubst <-
+          <$> mapM (uncurry solveGroupedSubstitution) varAndSubstList
+      finalSubst <-
         normalizeSubstitutionDuplication
-            (  Substitution.wrap (concat singletonSubstitutions)
-            <> Conditional.substitution predSubst
+          ( Substitution.wrap (concat singletonSubstitutions)
+              <> Conditional.substitution predSubst
             )
-    let
-        pred' =
+      let pred' =
             Predicate.makeAndPredicate
-                (Conditional.predicate predSubst)
-                (Conditional.predicate finalSubst)
-    return Conditional
-        { term = ()
-        , predicate = pred'
-        , substitution = Conditional.substitution finalSubst
-        }
+              (Conditional.predicate predSubst)
+              (Conditional.predicate finalSubst)
+      return Conditional
+        { term = (),
+          predicate = pred',
+          substitution = Conditional.substitution finalSubst
+          }
   where
     groupedSubstitution =
-        groupSubstitutionByVariable $ Substitution.unwrap subst
+      groupSubstitutionByVariable $ Substitution.unwrap subst
     isSingleton [_] = True
-    isSingleton _   = False
-    singletonSubstitutions, nonSingletonSubstitutions
+    isSingleton _ = False
+    singletonSubstitutions,
+      nonSingletonSubstitutions
         :: [[(UnifiedVariable variable, TermLike variable)]]
     (singletonSubstitutions, nonSingletonSubstitutions) =
-        partition isSingleton groupedSubstitution
+      partition isSingleton groupedSubstitution
     varAndSubstList
-        :: [(UnifiedVariable variable, NonEmpty (TermLike variable))]
+      :: [(UnifiedVariable variable, NonEmpty (TermLike variable))]
     varAndSubstList =
-        nonSingletonSubstitutions >>= \case
-            [] -> []
-            ((x, y) : ys) -> [(x, y :| (snd <$> ys))]
+      nonSingletonSubstitutions >>= \case
+        [] -> []
+        ((x, y) : ys) -> [(x, y :| (snd <$> ys))]
 
 mergePredicateList
-    :: ( Ord variable
-       , Show variable
-       , Unparse variable
-       , SortedVariable variable
+  :: ( Ord variable,
+       Show variable,
+       Unparse variable,
+       SortedVariable variable
        )
-    => [Predicate variable]
-    -> Predicate variable
+  => [Predicate variable]
+  -> Predicate variable
 mergePredicateList [] = Predicate.top
-mergePredicateList (p:ps) = foldl' (<>) p ps
+mergePredicateList (p : ps) = foldl' (<>) p ps

--- a/kore/src/Kore/Unification/Unify.hs
+++ b/kore/src/Kore/Unification/Unify.hs
@@ -2,42 +2,57 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-
 module Kore.Unification.Unify
-    ( MonadUnify (..)
-    , UnifierT (..)
-    , throwUnificationOrSubstitutionError
-    , lowerExceptT
-    , runUnifierT
-    , maybeUnifierT
-    ) where
+  ( MonadUnify (..),
+    UnifierT (..),
+    throwUnificationOrSubstitutionError,
+    lowerExceptT,
+    runUnifierT,
+    maybeUnifierT
+    )
+where
 
-import           Control.Applicative
-                 ( Alternative, empty )
-import           Control.Error
-import           Control.Monad
-                 ( MonadPlus )
+import Control.Applicative
+  ( Alternative,
+    empty
+    )
+import Control.Error
+import Control.Monad
+  ( MonadPlus
+    )
 import qualified Control.Monad.Except as Error
-import           Control.Monad.Trans.Class
-                 ( MonadTrans (..) )
-import           Data.Text.Prettyprint.Doc
-                 ( Doc )
-
-import           Kore.Internal.TermLike
-                 ( SortedVariable, TermLike )
-import           Kore.Logger
-                 ( LogMessage, WithLog (..) )
-import           Kore.Profiler.Data
-                 ( MonadProfiler )
-import           Kore.Step.Simplification.Data
-                 ( BranchT, MonadSimplify (..) )
+import Control.Monad.Trans.Class
+  ( MonadTrans (..)
+    )
+import Data.Text.Prettyprint.Doc
+  ( Doc
+    )
+import Kore.Internal.TermLike
+  ( SortedVariable,
+    TermLike
+    )
+import Kore.Logger
+  ( LogMessage,
+    WithLog (..)
+    )
+import Kore.Profiler.Data
+  ( MonadProfiler
+    )
+import Kore.Step.Simplification.Data
+  ( BranchT,
+    MonadSimplify (..)
+    )
 import qualified Kore.Step.Simplification.Data as BranchT
-                 ( gather, scatter )
-import           Kore.Unification.Error
-import           Kore.Unparser
-                 ( Unparse )
-import           SMT
-                 ( MonadSMT (..) )
+  ( gather,
+    scatter
+    )
+import Kore.Unification.Error
+import Kore.Unparser
+  ( Unparse
+    )
+import SMT
+  ( MonadSMT (..)
+    )
 
 -- | @MonadUnify@ is used throughout the step and unification modules. Its main
 -- goal is to abstract over an 'ExceptT' over a 'UnificationOrSubstitutionError'
@@ -47,55 +62,60 @@ import           SMT
 -- and provides functions to throw these errors. The point of this is to be able
 -- to display information about unification failures through 'explainFailure'.
 class (Alternative unifier, MonadSimplify unifier) => MonadUnify unifier where
-    throwSubstitutionError
-        :: SubstitutionError
-        -> unifier a
-    default throwSubstitutionError
-        :: (MonadTrans t, MonadUnify m, unifier ~ t m)
-        => SubstitutionError -> unifier a
-    throwSubstitutionError = lift . throwSubstitutionError
-    {-# INLINE throwSubstitutionError #-}
 
-    throwUnificationError
-        :: UnificationError
-        -> unifier a
-    default throwUnificationError
-        :: (MonadTrans t, MonadUnify m, unifier ~ t m)
-        => UnificationError -> unifier a
-    throwUnificationError = lift . throwUnificationError
-    {-# INLINE throwUnificationError #-}
+  throwSubstitutionError
+    :: SubstitutionError
+    -> unifier a
 
-    -- TODO: This is ugly and not type-safe
-    gather :: unifier a -> unifier [a]
+  default throwSubstitutionError
+    :: (MonadTrans t, MonadUnify m, unifier ~ t m)
+    => SubstitutionError
+    -> unifier a
+  throwSubstitutionError = lift . throwSubstitutionError
+  {-# INLINE throwSubstitutionError #-}
 
-    scatter :: Traversable t => t a -> unifier a
+  throwUnificationError
+    :: UnificationError
+    -> unifier a
 
-    explainBottom
-        :: (SortedVariable variable, Unparse variable)
-        => Doc ()
-        -> TermLike variable
-        -> TermLike variable
-        -> unifier ()
-    explainBottom _ _ _ = pure ()
+  default throwUnificationError
+    :: (MonadTrans t, MonadUnify m, unifier ~ t m)
+    => UnificationError
+    -> unifier a
+  throwUnificationError = lift . throwUnificationError
+  {-# INLINE throwUnificationError #-}
 
-    explainAndReturnBottom
-        :: (SortedVariable variable, Unparse variable)
-        => Doc ()
-        -> TermLike variable
-        -> TermLike variable
-        -> unifier a
-    explainAndReturnBottom message first second = do
-        explainBottom message first second
-        empty
+  -- TODO: This is ugly and not type-safe
+  gather :: unifier a -> unifier [a]
 
-newtype UnifierT (m :: * -> *) a =
-    UnifierT
-        { getUnifierT :: BranchT (ExceptT UnificationOrSubstitutionError m) a }
-    deriving (Functor, Applicative, Monad, Alternative, MonadPlus)
+  scatter :: Traversable t => t a -> unifier a
+
+  explainBottom
+    :: (SortedVariable variable, Unparse variable)
+    => Doc ()
+    -> TermLike variable
+    -> TermLike variable
+    -> unifier ()
+  explainBottom _ _ _ = pure ()
+
+  explainAndReturnBottom
+    :: (SortedVariable variable, Unparse variable)
+    => Doc ()
+    -> TermLike variable
+    -> TermLike variable
+    -> unifier a
+  explainAndReturnBottom message first second = do
+    explainBottom message first second
+    empty
+
+newtype UnifierT (m :: * -> *) a
+  = UnifierT
+      {getUnifierT :: BranchT (ExceptT UnificationOrSubstitutionError m) a}
+  deriving (Functor, Applicative, Monad, Alternative, MonadPlus)
 
 instance MonadTrans UnifierT where
-    lift = UnifierT . lift . lift
-    {-# INLINE lift #-}
+  lift = UnifierT . lift . lift
+  {-# INLINE lift #-}
 
 deriving instance WithLog LogMessage m => WithLog LogMessage (UnifierT m)
 
@@ -106,47 +126,48 @@ deriving instance MonadProfiler m => MonadProfiler (UnifierT m)
 deriving instance MonadSimplify m => MonadSimplify (UnifierT m)
 
 instance MonadSimplify m => MonadUnify (UnifierT m) where
-    throwSubstitutionError =
-        UnifierT
-        . lift
-        . Error.throwError
-        . SubstitutionError
-    {-# INLINE throwSubstitutionError #-}
 
-    throwUnificationError =
-        UnifierT
-        . lift
-        . Error.throwError
-        . UnificationError
-    {-# INLINE throwUnificationError #-}
+  throwSubstitutionError =
+    UnifierT
+      . lift
+      . Error.throwError
+      . SubstitutionError
+  {-# INLINE throwSubstitutionError #-}
 
-    gather = UnifierT . lift . BranchT.gather . getUnifierT
-    {-# INLINE gather #-}
+  throwUnificationError =
+    UnifierT
+      . lift
+      . Error.throwError
+      . UnificationError
+  {-# INLINE throwUnificationError #-}
 
-    scatter = UnifierT . BranchT.scatter
-    {-# INLINE scatter #-}
+  gather = UnifierT . lift . BranchT.gather . getUnifierT
+  {-# INLINE gather #-}
+
+  scatter = UnifierT . BranchT.scatter
+  {-# INLINE scatter #-}
 
 -- | Lower an 'ExceptT UnificationOrSubstitutionError' into a 'MonadUnify'.
 lowerExceptT
-    :: MonadUnify unifier
-    => ExceptT UnificationOrSubstitutionError unifier a
-    -> unifier a
+  :: MonadUnify unifier
+  => ExceptT UnificationOrSubstitutionError unifier a
+  -> unifier a
 lowerExceptT e =
-    runExceptT e >>= either throwUnificationOrSubstitutionError pure
+  runExceptT e >>= either throwUnificationOrSubstitutionError pure
 
 throwUnificationOrSubstitutionError
-    :: MonadUnify unifier
-    => UnificationOrSubstitutionError
-    -> unifier a
+  :: MonadUnify unifier
+  => UnificationOrSubstitutionError
+  -> unifier a
 throwUnificationOrSubstitutionError (SubstitutionError s) =
-    throwSubstitutionError s
+  throwSubstitutionError s
 throwUnificationOrSubstitutionError (UnificationError u) =
-    throwUnificationError u
+  throwUnificationError u
 
 runUnifierT
-    :: MonadSimplify m
-    => UnifierT m a
-    -> m (Either UnificationOrSubstitutionError [a])
+  :: MonadSimplify m
+  => UnifierT m a
+  -> m (Either UnificationOrSubstitutionError [a])
 runUnifierT = runExceptT . BranchT.gather . getUnifierT
 
 {- | Run a 'Unifier', returning 'Nothing' upon error.

--- a/kore/src/Kore/Unparser.hs
+++ b/kore/src/Kore/Unparser.hs
@@ -8,48 +8,54 @@ Stability   : experimental
 Portability : portable
 -}
 module Kore.Unparser
-    ( Unparse (..)
-    , unparseGeneric
-    , unparse2Generic
-    , unparseToText
-    , unparseToString
-    , renderDefault
-    , layoutPrettyUnbounded
-    , parameters
-    , arguments
-    , noArguments
-    , attributes
-    , unparseToText2
-    , unparseToString2
-    , parameters2
-    , arguments2
-    , attributes2
-    , parameters'
-    , arguments'
-    , argument'
-    , attributes'
-    , escapeString
-    , escapeStringT
-    , escapeChar
-    , escapeCharT
-    ) where
+  ( Unparse (..),
+    unparseGeneric,
+    unparse2Generic,
+    unparseToText,
+    unparseToString,
+    renderDefault,
+    layoutPrettyUnbounded,
+    parameters,
+    arguments,
+    noArguments,
+    attributes,
+    unparseToText2,
+    unparseToString2,
+    parameters2,
+    arguments2,
+    attributes2,
+    parameters',
+    arguments',
+    argument',
+    attributes',
+    escapeString,
+    escapeStringT,
+    escapeChar,
+    escapeCharT
+    )
+where
 
 import qualified Data.Char as Char
-import           Data.Functor.Const
-import           Data.Map.Strict
-                 ( Map )
+import Data.Functor.Const
+import Data.Map.Strict
+  ( Map
+    )
 import qualified Data.Map.Strict as Map
-import           Data.Text
-                 ( Text )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           Data.Text.Prettyprint.Doc hiding
-                 ( list )
-import           Data.Text.Prettyprint.Doc.Render.String
-                 ( renderString )
-import           Data.Text.Prettyprint.Doc.Render.Text
-                 ( renderStrict )
-import           Data.Void
-import           Generics.SOP
+import Data.Text.Prettyprint.Doc hiding
+  ( list
+    )
+import Data.Text.Prettyprint.Doc.Render.String
+  ( renderString
+    )
+import Data.Text.Prettyprint.Doc.Render.Text
+  ( renderStrict
+    )
+import Data.Void
+import Generics.SOP
 import qualified Numeric
 
 {- | Class of types that can be rendered in concrete Kore syntax.
@@ -60,19 +66,26 @@ parser in "Kore.Parser.Parser".
 
  -}
 class Unparse p where
-    -- | Render a type from abstract to concrete Kore syntax.
-    unparse :: p -> Doc ann
-    -- | Render a type from abstract to concrete Applicative Kore syntax.
-    unparse2 :: p -> Doc ann
+
+  -- | Render a type from abstract to concrete Kore syntax.
+  unparse :: p -> Doc ann
+
+  -- | Render a type from abstract to concrete Applicative Kore syntax.
+  unparse2 :: p -> Doc ann
 
 instance Unparse a => Unparse (Const a child) where
-    unparse (Const a) = unparse a
-    unparse2 (Const a) = unparse2 a
 
+  unparse (Const a) = unparse a
+
+  unparse2 (Const a) = unparse2 a
 
 instance Unparse Void where
-    unparse = \case {}
-    unparse2 = \case {}
+
+  unparse = \case
+
+
+  unparse2 = \case
+
 
 {- | Unparse a 'Generic' type with 'unparse'.
 
@@ -111,12 +124,12 @@ unparse2Generic = unparseGenericWith unparse2
 {-# INLINE unparse2Generic #-}
 
 unparseGenericWith
-    :: (Generic a, All2 Unparse (Code a))
-    => (forall x. Unparse x => x -> Doc ann)  -- ^ function to unparse anything
-    -> a
-    -> Doc ann
+  :: (Generic a, All2 Unparse (Code a))
+  => (forall x. Unparse x => x -> Doc ann) -- ^ function to unparse anything
+  -> a
+  -> Doc ann
 unparseGenericWith helper =
-    sep . hcollapse . hcmap constraint (mapIK helper) . from
+  sep . hcollapse . hcmap constraint (mapIK helper) . from
   where
     constraint = Proxy :: Proxy Unparse
 {-# INLINE unparseGenericWith #-}
@@ -147,6 +160,7 @@ parameters2 = parameters2' . map unparse2
 -- | Print a list of sort parameters.
 parameters' :: [Doc ann] -> Doc ann
 parameters' = list lbrace rbrace
+
 parameters2' :: [Doc ann] -> Doc ann
 parameters2' = list2 "" ""
 
@@ -159,13 +173,13 @@ arguments2 = arguments2' . map unparse2
 -- | Print a list of documents as arguments.
 arguments' :: [Doc ann] -> Doc ann
 arguments' = list lparen rparen
+
 arguments2' :: [Doc ann] -> Doc ann
 arguments2' = list2 "" ""
 
 -- | Print a document as arguments.
 argument' :: Doc ann -> Doc ann
 argument' = list lparen rparen . (: [])
-
 
 -- | Print a list of no arguments.
 noArguments :: Doc ann
@@ -183,16 +197,16 @@ attributes' = list lbracket rbracket
 
 -- | Print a list of documents separated by commas in the preferred Kore format.
 list
-    :: Doc ann  -- ^ opening list delimiter
-    -> Doc ann  -- ^ closing list delimiter
-    -> [Doc ann]  -- ^ list items
-    -> Doc ann
+  :: Doc ann -- ^ opening list delimiter
+  -> Doc ann -- ^ closing list delimiter
+  -> [Doc ann] -- ^ list items
+  -> Doc ann
 list left right =
-    \case
-        [] -> left <> right
-        xs ->
-            (group . (<> close) . nest 4 . (open <>) . vsep . punctuate between)
-                xs
+  \case
+    [] -> left <> right
+    xs ->
+      (group . (<> close) . nest 4 . (open <>) . vsep . punctuate between)
+        xs
   where
     open = left <> line'
     close = line' <> right
@@ -200,26 +214,25 @@ list left right =
 
 -- | Print a list of documents separated by space in the preferred Kore format.
 list2
-    :: Doc ann  -- ^ opening list delimiter
-    -> Doc ann  -- ^ closing list delimiter
-    -> [Doc ann]  -- ^ list items
-    -> Doc ann
+  :: Doc ann -- ^ opening list delimiter
+  -> Doc ann -- ^ closing list delimiter
+  -> [Doc ann] -- ^ list items
+  -> Doc ann
 list2 left right =
-    \case
-        [] -> left <> right
-        xs ->
-            (group . (<> close) . nest 4 . (open <>) . vsep . punctuate between)
-                xs
+  \case
+    [] -> left <> right
+    xs ->
+      (group . (<> close) . nest 4 . (open <>) . vsep . punctuate between)
+        xs
   where
     open = left <> line'
     close = line' <> right
     between = space
 
-
 -- | Render a 'Doc ann' with indentation and without extra line breaks.
 layoutPrettyUnbounded :: Doc ann -> SimpleDocStream ann
 layoutPrettyUnbounded =
-    layoutPretty LayoutOptions { layoutPageWidth = Unbounded }
+  layoutPretty LayoutOptions {layoutPageWidth = Unbounded}
 
 {- | Escape a 'String' for a Kore string literal.
 
@@ -244,15 +257,15 @@ escapeCharS :: Char -> ShowS
 escapeCharS c
   | c >= '\x20' && c < '\x7F' =
     case Map.lookup c oneCharEscapes of
-        Nothing ->
-            -- printable 7-bit ASCII
-            showChar c
-        Just esc ->
-            -- single-character escape sequence
-            showChar '\\' . showChar esc
-  | c < '\x100'   = showString "\\x" . zeroPad 2 (showHexCode c)
+      Nothing ->
+        -- printable 7-bit ASCII
+        showChar c
+      Just esc ->
+        -- single-character escape sequence
+        showChar '\\' . showChar esc
+  | c < '\x100' = showString "\\x" . zeroPad 2 (showHexCode c)
   | c < '\x10000' = showString "\\u" . zeroPad 4 (showHexCode c)
-  | otherwise     = showString "\\U" . zeroPad 8 (showHexCode c)
+  | otherwise = showString "\\U" . zeroPad 8 (showHexCode c)
   where
     showHexCode = Numeric.showHex . Char.ord
     zeroPad = padLeftWithCharToLength '0'
@@ -261,31 +274,30 @@ escapeCharT :: Char -> Text
 escapeCharT c
   | c >= '\x20' && c < '\x7F' =
     case Map.lookup c oneCharEscapes of
-        Nothing ->
-            -- printable 7-bit ASCII
-            Text.singleton c
-        Just esc ->
-            -- single-character escape sequence
-            "\\" <> Text.singleton esc
-  | c < '\x100'   = "\\x" <> zeroPad 2 (Text.pack $ showHexCode c "")
+      Nothing ->
+        -- printable 7-bit ASCII
+        Text.singleton c
+      Just esc ->
+        -- single-character escape sequence
+        "\\" <> Text.singleton esc
+  | c < '\x100' = "\\x" <> zeroPad 2 (Text.pack $ showHexCode c "")
   | c < '\x10000' = "\\u" <> zeroPad 4 (Text.pack $ showHexCode c "")
-  | otherwise     = "\\U" <> zeroPad 8 (Text.pack $ showHexCode c "")
+  | otherwise = "\\U" <> zeroPad 8 (Text.pack $ showHexCode c "")
   where
     showHexCode = Numeric.showHex . Char.ord
     zeroPad i = Text.justifyRight i '0'
 
-
 padLeftWithCharToLength :: Char -> Int -> ShowS -> ShowS
 padLeftWithCharToLength c i ss =
-    showString (replicate (i - length (ss "")) c) . ss
+  showString (replicate (i - length (ss "")) c) . ss
 
 oneCharEscapes :: Map Char Char
 oneCharEscapes =
-    Map.fromList
-        [ ('\\', '\\')
-        , ('"', '"')
-        , ('\f', 'f')
-        , ('\n', 'n')
-        , ('\r', 'r')
-        , ('\t', 't')
-        ]
+  Map.fromList
+    [ ('\\', '\\'),
+      ('"', '"'),
+      ('\f', 'f'),
+      ('\n', 'n'),
+      ('\r', 'r'),
+      ('\t', 't')
+      ]

--- a/kore/src/Kore/Variables/Binding.hs
+++ b/kore/src/Kore/Variables/Binding.hs
@@ -3,23 +3,23 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 
  -}
-
 module Kore.Variables.Binding
-    ( Binding (..)
-    , matchWith
+  ( Binding (..),
+    matchWith,
     -- * Binders
-    , Binder (..)
-    , existsBinder
-    , forallBinder
-    , muBinder
-    , nuBinder
-    ) where
+    Binder (..),
+    existsBinder,
+    forallBinder,
+    muBinder,
+    nuBinder
+    )
+where
 
-import           Control.Comonad.Trans.Env
+import Control.Comonad.Trans.Env
 import qualified Control.Lens as Lens
-import           Data.Monoid
-                 ( Any (..) )
-
+import Data.Monoid
+  ( Any (..)
+    )
 import Kore.Syntax.Exists
 import Kore.Syntax.Forall
 import Kore.Syntax.Mu
@@ -33,19 +33,20 @@ respectively a binder or a variable at the top level.
 
  -}
 class Show patternType => Binding patternType where
-    -- | The type of variables bound in @patternType@.
-    type VariableType patternType
 
-    -- | Traverse the binder at the top of a pattern.
-    traverseBinder
-        ::  Lens.Traversal' patternType
-                (Binder (VariableType patternType) patternType)
+  -- | The type of variables bound in @patternType@.
+  type VariableType patternType
 
-    -- | Traverse the variable at the top of a pattern.
-    traverseVariable
-        :: Lens.Traversal'
-            patternType
-            (VariableType patternType)
+  -- | Traverse the binder at the top of a pattern.
+  traverseBinder
+    :: Lens.Traversal' patternType
+         (Binder (VariableType patternType) patternType)
+
+  -- | Traverse the variable at the top of a pattern.
+  traverseVariable
+    :: Lens.Traversal'
+         patternType
+         (VariableType patternType)
 
 {- | Apply a traversing function while distinguishing an empty 'Lens.Traversal'.
 
@@ -54,17 +55,19 @@ traversing function was ever applied.
 
  -}
 matchWith
-    :: Applicative f
-    => Lens.ATraversal s t a b  -- ^ 'Lens.Traversal'
-    -> (a -> f b)  -- ^ Traversing function
-    -> s -> Maybe (f t)
+  :: Applicative f
+  => Lens.ATraversal s t a b -- ^ 'Lens.Traversal'
+  -> (a -> f b) -- ^ Traversing function
+  -> s
+  -> Maybe (f t)
 matchWith (Lens.cloneTraversal -> traverse') = \afb s ->
-    let (getAny -> matched, ft) = runEnvT (traverse' (EnvT (Any True) . afb) s)
-    in if matched then Just ft else Nothing
+  let (getAny -> matched, ft) = runEnvT (traverse' (EnvT (Any True) . afb) s)
+   in if matched then Just ft else Nothing
 
 -- | @Binder@ abstracts over binders such as 'Exists' and 'Forall'.
-data Binder variable child = Binder
-    { binderVariable :: variable, binderChild :: !child }
+data Binder variable child
+  = Binder
+      {binderVariable :: variable, binderChild :: !child}
 
 {- | A 'Lens.Lens' to view an 'Exists' as a 'Binder'.
 
@@ -74,22 +77,22 @@ See also: 'forallBinder'.
 
  -}
 existsBinder
-    :: Lens.Lens'
-        (Exists sort variable child)
-        (Binder (UnifiedVariable variable) child)
+  :: Lens.Lens'
+       (Exists sort variable child)
+       (Binder (UnifiedVariable variable) child)
 existsBinder mapping exists =
-    finish <$> mapping binder
+  finish <$> mapping binder
   where
     binder =
-        Binder { binderVariable =  ElemVar existsVariable, binderChild }
+      Binder {binderVariable = ElemVar existsVariable, binderChild}
       where
-        Exists { existsVariable } = exists
-        Exists { existsChild    = binderChild    } = exists
+        Exists {existsVariable} = exists
+        Exists {existsChild = binderChild} = exists
     finish binder' =
-        exists { existsVariable, existsChild }
+      exists {existsVariable, existsChild}
       where
-        Binder { binderVariable = ElemVar existsVariable } = binder'
-        Binder { binderChild    = existsChild    } = binder'
+        Binder {binderVariable = ElemVar existsVariable} = binder'
+        Binder {binderChild = existsChild} = binder'
 
 {- | A 'Lens.Lens' to view a 'Forall' as a 'Binder'.
 
@@ -99,22 +102,22 @@ See also: 'existsBinder'.
 
  -}
 forallBinder
-    :: Lens.Lens'
-        (Forall sort variable child)
-        (Binder (UnifiedVariable variable) child)
+  :: Lens.Lens'
+       (Forall sort variable child)
+       (Binder (UnifiedVariable variable) child)
 forallBinder mapping forall =
-    finish <$> mapping binder
+  finish <$> mapping binder
   where
     binder =
-        Binder { binderVariable = ElemVar forallVariable, binderChild }
+      Binder {binderVariable = ElemVar forallVariable, binderChild}
       where
-        Forall { forallVariable } = forall
-        Forall { forallChild    = binderChild    } = forall
+        Forall {forallVariable} = forall
+        Forall {forallChild = binderChild} = forall
     finish binder' =
-        forall { forallVariable, forallChild }
+      forall {forallVariable, forallChild}
       where
-        Binder { binderVariable = ElemVar forallVariable } = binder'
-        Binder { binderChild    = forallChild    } = binder'
+        Binder {binderVariable = ElemVar forallVariable} = binder'
+        Binder {binderChild = forallChild} = binder'
 
 {- | A 'Lens.Lens' to view a 'Mu' as a 'Binder'.
 
@@ -124,22 +127,22 @@ See also: 'nuBinder'.
 
  -}
 muBinder
-    :: Lens.Lens'
-        (Mu variable child)
-        (Binder (UnifiedVariable variable) child)
+  :: Lens.Lens'
+       (Mu variable child)
+       (Binder (UnifiedVariable variable) child)
 muBinder mapping mu =
-    finish <$> mapping binder
+  finish <$> mapping binder
   where
     binder =
-        Binder { binderVariable = SetVar muVariable, binderChild }
+      Binder {binderVariable = SetVar muVariable, binderChild}
       where
-        Mu { muVariable } = mu
-        Mu { muChild    = binderChild    } = mu
+        Mu {muVariable} = mu
+        Mu {muChild = binderChild} = mu
     finish binder' =
-        mu { muVariable, muChild }
+      mu {muVariable, muChild}
       where
-        Binder { binderVariable = SetVar muVariable } = binder'
-        Binder { binderChild    = muChild    } = binder'
+        Binder {binderVariable = SetVar muVariable} = binder'
+        Binder {binderChild = muChild} = binder'
 
 {- | A 'Lens.Lens' to view a 'Nu' as a 'Binder'.
 
@@ -149,19 +152,19 @@ See also: 'muBinder'.
 
  -}
 nuBinder
-    :: Lens.Lens'
-        (Nu variable child)
-        (Binder (UnifiedVariable variable) child)
+  :: Lens.Lens'
+       (Nu variable child)
+       (Binder (UnifiedVariable variable) child)
 nuBinder mapping nu =
-    finish <$> mapping binder
+  finish <$> mapping binder
   where
     binder =
-        Binder { binderVariable = SetVar nuVariable, binderChild }
+      Binder {binderVariable = SetVar nuVariable, binderChild}
       where
-        Nu { nuVariable } = nu
-        Nu { nuChild    = binderChild    } = nu
+        Nu {nuVariable} = nu
+        Nu {nuChild = binderChild} = nu
     finish binder' =
-        nu { nuVariable, nuChild }
+      nu {nuVariable, nuChild}
       where
-        Binder { binderVariable = SetVar nuVariable } = binder'
-        Binder { binderChild    = nuChild    } = binder'
+        Binder {binderVariable = SetVar nuVariable} = binder'
+        Binder {binderChild = nuChild} = binder'

--- a/kore/src/Kore/Variables/Free.hs
+++ b/kore/src/Kore/Variables/Free.hs
@@ -10,93 +10,92 @@ Portability : portable
 
 -}
 module Kore.Variables.Free
-    ( freePureVariables
-    , pureAllVariables
-    ) where
+  ( freePureVariables,
+    pureAllVariables
+    )
+where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
 import qualified Control.Monad.Extra as Monad
 import qualified Control.Monad.RWS.Strict as Monad.RWS
 import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
-import           Data.Set
-                 ( Set )
+import Data.Set
+  ( Set
+    )
 import qualified Data.Set as Set
-
 import Kore.Syntax
 import Kore.Variables.UnifiedVariable
 
 -- | The free variables of a pure pattern.
 freePureVariables
-    :: Ord variable
-    => Pattern variable annotation
-    -> Set (UnifiedVariable variable)
+  :: Ord variable
+  => Pattern variable annotation
+  -> Set (UnifiedVariable variable)
 freePureVariables root =
-    let (free, ()) =
-            Monad.RWS.execRWS
-                (freePureVariables1 root)
-                Set.empty  -- initial set of bound variables
-                Set.empty  -- initial set of free variables
-    in
-        free
+  let (free, ()) =
+        Monad.RWS.execRWS
+          (freePureVariables1 root)
+          Set.empty -- initial set of bound variables
+          Set.empty -- initial set of free variables
+   in free
   where
     isBound v = Monad.RWS.asks (Set.member v)
     recordFree v = Monad.RWS.modify' (Set.insert v)
-
     freePureVariables1 recursive =
-        case Cofree.tailF (Recursive.project recursive) of
-            VariableF (Const variable) ->
-                Monad.unlessM (isBound variable) (recordFree variable)
-            ExistsF Exists { existsVariable, existsChild } ->
-                Monad.RWS.local
-                    -- record the bound variable
-                    (Set.insert (ElemVar existsVariable))
-                    -- descend into the bound pattern
-                    (freePureVariables1 existsChild)
-            ForallF Forall { forallVariable, forallChild } ->
-                Monad.RWS.local
-                    -- record the bound variable
-                    (Set.insert (ElemVar forallVariable))
-                    -- descend into the bound pattern
-                    (freePureVariables1 forallChild)
-            MuF Mu { muVariable, muChild } ->
-                Monad.RWS.local
-                    -- record the bound variable
-                    (Set.insert (SetVar muVariable))
-                    -- descend into the bound pattern
-                    (freePureVariables1 muChild)
-            NuF Nu { nuVariable, nuChild } ->
-                Monad.RWS.local
-                    -- record the bound variable
-                    (Set.insert (SetVar nuVariable))
-                    -- descend into the bound pattern
-                    (freePureVariables1 nuChild)
-            p -> mapM_ freePureVariables1 p
+      case Cofree.tailF (Recursive.project recursive) of
+        VariableF (Const variable) ->
+          Monad.unlessM (isBound variable) (recordFree variable)
+        ExistsF Exists {existsVariable, existsChild} ->
+          Monad.RWS.local
+            -- record the bound variable
+            (Set.insert (ElemVar existsVariable))
+            -- descend into the bound pattern
+            (freePureVariables1 existsChild)
+        ForallF Forall {forallVariable, forallChild} ->
+          Monad.RWS.local
+            -- record the bound variable
+            (Set.insert (ElemVar forallVariable))
+            -- descend into the bound pattern
+            (freePureVariables1 forallChild)
+        MuF Mu {muVariable, muChild} ->
+          Monad.RWS.local
+            -- record the bound variable
+            (Set.insert (SetVar muVariable))
+            -- descend into the bound pattern
+            (freePureVariables1 muChild)
+        NuF Nu {nuVariable, nuChild} ->
+          Monad.RWS.local
+            -- record the bound variable
+            (Set.insert (SetVar nuVariable))
+            -- descend into the bound pattern
+            (freePureVariables1 nuChild)
+        p -> mapM_ freePureVariables1 p
 
 pureMergeVariables
-    :: Ord variable
-    => Base
-        (Pattern variable annotation)
-        (Set.Set (UnifiedVariable variable))
-    -> Set.Set (UnifiedVariable variable)
+  :: Ord variable
+  => Base
+       (Pattern variable annotation)
+       (Set.Set (UnifiedVariable variable))
+  -> Set.Set (UnifiedVariable variable)
 pureMergeVariables base =
-    case Cofree.tailF base of
-        VariableF (Const variable) -> Set.singleton variable
-        ExistsF Exists { existsVariable, existsChild } ->
-            Set.insert (ElemVar existsVariable) existsChild
-        ForallF Forall { forallVariable, forallChild } ->
-            Set.insert (ElemVar forallVariable) forallChild
-        MuF Mu { muVariable, muChild } ->
-            Set.insert (SetVar muVariable) muChild
-        NuF Nu { nuVariable, nuChild } ->
-            Set.insert (SetVar nuVariable) nuChild
-        p -> Foldable.foldl' Set.union Set.empty p
+  case Cofree.tailF base of
+    VariableF (Const variable) -> Set.singleton variable
+    ExistsF Exists {existsVariable, existsChild} ->
+      Set.insert (ElemVar existsVariable) existsChild
+    ForallF Forall {forallVariable, forallChild} ->
+      Set.insert (ElemVar forallVariable) forallChild
+    MuF Mu {muVariable, muChild} ->
+      Set.insert (SetVar muVariable) muChild
+    NuF Nu {nuVariable, nuChild} ->
+      Set.insert (SetVar nuVariable) nuChild
+    p -> Foldable.foldl' Set.union Set.empty p
 
 {-| 'pureAllVariables' extracts all variables of a given level in a pattern as a
 set, regardless of whether they are quantified or not.
 -}
 pureAllVariables
-    :: Ord variable
-    => Pattern variable annotation
-    -> Set.Set (UnifiedVariable variable)
+  :: Ord variable
+  => Pattern variable annotation
+  -> Set.Set (UnifiedVariable variable)
 pureAllVariables = Recursive.fold pureMergeVariables

--- a/kore/src/Kore/Variables/Target.hs
+++ b/kore/src/Kore/Variables/Target.hs
@@ -5,26 +5,30 @@ License     : NCSA
 Target specific variables for unification.
 
  -}
-
 module Kore.Variables.Target
-    ( Target (..)
-    , unwrapVariable
-    , isTarget
-    , isNonTarget
-    ) where
+  ( Target (..),
+    unwrapVariable,
+    isTarget,
+    isNonTarget
+    )
+where
 
-import           Data.Hashable
-                 ( Hashable )
+import Data.Hashable
+  ( Hashable
+    )
 import qualified Data.Set as Set
-import           GHC.Generics
-                 ( Generic )
-
+import GHC.Generics
+  ( Generic
+    )
 import Kore.Syntax.Variable
-       ( SortedVariable (..) )
+  ( SortedVariable (..)
+    )
 import Kore.Unparser
-       ( Unparse (..) )
+  ( Unparse (..)
+    )
 import Kore.Variables.Fresh
-       ( FreshVariable (..) )
+  ( FreshVariable (..)
+    )
 
 {- | Distinguish variables by their source.
 
@@ -34,15 +38,15 @@ instead of 'NonTarget' variables.
 
  -}
 data Target variable
-    = Target !variable
-    | NonTarget !variable
-    deriving (Eq, Generic, Show)
+  = Target !variable
+  | NonTarget !variable
+  deriving (Eq, Generic, Show)
 
 instance Ord variable => Ord (Target variable) where
-    compare (Target var1) (Target var2) = compare var1 var2
-    compare (Target _) (NonTarget _) = LT
-    compare (NonTarget var1) (NonTarget var2) = compare var1 var2
-    compare (NonTarget _) (Target _) = GT
+  compare (Target var1) (Target var2) = compare var1 var2
+  compare (Target _) (NonTarget _) = LT
+  compare (NonTarget var1) (NonTarget var2) = compare var1 var2
+  compare (NonTarget _) (Target _) = GT
 
 instance Hashable variable => Hashable (Target variable)
 
@@ -58,30 +62,35 @@ isNonTarget :: Target variable -> Bool
 isNonTarget = not . isTarget
 
 instance
-    SortedVariable variable
-    => SortedVariable (Target variable)
+  SortedVariable variable
+  => SortedVariable (Target variable)
   where
-    sortedVariableSort (Target variable) = sortedVariableSort variable
-    sortedVariableSort (NonTarget variable) = sortedVariableSort variable
-    fromVariable = Target . fromVariable
-    toVariable (Target var) = toVariable var
-    toVariable (NonTarget var) = toVariable var
+
+  sortedVariableSort (Target variable) = sortedVariableSort variable
+  sortedVariableSort (NonTarget variable) = sortedVariableSort variable
+
+  fromVariable = Target . fromVariable
+
+  toVariable (Target var) = toVariable var
+  toVariable (NonTarget var) = toVariable var
 
 {- | Ensures that fresh variables are unique under 'unwrapStepperVariable'.
  -}
 instance FreshVariable variable => FreshVariable (Target variable) where
-    refreshVariable (Set.map unwrapVariable -> avoiding) =
-        \case
-            Target variable ->
-                Target <$> refreshVariable avoiding variable
-            NonTarget variable ->
-                NonTarget <$> refreshVariable avoiding variable
+  refreshVariable (Set.map unwrapVariable -> avoiding) =
+    \case
+      Target variable ->
+        Target <$> refreshVariable avoiding variable
+      NonTarget variable ->
+        NonTarget <$> refreshVariable avoiding variable
 
 instance
-    Unparse variable =>
-    Unparse (Target variable)
+  Unparse variable
+  => Unparse (Target variable)
   where
-    unparse (Target var) = unparse var
-    unparse (NonTarget var) = unparse var
-    unparse2 (Target var) = unparse2 var
-    unparse2 (NonTarget var) = unparse2 var
+
+  unparse (Target var) = unparse var
+  unparse (NonTarget var) = unparse var
+
+  unparse2 (Target var) = unparse2 var
+  unparse2 (NonTarget var) = unparse2 var

--- a/kore/src/Kore/Variables/UnifiedVariable.hs
+++ b/kore/src/Kore/Variables/UnifiedVariable.hs
@@ -4,37 +4,40 @@ License     : NCSA
 
 -}
 module Kore.Variables.UnifiedVariable
-    ( UnifiedVariable (..)
-    , isElemVar
-    , isSetVar
-    , extractElementVariable
-    , foldMapVariable
-    ) where
+  ( UnifiedVariable (..),
+    isElemVar,
+    isSetVar,
+    extractElementVariable,
+    foldMapVariable
+    )
+where
 
-import           Control.DeepSeq
-                 ( NFData )
-import           Data.Functor.Const
-import           Data.Hashable
+import Control.DeepSeq
+  ( NFData
+    )
+import Data.Functor.Const
+import Data.Hashable
+import GHC.Generics
+  ( Generic
+    )
 import qualified Generics.SOP as SOP
-import           GHC.Generics
-                 ( Generic )
-
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
 import Kore.Syntax.ElementVariable
 import Kore.Syntax.SetVariable
 import Kore.Syntax.Variable
-       ( SortedVariable (..) )
+  ( SortedVariable (..)
+    )
 import Kore.Unparser
 
 {- | @UnifiedVariable@ helps distinguish set variables (introduced by 'SetVar')
 from element variables (introduced by 'ElemVar').
  -}
 data UnifiedVariable variable
-    = ElemVar !(ElementVariable variable)
-    | SetVar  !(SetVariable variable)
-    deriving (Generic, Eq, Ord, Show, Functor, Foldable, Traversable)
+  = ElemVar !(ElementVariable variable)
+  | SetVar !(SetVariable variable)
+  deriving (Generic, Eq, Ord, Show, Functor, Foldable, Traversable)
 
 instance NFData variable => NFData (UnifiedVariable variable)
 
@@ -47,8 +50,10 @@ instance Debug variable => Debug (UnifiedVariable variable)
 instance Hashable variable => Hashable (UnifiedVariable variable)
 
 instance Unparse variable => Unparse (UnifiedVariable variable) where
-    unparse = foldMapVariable unparse
-    unparse2 = foldMapVariable unparse2
+
+  unparse = foldMapVariable unparse
+
+  unparse2 = foldMapVariable unparse2
 
 isElemVar :: UnifiedVariable variable -> Bool
 isElemVar (ElemVar _) = True
@@ -59,14 +64,14 @@ isSetVar (SetVar _) = True
 isSetVar _ = False
 
 instance
-    SortedVariable variable =>
-    Synthetic Sort (Const (UnifiedVariable variable))
+  SortedVariable variable
+  => Synthetic Sort (Const (UnifiedVariable variable))
   where
-    synthetic (Const var) = foldMapVariable sortedVariableSort var
-    {-# INLINE synthetic #-}
+  synthetic (Const var) = foldMapVariable sortedVariableSort var
+  {-# INLINE synthetic #-}
 
 extractElementVariable
-    :: UnifiedVariable variable -> Maybe (ElementVariable variable)
+  :: UnifiedVariable variable -> Maybe (ElementVariable variable)
 extractElementVariable (ElemVar var) = Just var
 extractElementVariable _ = Nothing
 

--- a/kore/src/Kore/Verified.hs
+++ b/kore/src/Kore/Verified.hs
@@ -3,19 +3,22 @@ Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
  -}
 module Kore.Verified
-    ( Pattern
-    , Sentence
-    , SentenceAlias
-    , SentenceAxiom
-    , SentenceClaim
-    , SentenceHook
-    , SentenceImport
-    , SentenceSort
-    , SentenceSymbol
-    ) where
+  ( Pattern,
+    Sentence,
+    SentenceAlias,
+    SentenceAxiom,
+    SentenceClaim,
+    SentenceHook,
+    SentenceImport,
+    SentenceSort,
+    SentenceSymbol
+    )
+where
 
-import           Kore.Internal.TermLike
-                 ( TermLike, Variable )
+import Kore.Internal.TermLike
+  ( TermLike,
+    Variable
+    )
 import qualified Kore.Syntax.Sentence as Syntax
 
 type Pattern = TermLike Variable

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -5,215 +5,262 @@ Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
 Maintainer  : thomas.tuegel@runtimeverification.com
 -}
-
-
 module SMT
-    ( SMT, SmtT, runSmtT
-    , Solver
-    , newSolver, stopSolver
-    , runSMT
-    , MonadSMT (..)
-    , Config (..)
-    , defaultConfig
-    , TimeOut (..)
-    , Result (..)
-    , Constructor (..)
-    , ConstructorArgument (..)
-    , DataTypeDeclaration (..)
-    , SmtDataTypeDeclaration
-    , FunctionDeclaration (..)
-    , SortDeclaration (..)
-    , SmtSortDeclaration
-    , escapeId
-    , declareFun_
-    , setInfo
-    , NoSMT (..), runNoSMT
+  ( SMT,
+    SmtT,
+    runSmtT,
+    Solver,
+    newSolver,
+    stopSolver,
+    runSMT,
+    MonadSMT (..),
+    Config (..),
+    defaultConfig,
+    TimeOut (..),
+    Result (..),
+    Constructor (..),
+    ConstructorArgument (..),
+    DataTypeDeclaration (..),
+    SmtDataTypeDeclaration,
+    FunctionDeclaration (..),
+    SortDeclaration (..),
+    SmtSortDeclaration,
+    escapeId,
+    declareFun_,
+    setInfo,
+    NoSMT (..),
+    runNoSMT,
     -- * Expressions
-    , SExpr (..)
-    , SimpleSMT.Logger
-    , SimpleSMT.nameFromSExpr
-    , SimpleSMT.showSExpr
-    , SimpleSMT.tBool
-    , SimpleSMT.tInt
-    , SimpleSMT.and
-    , SimpleSMT.bool
-    , SimpleSMT.eq
-    , SimpleSMT.lt
-    , SimpleSMT.gt
-    , SimpleSMT.implies
-    , SimpleSMT.int
-    , SimpleSMT.not
-    , SimpleSMT.or
-    , SimpleSMT.forallQ
-    ) where
+    SExpr (..),
+    SimpleSMT.Logger,
+    SimpleSMT.nameFromSExpr,
+    SimpleSMT.showSExpr,
+    SimpleSMT.tBool,
+    SimpleSMT.tInt,
+    SimpleSMT.and,
+    SimpleSMT.bool,
+    SimpleSMT.eq,
+    SimpleSMT.lt,
+    SimpleSMT.gt,
+    SimpleSMT.implies,
+    SimpleSMT.int,
+    SimpleSMT.not,
+    SimpleSMT.or,
+    SimpleSMT.forallQ
+    )
+where
 
-import           Control.Concurrent.MVar
+import Control.Concurrent.MVar
 import qualified Control.Lens as Lens hiding
-                 ( makeLenses )
+  ( makeLenses
+    )
 import qualified Control.Monad as Monad
-import           Control.Monad.Catch
-                 ( MonadCatch, MonadThrow )
+import Control.Monad.Catch
+  ( MonadCatch,
+    MonadThrow
+    )
 import qualified Control.Monad.Counter as Counter
-import           Control.Monad.IO.Class
-                 ( MonadIO, liftIO )
-import           Control.Monad.IO.Unlift
-                 ( MonadUnliftIO (..), UnliftIO (..), withRunInIO,
-                 withUnliftIO )
+import Control.Monad.IO.Class
+  ( MonadIO,
+    liftIO
+    )
+import Control.Monad.IO.Unlift
+  ( MonadUnliftIO (..),
+    UnliftIO (..),
+    withRunInIO,
+    withUnliftIO
+    )
 import qualified Control.Monad.Morph as Morph
-import           Control.Monad.Reader
-                 ( ReaderT (..), runReaderT )
+import Control.Monad.Reader
+  ( ReaderT (..),
+    runReaderT
+    )
 import qualified Control.Monad.Reader as Reader
 import qualified Control.Monad.State.Lazy as State.Lazy
 import qualified Control.Monad.State.Strict as State.Strict
 import qualified Control.Monad.Trans as Trans
-import           Control.Monad.Trans.Accum
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Identity
+import Control.Monad.Trans.Accum
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Identity
 import qualified Control.Monad.Trans.Maybe as Maybe
-import           Data.Generics.Product
-import           Data.Limit
-import           Data.Text
-                 ( Text )
-
+import Data.Generics.Product
+import Data.Limit
+import Data.Text
+  ( Text
+    )
 import qualified Kore.Logger as Logger
-import           Kore.Profiler.Data
-                 ( MonadProfiler (..), profileDurationEvent )
-import           ListT
-                 ( ListT, mapListT )
-import           SMT.SimpleSMT
-                 ( Constructor (..), ConstructorArgument (..),
-                 DataTypeDeclaration (..), FunctionDeclaration (..), Logger,
-                 Result (..), SExpr (..), SmtDataTypeDeclaration,
-                 SmtFunctionDeclaration, SmtSortDeclaration, Solver,
-                 SortDeclaration (..) )
+import Kore.Profiler.Data
+  ( MonadProfiler (..),
+    profileDurationEvent
+    )
+import ListT
+  ( ListT,
+    mapListT
+    )
+import SMT.SimpleSMT
+  ( Constructor (..),
+    ConstructorArgument (..),
+    DataTypeDeclaration (..),
+    FunctionDeclaration (..),
+    Logger,
+    Result (..),
+    SExpr (..),
+    SmtDataTypeDeclaration,
+    SmtFunctionDeclaration,
+    SmtSortDeclaration,
+    Solver,
+    SortDeclaration (..)
+    )
 import qualified SMT.SimpleSMT as SimpleSMT
 
 -- * Interface
 
 -- | Access 'SMT' through monad transformers.
 class Monad m => MonadSMT m where
-    withSolver :: m a -> m a
-    default withSolver
-        ::  ( Morph.MFunctor t
-            , MonadSMT n
-            , m ~ t n
-            )
-        => m a
-        -> m a
-    withSolver action = Morph.hoist withSolver action
-    {-# INLINE withSolver #-}
 
-    -- | Declares a general SExpr to SMT.
-    declare :: Text -> SExpr -> m SExpr
-    default declare
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => Text
-        -> SExpr
-        -> m SExpr
-    declare text = Trans.lift . declare text
-    {-# INLINE declare #-}
+  withSolver :: m a -> m a
 
-    -- | Declares a function symbol to SMT.
-    declareFun :: SmtFunctionDeclaration -> m SExpr
-    default declareFun
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => SmtFunctionDeclaration
-        -> m SExpr
-    declareFun = Trans.lift . declareFun
-    {-# INLINE declareFun #-}
+  default withSolver
+    :: ( Morph.MFunctor t,
+         MonadSMT n,
+         m ~ t n
+         )
+    => m a
+    -> m a
+  withSolver action = Morph.hoist withSolver action
+  {-# INLINE withSolver #-}
 
-    -- | Declares a sort to SMT.
-    declareSort :: SmtSortDeclaration -> m SExpr
-    default declareSort
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => SmtSortDeclaration
-        -> m SExpr
-    declareSort = Trans.lift . declareSort
-    {-# INLINE declareSort #-}
+  -- | Declares a general SExpr to SMT.
+  declare :: Text -> SExpr -> m SExpr
 
-    -- | Declares a constructor-based sort to SMT.
-    declareDatatype :: SmtDataTypeDeclaration -> m ()
-    default declareDatatype
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => SmtDataTypeDeclaration
-        -> m ()
-    declareDatatype = Trans.lift . declareDatatype
-    {-# INLINE declareDatatype #-}
+  default declare
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => Text
+    -> SExpr
+    -> m SExpr
+  declare text = Trans.lift . declare text
+  {-# INLINE declare #-}
 
-    -- | Declares a constructor-based sort to SMT.
-    declareDatatypes ::  [SmtDataTypeDeclaration] -> m ()
-    default declareDatatypes
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => [SmtDataTypeDeclaration]
-        -> m ()
-    declareDatatypes = Trans.lift . declareDatatypes
-    {-# INLINE declareDatatypes #-}
+  -- | Declares a function symbol to SMT.
+  declareFun :: SmtFunctionDeclaration -> m SExpr
 
-    -- | Assume a fact.
-    assert :: SExpr -> m ()
-    default assert
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => SExpr
-        -> m ()
-    assert = Trans.lift . assert
-    {-# INLINE assert #-}
+  default declareFun
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => SmtFunctionDeclaration
+    -> m SExpr
+  declareFun = Trans.lift . declareFun
+  {-# INLINE declareFun #-}
 
-    {- | Check if the current set of assertions is satisfiable.
+  -- | Declares a sort to SMT.
+  declareSort :: SmtSortDeclaration -> m SExpr
 
-    See also: 'assert'
+  default declareSort
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => SmtSortDeclaration
+    -> m SExpr
+  declareSort = Trans.lift . declareSort
+  {-# INLINE declareSort #-}
 
-    -}
-    check :: m Result
-    default check
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => m Result
-    check = Trans.lift check
-    {-# INLINE check #-}
+  -- | Declares a constructor-based sort to SMT.
+  declareDatatype :: SmtDataTypeDeclaration -> m ()
 
-    -- | A command with an uninteresting result.
-    ackCommand :: SExpr -> m ()
-    default ackCommand
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => SExpr
-        -> m ()
-    ackCommand = Trans.lift . ackCommand
-    {-# INLINE ackCommand #-}
+  default declareDatatype
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => SmtDataTypeDeclaration
+    -> m ()
+  declareDatatype = Trans.lift . declareDatatype
+  {-# INLINE declareDatatype #-}
 
-    -- | Load a .smt2 file
-    loadFile :: FilePath -> m ()
-    default loadFile
-        :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
-        => FilePath
-        -> m ()
-    loadFile = Trans.lift . loadFile
-    {-# INLINE loadFile #-}
+  -- | Declares a constructor-based sort to SMT.
+  declareDatatypes :: [SmtDataTypeDeclaration] -> m ()
+
+  default declareDatatypes
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => [SmtDataTypeDeclaration]
+    -> m ()
+  declareDatatypes = Trans.lift . declareDatatypes
+  {-# INLINE declareDatatypes #-}
+
+  -- | Assume a fact.
+  assert :: SExpr -> m ()
+
+  default assert
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => SExpr
+    -> m ()
+  assert = Trans.lift . assert
+  {-# INLINE assert #-}
+
+  {- | Check if the current set of assertions is satisfiable.
+  
+  See also: 'assert'
+  
+  -}
+  check :: m Result
+
+  default check
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => m Result
+  check = Trans.lift check
+  {-# INLINE check #-}
+
+  -- | A command with an uninteresting result.
+  ackCommand :: SExpr -> m ()
+
+  default ackCommand
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => SExpr
+    -> m ()
+  ackCommand = Trans.lift . ackCommand
+  {-# INLINE ackCommand #-}
+
+  -- | Load a .smt2 file
+  loadFile :: FilePath -> m ()
+
+  default loadFile
+    :: (Trans.MonadTrans t, MonadSMT n, Monad n, m ~ t n)
+    => FilePath
+    -> m ()
+  loadFile = Trans.lift . loadFile
+  {-# INLINE loadFile #-}
 
 -- * Dummy implementation
-
-newtype NoSMT a = NoSMT { getNoSMT :: ReaderT Logger IO a }
-    deriving (Functor, Applicative, Monad, MonadIO)
+newtype NoSMT a = NoSMT {getNoSMT :: ReaderT Logger IO a}
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 runNoSMT :: Logger -> NoSMT a -> IO a
 runNoSMT logger noSMT = runReaderT (getNoSMT noSMT) logger
 
 instance Logger.WithLog Logger.LogMessage NoSMT where
-    askLogAction = NoSMT (Logger.hoistLogAction liftIO <$> Reader.ask)
-    localLogAction locally = NoSMT . Reader.local locally . getNoSMT
+
+  askLogAction = NoSMT (Logger.hoistLogAction liftIO <$> Reader.ask)
+
+  localLogAction locally = NoSMT . Reader.local locally . getNoSMT
 
 instance MonadSMT NoSMT where
-    withSolver = id
-    declare name _ = return (Atom name)
-    declareFun FunctionDeclaration { name } = return (Atom name)
-    declareSort SortDeclaration { name } = return (Atom name)
-    declareDatatype _ = return ()
-    declareDatatypes _ = return ()
-    loadFile _ = return ()
-    ackCommand _ = return ()
-    assert _ = return ()
-    check = return Unknown
+
+  withSolver = id
+
+  declare name _ = return (Atom name)
+
+  declareFun FunctionDeclaration {name} = return (Atom name)
+
+  declareSort SortDeclaration {name} = return (Atom name)
+
+  declareDatatype _ = return ()
+
+  declareDatatypes _ = return ()
+
+  loadFile _ = return ()
+
+  ackCommand _ = return ()
+
+  assert _ = return ()
+
+  check = return Unknown
 
 instance MonadProfiler NoSMT where
-    profileDuration = profileDurationEvent
+  profileDuration = profileDurationEvent
 
 deriving instance MonadUnliftIO NoSMT
 
@@ -227,105 +274,110 @@ different threads may be interleaved; use 'inNewScope' to acquire exclusive
 access to the solver for a sequence of commands.
 
  -}
-newtype SmtT m a = SmtT { runSmtT :: ReaderT (MVar Solver) m a }
-    deriving
-        ( Applicative
-        , Functor
-        , Monad
-        , MonadCatch
-        , MonadIO
-        , MonadThrow
-        , Morph.MFunctor
-        )
+newtype SmtT m a = SmtT {runSmtT :: ReaderT (MVar Solver) m a}
+  deriving
+    ( Applicative,
+      Functor,
+      Monad,
+      MonadCatch,
+      MonadIO,
+      MonadThrow,
+      Morph.MFunctor
+      )
 
 instance MonadUnliftIO m => MonadUnliftIO (SmtT m) where
-    askUnliftIO =
-        SmtT $ ReaderT $ \r ->
-            withUnliftIO $ \u ->
-                return (UnliftIO (unliftIO u . flip runReaderT r . runSmtT))
+  askUnliftIO =
+    SmtT $ ReaderT $ \r ->
+      withUnliftIO $ \u ->
+        return (UnliftIO (unliftIO u . flip runReaderT r . runSmtT))
 
 type SMT = SmtT IO
 
 withSolver' :: (Solver -> IO a) -> SMT a
 withSolver' action = SmtT $ do
-    mvar <- Reader.ask
-    liftIO $ withMVar mvar action
+  mvar <- Reader.ask
+  liftIO $ withMVar mvar action
 
 withSolverT' :: MonadUnliftIO m => (Solver -> m a) -> SmtT m a
 withSolverT' action = SmtT $ do
-    mvar <- Reader.ask
-    Trans.lift $ withRunInIO $ \runInIO -> withMVar mvar (runInIO . action)
+  mvar <- Reader.ask
+  Trans.lift $ withRunInIO $ \runInIO -> withMVar mvar (runInIO . action)
 
-instance (MonadIO m, MonadUnliftIO m)
-    => Logger.WithLog Logger.LogMessage (SmtT m)
+instance
+  (MonadIO m, MonadUnliftIO m)
+  => Logger.WithLog Logger.LogMessage (SmtT m)
   where
-    askLogAction =
-        withSolverT' (return . hoistLogAction . SimpleSMT.logger)
-      where
-        hoistLogAction = Logger.hoistLogAction (SmtT . liftIO)
 
-    localLogAction mapping (SmtT action) =
-        withSolverT' $ \solver -> do
-            let solver' = Lens.over (field @"logger") mapping solver
-            runReaderT action =<< liftIO (newMVar solver')
+  askLogAction =
+    withSolverT' (return . hoistLogAction . SimpleSMT.logger)
+    where
+      hoistLogAction = Logger.hoistLogAction (SmtT . liftIO)
+
+  localLogAction mapping (SmtT action) =
+    withSolverT' $ \solver -> do
+      let solver' = Lens.over (field @"logger") mapping solver
+      runReaderT action =<< liftIO (newMVar solver')
 
 instance (MonadIO m, MonadUnliftIO m) => MonadSMT (SmtT m) where
-    withSolver (SmtT action) =
-        Logger.withLogScope "SMT.withSolver"
-        $ withSolverT' $ \solver -> do
-            -- Create an unshared "dummy" mutex for the solver.
-            mvar <- liftIO $ newMVar solver
-            -- Run the inner action with the unshared mutex.
-            -- The action will never block waiting to acquire the solver.
-            withRunInIO $ \runInIO ->
-                SimpleSMT.inNewScope solver (runInIO $ runReaderT action mvar)
 
-    declare name typ =
-        Logger.withLogScope "SMT.declare"
-        $ withSolverT' $ \solver -> liftIO $ SimpleSMT.declare solver name typ
+  withSolver (SmtT action) =
+    Logger.withLogScope "SMT.withSolver"
+      $ withSolverT'
+      $ \solver -> do
+        -- Create an unshared "dummy" mutex for the solver.
+        mvar <- liftIO $ newMVar solver
+        -- Run the inner action with the unshared mutex.
+        -- The action will never block waiting to acquire the solver.
+        withRunInIO $ \runInIO ->
+          SimpleSMT.inNewScope solver (runInIO $ runReaderT action mvar)
 
-    declareFun declaration =
-        Logger.withLogScope "SMT.declareFun"
-        $ withSolverT' $ \solver ->
-            liftIO $ SimpleSMT.declareFun solver declaration
+  declare name typ =
+    Logger.withLogScope "SMT.declare"
+      $ withSolverT'
+      $ \solver -> liftIO $ SimpleSMT.declare solver name typ
 
-    declareSort declaration =
-        withSolverT' $ \solver ->
-            liftIO $ SimpleSMT.declareSort solver declaration
+  declareFun declaration =
+    Logger.withLogScope "SMT.declareFun"
+      $ withSolverT'
+      $ \solver ->
+        liftIO $ SimpleSMT.declareFun solver declaration
 
-    declareDatatype declaration =
-        withSolverT' $ \solver ->
-            liftIO $ SimpleSMT.declareDatatype solver declaration
+  declareSort declaration =
+    withSolverT' $ \solver ->
+      liftIO $ SimpleSMT.declareSort solver declaration
 
-    declareDatatypes datatypes =
-        withSolverT' $ \solver ->
-            liftIO $ SimpleSMT.declareDatatypes solver datatypes
+  declareDatatype declaration =
+    withSolverT' $ \solver ->
+      liftIO $ SimpleSMT.declareDatatype solver declaration
 
-    assert fact =
-        withSolverT' $ \solver -> liftIO $ SimpleSMT.assert solver fact
+  declareDatatypes datatypes =
+    withSolverT' $ \solver ->
+      liftIO $ SimpleSMT.declareDatatypes solver datatypes
 
-    check = Morph.hoist liftIO $ withSolver' SimpleSMT.check
+  assert fact =
+    withSolverT' $ \solver -> liftIO $ SimpleSMT.assert solver fact
 
-    ackCommand command =
-        withSolverT' $ \solver -> liftIO $ SimpleSMT.ackCommand solver command
+  check = Morph.hoist liftIO $ withSolver' SimpleSMT.check
 
-    loadFile path =
-        withSolverT' $ \solver -> liftIO $ SimpleSMT.loadFile solver path
+  ackCommand command =
+    withSolverT' $ \solver -> liftIO $ SimpleSMT.ackCommand solver command
+
+  loadFile path =
+    withSolverT' $ \solver -> liftIO $ SimpleSMT.loadFile solver path
 
 instance (MonadSMT m, Monoid w) => MonadSMT (AccumT w m) where
-    withSolver = mapAccumT withSolver
-    {-# INLINE withSolver #-}
+  withSolver = mapAccumT withSolver
+  {-# INLINE withSolver #-}
 
-instance MonadIO m => MonadProfiler (SmtT m)
-  where
-    profileDuration a action = SmtT (profileDurationEvent a (runSmtT action))
-    {-# INLINE profileDuration #-}
+instance MonadIO m => MonadProfiler (SmtT m) where
+  profileDuration a action = SmtT (profileDurationEvent a (runSmtT action))
+  {-# INLINE profileDuration #-}
 
 instance MonadSMT m => MonadSMT (IdentityT m)
 
 instance MonadSMT m => MonadSMT (ListT m) where
-    withSolver = mapListT withSolver
-    {-# INLINE withSolver #-}
+  withSolver = mapListT withSolver
+  {-# INLINE withSolver #-}
 
 instance MonadSMT m => MonadSMT (ReaderT r m)
 
@@ -340,37 +392,37 @@ instance MonadSMT m => MonadSMT (State.Strict.StateT s m)
 instance MonadSMT m => MonadSMT (ExceptT e m)
 
 -- | Time-limit for SMT queries.
-newtype TimeOut = TimeOut { getTimeOut :: Limit Integer }
-    deriving (Eq, Ord, Read, Show)
+newtype TimeOut = TimeOut {getTimeOut :: Limit Integer}
+  deriving (Eq, Ord, Read, Show)
 
 -- | Solver configuration
-data Config =
-    Config
-        { executable :: FilePath
+data Config
+  = Config
+      { executable :: FilePath,
         -- ^ solver executable file name
-        , arguments :: [String]
+        arguments :: [String],
         -- ^ default command-line arguments to solver
-        , preludeFile :: Maybe FilePath
+        preludeFile :: Maybe FilePath,
         -- ^ prelude of definitions to initialize solver
-        , logFile :: Maybe FilePath
+        logFile :: Maybe FilePath,
         -- ^ optional log file name
-        , timeOut :: TimeOut
+        timeOut :: TimeOut
         -- ^ query time limit
         }
 
 -- | Default configuration using the Z3 solver.
 defaultConfig :: Config
 defaultConfig =
-    Config
-        { executable = "z3"
-        , arguments =
-            [ "-smt2"  -- use SMT-LIB2 format
-            , "-in"    -- read from standard input
-            ]
-        , preludeFile = Nothing
-        , logFile = Nothing
-        , timeOut = TimeOut (Limit 40)
-        }
+  Config
+    { executable = "z3",
+      arguments =
+        [ "-smt2", -- use SMT-LIB2 format
+          "-in" -- read from standard input
+          ],
+      preludeFile = Nothing,
+      logFile = Nothing,
+      timeOut = TimeOut (Limit 40)
+      }
 
 {- | Initialize a new solver with the given 'Config'.
 
@@ -379,17 +431,17 @@ The new solver is returned in an 'MVar' for thread-safety.
  -}
 newSolver :: Config -> Logger -> IO (MVar Solver)
 newSolver config logger = do
-    solver <- SimpleSMT.newSolver exe args logger
-    mvar <- newMVar solver
-    runReaderT runSmtT mvar
-    return mvar
+  solver <- SimpleSMT.newSolver exe args logger
+  mvar <- newMVar solver
+  runReaderT runSmtT mvar
+  return mvar
   where
-    Config { timeOut } = config
-    Config { executable = exe, arguments = args } = config
-    Config { preludeFile } = config
-    SmtT { runSmtT } = do
-        setTimeOut timeOut
-        maybe (pure ()) loadFile preludeFile
+    Config {timeOut} = config
+    Config {executable = exe, arguments = args} = config
+    Config {preludeFile} = config
+    SmtT {runSmtT} = do
+      setTimeOut timeOut
+      maybe (pure ()) loadFile preludeFile
 
 {- | Shut down a solver.
 
@@ -400,42 +452,41 @@ solver will hang.
  -}
 stopSolver :: MVar Solver -> IO ()
 stopSolver mvar = do
-    solver <- takeMVar mvar
-    _ <- SimpleSMT.stop solver
-    return ()
+  solver <- takeMVar mvar
+  _ <- SimpleSMT.stop solver
+  return ()
 
 -- | Run an external SMT solver.
 runSMT :: Config -> Logger -> SMT a -> IO a
-runSMT config logger SmtT { runSmtT } = do
-    solver <- newSolver config logger
-    a <- runReaderT runSmtT solver
-    stopSolver solver
-    return a
+runSMT config logger SmtT {runSmtT} = do
+  solver <- newSolver config logger
+  a <- runReaderT runSmtT solver
+  stopSolver solver
+  return a
 
 -- Need to quote every identifier in SMT between pipes
 -- to escape special chars
 escapeId :: Text -> Text
 escapeId name = "|" <> name <> "|"
 
-
 -- | Declares a function symbol to SMT, returning ().
 declareFun_ :: MonadSMT m => SmtFunctionDeclaration -> m ()
 declareFun_ declaration =
-    Monad.void $ declareFun declaration
+  Monad.void $ declareFun declaration
 
 -- | SMT-LIB @set-info@ command.
 setInfo :: MonadSMT m => Text -> SExpr -> m ()
 setInfo infoFlag expr =
-    ackCommand $ List (Atom "set-info" : Atom infoFlag : [expr])
+  ackCommand $ List (Atom "set-info" : Atom infoFlag : [expr])
 
 -- --------------------------------
 -- Internal
 
 -- | Set the query time limit.
 setTimeOut :: MonadSMT m => TimeOut -> m ()
-setTimeOut TimeOut { getTimeOut } =
-    case getTimeOut of
-        Limit timeOut ->
-            setInfo ":time" (SimpleSMT.int timeOut)
-        Unlimited ->
-            return ()
+setTimeOut TimeOut {getTimeOut} =
+  case getTimeOut of
+    Limit timeOut ->
+      setInfo ":time" (SimpleSMT.int timeOut)
+    Unlimited ->
+      return ()

--- a/kore/src/SMT/AST.hs
+++ b/kore/src/SMT/AST.hs
@@ -8,62 +8,77 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 
 Use the Smt* versions of data types to work with the SimpleSMT interface.
 -}
-
 module SMT.AST
-    ( Constructor (..)
-    , ConstructorArgument (..)
-    , DataTypeDeclaration (..)
-    , FunctionDeclaration (..)
-    , SortDeclaration (..)
+  ( Constructor (..),
+    ConstructorArgument (..),
+    DataTypeDeclaration (..),
+    FunctionDeclaration (..),
+    SortDeclaration (..),
+    SExpr (..),
+    buildSExpr,
+    parseSExpr,
+    readSExpr,
+    readSExprs,
+    sendSExpr,
+    showSExpr,
+    nameFromSExpr,
+    SmtConstructor,
+    SmtConstructorArgument,
+    SmtDataTypeDeclaration,
+    SmtSortDeclaration,
+    SmtFunctionDeclaration
+    )
+where
 
-    , SExpr (..)
-    , buildSExpr, parseSExpr, readSExpr, readSExprs, sendSExpr, showSExpr
-    , nameFromSExpr
-
-    , SmtConstructor
-    , SmtConstructorArgument
-    , SmtDataTypeDeclaration
-    , SmtSortDeclaration
-    , SmtFunctionDeclaration
-    ) where
-
-import           Control.Applicative
-                 ( Alternative (..) )
-import           Control.DeepSeq
-                 ( NFData )
-import           Control.Monad.Fail
-                 ( MonadFail )
-import           Data.Char
-                 ( isSpace )
-import           Data.Maybe
-                 ( fromMaybe )
-import           Data.String
-                 ( IsString (..) )
-import           Data.Text
-                 ( Text )
+import Control.Applicative
+  ( Alternative (..)
+    )
+import Control.DeepSeq
+  ( NFData
+    )
+import Control.Monad.Fail
+  ( MonadFail
+    )
+import Data.Char
+  ( isSpace
+    )
+import Data.Maybe
+  ( fromMaybe
+    )
+import Data.String
+  ( IsString (..)
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import           Data.Text.Internal.Builder
-                 ( Builder )
-import qualified Data.Text.Internal.Builder as Text.Builder
 import qualified Data.Text.IO as Text
+import Data.Text.Internal.Builder
+  ( Builder
+    )
+import qualified Data.Text.Internal.Builder as Text.Builder
 import qualified Data.Text.Lazy as Text.Lazy
-import           Data.Void
-                 ( Void )
-import qualified Generics.SOP as SOP
+import Data.Void
+  ( Void
+    )
 import qualified GHC.Generics as GHC
-import           System.IO
-                 ( Handle, hPutChar )
-import           Text.Megaparsec
-                 ( Parsec )
+import qualified Generics.SOP as SOP
+import System.IO
+  ( Handle,
+    hPutChar
+    )
+import Text.Megaparsec
+  ( Parsec
+    )
 import qualified Text.Megaparsec as Parser
 import qualified Text.Megaparsec.Char as Parser
 import qualified Text.Megaparsec.Char.Lexer as Lexer
 
 -- | S-expressions, the basic format for SMT-LIB 2.
 data SExpr
-    = Atom !Text
-    | List ![SExpr]
-    deriving (GHC.Generic, Eq, Ord, Show)
+  = Atom !Text
+  | List ![SExpr]
+  deriving (GHC.Generic, Eq, Ord, Show)
 
 instance NFData SExpr
 
@@ -72,7 +87,7 @@ instance SOP.Generic SExpr
 instance SOP.HasDatatypeInfo SExpr
 
 instance IsString SExpr where
-    fromString = Atom . Text.pack
+  fromString = Atom . Text.pack
 
 {-| An argument to a data type constructor.
 
@@ -81,81 +96,85 @@ working due to a bug in z3 data type declaration,
 see https://github.com/Z3Prover/z3/issues/2217 , also see the similar comment
 in declareDatatypes in SimpleSMT.hs)
 --}
-data ConstructorArgument sort name =
-    ConstructorArgument
-        { name :: !name
-        , argType :: !sort
+data ConstructorArgument sort name
+  = ConstructorArgument
+      { name :: !name,
+        argType :: !sort
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-| A data type constructor.
 --}
-data Constructor sort symbol name =
-    Constructor
-        { name :: !symbol
-        , arguments :: ![ConstructorArgument sort name]
+data Constructor sort symbol name
+  = Constructor
+      { name :: !symbol,
+        arguments :: ![ConstructorArgument sort name]
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 {-| A constructor-based data type declaration.
 
 If the list of constructors is empty, the data type is empty.
 --}
-data DataTypeDeclaration sort symbol name =
-    DataTypeDeclaration
-        { name :: !name
-        , typeArguments :: ![name]
-        , constructors :: ![Constructor sort symbol name]
+data DataTypeDeclaration sort symbol name
+  = DataTypeDeclaration
+      { name :: !name,
+        typeArguments :: ![name],
+        constructors :: ![Constructor sort symbol name]
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 -- | A non-constructor-based data type declaration.
-data SortDeclaration name =
-    SortDeclaration
-        { name :: !name
-        , arity :: Int
+data SortDeclaration name
+  = SortDeclaration
+      { name :: !name,
+        arity :: Int
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 -- | A function declaration.
-data FunctionDeclaration sort name =
-    FunctionDeclaration
-        { name :: !name
-        , inputSorts :: ![sort]
-        , resultSort :: !sort
+data FunctionDeclaration sort name
+  = FunctionDeclaration
+      { name :: !name,
+        inputSorts :: ![sort],
+        resultSort :: !sort
         }
-    deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 -- | Extracts the name from a sexpression denoting a named object.
 nameFromSExpr :: SExpr -> Text
 nameFromSExpr (Atom name) = name
 nameFromSExpr (List (Atom name : _)) = name
 nameFromSExpr e =
-    (error . unlines)
-        [ "Cannot extract name from s-expression."
-        , "expression=" ++ showSExpr e
-        ]
+  (error . unlines)
+    [ "Cannot extract name from s-expression.",
+      "expression=" ++ showSExpr e
+      ]
 
 -- | Instantiate Constructor with the types needed by SimpleSMT.
 type SmtConstructor = Constructor SExpr Text Text
+
 -- | Instantiate ConstructorArgument with the types needed by SimpleSMT.
 type SmtConstructorArgument = ConstructorArgument SExpr Text
+
 -- | Instantiate DataTypeDeclaration with the types needed by SimpleSMT.
 type SmtDataTypeDeclaration = DataTypeDeclaration SExpr Text Text
+
 -- | Instantiate SortDeclaration with the types needed by SimpleSMT.
 type SmtSortDeclaration = SortDeclaration Text
+
 -- | Instantiate FunctionDeclaration with the types needed by SimpleSMT.
 type SmtFunctionDeclaration = FunctionDeclaration SExpr Text
 
 -- | Stream an S-expression into 'Builder'.
 buildSExpr :: SExpr -> Builder
 buildSExpr =
-    \case
-        Atom x  -> Text.Builder.fromText x
-        List es ->
-            Text.Builder.singleton '('
-            <> foldMap (\e -> buildSExpr e <> Text.Builder.singleton ' ') es
-            <> Text.Builder.singleton ')'
+  \case
+    Atom x -> Text.Builder.fromText x
+    List es ->
+      Text.Builder.singleton '('
+        <> foldMap (\e -> buildSExpr e <> Text.Builder.singleton ' ') es
+        <> Text.Builder.singleton ')'
 
 -- | Show an S-expression.
 showSExpr :: SExpr -> String
@@ -174,15 +193,15 @@ sendSExpr :: Handle -> SExpr -> IO ()
 sendSExpr h = sendSExprWorker
   where
     sendSExprWorker =
-        \case
-            Atom atom -> Text.hPutStr h atom
-            List atoms -> do
-                hPutChar h '('
-                mapM_ sendListElement atoms
-                hPutChar h ')'
+      \case
+        Atom atom -> Text.hPutStr h atom
+        List atoms -> do
+          hPutChar h '('
+          mapM_ sendListElement atoms
+          hPutChar h ')'
     sendListElement sExpr = do
-        sendSExprWorker sExpr
-        hPutChar h ' '
+      sendSExprWorker sExpr
+      hPutChar h ' '
 
 type Parser = Parsec Void Text
 
@@ -192,39 +211,32 @@ parseSExpr = parseAtom <|> parseList
   where
     parseAtom :: Parser SExpr
     parseAtom = lexeme (Atom <$> Parser.takeWhile1P Nothing notSpecial)
-
     parseList :: Parser SExpr
     parseList =
-        List <$> (lparen *> Parser.many parseSExpr <* rparen)
-
+      List <$> (lparen *> Parser.many parseSExpr <* rparen)
     special :: Char -> Bool
     special c = isSpace c || c == '(' || c == ')' || c == ';'
-
     notSpecial :: Char -> Bool
     notSpecial = Prelude.not . special
-
     lparen :: Parser Char
     lparen = lexeme (Parser.char '(')
-
     rparen :: Parser Char
     rparen = lexeme (Parser.char ')')
-
     skipLineComment = Lexer.skipLineComment ";"
     space = Lexer.space Parser.space1 skipLineComment empty
-
     lexeme :: Parser a -> Parser a
     lexeme = Lexer.lexeme space
 
 -- | Parse one S-expression.
 readSExpr :: MonadFail m => Text -> m SExpr
 readSExpr txt =
-    case Parser.parse parseSExpr "<unknown>" txt of
-        Left err -> fail (Parser.errorBundlePretty err)
-        Right sExpr -> return sExpr
+  case Parser.parse parseSExpr "<unknown>" txt of
+    Left err -> fail (Parser.errorBundlePretty err)
+    Right sExpr -> return sExpr
 
 -- | Parse many S-expressions.
 readSExprs :: Text -> [SExpr]
 readSExprs txt =
-    fromMaybe
-        []
-        (Parser.parseMaybe (Parser.some parseSExpr) txt)
+  fromMaybe
+    []
+    (Parser.parseMaybe (Parser.some parseSExpr) txt)

--- a/kore/src/SMT/SimpleSMT.hs
+++ b/kore/src/SMT/SimpleSMT.hs
@@ -8,186 +8,207 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 
 A module for interacting with an external SMT solver, using SMT-LIB 2 format.
 -}
-
 module SMT.SimpleSMT
-    (
-    -- * Basic Solver Interface
-      Solver (..)
-    , send
-    , recv
-    , debug
-    , command
-    , stop
-    , Logger
-    , newSolver
-    , ackCommand
-    , ackCommandIgnoreErr
-    , simpleCommand
-    , simpleCommandMaybe
-    , loadFile
-
+  ( -- * Basic Solver Interface
+    Solver (..),
+    send,
+    recv,
+    debug,
+    command,
+    stop,
+    Logger,
+    newSolver,
+    ackCommand,
+    ackCommandIgnoreErr,
+    simpleCommand,
+    simpleCommandMaybe,
+    loadFile,
     -- ** S-Expressions
-    , SExpr(..)
-    , showSExpr, readSExprs
-    , nameFromSExpr
-
+    SExpr (..),
+    showSExpr,
+    readSExprs,
+    nameFromSExpr,
     -- * Common SMT-LIB 2 Commands
-    , Constructor (..)
-    , SmtConstructor
-    , ConstructorArgument (..)
-    , SmtConstructorArgument
-    , DataTypeDeclaration (..)
-    , SmtDataTypeDeclaration
-    , FunctionDeclaration (..)
-    , SmtFunctionDeclaration
-    , SortDeclaration (..)
-    , SmtSortDeclaration
-    , setLogic, setLogicMaybe
-    , setOption, setOptionMaybe
-    , produceUnsatCores
-    , named
-    , push, pushMany
-    , pop, popMany
-    , inNewScope
-    , declare
-    , declareFun
-    , declareDatatype
-    , declareDatatypes
-    , declareSort
-    , define
-    , defineFun
-    , assert
-    , check
-    , Result(..)
-    , getExprs, getExpr
-    , getConsts, getConst
-    , getUnsatCore
-    , Value(..)
-    , sexprToVal
-
+    Constructor (..),
+    SmtConstructor,
+    ConstructorArgument (..),
+    SmtConstructorArgument,
+    DataTypeDeclaration (..),
+    SmtDataTypeDeclaration,
+    FunctionDeclaration (..),
+    SmtFunctionDeclaration,
+    SortDeclaration (..),
+    SmtSortDeclaration,
+    setLogic,
+    setLogicMaybe,
+    setOption,
+    setOptionMaybe,
+    produceUnsatCores,
+    named,
+    push,
+    pushMany,
+    pop,
+    popMany,
+    inNewScope,
+    declare,
+    declareFun,
+    declareDatatype,
+    declareDatatypes,
+    declareSort,
+    define,
+    defineFun,
+    assert,
+    check,
+    Result (..),
+    getExprs,
+    getExpr,
+    getConsts,
+    getConst,
+    getUnsatCore,
+    Value (..),
+    sexprToVal,
     -- * Convenience Functions for SMT-LIB2 Expressions
-    , fam
-    , fun
-    , const
-
+    fam,
+    fun,
+    const,
     -- ** Types
-    , tInt
-    , tBool
-    , tReal
-    , tArray
-    , tBits
-
+    tInt,
+    tBool,
+    tReal,
+    tArray,
+    tBits,
     -- ** Literals
-    , int
-    , real
-    , bool
-    , bvBin
-    , bvHex
-    , value
-
+    int,
+    real,
+    bool,
+    bvBin,
+    bvHex,
+    value,
     -- ** Connectives
-    , not
-    , and
-    , andMany
-    , or
-    , orMany
-    , xor
-    , implies
-
+    not,
+    and,
+    andMany,
+    or,
+    orMany,
+    xor,
+    implies,
     -- ** If-then-else
-    , ite
-
+    ite,
     -- ** Relational Predicates
-    , eq
-    , distinct
-    , gt
-    , lt
-    , geq
-    , leq
-    , bvULt
-    , bvULeq
-    , bvSLt
-    , bvSLeq
-
+    eq,
+    distinct,
+    gt,
+    lt,
+    geq,
+    leq,
+    bvULt,
+    bvULeq,
+    bvSLt,
+    bvSLeq,
     -- ** Arithmetic
-    , add
-    , addMany
-    , sub
-    , neg
-    , mul
-    , abs
-    , div
-    , mod
-    , divisible
-    , realDiv
-
+    add,
+    addMany,
+    sub,
+    neg,
+    mul,
+    abs,
+    div,
+    mod,
+    divisible,
+    realDiv,
     -- ** Bit Vectors
-    , concat
-    , extract
-    , bvNot
-    , bvNeg
-    , bvAnd
-    , bvXOr
-    , bvOr
-    , bvAdd
-    , bvSub
-    , bvMul
-    , bvUDiv
-    , bvURem
-    , bvSDiv
-    , bvSRem
-    , bvShl
-    , bvLShr
-    , bvAShr
-    , signExtend
-    , zeroExtend
-
+    concat,
+    extract,
+    bvNot,
+    bvNeg,
+    bvAnd,
+    bvXOr,
+    bvOr,
+    bvAdd,
+    bvSub,
+    bvMul,
+    bvUDiv,
+    bvURem,
+    bvSDiv,
+    bvSRem,
+    bvShl,
+    bvLShr,
+    bvAShr,
+    signExtend,
+    zeroExtend,
     -- ** Arrays
-    , select
-    , store
-
+    select,
+    store,
     -- Quantifiers
-    , forallQ
-    ) where
+    forallQ
+    )
+where
 
 import qualified Colog
-import           Control.Concurrent
-                 ( forkIO )
+import Control.Concurrent
+  ( forkIO
+    )
 import qualified Control.Exception as X
 import qualified Control.Monad as Monad
-import           Data.Bits
-                 ( testBit )
-import           Data.Ratio
-                 ( denominator, numerator, (%) )
-import           Data.Text
-                 ( Text )
+import Data.Bits
+  ( testBit
+    )
+import Data.Ratio
+  ( (%),
+    denominator,
+    numerator
+    )
+import Data.Text
+  ( Text
+    )
 import qualified Data.Text as Text
-import qualified Data.Text.Internal.Builder as Text.Builder
 import qualified Data.Text.IO as Text
+import qualified Data.Text.Internal.Builder as Text.Builder
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified GHC.Generics as GHC
-import           GHC.Stack
-                 ( callStack )
+import GHC.Stack
+  ( callStack
+    )
 import qualified GHC.Stack as GHC
-import           Numeric
-                 ( readHex, showFFloat, showHex )
-import           Prelude hiding
-                 ( abs, and, concat, const, div, mod, not, or )
-import qualified Prelude
-import           System.Exit
-                 ( ExitCode )
-import           System.IO
-                 ( Handle, hClose, hFlush, hPutChar )
-import           System.Process
-                 ( ProcessHandle, runInteractiveProcess, waitForProcess )
-import qualified Text.Megaparsec as Parser
-import           Text.Read
-                 ( readMaybe )
-
-import           Kore.Debug hiding
-                 ( debug )
+import Kore.Debug hiding
+  ( debug
+    )
 import qualified Kore.Logger as Logger
-import           SMT.AST
+import Numeric
+  ( readHex,
+    showFFloat,
+    showHex
+    )
+import SMT.AST
+import System.Exit
+  ( ExitCode
+    )
+import System.IO
+  ( Handle,
+    hClose,
+    hFlush,
+    hPutChar
+    )
+import System.Process
+  ( ProcessHandle,
+    runInteractiveProcess,
+    waitForProcess
+    )
+import qualified Text.Megaparsec as Parser
+import Text.Read
+  ( readMaybe
+    )
+import Prelude hiding
+  ( abs,
+    and,
+    concat,
+    const,
+    div,
+    mod,
+    not,
+    or
+    )
+import qualified Prelude
 
 -- ---------------------------------------------------------------------
 -- * Features
@@ -196,91 +217,91 @@ import           SMT.AST
  -}
 featureProduceAssertions :: Bool
 featureProduceAssertions =
-    -- TODO (thomas.tuegel): Change this to 'True' when we drop support for
-    -- older versions.
-    False
+  -- TODO (thomas.tuegel): Change this to 'True' when we drop support for
+  -- older versions.
+  False
 
 -- ---------------------------------------------------------------------
 
 -- | Results of checking for satisfiability.
-data Result = Sat         -- ^ The assertions are satisfiable
-            | Unsat       -- ^ The assertions are unsatisfiable
-            | Unknown     -- ^ The result is inconclusive
-              deriving (Eq,Show)
+data Result
+  = Sat -- ^ The assertions are satisfiable
+  | Unsat -- ^ The assertions are unsatisfiable
+  | Unknown -- ^ The result is inconclusive
+  deriving (Eq, Show)
 
 -- | Common values returned by SMT solvers.
-data Value =  Bool  !Bool           -- ^ Boolean value
-            | Int   !Integer        -- ^ Integral value
-            | Real  !Rational       -- ^ Rational value
-            | Bits  !Int !Integer   -- ^ Bit vector: width, value
-            | Other !SExpr          -- ^ Some other value
-              deriving (Eq, Show)
+data Value
+  = Bool !Bool -- ^ Boolean value
+  | Int !Integer -- ^ Integral value
+  | Real !Rational -- ^ Rational value
+  | Bits !Int !Integer -- ^ Bit vector: width, value
+  | Other !SExpr -- ^ Some other value
+  deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
-
 type Logger = Logger.LogAction IO Logger.LogMessage
 
 -- | An interactive solver process.
-data Solver = Solver
-    { hIn    :: !Handle
-    , hOut   :: !Handle
-    , hErr   :: !Handle
-    , hProc  :: !ProcessHandle
-    , logger :: !Logger
-    }
-    deriving (GHC.Generic)
+data Solver
+  = Solver
+      { hIn :: !Handle,
+        hOut :: !Handle,
+        hErr :: !Handle,
+        hProc :: !ProcessHandle,
+        logger :: !Logger
+        }
+  deriving (GHC.Generic)
 
 -- | Start a new solver process.
 newSolver
-    :: FilePath -- ^ Executable
-    -> [String] -- ^ Arguments
-    -> Logger   -- ^ Logger
-    -> IO Solver
+  :: FilePath -- ^ Executable
+  -> [String] -- ^ Arguments
+  -> Logger -- ^ Logger
+  -> IO Solver
 newSolver exe opts logger = do
-    (hIn, hOut, hErr, hProc) <- runInteractiveProcess exe opts Nothing Nothing
-    let solver = Solver { hIn, hOut, hErr, hProc, logger }
-
-    _ <- forkIO $ do
-        let handler X.SomeException {} = return ()
-        X.handle handler $ Monad.forever $ do
-            errs <- Text.hGetLine hErr
-            debug solver ["stderr"] errs
-
-    setOption solver ":print-success" "true"
-    setOption solver ":produce-models" "true"
-    Monad.when featureProduceAssertions
-        $ setOption solver ":produce-assertions" "true"
-
-    return solver
+  (hIn, hOut, hErr, hProc) <- runInteractiveProcess exe opts Nothing Nothing
+  let solver = Solver {hIn, hOut, hErr, hProc, logger}
+  _ <-
+    forkIO $ do
+      let handler X.SomeException {} = return ()
+      X.handle handler $ Monad.forever $ do
+        errs <- Text.hGetLine hErr
+        debug solver ["stderr"] errs
+  setOption solver ":print-success" "true"
+  setOption solver ":produce-models" "true"
+  Monad.when featureProduceAssertions
+    $ setOption solver ":produce-assertions" "true"
+  return solver
 
 debug :: GHC.HasCallStack => Solver -> [Logger.Scope] -> Text -> IO ()
-debug Solver { logger } scope a =
-    logger Colog.<& message
+debug Solver {logger} scope a =
+  logger Colog.<& message
   where
     message = Logger.LogMessage a Logger.Debug ("SimpleSMT" : scope) callStack
 
 warn :: GHC.HasCallStack => Solver -> [Logger.Scope] -> Text -> IO ()
-warn Solver { logger } scope a =
-    logger Colog.<& message
+warn Solver {logger} scope a =
+  logger Colog.<& message
   where
     message = Logger.LogMessage a Logger.Warning ("SimpleSMT" : scope) callStack
 
 send :: Solver -> SExpr -> IO ()
-send solver@Solver { hIn } command' = do
-    debug solver ["send"] (buildText command')
-    sendSExpr hIn command'
-    hPutChar hIn '\n'
-    hFlush hIn
+send solver@Solver {hIn} command' = do
+  debug solver ["send"] (buildText command')
+  sendSExpr hIn command'
+  hPutChar hIn '\n'
+  hFlush hIn
 
 recv :: Solver -> IO SExpr
-recv solver@Solver { hOut } = do
-    responseLines <- readResponse 0 []
-    let resp = Text.unlines (reverse responseLines)
-    debug solver ["recv"] resp
-    readSExpr resp
+recv solver@Solver {hOut} = do
+  responseLines <- readResponse 0 []
+  let resp = Text.unlines (reverse responseLines)
+  debug solver ["recv"] resp
+  readSExpr resp
   where
     {-| Reads an SMT response.
-
+    
     An SMT response is either an one line atom like "sat", or an s-expression
     that may span multiple lines. To find the end of the s-expression we check
     that all parentheses are closed.
@@ -291,59 +312,59 @@ recv solver@Solver { hOut } = do
       -- one line, then we finished reading the entire z3 response so we return.
       | Prelude.not (Prelude.null lines') = return lines'
     readResponse open lines' = do
-        line <- Text.hGetLine hOut
-        readResponse (open + deltaOpen line) (line : lines')
-
+      line <- Text.hGetLine hOut
+      readResponse (open + deltaOpen line) (line : lines')
     deltaOpen :: Text -> Int
     deltaOpen line = Text.count "(" line - Text.count ")" line
 
 command :: Solver -> SExpr -> IO SExpr
 command solver c =
-    traceNonErrorMonad D_SMT_command [debugArg "c" (showSExpr c)] $ do
-        send solver c
-        recv solver
+  traceNonErrorMonad D_SMT_command [debugArg "c" (showSExpr c)] $ do
+    send solver c
+    recv solver
 
 stop :: Solver -> IO ExitCode
-stop solver@Solver { hIn, hOut, hErr, hProc } = do
-    send solver (List [Atom "exit"])
-    ec <- waitForProcess hProc
-    let handler :: X.IOException -> IO ()
-        handler ex = (debug solver ["stop"] . Text.pack) (show ex)
-    X.handle handler $ do
-        hClose hIn
-        hClose hOut
-        hClose hErr
-    return ec
-
+stop solver@Solver {hIn, hOut, hErr, hProc} = do
+  send solver (List [Atom "exit"])
+  ec <- waitForProcess hProc
+  let handler :: X.IOException -> IO ()
+      handler ex = (debug solver ["stop"] . Text.pack) (show ex)
+  X.handle handler $ do
+    hClose hIn
+    hClose hOut
+    hClose hErr
+  return ec
 
 -- | Load the contents of a file.
 loadFile :: Solver -> FilePath -> IO ()
 loadFile s file = do
-    txt <- Text.readFile file
-    case Parser.runParser (Parser.some parseSExpr) file txt of
-        Left err -> fail (show err)
-        Right exprs ->
-            mapM_ (command s) exprs
-
+  txt <- Text.readFile file
+  case Parser.runParser (Parser.some parseSExpr) file txt of
+    Left err -> fail (show err)
+    Right exprs ->
+      mapM_ (command s) exprs
 
 -- | A command with no interesting result.
 ackCommand :: Solver -> SExpr -> IO ()
 ackCommand solver c =
-  do res <- command solver c
-     case res of
-       Atom "success" -> return ()
-       _  -> fail $ unlines
-                      [ "Unexpected result from the SMT solver:"
-                      , "  Command: " ++ showSExpr c
-                      , "  Expected: success"
-                      , "  Result: " ++ showSExpr res
-                      ]
+  do
+    res <- command solver c
+    case res of
+      Atom "success" -> return ()
+      _ ->
+        fail
+          $ unlines
+              [ "Unexpected result from the SMT solver:",
+                "  Command: " ++ showSExpr c,
+                "  Expected: success",
+                "  Result: " ++ showSExpr res
+                ]
 
 -- | A command with no interesting result.
 ackCommandIgnoreErr :: Solver -> SExpr -> IO ()
 ackCommandIgnoreErr proc c = do
-    _ <- command proc c
-    pure ()
+  _ <- command proc c
+  pure ()
 
 -- | A command entirely made out of atoms, with no interesting result.
 simpleCommand :: Solver -> [Text] -> IO ()
@@ -354,35 +375,36 @@ simpleCommand proc = ackCommand proc . List . map Atom
 -- by others.
 simpleCommandMaybe :: Solver -> [Text] -> IO Bool
 simpleCommandMaybe solver c =
-  do let cmd = List (map Atom c)
-     res <- command solver cmd
-     case res of
-       Atom "success"     -> return True
-       Atom "unsupported" -> return False
-       _                  -> fail $ unlines
-                                      [ "Unexpected result from the SMT solver:"
-                                      , "  Command: " ++ showSExpr cmd
-                                      , "  Expected: success or unsupported"
-                                      , "  Result: " ++ showSExpr res
-                                      ]
-
+  do
+    let cmd = List (map Atom c)
+    res <- command solver cmd
+    case res of
+      Atom "success" -> return True
+      Atom "unsupported" -> return False
+      _ ->
+        fail
+          $ unlines
+              [ "Unexpected result from the SMT solver:",
+                "  Command: " ++ showSExpr cmd,
+                "  Expected: success or unsupported",
+                "  Result: " ++ showSExpr res
+                ]
 
 -- | Set a solver option.
 setOption :: Solver -> Text -> Text -> IO ()
-setOption s x y = simpleCommand s [ "set-option", x, y ]
+setOption s x y = simpleCommand s ["set-option", x, y]
 
 -- | Set a solver option, returning False if the option is unsupported.
 setOptionMaybe :: Solver -> Text -> Text -> IO Bool
-setOptionMaybe s x y = simpleCommandMaybe s [ "set-option", x, y ]
+setOptionMaybe s x y = simpleCommandMaybe s ["set-option", x, y]
 
 -- | Set the solver's logic.  Usually, this should be done first.
 setLogic :: Solver -> Text -> IO ()
-setLogic s x = simpleCommand s [ "set-logic", x ]
-
+setLogic s x = simpleCommand s ["set-logic", x]
 
 -- | Set the solver's logic, returning False if the logic is unsupported.
 setLogicMaybe :: Solver -> Text -> IO Bool
-setLogicMaybe s x = simpleCommandMaybe s [ "set-logic", x ]
+setLogicMaybe s x = simpleCommandMaybe s ["set-logic", x]
 
 -- | Request unsat cores.  Returns if the solver supports them.
 produceUnsatCores :: Solver -> IO Bool
@@ -398,18 +420,17 @@ pop proc = popMany proc 1
 
 -- | Push multiple scopes.
 pushMany :: Solver -> Integer -> IO ()
-pushMany proc n = simpleCommand proc [ "push", Text.pack (show n) ]
+pushMany proc n = simpleCommand proc ["push", Text.pack (show n)]
 
 -- | Pop multiple scopes.
 popMany :: Solver -> Integer -> IO ()
-popMany proc n = simpleCommand proc [ "pop", Text.pack (show n) ]
+popMany proc n = simpleCommand proc ["pop", Text.pack (show n)]
 
 -- | Execute the IO action in a new solver scope (push before, pop after)
 inNewScope :: Solver -> IO a -> IO a
 inNewScope s m = do
-    push s
-    m `X.finally` pop s
-
+  push s
+  m `X.finally` pop s
 
 -- | Declare a constant.  A common abbreviation for 'declareFun'.
 -- For convenience, returns an the declared name as a constant expression.
@@ -420,120 +441,111 @@ declare proc f t = declareFun proc (FunctionDeclaration f [] t)
 -- For convenience, returns an the declared name as a constant expression.
 declareFun :: Solver -> SmtFunctionDeclaration -> IO SExpr
 declareFun proc FunctionDeclaration {name, inputSorts, resultSort} = do
-    ackCommandIgnoreErr proc
-        $ fun "declare-fun" [ Atom name, List inputSorts, resultSort ]
-    return (const name)
+  ackCommandIgnoreErr proc
+    $ fun "declare-fun" [Atom name, List inputSorts, resultSort]
+  return (const name)
 
 declareSort :: Solver -> SmtSortDeclaration -> IO SExpr
 declareSort
-    proc
-    SortDeclaration {name, arity}
-  = do
-    ackCommandIgnoreErr proc
-        $ fun "declare-sort" [ Atom name, (Atom . Text.pack . show) arity ]
-    pure (const name)
+  proc
+  SortDeclaration {name, arity} =
+    do
+      ackCommandIgnoreErr proc
+        $ fun "declare-sort" [Atom name, (Atom . Text.pack . show) arity]
+      pure (const name)
 
 -- | Declare a set of ADTs
 declareDatatypes
-    :: Solver
-    -> [ SmtDataTypeDeclaration ]
-    -> IO ()
+  :: Solver
+  -> [SmtDataTypeDeclaration]
+  -> IO ()
 declareDatatypes proc datatypes = do
-    mapM_ declareDatatypeSort datatypes
-    mapM_ addSortConstructors datatypes
+  mapM_ declareDatatypeSort datatypes
+  mapM_ addSortConstructors datatypes
   where
     declareDatatypeSort :: SmtDataTypeDeclaration -> IO SExpr
-    declareDatatypeSort DataTypeDeclaration { name, typeArguments } =
-        declareSort
-            proc
-            SortDeclaration { name, arity = length typeArguments }
-
+    declareDatatypeSort DataTypeDeclaration {name, typeArguments} =
+      declareSort
+        proc SortDeclaration {name, arity = length typeArguments}
     addSortConstructors :: SmtDataTypeDeclaration -> IO ()
-    addSortConstructors
-        d@DataTypeDeclaration { constructors }
-      = do
+    addSortConstructors d@DataTypeDeclaration {constructors} =
+      do
         declareConstructors d constructors
         assert proc (noJunkAxiom d constructors)
         return ()
-
     declareConstructors :: SmtDataTypeDeclaration -> [SmtConstructor] -> IO ()
     declareConstructors
-        DataTypeDeclaration { name, typeArguments = [] }
-        constructors
-      =
+      DataTypeDeclaration {name, typeArguments = []}
+      constructors =
         mapM_ (declareConstructor (Atom name)) constructors
-    declareConstructors declaration constructors = (error . unlines)
-        [ "Not implemented."
-        , "declaration = " ++ show declaration
-        , "constructors = " ++ show constructors
-        ]
-
+    declareConstructors declaration constructors =
+      (error . unlines)
+        [ "Not implemented.",
+          "declaration = " ++ show declaration,
+          "constructors = " ++ show constructors
+          ]
     declareConstructor :: SExpr -> SmtConstructor -> IO SExpr
     declareConstructor sort Constructor {name, arguments} =
-        declareFun
-            proc
-            FunctionDeclaration
-                { name
-                , inputSorts = map argType arguments
-                , resultSort = sort
-                }
-
+      declareFun
+        proc FunctionDeclaration
+        { name,
+          inputSorts = map argType arguments,
+          resultSort = sort
+          }
     noJunkAxiom :: SmtDataTypeDeclaration -> [SmtConstructor] -> SExpr
     noJunkAxiom
-        DataTypeDeclaration { name, typeArguments = [] }
-        constructors
-      =
+      DataTypeDeclaration {name, typeArguments = []}
+      constructors =
         forallQ
-            -- TODO(virgil): make sure that "x" is not used in any constructors
-            -- or sorts.
-            [List [Atom "x", Atom name]]
-            (orMany (map (builtWithConstructor "x") constructors))
-    noJunkAxiom declaration constructors = (error . unlines)
-        [ "Not implemented."
-        , "declaration = " ++ show declaration
-        , "constructors = " ++ show constructors
-        ]
-
+          -- TODO(virgil): make sure that "x" is not used in any constructors
+          -- or sorts.
+          [List [Atom "x", Atom name]]
+          (orMany (map (builtWithConstructor "x") constructors))
+    noJunkAxiom declaration constructors =
+      (error . unlines)
+        [ "Not implemented.",
+          "declaration = " ++ show declaration,
+          "constructors = " ++ show constructors
+          ]
     builtWithConstructor :: Text -> SmtConstructor -> SExpr
     builtWithConstructor
-        variable
-        Constructor {name, arguments = []}
-      =
+      variable
+      Constructor {name, arguments = []} =
         eq (Atom variable) (Atom name)
     builtWithConstructor
-        variable
-        Constructor {name, arguments}
-      =
+      variable
+      Constructor {name, arguments} =
         existsQ
-            (map mkQuantifier arguments)
-            (eq (Atom variable) (fun name (map mkArg arguments)))
-      where
-        mkArg :: SmtConstructorArgument -> SExpr
-        mkArg ConstructorArgument {name = argName} = Atom argName
-        mkQuantifier :: SmtConstructorArgument -> SExpr
-        mkQuantifier c@ConstructorArgument {argType} =
+          (map mkQuantifier arguments)
+          (eq (Atom variable) (fun name (map mkArg arguments)))
+        where
+          mkArg :: SmtConstructorArgument -> SExpr
+          mkArg ConstructorArgument {name = argName} = Atom argName
+          mkQuantifier :: SmtConstructorArgument -> SExpr
+          mkQuantifier c@ConstructorArgument {argType} =
             List [mkArg c, argType]
-  -- TODO(virgil): Currently using the code below to declare datatypes crashes
-  -- z3 when testing that things can't be built out of them, e.g. things like
-  -- (declare-datatypes ()
-  --   (
-  --       (HB_S
-  --           HB_C
-  --           (HB_D (HB_D1 HB_T))
-  --       )
-  --       (HB_T HB_E )
-  --   )
-  -- )
-  -- (declare-fun x () HB_S )
-  -- (assert (not (= x HB_C ) ) )
-  -- (assert (not (= x (HB_D HB_E ) ) ) )
-  -- (check-sat )
-  -- will crash z3.
-  --
-  -- This was fixed, see https://github.com/Z3Prover/z3/issues/2217
-  -- We should switch to the proper way of declaring datatypes below
-  -- whenever we think we can ask people to use a version of z3 that
-  -- supports them.
+
+-- TODO(virgil): Currently using the code below to declare datatypes crashes
+-- z3 when testing that things can't be built out of them, e.g. things like
+-- (declare-datatypes ()
+--   (
+--       (HB_S
+--           HB_C
+--           (HB_D (HB_D1 HB_T))
+--       )
+--       (HB_T HB_E )
+--   )
+-- )
+-- (declare-fun x () HB_S )
+-- (assert (not (= x HB_C ) ) )
+-- (assert (not (= x (HB_D HB_E ) ) ) )
+-- (check-sat )
+-- will crash z3.
+--
+-- This was fixed, see https://github.com/Z3Prover/z3/issues/2217
+-- We should switch to the proper way of declaring datatypes below
+-- whenever we think we can ask people to use a version of z3 that
+-- supports them.
 {-
 declareDatatypes proc datatypes =
   ackCommand proc $
@@ -564,26 +576,28 @@ declareDatatype proc declaration = declareDatatypes proc [declaration]
 
 -- | Declare a constant.  A common abbreviation for 'declareFun'.
 -- For convenience, returns the defined name as a constant expression.
-define :: Solver ->
-          Text {- ^ New symbol -} ->
-          SExpr  {- ^ Symbol type -} ->
-          SExpr  {- ^ Symbol definition -} ->
-          IO SExpr
+define
+  :: Solver
+  -> Text {- ^ New symbol -}
+  -> SExpr {- ^ Symbol type -}
+  -> SExpr {- ^ Symbol definition -}
+  -> IO SExpr
 define proc f = defineFun proc f []
 
 -- | Define a function or a constant.
 -- For convenience, returns an the defined name as a constant expression.
-defineFun :: Solver ->
-             Text           {- ^ New symbol -} ->
-             [(Text,SExpr)] {- ^ Parameters, with types -} ->
-             SExpr            {- ^ Type of result -} ->
-             SExpr            {- ^ Definition -} ->
-             IO SExpr
+defineFun
+  :: Solver
+  -> Text {- ^ New symbol -}
+  -> [(Text, SExpr)] {- ^ Parameters, with types -}
+  -> SExpr {- ^ Type of result -}
+  -> SExpr {- ^ Definition -}
+  -> IO SExpr
 defineFun proc f as t e = do
-    ackCommand proc $ fun "define-fun"
-        [ Atom f, List [ List [const x,a] | (x,a) <- as ], t, e]
-    return (const f)
-
+  ackCommand proc
+    $ fun "define-fun"
+        [Atom f, List [List [const x, a] | (x, a) <- as], t, e]
+  return (const f)
 
 buildText :: SExpr -> Text
 buildText = Text.Lazy.toStrict . Text.Builder.toLazyText . buildSExpr
@@ -595,89 +609,98 @@ assert proc e = ackCommand proc $ fun "assert" [e]
 -- | Check if the current set of assertion is consistent.
 check :: Solver -> IO Result
 check solver = do
-    res <- command solver (List [ Atom "check-sat" ])
-    case res of
-        Atom "unsat"   -> return Unsat
-        Atom "unknown" -> do
-            Monad.when featureProduceAssertions $ do
-                asserts <- command solver (List [Atom "get-assertions"])
-                warn solver ["check"] (buildText asserts)
-            return Unknown
-        Atom "sat"     -> do
-            model <- command solver (List [Atom "get-model"])
-            debug solver ["check"] (buildText model)
-            return Sat
-        _ -> fail $ unlines
-            [ "Unexpected result from the SMT solver:"
-            , "  Expected: unsat, unknown, or sat"
-            , "  Result: " ++ showSExpr res
-            ]
+  res <- command solver (List [Atom "check-sat"])
+  case res of
+    Atom "unsat" -> return Unsat
+    Atom "unknown" -> do
+      Monad.when featureProduceAssertions $ do
+        asserts <- command solver (List [Atom "get-assertions"])
+        warn solver ["check"] (buildText asserts)
+      return Unknown
+    Atom "sat" -> do
+      model <- command solver (List [Atom "get-model"])
+      debug solver ["check"] (buildText model)
+      return Sat
+    _ ->
+      fail
+        $ unlines
+            [ "Unexpected result from the SMT solver:",
+              "  Expected: unsat, unknown, or sat",
+              "  Result: " ++ showSExpr res
+              ]
 
 -- | Convert an s-expression to a value.
 sexprToVal :: SExpr -> Value
 sexprToVal expr =
   case expr of
-    Atom "true"                    -> Bool True
-    Atom "false"                   -> Bool False
+    Atom "true" -> Bool True
+    Atom "false" -> Bool False
     Atom (Text.unpack -> ('#' : 'b' : ds))
-      | Just n <- binLit ds         -> Bits (length ds) n
+      | Just n <- binLit ds -> Bits (length ds) n
     Atom (Text.unpack -> ('#' : 'x' : ds))
-      | [(n,[])] <- readHex ds      -> Bits (4 * length ds) n
+      | [(n, [])] <- readHex ds -> Bits (4 * length ds) n
     Atom (Text.unpack -> txt)
-      | Just n <- readMaybe txt     -> Int n
-    List [ Atom "-", x ]
-      | Int a <- sexprToVal x    -> Int (negate a)
-    List [ Atom "/", x, y ]
-      | Int a <- sexprToVal x
-      , Int b <- sexprToVal y    -> Real (a % b)
+      | Just n <- readMaybe txt -> Int n
+    List [Atom "-", x]
+      | Int a <- sexprToVal x -> Int (negate a)
+    List [Atom "/", x, y]
+      | Int a <- sexprToVal x,
+        Int b <- sexprToVal y ->
+        Real (a % b)
     _ -> Other expr
-
   where
-  binLit cs = do ds <- mapM binDigit cs
-                 return $ sum $ zipWith (*) (reverse ds) powers2
-  powers2   = 1 : map (2 *) powers2
-  binDigit '0' = Just 0
-  binDigit '1' = Just 1
-  binDigit _   = Nothing
+    binLit cs = do
+      ds <- mapM binDigit cs
+      return $ sum $ zipWith (*) (reverse ds) powers2
+    powers2 = 1 : map (2 *) powers2
+    binDigit '0' = Just 0
+    binDigit '1' = Just 1
+    binDigit _ = Nothing
 
 -- | Get the values of some s-expressions.
 -- Only valid after a 'Sat' result.
 getExprs :: Solver -> [SExpr] -> IO [(SExpr, Value)]
 getExprs solver vals =
-  do let cmd = List [ Atom "get-value", List vals ]
-     res <- command solver cmd
-     case res of
-       List xs -> mapM getAns xs
-       _ -> fail $ unlines
-                 [ "Unexpected response from the SMT solver:"
-                 , "  Command: " ++ showSExpr cmd
-                 , "  Expected: a list"
-                 , "  Result: " ++ showSExpr res
-                 ]
+  do
+    let cmd = List [Atom "get-value", List vals]
+    res <- command solver cmd
+    case res of
+      List xs -> mapM getAns xs
+      _ ->
+        fail
+          $ unlines
+              [ "Unexpected response from the SMT solver:",
+                "  Command: " ++ showSExpr cmd,
+                "  Expected: a list",
+                "  Result: " ++ showSExpr res
+                ]
   where
-  getAns expr =
-    case expr of
-      List [ e, v ] -> return (e, sexprToVal v)
-      _             -> fail $ unlines
-                            [ "Unexpected response from the SMT solver:"
-                            , "  Expected: (expr val)"
-                            , "  Result: " ++ showSExpr expr
-                            ]
+    getAns expr =
+      case expr of
+        List [e, v] -> return (e, sexprToVal v)
+        _ ->
+          fail
+            $ unlines
+                [ "Unexpected response from the SMT solver:",
+                  "  Expected: (expr val)",
+                  "  Result: " ++ showSExpr expr
+                  ]
 
 -- | Get the values of some constants in the current model.
 -- A special case of 'getExprs'.
 -- Only valid after a 'Sat' result.
 getConsts :: Solver -> [Text] -> IO [(Text, Value)]
 getConsts proc xs =
-  do ans <- getExprs proc (map Atom xs)
-     return [ (x,e) | (Atom x, e) <- ans ]
-
+  do
+    ans <- getExprs proc (map Atom xs)
+    return [(x, e) | (Atom x, e) <- ans]
 
 -- | Get the value of a single expression.
 getExpr :: Solver -> SExpr -> IO Value
 getExpr proc x =
-  do [ (_,v) ] <- getExprs proc [x]
-     return v
+  do
+    [(_, v)] <- getExprs proc [x]
+    return v
 
 -- | Get the value of a single constant.
 getConst :: Solver -> Text -> IO Value
@@ -686,24 +709,25 @@ getConst proc x = getExpr proc (Atom x)
 -- | Returns the names of the (named) formulas involved in a contradiction.
 getUnsatCore :: Solver -> IO [Text]
 getUnsatCore s =
-  do res <- command s $ List [ Atom "get-unsat-core" ]
-     case res of
-       List xs -> mapM fromAtom xs
-       _       -> unexpected "a list of atoms" res
+  do
+    res <- command s $ List [Atom "get-unsat-core"]
+    case res of
+      List xs -> mapM fromAtom xs
+      _ -> unexpected "a list of atoms" res
   where
-  fromAtom x =
-    case x of
-      Atom a -> return a
-      _      -> unexpected "an atom" x
-
-  unexpected x e =
-    fail $ unlines [ "Unexpected response from the SMT Solver:"
-                   , "  Expected: " ++ x
-                   , "  Result: " ++ showSExpr e
-                   ]
+    fromAtom x =
+      case x of
+        Atom a -> return a
+        _ -> unexpected "an atom" x
+    unexpected x e =
+      fail
+        $ unlines
+            [ "Unexpected response from the SMT Solver:",
+              "  Expected: " ++ x,
+              "  Result: " ++ showSExpr e
+              ]
 
 --------------------------------------------------------------------------------
-
 
 -- | A constant, corresponding to a family indexed by some integers.
 fam :: Text -> [Integer] -> SExpr
@@ -718,9 +742,7 @@ fun f as = List (Atom f : as)
 const :: Text -> SExpr
 const f = fun f []
 
-
 -- Types -----------------------------------------------------------------------
-
 
 -- | The type of integers.
 tInt :: SExpr
@@ -735,17 +757,17 @@ tReal :: SExpr
 tReal = const "Real"
 
 -- | The type of arrays.
-tArray :: SExpr {- ^ Type of indexes  -} ->
-          SExpr {- ^ Type of elements -} ->
-          SExpr
-tArray x y = fun "Array" [x,y]
+tArray
+  :: SExpr {- ^ Type of indexes  -}
+  -> SExpr {- ^ Type of elements -}
+  -> SExpr
+tArray x y = fun "Array" [x, y]
 
 -- | The type of bit vectors.
-tBits :: Integer {- ^ Number of bits -} ->
-         SExpr
+tBits
+  :: Integer {- ^ Number of bits -}
+  -> SExpr
 tBits w = fam "BitVec" [w]
-
-
 
 -- Literals --------------------------------------------------------------------
 
@@ -755,26 +777,29 @@ bool b = const (if b then "true" else "false")
 
 -- | Integer literals.
 int :: Integer -> SExpr
-int x | x < 0     = neg (int (negate x))
-      | otherwise = Atom (Text.pack $ show x)
+int x
+  | x < 0 = neg (int (negate x))
+  | otherwise = Atom (Text.pack $ show x)
 
 -- | Real (well, rational) literals.
 real :: Rational -> SExpr
 real x
   | toRational y == x = Atom (Text.pack $ showFFloat Nothing y "")
   | otherwise = realDiv (int (numerator x)) (int (denominator x))
-  where y = fromRational x :: Double
+  where
+    y = fromRational x :: Double
 
 -- | A bit vector represented in binary.
 --
 --     * If the value does not fit in the bits, then the bits will be increased.
 --     * The width should be strictly positive.
-bvBin :: Int {- ^ Width, in bits -} -> Integer {- ^ Value -} -> SExpr
+bvBin :: Int -> Integer -> SExpr {- ^ Width, in bits -}
+  {- ^ Value -}
 bvBin w v = const ("#b" <> bits)
   where
-  bits =
+    bits =
       (Text.pack . reverse)
-      [ if testBit v n then '1' else '0' | n <- [ 0 .. w - 1 ] ]
+        [if testBit v n then '1' else '0' | n <- [0 .. w - 1]]
 
 -- | A bit vector represented in hex.
 --
@@ -783,27 +808,27 @@ bvBin w v = const ("#b" <> bits)
 --    * If the width is not a multiple of 4, it will be rounded
 --      up so that it is.
 --    * The width should be strictly positive.
-bvHex :: Int {- ^ Width, in bits -} -> Integer {- ^ Value -} -> SExpr
+bvHex :: Int -> Integer -> SExpr {- ^ Width, in bits -}
+  {- ^ Value -}
 bvHex w v
-  | v >= 0    = const (Text.pack $ "#x" ++ padding ++ hex)
-  | otherwise = bvHex w (2^w + v)
+  | v >= 0 = const (Text.pack $ "#x" ++ padding ++ hex)
+  | otherwise = bvHex w (2 ^ w + v)
   where
-  hex     = showHex v ""
-  padding = replicate (Prelude.div (w + 3) 4 - length hex) '0'
-
+    hex = showHex v ""
+    padding = replicate (Prelude.div (w + 3) 4 - length hex) '0'
 
 -- | Render a value as an expression.  Bit-vectors are rendered in hex,
 -- if their width is a multiple of 4, and in binary otherwise.
 value :: Value -> SExpr
 value val =
   case val of
-    Bool b    -> bool b
-    Int n     -> int n
-    Real r    -> real r
+    Bool b -> bool b
+    Int n -> int n
+    Real r -> real r
     Bits w v
       | Prelude.mod w 4 == 0 -> bvHex w v
-      | otherwise      -> bvBin w v
-    Other o   -> o
+      | otherwise -> bvBin w v
+    Other o -> o
 
 -- Connectives -----------------------------------------------------------------
 
@@ -813,91 +838,84 @@ not p = fun "not" [p]
 
 -- | Conjunction.
 and :: SExpr -> SExpr -> SExpr
-and p q = fun "and" [p,q]
+and p q = fun "and" [p, q]
 
 andMany :: [SExpr] -> SExpr
 andMany xs = if null xs then bool True else fun "and" xs
 
 -- | Disjunction.
 or :: SExpr -> SExpr -> SExpr
-or p q = fun "or" [p,q]
+or p q = fun "or" [p, q]
 
 orMany :: [SExpr] -> SExpr
 orMany xs = if null xs then bool False else fun "or" xs
 
 -- | Exclusive-or.
 xor :: SExpr -> SExpr -> SExpr
-xor p q = fun "xor" [p,q]
+xor p q = fun "xor" [p, q]
 
 -- | Implication.
 implies :: SExpr -> SExpr -> SExpr
-implies p q = fun "=>" [p,q]
-
+implies p q = fun "=>" [p, q]
 
 -- If-then-else ----------------------------------------------------------------
 
 -- | If-then-else.  This is polymorphic and can be used to construct any term.
 ite :: SExpr -> SExpr -> SExpr -> SExpr
-ite x y z = fun "ite" [x,y,z]
-
-
-
+ite x y z = fun "ite" [x, y, z]
 
 -- Relations -------------------------------------------------------------------
 
 -- | Equality.
 eq :: SExpr -> SExpr -> SExpr
-eq x y = fun "=" [x,y]
+eq x y = fun "=" [x, y]
 
 distinct :: [SExpr] -> SExpr
 distinct xs = if null xs then bool True else fun "distinct" xs
 
 -- | Greater-then
 gt :: SExpr -> SExpr -> SExpr
-gt x y = fun ">" [x,y]
+gt x y = fun ">" [x, y]
 
 -- | Less-then.
 lt :: SExpr -> SExpr -> SExpr
-lt x y = fun "<" [x,y]
+lt x y = fun "<" [x, y]
 
 -- | Greater-than-or-equal-to.
 geq :: SExpr -> SExpr -> SExpr
-geq x y = fun ">=" [x,y]
+geq x y = fun ">=" [x, y]
 
 -- | Less-than-or-equal-to.
 leq :: SExpr -> SExpr -> SExpr
-leq x y = fun "<=" [x,y]
+leq x y = fun "<=" [x, y]
 
 -- | Unsigned less-than on bit-vectors.
 bvULt :: SExpr -> SExpr -> SExpr
-bvULt x y = fun "bvult" [x,y]
+bvULt x y = fun "bvult" [x, y]
 
 -- | Unsigned less-than-or-equal on bit-vectors.
 bvULeq :: SExpr -> SExpr -> SExpr
-bvULeq x y = fun "bvule" [x,y]
+bvULeq x y = fun "bvule" [x, y]
 
 -- | Signed less-than on bit-vectors.
 bvSLt :: SExpr -> SExpr -> SExpr
-bvSLt x y = fun "bvslt" [x,y]
+bvSLt x y = fun "bvslt" [x, y]
 
 -- | Signed less-than-or-equal on bit-vectors.
 bvSLeq :: SExpr -> SExpr -> SExpr
-bvSLeq x y = fun "bvsle" [x,y]
-
-
-
+bvSLeq x y = fun "bvsle" [x, y]
 
 -- | Addition.
 -- See also 'bvAdd'
 add :: SExpr -> SExpr -> SExpr
-add x y = fun "+" [x,y]
+add x y = fun "+" [x, y]
 
 addMany :: [SExpr] -> SExpr
 addMany xs = if null xs then int 0 else fun "+" xs
 
 -- | Subtraction.
 sub :: SExpr -> SExpr -> SExpr
-sub x y = fun "-" [x,y]
+sub x y = fun "-" [x, y]
 
 -- | Arithmetic negation for integers and reals.
 -- See also 'bvNeg'.
@@ -906,7 +924,7 @@ neg x = fun "-" [x]
 
 -- | Multiplication.
 mul :: SExpr -> SExpr -> SExpr
-mul x y = fun "*" [x,y]
+mul x y = fun "*" [x, y]
 
 -- | Absolute value.
 abs :: SExpr -> SExpr
@@ -914,36 +932,36 @@ abs x = fun "abs" [x]
 
 -- | Integer division.
 div :: SExpr -> SExpr -> SExpr
-div x y = fun "div" [x,y]
+div x y = fun "div" [x, y]
 
 -- | Modulus.
 mod :: SExpr -> SExpr -> SExpr
-mod x y = fun "mod" [x,y]
+mod x y = fun "mod" [x, y]
 
 -- | Is the number divisible by the given constant.
 divisible :: SExpr -> Integer -> SExpr
-divisible x n = List [ fam "divisible" [n], x ]
+divisible x n = List [fam "divisible" [n], x]
 
 -- | Division of real numbers.
 realDiv :: SExpr -> SExpr -> SExpr
-realDiv x y = fun "/" [x,y]
+realDiv x y = fun "/" [x, y]
 
 -- | Bit vector concatenation.
 concat :: SExpr -> SExpr -> SExpr
-concat x y = fun "concat" [x,y]
+concat x y = fun "concat" [x, y]
 
 -- | Extend to the signed equivalent bitvector by @i@ bits
 signExtend :: Integer -> SExpr -> SExpr
-signExtend i x = List [ fam "sign_extend" [i], x ]
+signExtend i x = List [fam "sign_extend" [i], x]
 
 -- | Extend with zeros to the unsigned equivalent bitvector
 -- by @i@ bits
 zeroExtend :: Integer -> SExpr -> SExpr
-zeroExtend i x = List [ fam "zero_extend" [i], x ]
+zeroExtend i x = List [fam "zero_extend" [i], x]
 
 -- | Extract a sub-sequence of a bit vector.
 extract :: SExpr -> Integer -> Integer -> SExpr
-extract x y z = List [ fam "extract" [y,z], x ]
+extract x y z = List [fam "extract" [y, z], x]
 
 -- | Bitwise negation.
 bvNot :: SExpr -> SExpr
@@ -951,15 +969,15 @@ bvNot x = fun "bvnot" [x]
 
 -- | Bitwise conjuction.
 bvAnd :: SExpr -> SExpr -> SExpr
-bvAnd x y = fun "bvand" [x,y]
+bvAnd x y = fun "bvand" [x, y]
 
 -- | Bitwise disjunction.
 bvOr :: SExpr -> SExpr -> SExpr
-bvOr x y = fun "bvor" [x,y]
+bvOr x y = fun "bvor" [x, y]
 
 -- | Bitwise exclusive or.
 bvXOr :: SExpr -> SExpr -> SExpr
-bvXOr x y = fun "bvxor" [x,y]
+bvXOr x y = fun "bvxor" [x, y]
 
 -- | Bit vector arithmetic negation.
 bvNeg :: SExpr -> SExpr
@@ -967,80 +985,77 @@ bvNeg x = fun "bvneg" [x]
 
 -- | Addition of bit vectors.
 bvAdd :: SExpr -> SExpr -> SExpr
-bvAdd x y = fun "bvadd" [x,y]
+bvAdd x y = fun "bvadd" [x, y]
 
 -- | Subtraction of bit vectors.
 bvSub :: SExpr -> SExpr -> SExpr
-bvSub x y = fun "bvsub" [x,y]
-
-
+bvSub x y = fun "bvsub" [x, y]
 
 -- | Multiplication of bit vectors.
 bvMul :: SExpr -> SExpr -> SExpr
-bvMul x y = fun "bvmul" [x,y]
+bvMul x y = fun "bvmul" [x, y]
 
 -- | Bit vector unsigned division.
 bvUDiv :: SExpr -> SExpr -> SExpr
-bvUDiv x y = fun "bvudiv" [x,y]
+bvUDiv x y = fun "bvudiv" [x, y]
 
 -- | Bit vector unsigned reminder.
 bvURem :: SExpr -> SExpr -> SExpr
-bvURem x y = fun "bvurem" [x,y]
+bvURem x y = fun "bvurem" [x, y]
 
 -- | Bit vector signed division.
 bvSDiv :: SExpr -> SExpr -> SExpr
-bvSDiv x y = fun "bvsdiv" [x,y]
+bvSDiv x y = fun "bvsdiv" [x, y]
 
 -- | Bit vector signed reminder.
 bvSRem :: SExpr -> SExpr -> SExpr
-bvSRem x y = fun "bvsrem" [x,y]
-
-
-
+bvSRem x y = fun "bvsrem" [x, y]
 
 -- | Shift left.
-bvShl :: SExpr {- ^ value -} -> SExpr {- ^ shift amount -} -> SExpr
-bvShl x y = fun "bvshl" [x,y]
+bvShl :: SExpr -> SExpr -> SExpr {- ^ value -}
+  {- ^ shift amount -}
+bvShl x y = fun "bvshl" [x, y]
 
 -- | Logical shift right.
-bvLShr :: SExpr {- ^ value -} -> SExpr {- ^ shift amount -} -> SExpr
-bvLShr x y = fun "bvlshr" [x,y]
+bvLShr :: SExpr -> SExpr -> SExpr {- ^ value -}
+  {- ^ shift amount -}
+bvLShr x y = fun "bvlshr" [x, y]
 
 -- | Arithemti shift right (copies most significant bit).
-bvAShr :: SExpr {- ^ value -} -> SExpr {- ^ shift amount -} -> SExpr
-bvAShr x y = fun "bvashr" [x,y]
-
+bvAShr :: SExpr -> SExpr -> SExpr {- ^ value -}
+  {- ^ shift amount -}
+bvAShr x y = fun "bvashr" [x, y]
 
 -- | Get an elemeent of an array.
-select :: SExpr {- ^ array -} -> SExpr {- ^ index -} -> SExpr
-select x y = fun "select" [x,y]
+select :: SExpr -> SExpr -> SExpr {- ^ array -}
+  {- ^ index -}
+select x y = fun "select" [x, y]
 
 -- | Update an array
-store :: SExpr {- ^ array -}     ->
-         SExpr {- ^ index -}     ->
-         SExpr {- ^ new value -} ->
-         SExpr
-store x y z = fun "store" [x,y,z]
+store
+  :: SExpr {- ^ array -}
+  -> SExpr {- ^ index -}
+  -> SExpr {- ^ new value -}
+  -> SExpr
+store x y z = fun "store" [x, y, z]
 
 -- | Quantifiers: forall
 --
 -- Each variable is an (variable-name variable-type) sexpression.
 forallQ :: [SExpr] -> SExpr -> SExpr
 forallQ variables expression =
-    fun "forall" [List variables, expression]
+  fun "forall" [List variables, expression]
 
 -- | Quantifiers: exists
 --
 -- Each variable is an (variable-name variable-type) sexpression.
 existsQ :: [SExpr] -> SExpr -> SExpr
 existsQ variables expression =
-    fun "exists" [List variables, expression]
+  fun "exists" [List variables, expression]
 
 --------------------------------------------------------------------------------
 -- Attributes
-
 named :: Text -> SExpr -> SExpr
-named x e = fun "!" [e, Atom ":named", Atom x ]
-
+named x e = fun "!" [e, Atom ":named", Atom x]
 
 --------------------------------------------------------------------------------

--- a/kore/src/Template/Tools.hs
+++ b/kore/src/Template/Tools.hs
@@ -6,7 +6,10 @@ License     : NCSA
 Maintainer  : virgil.serbanuta@runtimeverification.com
 
 -}
-module Template.Tools (newDefinitionGroup) where
+module Template.Tools
+  ( newDefinitionGroup
+    )
+where
 
 import Language.Haskell.TH
 


### PR DESCRIPTION
Adopting an automatic formatting tool is an extreme step, fraught with
trade-offs, but it mitigates the risk of accidents; specifically, it reduces the
potential damage caused by an accident. This is a soft suggestion: I'm offering
it for consideration because it's easy to implement, not because I have strong
feelings about it.

If we did adopt a formatting tool, Ormolu is the obvious choice:

- It is the only tool that will format 100% of the code without occasionally
  mangling anything.
- The dictated format is relatively diff-friendly.
- The result is just ugly enough that everyone will hate it a little, but not so
  ugly that anyone will hate it a lot.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

