### PR TITLE
Refactor DefinitionVerifier

### DIFF
--- a/kore/src/Kore/AST/Error.hs
+++ b/kore/src/Kore/AST/Error.hs
@@ -84,10 +84,10 @@ withLocationAndContext location message =
 {- | Identify and locate the given symbol declaration in the error context.
  -}
 withSentenceSymbolContext
-    :: MonadError (Error e) m
+    :: MonadError (Error e) error
     => SentenceSymbol patternType
-    -> m a
-    -> m a
+    -> error a
+    -> error a
 withSentenceSymbolContext
     SentenceSymbol { sentenceSymbolSymbol = Symbol { symbolConstructor } }
   =
@@ -97,9 +97,10 @@ withSentenceSymbolContext
 {- | Identify and locate the given alias declaration in the error context.
  -}
 withSentenceAliasContext
-    :: SentenceAlias patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceAlias patternType
+    -> error a
+    -> error a
 withSentenceAliasContext
     SentenceAlias { sentenceAliasAlias = Alias { aliasConstructor } }
   =
@@ -109,37 +110,39 @@ withSentenceAliasContext
 {- | Identify and locate the given axiom declaration in the error context.
  -}
 withSentenceAxiomContext
-    :: SentenceAxiom patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceAxiom patternType
+    -> error a
+    -> error a
 withSentenceAxiomContext _ = withContext "axiom declaration"
 
 {- | Identify and locate the given claim declaration in the error context.
  -}
 withSentenceClaimContext
-    :: SentenceClaim patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceClaim patternType
+    -> error a
+    -> error a
 withSentenceClaimContext _ = withContext "claim declaration"
 
 {- | Identify and locate the given sort declaration in the error context.
  -}
 withSentenceSortContext
-    :: SentenceSort patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
-withSentenceSortContext
-    SentenceSort { sentenceSortName }
-  =
+    :: MonadError (Error e) error
+    => SentenceSort patternType
+    -> error a
+    -> error a
+withSentenceSortContext SentenceSort { sentenceSortName } =
     withLocationAndContext sentenceSortName
         ("sort '" <> getId sentenceSortName <> "' declaration")
 
 {- | Identify and locate the given hooked declaration in the error context.
  -}
 withSentenceHookContext
-    :: SentenceHook patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceHook patternType
+    -> error a
+    -> error a
 withSentenceHookContext =
     \case
         SentenceHookedSort SentenceSort { sentenceSortName } ->
@@ -160,17 +163,19 @@ withSentenceHookContext =
 {- | Locate the given import declaration in the error context.
  -}
 withSentenceImportContext
-    :: SentenceImport patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceImport patternType
+    -> error a
+    -> error a
 withSentenceImportContext _ = id
 
 {- | Identify and  locate the given sentence in the error context.
  -}
 withSentenceContext
-    :: Sentence patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => Sentence patternType
+    -> error a
+    -> error a
 withSentenceContext =
     \case
         SentenceAliasSentence s -> withSentenceAliasContext s

--- a/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
@@ -25,8 +25,6 @@ import           Kore.ASTVerifier.Error
 import           Kore.Attribute.Hook
 import qualified Kore.Attribute.Parser as Attribute.Parser
 import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule )
 import           Kore.Syntax.Definition
 import           Kore.Syntax.Pattern
 
@@ -77,11 +75,11 @@ verifyAttributePattern pat =
 
  -}
 verifySortHookAttribute
-    :: KoreIndexedModule declAtts axiomAtts
-    -> AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) Hook
-verifySortHookAttribute _indexedModule =
+    -> error Hook
+verifySortHookAttribute =
     \case
         DoNotVerifyAttributes ->
             \_ -> return emptyHook
@@ -96,9 +94,10 @@ verifySortHookAttribute _indexedModule =
 
  -}
 verifySymbolHookAttribute
-    :: AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) Hook
+    -> error Hook
 verifySymbolHookAttribute =
     \case
         DoNotVerifyAttributes ->
@@ -113,16 +112,17 @@ verifySymbolHookAttribute =
 
  -}
 verifyNoHookAttribute
-    :: AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) ()
+    -> error ()
 verifyNoHookAttribute =
     \case
         DoNotVerifyAttributes ->
             -- Do not verify anything.
             \_ -> return ()
         VerifyAttributes _ _ -> \attributes -> do
-            Hook { getHook } <- castError (parseAttributes attributes)
+            Hook { getHook } <- parseAttributes attributes
             case getHook of
                 Nothing ->
                     -- The hook attribute is (correctly) absent.

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -18,24 +18,27 @@ module Kore.ASTVerifier.DefinitionVerifier
 
 import           Control.Monad
                  ( foldM )
+import           Control.Monad.State.Strict
+                 ( execStateT )
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Proxy
                  ( Proxy (..) )
+import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
 
-import           Kore.ASTVerifier.AttributesVerifier
+import           Kore.ASTVerifier.AttributesVerifier hiding
+                 ( parseAttributes )
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.ModuleVerifier
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Attribute.Parser
-                 ( ParseAttributes (..) )
+import           Kore.Attribute.Parser as Attribute.Parser
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
 import           Kore.IndexedModule.IndexedModule
-import           Kore.Syntax as Syntax
 import           Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
 
@@ -59,8 +62,8 @@ e.g.:
 
 -}
 verifyDefinition
-    :: ParseAttributes axiomAtts
-    => AttributesVerification Attribute.Symbol axiomAtts
+    :: ParseAttributes Attribute.Axiom
+    => AttributesVerification Attribute.Symbol Attribute.Axiom
     -> Builtin.Verifiers
     -> ParsedDefinition
     -> Either (Error VerifyError) VerifySuccess
@@ -74,13 +77,13 @@ verifyDefinition attributesVerification builtinVerifiers definition = do
 collection of the definition's modules.
 -}
 verifyAndIndexDefinition
-    :: ParseAttributes axiomAtts
-    => AttributesVerification Attribute.Symbol axiomAtts
+    :: ParseAttributes Attribute.Axiom
+    => AttributesVerification Attribute.Symbol Attribute.Axiom
     -> Builtin.Verifiers
     -> ParsedDefinition
     -> Either
         (Error VerifyError)
-        (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
+        (Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
 verifyAndIndexDefinition attributesVerification builtinVerifiers definition = do
     (indexedModules, _defaultNames) <-
         verifyAndIndexDefinitionWithBase
@@ -97,17 +100,15 @@ If verification is successfull, it returns the updated maps op indexed modules
 and defined names.
 -}
 verifyAndIndexDefinitionWithBase
-    :: forall axiomAtts
-    .  ParseAttributes axiomAtts
-    => Maybe
-        ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts)
+    :: Maybe
+        ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol Attribute.Axiom)
         , Map.Map Text AstLocation
         )
-    -> AttributesVerification Attribute.Symbol axiomAtts
+    -> AttributesVerification Attribute.Symbol Attribute.Axiom
     -> Builtin.Verifiers
     -> ParsedDefinition
     -> Either (Error VerifyError)
-        ( Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts)
+        ( Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
         , Map.Map Text AstLocation
         )
 verifyAndIndexDefinitionWithBase
@@ -117,64 +118,35 @@ verifyAndIndexDefinitionWithBase
     definition
   = do
     let
-        (baseIndexedModules, baseNames) =
+        (_, baseNames) =
             fromMaybe (implicitModules, implicitNames) maybeBaseDefinition
 
     names <- foldM verifyUniqueNames baseNames (definitionModules definition)
 
     let
-        defaultModule
-            :: ImplicitIndexedModule ParsedPattern Attribute.Symbol axiomAtts
-        defaultModule = ImplicitIndexedModule implicitIndexedModule
-        indexModules
-            :: [ParsedModule]
-            -> Either
-                (Error VerifyError)
-                (Map.Map ModuleName (KoreIndexedModule Attribute.Symbol axiomAtts))
-        indexModules modules =
-            castError $ foldM
-                (indexModuleIfNeeded
-                    (Just defaultModule)
-                    (modulesByName modules)
-                )
-                baseIndexedModules
-                modules
-
-        verifyModule' = verifyModule attributesVerification builtinVerifiers
-        verifyModules = traverse verifyModule'
-
-    -- Index the unverified modules.
-    indexedModules <- indexModules (definitionModules definition)
+        verifiedDefaultModule
+            :: ImplicitIndexedModule Verified.Pattern Attribute.Symbol Attribute.Axiom
+        verifiedDefaultModule = ImplicitIndexedModule implicitIndexedModule
 
     -- Verify the contents of the definition.
-    verifiedModules <- verifyModules (Map.elems indexedModules)
+    index <-
+        execStateT
+            (traverse
+                (verifyModuleByName
+                    (Just verifiedDefaultModule)
+                    (modulesByName $ definitionModules definition)
+                    Set.empty
+                    attributesVerification
+                    builtinVerifiers
+                )
+                (moduleName <$> definitionModules definition)
+            )
+            Map.empty
     verifyAttributes
         (definitionAttributes definition)
         attributesVerification
 
-    let
-        verifiedDefaultModule
-            :: ImplicitIndexedModule Verified.Pattern Attribute.Symbol axiomAtts
-        verifiedDefaultModule = ImplicitIndexedModule implicitIndexedModule
-        indexVerifiedModules
-            :: [Module Verified.Sentence]
-            -> Either
-                (Error VerifyError)
-                (Map.Map ModuleName (VerifiedModule Attribute.Symbol axiomAtts))
-        indexVerifiedModules modules =
-            castError $ foldM
-                (indexModuleIfNeeded
-                    (Just verifiedDefaultModule)
-                    verifiedModulesByName
-                )
-                implicitModules
-                modules
-          where
-            verifiedModulesByName = modulesByName modules
-
-    -- Re-index the (now verified) modules.
-    reindexedModules <- indexVerifiedModules verifiedModules
-    return (reindexedModules, names)
+    return (index, names)
   where
     modulesByName = Map.fromList . map (\m -> (moduleName m, m))
 

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -52,23 +52,16 @@ verifyModule
     -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
     -> Either (Error VerifyError) (Module Verified.Sentence)
 verifyModule attributesVerification builtinVerifiers indexedModule =
-    withContext
-        (  "module '"
-        ++ getModuleNameForError (indexedModuleName indexedModule)
-        ++ "'"
-        )
-        (do
-            verifyAttributes
-                (snd (indexedModuleAttributes indexedModule))
+    withContext context $ do
+        verifyAttributes moduleAttributes attributesVerification
+        moduleSentences <-
+            SentenceVerifier.verifySentences
+                indexedModule
                 attributesVerification
-            moduleSentences <-
-                SentenceVerifier.verifySentences
-                    indexedModule
-                    attributesVerification
-                    builtinVerifiers
-                    (indexedModuleRawSentences indexedModule)
-            return Module { moduleName, moduleSentences, moduleAttributes }
-        )
+                builtinVerifiers
+                (indexedModuleRawSentences indexedModule)
+        return Module { moduleName, moduleSentences, moduleAttributes }
   where
     moduleName = indexedModuleName indexedModule
     (_, moduleAttributes) = indexedModuleAttributes indexedModule
+    context = "module '" ++ getModuleNameForError moduleName ++ "'"

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -8,17 +8,39 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.ASTVerifier.ModuleVerifier
-    ( verifyModule
+    ( verifyModuleByName
     , verifyUniqueNames
     ) where
 
+import           Control.Lens
+                 ( (%=), (.=) )
+import qualified Control.Monad as Monad
+import           Control.Monad.State.Strict
+                 ( StateT, execStateT )
+import qualified Control.Monad.State.Strict as State
+import qualified Control.Monad.Trans as Trans
+import qualified Data.Foldable as Foldable
+import           Data.Function
+import           Data.Generics.Product
+import qualified Data.List as List
+import           Data.Map
+                 ( Map )
 import qualified Data.Map as Map
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
 
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
+import qualified Kore.Attribute.Axiom as Attribute
+import           Kore.Attribute.Hook
+                 ( getHookAttribute )
+import           Kore.Attribute.Parser
+                 ( ParseAttributes )
+import qualified Kore.Attribute.Parser as Attribute.Parser
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
@@ -43,25 +65,199 @@ verifyUniqueNames existingNames koreModule =
         ("module '" ++ getModuleNameForError (moduleName koreModule) ++ "'")
         (SentenceVerifier.verifyUniqueNames
             (moduleSentences koreModule)
-            existingNames)
+            existingNames
+        )
 
-{-|'verifyModule' verifies the welformedness of a Kore 'Module'. -}
-verifyModule
-    :: AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
-    -> Either (Error VerifyError) (Module Verified.Sentence)
-verifyModule attributesVerification builtinVerifiers indexedModule =
-    withContext context $ do
-        verifyAttributes moduleAttributes attributesVerification
-        moduleSentences <-
-            SentenceVerifier.verifySentences
-                indexedModule
+verifyModuleByName
+    ::  Maybe (ImplicitIndexedModule Verified.Pattern Attribute.Symbol Attribute.Axiom)
+            -- TODO: Move ImplicitIndexedModule into a reader field.
+    ->  Map ModuleName (Module ParsedSentence)
+            -- TODO: Move this Map into a reader field.
+    ->  Set ModuleName
+            -- TODO: Move this Set into a reader field.
+    ->  AttributesVerification Attribute.Symbol Attribute.Axiom
+            -- TODO: Move AttributesVerification into a reader field.
+    ->  Builtin.Verifiers
+            -- TODO: Move BuiltinVerifiers into a reader field.
+    ->  ModuleName
+    ->  StateT
+            (Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+            (Either (Error VerifyError))
+            (VerifiedModule Attribute.Symbol Attribute.Axiom)
+verifyModuleByName
+    implicitModule
+    modules
+    importing
+    attributesVerification
+    builtinVerifiers
+    name
+  =
+    withContext moduleContext $ do
+        checkImportCycle
+        indexed <- State.get
+        Map.lookup name indexed & maybe notYetIndexed alreadyIndexed
+  where
+    moduleContext = "module '" ++ getModuleNameForError name ++ "'"
+    importing' = Set.insert name importing'
+    checkImportCycle =
+        koreFailWhen
+            (Set.member name importing)
+            "Circular module import dependency."
+    notFound = koreFail "Module not found."
+    alreadyIndexed = return
+    notYetIndexed = do
+        module' <- Map.lookup name modules & maybe notFound return
+        let Module { moduleAttributes } = module'
+        attrs <- parseAttributes' moduleAttributes
+        let indexedModule0 = indexedModuleWithDefaultImports name implicitModule
+            Module { moduleSentences } = module'
+            sentences = List.sort moduleSentences
+        indexedModule1 <-
+            flip execStateT indexedModule0 $ do
+                field @"indexedModuleAttributes" .= (attrs, moduleAttributes)
+                Foldable.traverse_
+                    (indexSentenceImport implicitModule modules importing' attributesVerification builtinVerifiers)
+                    sentences
+                Foldable.traverse_
+                    (indexSentenceSort attributesVerification builtinVerifiers)
+                    sentences
+                Foldable.traverse_
+                    (indexSentenceSymbol attributesVerification builtinVerifiers)
+                    sentences
+                -- TODO: indexSentenceAlias
+                -- TODO: indexSentenceAxiom
+                -- TODO: indexSentenceClaim
+                -- TODO: The corresponding functions in
+                -- Kore.IndexedModule.IndexedModule can go away.
+        _ <- internalIndexedModuleSubsorts indexedModule1
+        State.modify (Map.insert name indexedModule1)
+        return indexedModule1
+
+indexSentenceImport
+    ::  Maybe (ImplicitIndexedModule Verified.Pattern Attribute.Symbol Attribute.Axiom)
+    ->  Map ModuleName (Module ParsedSentence)
+    ->  Set ModuleName
+    ->  AttributesVerification Attribute.Symbol Attribute.Axiom
+    ->  Builtin.Verifiers
+    ->  Sentence ParsedPattern
+    ->  StateT (VerifiedModule Attribute.Symbol Attribute.Axiom)
+            (StateT (Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+                (Either (Error VerifyError)))
+            ()
+indexSentenceImport
+    implicitModule
+    modules
+    importing
+    attributesVerification
+    builtinVerifiers
+  =
+    \case
+        SentenceImportSentence sentence -> worker sentence
+        _ -> return ()
+  where
+    worker sentence = do
+        _ <- parseAttributes' @Attribute.Symbol (sentenceImportAttributes sentence)
+        let name = sentenceImportModuleName sentence
+        _ <- Trans.lift $ verifyModuleByName implicitModule modules importing attributesVerification builtinVerifiers name
+        return ()
+
+parseAttributes'
+    :: forall attrs error e
+    .  (MonadError (Error e) error, ParseAttributes attrs)
+    => Attributes
+    -> error attrs
+parseAttributes' =
+    Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
+
+indexSentenceSort
+    ::  AttributesVerification Attribute.Symbol Attribute.Axiom
+    ->  Builtin.Verifiers
+    ->  Sentence ParsedPattern
+    ->  StateT (VerifiedModule Attribute.Symbol Attribute.Axiom)
+            (StateT (Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+                (Either (Error VerifyError)))
+            ()
+indexSentenceSort
+    attributesVerification
+    builtinVerifiers
+  =
+    \case
+        SentenceSortSentence sentence ->
+            worker False sentence
+        SentenceHookSentence (SentenceHookedSort sentence) ->
+            worker True sentence
+        _ -> return ()
+  where
+    worker isHooked sentence = do
+        verified <-
+            liftSentenceVerifier
+                (SentenceVerifier.verifySortSentence sentence)
                 attributesVerification
                 builtinVerifiers
-                (indexedModuleRawSentences indexedModule)
-        return Module { moduleName, moduleSentences, moduleAttributes }
+        let name = sentenceSortName sentence
+            attrs0 = sentenceSortAttributes verified
+        attrs1 <- parseAttributes' attrs0
+        field @"indexedModuleSortDescriptions"
+            %= Map.insert name (attrs1, verified)
+        Monad.when isHooked $ do
+            field @"indexedModuleHookedIdentifiers" %= Set.insert name
+            hook <- getHookAttribute attrs0
+            field @"indexedModuleHooks"
+                %= Map.alter (Just . maybe [name] (name :)) hook
+
+indexSentenceSymbol
+    ::  AttributesVerification Attribute.Symbol Attribute.Axiom
+    ->  Builtin.Verifiers
+    ->  Sentence ParsedPattern
+    ->  StateT (VerifiedModule Attribute.Symbol Attribute.Axiom)
+            (StateT (Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+                (Either (Error VerifyError)))
+            ()
+indexSentenceSymbol
+    attributesVerification
+    builtinVerifiers
+  =
+    \case
+        SentenceSymbolSentence sentence ->
+            worker False sentence
+        SentenceHookSentence (SentenceHookedSymbol sentence) ->
+            worker True sentence
+        _ -> return ()
   where
-    moduleName = indexedModuleName indexedModule
-    (_, moduleAttributes) = indexedModuleAttributes indexedModule
-    context = "module '" ++ getModuleNameForError moduleName ++ "'"
+    worker isHooked sentence = do
+        verified <-
+            liftSentenceVerifier
+                (SentenceVerifier.verifySymbolSentence sentence)
+                attributesVerification
+                builtinVerifiers
+        let Symbol { symbolConstructor = name } = sentenceSymbolSymbol sentence
+            attrs0 = sentenceSymbolAttributes sentence
+        attrs1 <- parseAttributes' attrs0
+        field @"indexedModuleSymbolSentences"
+            %= Map.insert name (attrs1, verified)
+        Monad.when isHooked $ do
+            field @"indexedModuleHookedIdentifiers" %= Set.insert name
+            hook <- getHookAttribute attrs0
+            field @"indexedModuleHooks"
+                %= Map.alter (Just . maybe [name] (name :)) hook
+
+liftSentenceVerifier
+    ::  SentenceVerifier.SentenceVerifier a
+    ->  AttributesVerification Attribute.Symbol Attribute.Axiom
+    ->  Builtin.Verifiers
+    ->  StateT (VerifiedModule Attribute.Symbol Attribute.Axiom)
+            (StateT (Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+                (Either (Error VerifyError)))
+            a
+liftSentenceVerifier
+    sentenceVerifier
+    attributesVerification
+    builtinVerifiers
+  = do
+    verifiedModule <- State.get
+    Trans.lift . Trans.lift
+        $ SentenceVerifier.runSentenceVerifier
+            sentenceVerifier
+            verifiedModule
+            attributesVerification
+            builtinVerifiers

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -104,7 +104,7 @@ import           Kore.Error
                  ( Error )
 import qualified Kore.Error
 import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule, VerifiedModule )
+                 ( IndexedModule, VerifiedModule )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (MetadataTools), SmtMetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -144,7 +144,7 @@ type Function = BuiltinAndAxiomSimplifier
 
 -- | Verify a sort declaration.
 type SortDeclVerifier =
-        KoreIndexedModule Attribute.Null Attribute.Null
+        VerifiedModule Attribute.Null Attribute.Null
     -- ^ Indexed module, to look up symbol declarations
     ->  ParsedSentenceSort
     -- ^ Sort declaration to verify
@@ -320,7 +320,7 @@ Fail if the symbol is not defined or the attribute is missing.
 
  -}
 assertSymbolHook
-    :: KoreIndexedModule declAttrs axiomAttrs
+    :: IndexedModule patternType declAttrs axiomAttrs
     -> Id
     -- ^ Symbol identifier
     -> Text
@@ -350,7 +350,7 @@ Fail if the symbol is not defined.
 
  -}
 assertSymbolResultSort
-    :: KoreIndexedModule declAttrs axiomAttrs
+    :: IndexedModule patternType declAttrs axiomAttrs
     -> Id
     -- ^ Symbol identifier
     -> Sort

--- a/kore/src/Kore/IndexedModule/Resolvers.hs
+++ b/kore/src/Kore/IndexedModule/Resolvers.hs
@@ -266,11 +266,12 @@ resolveHooks indexedModule builtinName =
 
  -}
 findIndexedSort
-    :: IndexedModule patternType declAtts axiomAtts
+    :: MonadError (Error e) error
+    => IndexedModule patternType declAtts axiomAtts
     -- ^ indexed module
     -> Id
     -- ^ sort identifier
-    -> Either (Error e) (SentenceSort patternType)
+    -> error (SentenceSort patternType)
 findIndexedSort indexedModule sort =
     fmap getIndexedSentence (resolveSort indexedModule sort)
 

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -11,7 +11,7 @@ import Data.Text
 
 import           Kore.ASTVerifier.DefinitionVerifier
 import           Kore.ASTVerifier.Error
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Debug
@@ -129,7 +129,7 @@ expectFailureWithError description expectedError unverifiedDefinition =
         )
 
 attributesVerificationForTests
-    :: AttributesVerification Attribute.Symbol Attribute.Null
+    :: AttributesVerification Attribute.Symbol Attribute.Axiom
 attributesVerificationForTests = defaultAttributesVerification Proxy Proxy
 
 printDefinition :: ParsedDefinition -> String

--- a/kore/test/Test/Kore/IndexedModule/Resolvers.hs
+++ b/kore/test/Test/Kore/IndexedModule/Resolvers.hs
@@ -11,7 +11,7 @@ import qualified Data.Map as Map
 import qualified Data.Ord
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
@@ -150,7 +150,7 @@ testDefinition =
             ]
         }
 
-indexedModules :: Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Null)
+indexedModules :: Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
 Right indexedModules =
     verifyAndIndexDefinition
         DoNotVerifyAttributes
@@ -158,7 +158,7 @@ Right indexedModules =
         testDefinition
 
 testIndexedModule, testIndexedObjectModule
-    :: VerifiedModule Attribute.Symbol Attribute.Null
+    :: VerifiedModule Attribute.Symbol Attribute.Axiom
 Just testIndexedModule = Map.lookup testMainModuleName indexedModules
 Just testIndexedObjectModule = Map.lookup testObjectModuleName indexedModules
 

--- a/kore/test/Test/Kore/Parser/Regression.hs
+++ b/kore/test/Test/Kore/Parser/Regression.hs
@@ -27,7 +27,7 @@ import           System.FilePath
                  ( addExtension, splitFileName, (</>) )
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
@@ -83,7 +83,7 @@ verify definition =
     verifyDefinition attrVerify Builtin.koreVerifiers definition
     & bimap printError (const definition)
   where
-    attrVerify :: AttributesVerification Attribute.Symbol Attribute.Null
+    attrVerify :: AttributesVerification Attribute.Symbol Attribute.Axiom
     attrVerify = defaultAttributesVerification Proxy Proxy
 
 runParser :: String -> VerifyRequest -> IO ByteString

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -18,7 +18,7 @@ import           Data.Text
 import qualified Data.Text as Text
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Pattern as Attribute
 import           Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Attribute.Symbol as Attribute
@@ -330,8 +330,8 @@ extractIndexedModule
     :: Text
     -> Either
         (Error a)
-        (Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Null))
-    -> VerifiedModule Attribute.Symbol Attribute.Null
+        (Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+    -> VerifiedModule Attribute.Symbol Attribute.Axiom
 extractIndexedModule name eModules =
     case eModules of
         Left err -> error (printError err)


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

@ana-pantilie 
This refactors the definition verifier so that you don't have the problem with `verifyModule` anymore. It's not finished, but if you look at the `TODO`s in `Kore.ASTVerifier.SentenceVerifier` and `Kore.ASTVerifier.ModuleVerifier`, I think you could probably finish it up and merge it into your refactoring.