### PR TITLE
Refactor DefinitionVerifier (again)

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -9,7 +9,6 @@ import           Control.Monad.IO.Unlift
 import qualified Control.Monad.Reader.Class as Reader
 import           Control.Monad.Trans
                  ( lift )
-import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Char as Char
 import qualified Data.Foldable as Foldable
 import           Data.List
@@ -40,13 +39,11 @@ import           Data.Limit
 import qualified Data.Limit as Limit
 import qualified Kore.Attribute.Axiom as Attribute
 import           Kore.Attribute.Symbol as Attribute
-import qualified Kore.Builtin as Builtin
 import           Kore.Error
                  ( printError )
 import           Kore.Exec
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
-import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
                  ( build )
 import           Kore.Internal.Pattern
@@ -388,7 +385,7 @@ loadDefinition options = do
     let KoreExecOptions { definitionFileName } = options
     parsedDefinition <- parseDefinition definitionFileName
     definition@(indexedModules, _) <-
-        verifyDefinitionWithBase Nothing Nothing True parsedDefinition
+        verifyDefinitionWithBase Nothing True parsedDefinition
     let KoreExecOptions { mainModuleName } = options
     mainModule <- lookupMainModule mainModuleName indexedModules
     return (mainModule, definition)
@@ -398,13 +395,9 @@ loadSpecification
     -> LoadedDefinition
     -> Main (LoadedModule, LoadedDefinition)
 loadSpecification proveOptions definition = do
-    let base =
-            (Bifunctor.first . fmap . IndexedModule.mapPatterns)
-                Builtin.externalizePattern
-                definition
     let KoreProveOptions { specFileName } = proveOptions
     spec <- parseDefinition specFileName
-    specDef@(modules, _) <- verifyDefinitionWithBase (Just definition) (Just base) True spec
+    specDef@(modules, _) <- verifyDefinitionWithBase (Just definition) True spec
     let KoreProveOptions { specMainModule } = proveOptions
     specModule <- lookupMainModule specMainModule modules
     return (specModule, specDef)

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -383,16 +383,6 @@ type LoadedModule = VerifiedModule Attribute.Symbol Attribute.Axiom
 
 type LoadedDefinition = (Map ModuleName LoadedModule, Map Text AstLocation)
 
--- loadDefinitionAndSpecification
---     :: KoreExecOptions
---     -> Main (LoadedModule, LoadedModule, LoadedDefinition)
---     --       ^ spec        ^ definition
--- loadDefinitionAndSpecification options = do
---     let KoreExecOptions { definitionFileName } = options
---     parsedDefinition <- parseDefinition definitionFileName
---     let KoreProveOptions { specFileName } = proveOptions
---     spec <- parseDefinition specFileName
-
 loadDefinition :: KoreExecOptions -> Main (LoadedModule, LoadedDefinition)
 loadDefinition options = do
     let KoreExecOptions { definitionFileName } = options

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -383,12 +383,22 @@ type LoadedModule = VerifiedModule Attribute.Symbol Attribute.Axiom
 
 type LoadedDefinition = (Map ModuleName LoadedModule, Map Text AstLocation)
 
+-- loadDefinitionAndSpecification
+--     :: KoreExecOptions
+--     -> Main (LoadedModule, LoadedModule, LoadedDefinition)
+--     --       ^ spec        ^ definition
+-- loadDefinitionAndSpecification options = do
+--     let KoreExecOptions { definitionFileName } = options
+--     parsedDefinition <- parseDefinition definitionFileName
+--     let KoreProveOptions { specFileName } = proveOptions
+--     spec <- parseDefinition specFileName
+
 loadDefinition :: KoreExecOptions -> Main (LoadedModule, LoadedDefinition)
 loadDefinition options = do
     let KoreExecOptions { definitionFileName } = options
     parsedDefinition <- parseDefinition definitionFileName
     definition@(indexedModules, _) <-
-        verifyDefinitionWithBase Nothing True parsedDefinition
+        verifyDefinitionWithBase Nothing Nothing True parsedDefinition
     let KoreExecOptions { mainModuleName } = options
     mainModule <- lookupMainModule mainModuleName indexedModules
     return (mainModule, definition)
@@ -404,7 +414,7 @@ loadSpecification proveOptions definition = do
                 definition
     let KoreProveOptions { specFileName } = proveOptions
     spec <- parseDefinition specFileName
-    specDef@(modules, _) <- verifyDefinitionWithBase (Just base) True spec
+    specDef@(modules, _) <- verifyDefinitionWithBase (Just definition) (Just base) True spec
     let KoreProveOptions { specMainModule } = proveOptions
     specModule <- lookupMainModule specMainModule modules
     return (specModule, specDef)

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -3,30 +3,26 @@
 
 module Main (main) where
 
-import           Control.Applicative
-                 ( optional )
-import           Control.Concurrent.MVar
-import           Control.Monad.Trans
-                 ( lift )
-import           Control.Monad.Trans.Reader
-                 ( runReaderT )
-import qualified Data.Bifunctor as Bifunctor
-import           Data.Maybe
-import           Data.Semigroup
-                 ( (<>) )
-import           Options.Applicative
-                 ( InfoMod, Parser, argument, auto, flag, fullDesc, header,
-                 help, long, metavar, option, progDesc, readerError, short,
-                 str, strOption, value )
-import           System.Exit
-                 ( exitFailure )
+import Control.Applicative
+       ( optional )
+import Control.Concurrent.MVar
+import Control.Monad.Trans
+       ( lift )
+import Control.Monad.Trans.Reader
+       ( runReaderT )
+import Data.Maybe
+import Data.Semigroup
+       ( (<>) )
+import Options.Applicative
+       ( InfoMod, Parser, argument, auto, flag, fullDesc, header, help, long,
+       metavar, option, progDesc, readerError, short, str, strOption, value )
+import System.Exit
+       ( exitFailure )
 
 import           Data.Limit
                  ( Limit (..) )
-import qualified Kore.Builtin as Builtin
 import           Kore.Exec
                  ( proveWithRepl )
-import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import           Kore.Logger.Output
                  ( emptyLogger, getLoggerT, swappableLogger )
 import           Kore.Repl.Data
@@ -174,22 +170,14 @@ mainWithOptions
         indexedDefinition@(indexedModules, _) <-
             verifyDefinitionWithBase
               Nothing
-              Nothing
               True
               parsedDefinition
         indexedModule <-
             lift $ lookupMainModule mainModuleName indexedModules
         specDef <- parseDefinition specFile
-        let unverifiedDefinition =
-                Bifunctor.first
-                    ((fmap . IndexedModule.mapPatterns)
-                        Builtin.externalizePattern
-                    )
-                    indexedDefinition
         (specDefIndexedModules, _) <-
             verifyDefinitionWithBase
               (Just indexedDefinition)
-              (Just unverifiedDefinition)
               True
               specDef
 

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -166,23 +166,9 @@ mainWithOptions
     mLogger <- newMVar emptyLogger
     let emptySwappableLogger = swappableLogger mLogger
     flip runReaderT emptySwappableLogger . getLoggerT $ do
-        parsedDefinition <- parseDefinition definitionFileName
-        indexedDefinition@(indexedModules, _) <-
-            verifyDefinitionWithBase
-              Nothing
-              True
-              parsedDefinition
-        indexedModule <-
-            lift $ lookupMainModule mainModuleName indexedModules
-        specDef <- parseDefinition specFile
-        (specDefIndexedModules, _) <-
-            verifyDefinitionWithBase
-              (Just indexedDefinition)
-              True
-              specDef
-
-        specDefIndexedModule <-
-            lift $ lookupMainModule specModule specDefIndexedModules
+        definition <- loadDefinitions [definitionFileName, specFile]
+        indexedModule <- loadModule mainModuleName definition
+        specDefIndexedModule <- loadModule specModule definition
 
         let
             smtConfig =

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -174,6 +174,7 @@ mainWithOptions
         indexedDefinition@(indexedModules, _) <-
             verifyDefinitionWithBase
               Nothing
+              Nothing
               True
               parsedDefinition
         indexedModule <-
@@ -187,6 +188,7 @@ mainWithOptions
                     indexedDefinition
         (specDefIndexedModules, _) <-
             verifyDefinitionWithBase
+              (Just indexedDefinition)
               (Just unverifiedDefinition)
               True
               specDef

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -330,8 +330,7 @@ Also prints timing information; see 'mainParse'.
 
  -}
 verifyDefinitionWithBase
-    :: Maybe
-        ( Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
+    ::  ( Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
         , Map.Map Text AstLocation
         )
     -- ^ already verified definition
@@ -345,7 +344,7 @@ verifyDefinitionWithBase
         , Map.Map Text AstLocation
         )
 verifyDefinitionWithBase
-    maybeAlreadyVerified
+    alreadyVerified
     willChkAttr
     definition
   =
@@ -357,7 +356,7 @@ verifyDefinitionWithBase
       verifyResult <-
         clockSomething "Verifying the definition"
             (verifyAndIndexDefinitionWithBase
-                maybeAlreadyVerified
+                alreadyVerified
                 attributesVerification
                 Builtin.koreVerifiers
                 definition

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -67,7 +67,7 @@ import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
 import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule, VerifiedModule )
+                 ( VerifiedModule )
 import qualified Kore.IndexedModule.IndexedModule as IndexedModule
 import           Kore.Logger.Output as Logger
 import           Kore.Parser
@@ -335,11 +335,6 @@ verifyDefinitionWithBase
         , Map.Map Text AstLocation
         )
     -- ^ already verified definition
-    -> Maybe
-        ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol Attribute.Axiom)
-        , Map.Map Text AstLocation
-        )
-    -- ^ base definition to use for verification
     -> Bool
     -- ^ whether to check (True) or ignore attributes during verification
     -> ParsedDefinition
@@ -350,8 +345,7 @@ verifyDefinitionWithBase
         , Map.Map Text AstLocation
         )
 verifyDefinitionWithBase
-    maybeAlreadyVerifiedDefinition
-    maybeBaseModule
+    maybeAlreadyVerified
     willChkAttr
     definition
   =
@@ -363,8 +357,7 @@ verifyDefinitionWithBase
       verifyResult <-
         clockSomething "Verifying the definition"
             (verifyAndIndexDefinitionWithBase
-                maybeAlreadyVerifiedDefinition
-                maybeBaseModule
+                maybeAlreadyVerified
                 attributesVerification
                 Builtin.koreVerifiers
                 definition

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -331,8 +331,12 @@ Also prints timing information; see 'mainParse'.
  -}
 verifyDefinitionWithBase
     :: Maybe
-        ( Map.Map ModuleName
-            (KoreIndexedModule Attribute.Symbol Attribute.Axiom)
+        ( Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
+        , Map.Map Text AstLocation
+        )
+    -- ^ already verified definition
+    -> Maybe
+        ( Map.Map ModuleName (KoreIndexedModule Attribute.Symbol Attribute.Axiom)
         , Map.Map Text AstLocation
         )
     -- ^ base definition to use for verification
@@ -345,7 +349,12 @@ verifyDefinitionWithBase
             (VerifiedModule Attribute.Symbol Attribute.Axiom)
         , Map.Map Text AstLocation
         )
-verifyDefinitionWithBase maybeBaseModule willChkAttr definition =
+verifyDefinitionWithBase
+    maybeAlreadyVerifiedDefinition
+    maybeBaseModule
+    willChkAttr
+    definition
+  =
     let attributesVerification =
             if willChkAttr
             then defaultAttributesVerification Proxy Proxy
@@ -354,6 +363,7 @@ verifyDefinitionWithBase maybeBaseModule willChkAttr definition =
       verifyResult <-
         clockSomething "Verifying the definition"
             (verifyAndIndexDefinitionWithBase
+                maybeAlreadyVerifiedDefinition
                 maybeBaseModule
                 attributesVerification
                 Builtin.koreVerifiers

--- a/kore/src/Kore/AST/Error.hs
+++ b/kore/src/Kore/AST/Error.hs
@@ -20,6 +20,7 @@ module Kore.AST.Error
     , withSentenceSortContext
     , withSentenceSymbolContext
     , withSentenceContext
+    , withModuleContext
     ) where
 
 import           Data.Text
@@ -169,7 +170,7 @@ withSentenceImportContext
     -> error a
 withSentenceImportContext _ = id
 
-{- | Identify and  locate the given sentence in the error context.
+{- | Identify and locate the given sentence in the error context.
  -}
 withSentenceContext
     :: MonadError (Error e) error
@@ -185,3 +186,13 @@ withSentenceContext =
         SentenceImportSentence s -> withSentenceImportContext s
         SentenceSortSentence s -> withSentenceSortContext s
         SentenceSymbolSentence s -> withSentenceSymbolContext s
+
+{- | Identify the given module in the error context.
+ -}
+withModuleContext
+    :: MonadError (Error e) error
+    => ModuleName
+    -> error a
+    -> error a
+withModuleContext moduleName =
+    withContext ("module '" ++ getModuleNameForError moduleName ++ "'")

--- a/kore/src/Kore/AST/Error.hs
+++ b/kore/src/Kore/AST/Error.hs
@@ -84,10 +84,10 @@ withLocationAndContext location message =
 {- | Identify and locate the given symbol declaration in the error context.
  -}
 withSentenceSymbolContext
-    :: MonadError (Error e) m
+    :: MonadError (Error e) error
     => SentenceSymbol patternType
-    -> m a
-    -> m a
+    -> error a
+    -> error a
 withSentenceSymbolContext
     SentenceSymbol { sentenceSymbolSymbol = Symbol { symbolConstructor } }
   =
@@ -97,9 +97,10 @@ withSentenceSymbolContext
 {- | Identify and locate the given alias declaration in the error context.
  -}
 withSentenceAliasContext
-    :: SentenceAlias patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceAlias patternType
+    -> error a
+    -> error a
 withSentenceAliasContext
     SentenceAlias { sentenceAliasAlias = Alias { aliasConstructor } }
   =
@@ -109,37 +110,39 @@ withSentenceAliasContext
 {- | Identify and locate the given axiom declaration in the error context.
  -}
 withSentenceAxiomContext
-    :: SentenceAxiom patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceAxiom patternType
+    -> error a
+    -> error a
 withSentenceAxiomContext _ = withContext "axiom declaration"
 
 {- | Identify and locate the given claim declaration in the error context.
  -}
 withSentenceClaimContext
-    :: SentenceClaim patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceClaim patternType
+    -> error a
+    -> error a
 withSentenceClaimContext _ = withContext "claim declaration"
 
 {- | Identify and locate the given sort declaration in the error context.
  -}
 withSentenceSortContext
-    :: SentenceSort patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
-withSentenceSortContext
-    SentenceSort { sentenceSortName }
-  =
+    :: MonadError (Error e) error
+    => SentenceSort patternType
+    -> error a
+    -> error a
+withSentenceSortContext SentenceSort { sentenceSortName } =
     withLocationAndContext sentenceSortName
         ("sort '" <> getId sentenceSortName <> "' declaration")
 
 {- | Identify and locate the given hooked declaration in the error context.
  -}
 withSentenceHookContext
-    :: SentenceHook patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceHook patternType
+    -> error a
+    -> error a
 withSentenceHookContext =
     \case
         SentenceHookedSort SentenceSort { sentenceSortName } ->
@@ -160,17 +163,19 @@ withSentenceHookContext =
 {- | Locate the given import declaration in the error context.
  -}
 withSentenceImportContext
-    :: SentenceImport patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => SentenceImport patternType
+    -> error a
+    -> error a
 withSentenceImportContext _ = id
 
 {- | Identify and  locate the given sentence in the error context.
  -}
 withSentenceContext
-    :: Sentence patternType
-    -> Either (Error e) a
-    -> Either (Error e) a
+    :: MonadError (Error e) error
+    => Sentence patternType
+    -> error a
+    -> error a
 withSentenceContext =
     \case
         SentenceAliasSentence s -> withSentenceAliasContext s

--- a/kore/src/Kore/ASTVerifier/AliasVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/AliasVerifier.hs
@@ -1,0 +1,123 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+module Kore.ASTVerifier.AliasVerifier
+    ( verifyAliases ) where
+
+import qualified Control.Lens as Lens
+import           Control.Monad.Reader
+                 ( ReaderT, runReaderT )
+import qualified Control.Monad.Reader as Reader
+import qualified Control.Monad.State.Class as State
+import qualified Control.Monad.Trans as Trans
+import qualified Data.Foldable as Foldable
+import           Data.Function
+import qualified Data.Functor.Foldable as Recursive
+import           Data.Generics.Product
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import           Data.Maybe
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
+import qualified GHC.Generics as GHC
+
+import           Kore.AST.Error
+import           Kore.ASTVerifier.SentenceVerifier
+                 ( SentenceVerifier )
+import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
+import           Kore.Attribute.Parser
+                 ( liftParser, parseAttributes )
+import qualified Kore.Attribute.Symbol as Attribute
+import           Kore.Error
+import           Kore.IndexedModule.IndexedModule as IndexedModule
+import           Kore.Syntax
+import           Kore.Syntax.Definition
+import qualified Kore.Verified as Verified
+
+verifyAliases
+    :: [ParsedSentence]
+    -> SentenceVerifier ()
+verifyAliases sentences = do
+    let aliases =
+            Map.fromList . map (\sentence -> (aliasName sentence, sentence))
+            $ mapMaybe projectSentenceAlias sentences
+        aliasIds = Map.keysSet aliases
+    runReaderT
+        (Foldable.traverse_ verifyAlias aliasIds)
+        AliasContext { aliases, verifying = Set.empty }
+
+aliasName :: SentenceAlias patternType -> Id
+aliasName = aliasConstructor . sentenceAliasAlias
+
+type AliasVerifier = ReaderT AliasContext SentenceVerifier
+
+data AliasContext =
+    AliasContext
+        { aliases   :: !(Map Id ParsedSentenceAlias)
+        , verifying :: !(Set Id)
+        }
+    deriving (GHC.Generic)
+
+type VerifiedAlias = (Attribute.Symbol, SentenceAlias Verified.Pattern)
+
+lookupVerifiedAlias :: Id -> AliasVerifier (Maybe VerifiedAlias)
+lookupVerifiedAlias name = do
+    verifiedAliases <- State.gets indexedModuleAliasSentences
+    return $ Map.lookup name verifiedAliases
+
+lookupParsedAlias :: Id -> AliasVerifier ParsedSentenceAlias
+lookupParsedAlias name =
+    Reader.asks (Map.lookup name . aliases) >>= maybe notFound return
+  where
+    notFound = koreFail "Alias not found."
+
+verifyAlias :: Id -> AliasVerifier ()
+verifyAlias name =
+    withLocationAndContext name aliasContext $ do
+        checkAliasCycle
+        lookupVerifiedAlias name >>= maybe notCached cached
+  where
+    aliasContext = "alias '" <> getId name <> "' declaration"
+    checkAliasCycle = do
+        isCycle <- Reader.asks (Set.member name . verifying)
+        koreFailWhen isCycle "Circular alias dependency."
+    cached _ = return ()
+    notCached = verifyUncachedAlias name
+
+verifyUncachedAlias :: Id -> AliasVerifier ()
+verifyUncachedAlias name = do
+    sentence <- lookupParsedAlias name
+    dependencies <- aliasDependencies sentence
+    Foldable.traverse_ verifyAlias dependencies
+    verified <- SentenceVerifier.verifyAliasSentence sentence & Trans.lift
+    attrs <- parseAttributes (sentenceAliasAttributes verified) & liftParser
+    State.modify' $ addAlias verified attrs
+  where
+    addAlias verified attrs =
+        Lens.over
+            (field @"indexedModuleAliasSentences")
+            (Map.insert (aliasName verified) (attrs, verified))
+
+aliasDependencies :: SentenceAlias ParsedPattern -> AliasVerifier (Set Id)
+aliasDependencies = Recursive.fold collectAliasIds . sentenceAliasRightPattern
+
+collectAliasIds
+    :: Base ParsedPattern (AliasVerifier (Set Id))
+    -> AliasVerifier (Set Id)
+collectAliasIds base = do
+    _ :< patternF <- sequence base
+    let names = Foldable.fold patternF
+    AliasContext { aliases } <- Reader.ask
+    case patternF of
+        ApplicationF application | Map.member name aliases ->
+            return $ Set.insert name names
+          where
+            name =
+                symbolOrAliasConstructor
+                . applicationSymbolOrAlias
+                $ application
+        _ -> return names

--- a/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
@@ -25,8 +25,6 @@ import           Kore.ASTVerifier.Error
 import           Kore.Attribute.Hook
 import qualified Kore.Attribute.Parser as Attribute.Parser
 import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule )
 import           Kore.Syntax.Definition
 import           Kore.Syntax.Pattern
 
@@ -77,11 +75,11 @@ verifyAttributePattern pat =
 
  -}
 verifySortHookAttribute
-    :: KoreIndexedModule declAtts axiomAtts
-    -> AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) Hook
-verifySortHookAttribute _indexedModule =
+    -> error Hook
+verifySortHookAttribute =
     \case
         DoNotVerifyAttributes ->
             \_ -> return emptyHook
@@ -96,9 +94,10 @@ verifySortHookAttribute _indexedModule =
 
  -}
 verifySymbolHookAttribute
-    :: AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) Hook
+    -> error Hook
 verifySymbolHookAttribute =
     \case
         DoNotVerifyAttributes ->
@@ -113,16 +112,17 @@ verifySymbolHookAttribute =
 
  -}
 verifyNoHookAttribute
-    :: AttributesVerification declAtts axiomAtts
+    :: MonadError (Error VerifyError) error
+    => AttributesVerification declAtts axiomAtts
     -> Attributes
-    -> Either (Error VerifyError) ()
+    -> error ()
 verifyNoHookAttribute =
     \case
         DoNotVerifyAttributes ->
             -- Do not verify anything.
             \_ -> return ()
         VerifyAttributes _ _ -> \attributes -> do
-            Hook { getHook } <- castError (parseAttributes attributes)
+            Hook { getHook } <- parseAttributes attributes
             case getHook of
                 Nothing ->
                     -- The hook attribute is (correctly) absent.

--- a/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/AttributesVerifier.hs
@@ -83,8 +83,11 @@ verifySortHookAttribute =
     \case
         DoNotVerifyAttributes ->
             \_ -> return emptyHook
-        VerifyAttributes _ _ ->
-            parseAttributes
+        VerifyAttributes _ _ -> \attrs -> do
+            hook <- parseAttributes attrs
+            case getHook hook of
+                Just _  -> return hook
+                Nothing -> koreFail "missing hook attribute"
 
 {- | Verify that the @hook{}()@ attribute is present and well-formed.
 
@@ -103,8 +106,11 @@ verifySymbolHookAttribute =
         DoNotVerifyAttributes ->
             -- Do not attempt to parse, verify, or return the hook attribute.
             \_ -> return emptyHook
-        VerifyAttributes _ _ ->
-            parseAttributes
+        VerifyAttributes _ _ -> \attrs -> do
+            hook <- parseAttributes attrs
+            case getHook hook of
+                Just _  -> return hook
+                Nothing -> koreFail "missing hook attribute"
 
 {- | Verify that the @hook{}()@ attribute is not present.
 

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -30,6 +30,7 @@ import           Kore.ASTVerifier.AttributesVerifier hiding
                  ( parseAttributes )
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.ModuleVerifier
+import           Kore.ASTVerifier.Verifier
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Null as Attribute
 import           Kore.Attribute.Parser as Attribute.Parser
@@ -142,7 +143,7 @@ verifyAndIndexDefinitionWithBase
 
     -- Verify the contents of the definition.
     (_, index) <-
-        runModuleVerifier
+        runVerifier
             verifyModules
             verifiedModulesCache
             (Just verifiedDefaultModule)

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -22,7 +22,6 @@ import qualified Data.Foldable as Foldable
 import           Data.Map
                  ( Map )
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
 import           Data.Proxy
                  ( Proxy (..) )
 import           Data.Text
@@ -88,7 +87,7 @@ verifyAndIndexDefinition
 verifyAndIndexDefinition attributesVerification builtinVerifiers definition = do
     (indexedModules, _defaultNames) <-
         verifyAndIndexDefinitionWithBase
-            Nothing
+            mempty
             attributesVerification
             builtinVerifiers
             definition
@@ -101,22 +100,21 @@ If verification is successfull, it returns the updated maps op indexed modules
 and defined names.
 -}
 verifyAndIndexDefinitionWithBase
-    ::  Maybe (Map ModuleName VerifiedModule', Map Text AstLocation)
+    ::  (Map ModuleName VerifiedModule', Map Text AstLocation)
     ->  AttributesVerification Attribute.Symbol Attribute.Axiom
     ->  Builtin.Verifiers
     ->  ParsedDefinition
     ->  Either (Error VerifyError)
             (Map ModuleName VerifiedModule', Map Text AstLocation)
 verifyAndIndexDefinitionWithBase
-    maybeAlreadyVerified
+    alreadyVerified
     attributesVerification
     builtinVerifiers
     definition
   = do
     let
-        (_, baseNames) =
-            fromMaybe (implicitModules, implicitNames) maybeAlreadyVerified
-        verifiedModulesCache = maybe Map.empty fst maybeAlreadyVerified
+        (verifiedModulesCache, baseNames) =
+            (implicitModules, implicitNames) <> alreadyVerified
 
     names <- foldM verifyUniqueNames baseNames (definitionModules definition)
 

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -121,9 +121,9 @@ verifyAndIndexDefinitionWithBase
     names <- foldM verifyUniqueNames baseNames (definitionModules definition)
 
     let
-        verifiedDefaultModule
+        implicitModule
             :: ImplicitIndexedModule Verified.Pattern Attribute.Symbol Attribute.Axiom
-        verifiedDefaultModule = ImplicitIndexedModule implicitIndexedModule
+        implicitModule = ImplicitIndexedModule implicitIndexedModule
         parsedModules = modulesByName (definitionModules definition)
         definitionModuleNames = moduleName <$> definitionModules definition
         verifyModules = Foldable.traverse_ verifyModule definitionModuleNames
@@ -133,7 +133,7 @@ verifyAndIndexDefinitionWithBase
         runVerifier
             verifyModules
             verifiedModulesCache
-            (Just verifiedDefaultModule)
+            implicitModule
             parsedModules
             attributesVerification
             builtinVerifiers

--- a/kore/src/Kore/ASTVerifier/Error.hs
+++ b/kore/src/Kore/ASTVerifier/Error.hs
@@ -9,15 +9,14 @@ Portability : POSIX
 -}
 module Kore.ASTVerifier.Error where
 
-import Data.Text
-       ( Text )
+import           Data.Text
+                 ( Text )
+import qualified Data.Text.Prettyprint.Doc as Pretty
 
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
 import           Kore.Error
 import           Kore.Sort
-                 ( Sort, getSortId )
-import           Kore.Syntax.Id
-                 ( Id (getId), getIdForError )
+import           Kore.Unparser
 
 {-| 'VerifyError' is a tag for verification errors. -}
 newtype VerifyError = VerifyError ()
@@ -30,11 +29,24 @@ newtype VerifySuccess = VerifySuccess ()
 verifySuccess :: MonadError (Error VerifyError) m => m VerifySuccess
 verifySuccess = return (VerifySuccess ())
 
-noConstructorWithDomainValuesMessage :: Id -> Sort -> String
-noConstructorWithDomainValuesMessage symbol resultSort =
-    "Cannot define constructor '" ++ getIdForError symbol
-    ++ "' for sort with domain values '" ++ getIdForError (getSortId resultSort)
-    ++ "'."
+noConstructorWithDomainValues :: Id -> Sort -> String
+noConstructorWithDomainValues symbolId sort =
+    (show . Pretty.hsep)
+        [ "Cannot define constructor"
+        , Pretty.squotes (unparse symbolId)
+        , "for sort"
+        , Pretty.squotes (unparse sort) <> Pretty.colon
+        , "sort has domain values."
+        ]
+
+noConstructorInHookedSort :: Id -> Sort -> String
+noConstructorInHookedSort symbolId sort =
+    (show . Pretty.hsep)
+        [ "Cannot define constructor"
+        , Pretty.squotes (unparse symbolId)
+        , "for hooked sort"
+        , Pretty.squotes (unparse sort) <> Pretty.dot
+        ]
 
 sortNeedsDomainValueAttributeMessage :: Text
 sortNeedsDomainValueAttributeMessage =

--- a/kore/src/Kore/ASTVerifier/Error.hs
+++ b/kore/src/Kore/ASTVerifier/Error.hs
@@ -48,6 +48,14 @@ noConstructorInHookedSort symbolId sort =
         , Pretty.squotes (unparse sort) <> Pretty.dot
         ]
 
+noConstructorWithVariableSort :: Id -> String
+noConstructorWithVariableSort symbolId =
+    (show . Pretty.hsep)
+        [ "Cannot define constructor"
+        , Pretty.squotes (unparse symbolId)
+        , "with variable result sort."
+        ]
+
 sortNeedsDomainValueAttributeMessage :: Text
 sortNeedsDomainValueAttributeMessage =
     "Sorts used with domain value must have the '"

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -34,8 +34,9 @@ import           Kore.ASTVerifier.AliasVerifier
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
-                 ( SentenceVerifier, verifyAxioms, verifyHookedSorts,
-                 verifyHookedSymbols, verifySorts, verifySymbols )
+                 ( SentenceVerifier, verifyAxioms, verifyClaims,
+                 verifyHookedSorts, verifyHookedSymbols, verifySorts,
+                 verifySymbols )
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Kore.ASTVerifier.Verifier
 import           Kore.Attribute.Parser
@@ -133,23 +134,6 @@ parseAttributes'
     -> error attrs
 parseAttributes' =
     Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
-
-verifyClaims
-    :: [ParsedSentence]
-    -> SentenceVerifier ()
-verifyClaims = Foldable.traverse_ verifyClaim . mapMaybe projectSentenceClaim
-
-verifyClaim :: SentenceClaim ParsedPattern -> SentenceVerifier ()
-verifyClaim sentence =
-    withSentenceClaimContext sentence $ do
-        verified <- SentenceVerifier.verifyClaimSentence sentence
-        attrs <- parseAttributes' $ sentenceClaimAttributes sentence
-        State.modify' $ addClaim verified attrs
-  where
-    addClaim verified attrs =
-        Lens.over
-            (field @"indexedModuleClaims")
-            ((attrs, verified) :)
 
 verifyNonHooks
     :: [ParsedSentence]

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -106,6 +106,7 @@ deriving instance MonadError (Error VerifyError) ModuleVerifier
 
 runModuleVerifier
     :: ModuleVerifier a
+    -> Map ModuleName VerifiedModule'
     -> Maybe ImplicitModule
     -> Map ModuleName (Module ParsedSentence)
     -> AttributesVerification'
@@ -113,6 +114,7 @@ runModuleVerifier
     -> Either (Error VerifyError) (a, Map ModuleName VerifiedModule')
 runModuleVerifier
     moduleVerifier
+    alreadyVerifiedModules
     implicitModule
     modules
     attributesVerification
@@ -125,7 +127,8 @@ runModuleVerifier
             moduleState
     return (a, verifiedModules moduleState')
   where
-    moduleState = ModuleState { verifiedModules = Map.empty }
+    moduleState =
+        ModuleState { verifiedModules = alreadyVerifiedModules}
     moduleContext =
         ModuleContext
             { implicitModule

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -26,7 +26,6 @@ import           Data.Generics.Product
 import qualified Data.List as List
 import qualified Data.Map as Map
 import           Data.Maybe
-import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
 
@@ -35,19 +34,15 @@ import           Kore.ASTVerifier.AliasVerifier
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
-                 ( SentenceVerifier, verifySortSentences )
+                 ( SentenceVerifier, verifyHookedSorts, verifyHookedSymbols,
+                 verifySorts )
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Kore.ASTVerifier.Verifier
 import           Kore.Attribute.Parser
                  ( ParseAttributes )
 import qualified Kore.Attribute.Parser as Attribute.Parser
-import qualified Kore.Attribute.Sort as Attribute
-import qualified Kore.Attribute.Symbol as Attribute
-import qualified Kore.Builtin as Builtin
 import           Kore.Error
-import           Kore.IndexedModule.Error
 import           Kore.IndexedModule.IndexedModule as IndexedModule
-import           Kore.IndexedModule.Resolvers
 import           Kore.Syntax
 import           Kore.Syntax.Definition
 import           Kore.Unparser
@@ -89,14 +84,14 @@ verifyUncachedModule name = whileImporting name $ do
                 withModuleContext name $ do
                     -- TODO: The corresponding functions in
                     -- Kore.IndexedModule.IndexedModule can go away.
-                    verifySortSentences  sentences
-                    verifySymbols        sentences
-                    verifyHookedSorts    sentences
-                    verifyHookedSymbols  sentences
-                    verifyNonHooks       sentences
-                    verifyAliases        sentences
-                    verifyAxioms         sentences
-                    verifyClaims         sentences
+                    verifySorts         sentences
+                    verifySymbols       sentences
+                    verifyHookedSorts   sentences
+                    verifyHookedSymbols sentences
+                    verifyNonHooks      sentences
+                    verifyAliases       sentences
+                    verifyAxioms        sentences
+                    verifyClaims        sentences
             )
     _ <-
         withModuleContext name
@@ -139,56 +134,6 @@ parseAttributes'
 parseAttributes' =
     Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
 
-addIndexedModuleHook
-    :: Id
-    -> Attribute.Hook
-    -> VerifiedModule'
-    -> VerifiedModule'
-addIndexedModuleHook name hook =
-    Lens.over (field @"indexedModuleHookedIdentifiers") (Set.insert name)
-    . Lens.over (field @"indexedModuleHooks") addHook
-  where
-    addHook
-      | Just hookId <- Attribute.getHook hook =
-        Map.alter (Just . maybe [name] (name :)) hookId
-      | otherwise           = id
-
-verifyHookedSorts :: [ParsedSentence] -> SentenceVerifier ()
-verifyHookedSorts =
-    Foldable.traverse_ verifyHookedSort . mapMaybe projectSentenceHookedSort
-
-{- | Find the attributes for the named sort.
-
-It is an error to use this before 'verifySorts'.
-
- -}
-lookupSortAttributes :: Id -> SentenceVerifier Attribute.Sort
-lookupSortAttributes name = do
-    sorts <- State.gets indexedModuleSortDescriptions
-    Map.lookup name sorts & maybe (error $ noSort name) (return . fst)
-
-verifyHookedSort :: SentenceSort ParsedPattern -> SentenceVerifier ()
-verifyHookedSort sentence =
-    withSentenceHookContext (SentenceHookedSort sentence) $ do
-        let SentenceSort { sentenceSortAttributes } = sentence
-        VerifierContext { attributesVerification } <- Reader.ask
-        hook <-
-            verifySortHookAttribute
-                attributesVerification
-                sentenceSortAttributes
-        let SentenceSort { sentenceSortName = name } = sentence
-        attrs <- lookupSortAttributes name
-        VerifierContext { builtinVerifiers } <- Reader.ask
-        verifiedModule <- State.get
-        Builtin.sortDeclVerifier
-            builtinVerifiers
-            hook
-            verifiedModule
-            sentence
-            attrs
-            & either throwError return
-        State.modify' $ addIndexedModuleHook name hook
-
 verifySymbols :: [ParsedSentence] -> SentenceVerifier ()
 verifySymbols = Foldable.traverse_ verifySymbol . mapMaybe project
   where
@@ -208,33 +153,6 @@ verifySymbol sentence =
             (Map.insert name (attrs, verified))
       where
         Symbol { symbolConstructor = name } = sentenceSymbolSymbol verified
-
-verifyHookedSymbols
-    :: [ParsedSentence]
-    -> SentenceVerifier ()
-verifyHookedSymbols =
-    Foldable.traverse_ verifyHookedSymbol . mapMaybe projectSentenceHookedSymbol
-
-verifyHookedSymbol
-    :: SentenceSymbol ParsedPattern
-    -> SentenceVerifier ()
-verifyHookedSymbol sentence =
-    withSentenceHookContext (SentenceHookedSymbol sentence) $ do
-        let SentenceSymbol { sentenceSymbolAttributes } = sentence
-        VerifierContext { attributesVerification } <- Reader.ask
-        hook <-
-            verifySymbolHookAttribute
-                attributesVerification
-                sentenceSymbolAttributes
-        VerifierContext { builtinVerifiers } <- Reader.ask
-        verifiedModule <- State.get
-        Builtin.runSymbolVerifier
-            (Builtin.symbolVerifier builtinVerifiers hook)
-            (findIndexedSort verifiedModule)
-            sentence
-            & either throwError return
-        let Symbol { symbolConstructor = name } = sentenceSymbolSymbol sentence
-        State.modify' $ addIndexedModuleHook name hook
 
 verifyAxioms :: [ParsedSentence] -> SentenceVerifier ()
 verifyAxioms = Foldable.traverse_ verifyAxiom . mapMaybe projectSentenceAxiom

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -34,8 +34,8 @@ import           Kore.ASTVerifier.AliasVerifier
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
-                 ( SentenceVerifier, verifyHookedSorts, verifyHookedSymbols,
-                 verifySorts, verifySymbols )
+                 ( SentenceVerifier, verifyAxioms, verifyHookedSorts,
+                 verifyHookedSymbols, verifySorts, verifySymbols )
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Kore.ASTVerifier.Verifier
 import           Kore.Attribute.Parser
@@ -133,21 +133,6 @@ parseAttributes'
     -> error attrs
 parseAttributes' =
     Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
-
-verifyAxioms :: [ParsedSentence] -> SentenceVerifier ()
-verifyAxioms = Foldable.traverse_ verifyAxiom . mapMaybe projectSentenceAxiom
-
-verifyAxiom :: SentenceAxiom ParsedPattern -> SentenceVerifier ()
-verifyAxiom sentence =
-    withSentenceAxiomContext sentence $ do
-        verified <- SentenceVerifier.verifyAxiomSentence sentence
-        attrs <- parseAttributes' $ sentenceAxiomAttributes sentence
-        State.modify $ addAxiom verified attrs
-  where
-    addAxiom verified attrs =
-        Lens.over
-            (field @"indexedModuleAxioms")
-            ((attrs, verified) :)
 
 verifyClaims
     :: [ParsedSentence]

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -159,14 +159,6 @@ whileImporting name locally = do
     foldr withModuleContext failCycle (reverse importing')
     Reader.local (Lens.set (field @"importing") importing') locally
 
-withModuleContext
-    :: MonadError (Error e) error
-    => ModuleName
-    -> error a
-    -> error a
-withModuleContext moduleName =
-    withContext ("module '" ++ getModuleNameForError moduleName ++ "'")
-
 newIndexedModule :: Module ParsedSentence -> ModuleVerifier VerifiedModule'
 newIndexedModule module' = do
     ModuleContext { implicitModule } <- Reader.ask

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -12,8 +12,6 @@ module Kore.ASTVerifier.ModuleVerifier
     , verifyUniqueNames
     ) where
 
-import           Control.Applicative
-                 ( Alternative (..) )
 import           Control.Lens
                  ( (%=) )
 import qualified Control.Lens as Lens
@@ -31,7 +29,6 @@ import           Data.Text
 
 import           Kore.AST.Error
 import           Kore.ASTVerifier.AliasVerifier
-import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
                  ( SentenceVerifier, verifyAxioms, verifyClaims,

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -35,7 +35,7 @@ import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
                  ( SentenceVerifier, verifyHookedSorts, verifyHookedSymbols,
-                 verifySorts )
+                 verifySorts, verifySymbols )
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Kore.ASTVerifier.Verifier
 import           Kore.Attribute.Parser
@@ -133,26 +133,6 @@ parseAttributes'
     -> error attrs
 parseAttributes' =
     Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
-
-verifySymbols :: [ParsedSentence] -> SentenceVerifier ()
-verifySymbols = Foldable.traverse_ verifySymbol . mapMaybe project
-  where
-    project sentence =
-        projectSentenceSymbol sentence <|> projectSentenceHookedSymbol sentence
-
-verifySymbol :: SentenceSymbol ParsedPattern -> SentenceVerifier ()
-verifySymbol sentence =
-    withSentenceSymbolContext sentence $ do
-        verified <- SentenceVerifier.verifySymbolSentence sentence
-        attrs <- parseAttributes' $ sentenceSymbolAttributes sentence
-        State.modify' $ addSymbol verified attrs
-  where
-    addSymbol verified attrs =
-        Lens.over
-            (field @"indexedModuleSymbolSentences")
-            (Map.insert name (attrs, verified))
-      where
-        Symbol { symbolConstructor = name } = sentenceSymbolSymbol verified
 
 verifyAxioms :: [ParsedSentence] -> SentenceVerifier ()
 verifyAxioms = Foldable.traverse_ verifyAxiom . mapMaybe projectSentenceAxiom

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -103,7 +103,7 @@ newVerifiedModule module' = do
     let Module { moduleName, moduleAttributes } = module'
     attrs <- parseAttributes' moduleAttributes
     return
-        ( indexedModuleWithDefaultImports moduleName implicitModule
+        ( indexedModuleWithDefaultImports moduleName (Just implicitModule)
         & Lens.set (field @"indexedModuleAttributes") (attrs, moduleAttributes)
         )
 

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -8,25 +8,155 @@ Stability   : experimental
 Portability : POSIX
 -}
 module Kore.ASTVerifier.ModuleVerifier
-    ( verifyModule
+    ( verifyModuleByName
     , verifyUniqueNames
+    , ModuleVerifier
+    , runModuleVerifier
     ) where
 
+import           Control.Applicative
+                 ( Alternative (..) )
+import           Control.Lens
+                 ( (%=) )
+import qualified Control.Lens as Lens
+import qualified Control.Monad as Monad
+import           Control.Monad.Reader
+                 ( ReaderT, runReaderT )
+import qualified Control.Monad.Reader as Reader
+import           Control.Monad.RWS.Strict
+                 ( MonadReader, MonadState, RWST, runRWST )
+import qualified Control.Monad.State.Strict as State
+import qualified Control.Monad.Trans as Trans
+import qualified Data.Foldable as Foldable
+import           Data.Function
+import qualified Data.Functor.Foldable as Recursive
+import           Data.Generics.Product
+import qualified Data.List as List
+import           Data.Map
+                 ( Map )
 import qualified Data.Map as Map
+import           Data.Maybe
+import           Data.Set
+                 ( Set )
+import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
+import qualified GHC.Generics as GHC
 
+import           Kore.AST.Error
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
+import qualified Kore.Attribute.Axiom as Attribute
+import           Kore.Attribute.Parser
+                 ( ParseAttributes )
+import qualified Kore.Attribute.Parser as Attribute.Parser
+import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
-import           Kore.IndexedModule.IndexedModule
+import           Kore.IndexedModule.Error
+import           Kore.IndexedModule.IndexedModule as IndexedModule
+import           Kore.IndexedModule.Resolvers
 import           Kore.Syntax
 import           Kore.Syntax.Definition
 import           Kore.Unparser
 import qualified Kore.Verified as Verified
+
+type ImplicitModule =
+    ImplicitIndexedModule
+        Verified.Pattern
+        Attribute.Symbol
+        Attribute.Axiom
+
+type AttributesVerification' =
+    AttributesVerification Attribute.Symbol Attribute.Axiom
+
+data ModuleContext =
+    ModuleContext
+        { implicitModule         :: !(Maybe ImplicitModule)
+        , modules                :: !(Map ModuleName (Module ParsedSentence))
+        , importing              :: !(Set ModuleName)
+        , attributesVerification :: !AttributesVerification'
+        , builtinVerifiers       :: !Builtin.Verifiers
+        }
+    deriving (GHC.Generic)
+
+type VerifiedModule' = VerifiedModule Attribute.Symbol Attribute.Axiom
+
+data ModuleState =
+    ModuleState
+        { verifiedModules :: !(Map ModuleName VerifiedModule')
+        }
+    deriving (GHC.Generic)
+
+newtype ModuleVerifier a =
+    ModuleVerifier
+        { getModuleVerifier
+            ::  RWST ModuleContext () ModuleState
+                    (Either (Error VerifyError)) a
+        }
+    deriving (Functor, Applicative, Monad)
+
+deriving instance MonadReader ModuleContext ModuleVerifier
+
+deriving instance MonadState ModuleState ModuleVerifier
+
+deriving instance MonadError (Error VerifyError) ModuleVerifier
+
+runModuleVerifier
+    :: ModuleVerifier a
+    -> Maybe ImplicitModule
+    -> Map ModuleName (Module ParsedSentence)
+    -> AttributesVerification'
+    -> Builtin.Verifiers
+    -> Either (Error VerifyError) (a, Map ModuleName VerifiedModule')
+runModuleVerifier
+    moduleVerifier
+    implicitModule
+    modules
+    attributesVerification
+    builtinVerifiers
+  = do
+    (a, moduleState', ()) <-
+        runRWST
+            (getModuleVerifier moduleVerifier)
+            moduleContext
+            moduleState
+    return (a, verifiedModules moduleState')
+  where
+    moduleState = ModuleState { verifiedModules = Map.empty }
+    moduleContext =
+        ModuleContext
+            { implicitModule
+            , modules
+            , importing = Set.empty
+            , attributesVerification
+            , builtinVerifiers
+            }
+
+lookupVerifiedModule :: ModuleName -> ModuleVerifier (Maybe VerifiedModule')
+lookupVerifiedModule name = State.gets (Map.lookup name . verifiedModules)
+
+lookupParsedModule :: ModuleName -> ModuleVerifier (Module ParsedSentence)
+lookupParsedModule name =
+    Reader.asks (Map.lookup name . modules) >>= maybe notFound return
+  where
+    notFound = koreFail "Module not found."
+
+whileImporting :: ModuleName -> ModuleVerifier a -> ModuleVerifier a
+whileImporting name =
+    Reader.local $ Lens.over (field @"importing") (Set.insert name)
+
+newIndexedModule :: Module ParsedSentence -> ModuleVerifier VerifiedModule'
+newIndexedModule module' = do
+    ModuleContext { implicitModule } <- Reader.ask
+    let Module { moduleName, moduleAttributes } = module'
+    attrs <- parseAttributes' moduleAttributes
+    return
+        ( indexedModuleWithDefaultImports moduleName implicitModule
+        & Lens.set (field @"indexedModuleAttributes") (attrs, moduleAttributes)
+        )
 
 {-|'verifyUniqueNames' verifies that names defined in a module are unique both
 within the module and outside, using the provided name set. -}
@@ -43,25 +173,380 @@ verifyUniqueNames existingNames koreModule =
         ("module '" ++ getModuleNameForError (moduleName koreModule) ++ "'")
         (SentenceVerifier.verifyUniqueNames
             (moduleSentences koreModule)
-            existingNames)
+            existingNames
+        )
 
-{-|'verifyModule' verifies the welformedness of a Kore 'Module'. -}
-verifyModule
-    :: AttributesVerification Attribute.Symbol axiomAtts
-    -> Builtin.Verifiers
-    -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
-    -> Either (Error VerifyError) (Module Verified.Sentence)
-verifyModule attributesVerification builtinVerifiers indexedModule =
-    withContext context $ do
-        verifyAttributes moduleAttributes attributesVerification
-        moduleSentences <-
-            SentenceVerifier.verifySentences
-                indexedModule
-                attributesVerification
-                builtinVerifiers
-                (indexedModuleRawSentences indexedModule)
-        return Module { moduleName, moduleSentences, moduleAttributes }
+verifyModuleByName :: ModuleName -> ModuleVerifier VerifiedModule'
+verifyModuleByName name =
+    withContext moduleContext $ do
+        checkImportCycle
+        lookupVerifiedModule name >>= maybe notYetIndexed alreadyIndexed
   where
-    moduleName = indexedModuleName indexedModule
-    (_, moduleAttributes) = indexedModuleAttributes indexedModule
-    context = "module '" ++ getModuleNameForError moduleName ++ "'"
+    moduleContext = "module '" ++ getModuleNameForError name ++ "'"
+    checkImportCycle = do
+        isCycle <- Reader.asks (Set.member name . importing)
+        koreFailWhen isCycle "Circular module import dependency."
+    alreadyIndexed = return
+    notYetIndexed = whileImporting name $ do
+        module' <- lookupParsedModule name
+        let Module { moduleSentences } = module'
+            sentences = List.sort moduleSentences
+        indexedModule <-
+            -- TODO: Refactor this in a type-safe way.
+                newIndexedModule module'
+            -- TODO: The corresponding functions in
+            -- Kore.IndexedModule.IndexedModule can go away.
+            >>= verifyImports        sentences
+            >>= verifySorts          sentences
+            >>= verifySymbols        sentences
+            >>= verifyHookedSorts    sentences
+            >>= verifyHookedSymbols  sentences
+            >>= verifyAliases        sentences
+            >>= verifyAxioms         sentences
+            >>= verifyClaims         sentences
+        _ <- internalIndexedModuleSubsorts indexedModule
+        field @"verifiedModules" %= Map.insert name indexedModule
+        return indexedModule
+
+verifyImports
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyImports sentences verifiedModule =
+    Monad.foldM verifyImport verifiedModule
+    $ mapMaybe projectSentenceImport sentences
+
+verifyImport
+    :: VerifiedModule'
+    -> SentenceImport ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifyImport verifiedModule sentence =
+    withSentenceImportContext sentence $ do
+        let SentenceImport { sentenceImportAttributes = attrs0 } = sentence
+        attrs1 <- parseAttributes' attrs0
+        verified <- verifyModuleByName $ sentenceImportModuleName sentence
+        return $ addImport verified attrs1 attrs0 verifiedModule
+  where
+    addImport verified attrs1 attrs0 =
+        Lens.over
+            (field @"indexedModuleImports")
+            ((attrs1, attrs0, verified) :)
+
+parseAttributes'
+    :: forall attrs error e
+    .  (MonadError (Error e) error, ParseAttributes attrs)
+    => Attributes
+    -> error attrs
+parseAttributes' =
+    Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
+
+verifySorts
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifySorts sentences verifiedModule =
+    Monad.foldM verifySort verifiedModule
+    $ mapMaybe project sentences
+  where
+    project sentence =
+        projectSentenceSort sentence <|> projectSentenceHookedSort sentence
+
+verifySort
+    :: VerifiedModule'
+    -> SentenceSort ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifySort verifiedModule sentence =
+    withSentenceSortContext sentence $ do
+        verified <-
+            liftSentenceVerifier verifiedModule
+            $ SentenceVerifier.verifySortSentence sentence
+        attrs <- parseAttributes' $ sentenceSortAttributes verified
+        return $ addSort verified attrs verifiedModule
+  where
+    addSort verified attrs =
+        Lens.over
+            (field @"indexedModuleSortDescriptions")
+            (Map.insert name (attrs, verified))
+      where
+        name = sentenceSortName verified
+
+verifyAliases
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyAliases sentences verifiedModule = do
+    let aliases =
+            Map.fromList . map (\sentence -> (aliasName sentence, sentence))
+            $ mapMaybe projectSentenceAlias sentences
+        aliasIds = Map.keysSet aliases
+    runReaderT
+        (Monad.foldM verifyAlias verifiedModule aliasIds)
+        AliasContext { aliases, verifying = Set.empty }
+
+aliasName :: SentenceAlias patternType -> Id
+aliasName = aliasConstructor . sentenceAliasAlias
+
+type AliasVerifierT = ReaderT AliasContext
+
+data AliasContext =
+    AliasContext
+        { aliases   :: !(Map Id ParsedSentenceAlias)
+        , verifying :: !(Set Id)
+        }
+    deriving (GHC.Generic)
+
+type VerifiedAlias = (Attribute.Symbol, SentenceAlias Verified.Pattern)
+
+lookupVerifiedAlias
+    :: Id
+    -> VerifiedModule'
+    -> AliasVerifierT ModuleVerifier (Maybe VerifiedAlias)
+lookupVerifiedAlias name verifiedModule =
+    return $ Map.lookup name $ indexedModuleAliasSentences verifiedModule
+
+lookupParsedAlias
+    :: MonadError (Error e) monad
+    => Id
+    -> AliasVerifierT monad ParsedSentenceAlias
+lookupParsedAlias name =
+    Reader.asks (Map.lookup name . aliases) >>= maybe notFound return
+  where
+    notFound = koreFail "Alias not found."
+
+verifyAlias
+    :: VerifiedModule'
+    -> Id
+    -> AliasVerifierT ModuleVerifier VerifiedModule'
+verifyAlias verifiedModule name =
+    withContext aliasContext $ do
+        checkAliasCycle
+        lookupVerifiedAlias name verifiedModule
+            >>= maybe notYetVerified alreadyVerified
+  where
+    aliasContext = "alias '" ++ getIdForError name ++ "' declaration"
+    alreadyVerified _ = return verifiedModule
+    checkAliasCycle = do
+        isCycle <- Reader.asks (Set.member name . verifying)
+        koreFailWhen isCycle "Circular alias dependency."
+    notYetVerified = do
+        sentence <- lookupParsedAlias name
+        verifiedModule' <- verifyAliasDependencies verifiedModule sentence
+        verified <-
+            Trans.lift . liftSentenceVerifier verifiedModule
+            $ SentenceVerifier.verifyAliasSentence sentence
+        attrs <- parseAttributes' $ sentenceAliasAttributes verified
+        return $ addAlias verified attrs verifiedModule'
+      where
+        addAlias verified attrs =
+            Lens.over
+                (field @"indexedModuleAliasSentences")
+                (Map.insert (aliasName verified) (attrs, verified))
+
+verifyAliasDependencies
+    :: VerifiedModule'
+    -> SentenceAlias ParsedPattern
+    -> AliasVerifierT ModuleVerifier VerifiedModule'
+verifyAliasDependencies verifiedModule sentence = do
+    deps <- Recursive.fold collectAliasIds aliasPattern
+    Monad.foldM verifyAlias verifiedModule deps
+  where
+    aliasPattern = sentenceAliasRightPattern sentence
+
+collectAliasIds
+    :: Monad monad
+    => Base ParsedPattern (AliasVerifierT monad (Set Id))
+    -> AliasVerifierT monad (Set Id)
+collectAliasIds base = do
+    _ :< patternF <- sequence base
+    let names = Foldable.fold patternF
+    AliasContext { aliases } <- Reader.ask
+    case patternF of
+        ApplicationF application | Map.member name aliases ->
+            return $ Set.insert name names
+          where
+            name =
+                symbolOrAliasConstructor
+                . applicationSymbolOrAlias
+                $ application
+        _ -> return names
+
+addIndexedModuleHook
+    :: Id
+    -> Attribute.Hook
+    -> VerifiedModule'
+    -> VerifiedModule'
+addIndexedModuleHook name hook =
+    Lens.over (field @"indexedModuleHookedIdentifiers") (Set.insert name)
+    . Lens.over (field @"indexedModuleHooks") addHook
+  where
+    addHook
+      | Just hookId <- Attribute.getHook hook =
+        Map.alter (Just . maybe [name] (name :)) hookId
+      | otherwise           = id
+
+verifyHookedSorts
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyHookedSorts sentences verifiedModule =
+    Monad.foldM verifyHookedSort verifiedModule
+    $ mapMaybe projectSentenceHookedSort sentences
+
+{- | Find the attributes for the named sort.
+
+It is an error to use this before 'verifySorts'.
+
+ -}
+lookupSortAttributesHere
+    :: Id
+    -> VerifiedModule'
+    -> Attribute.Sort
+lookupSortAttributesHere name verifiedModule =
+    Map.lookup name (indexedModuleSortDescriptions verifiedModule)
+    & maybe (error $ noSort name) fst
+
+verifyHookedSort
+    :: VerifiedModule'
+    -> SentenceSort ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifyHookedSort verifiedModule sentence =
+    withSentenceHookContext (SentenceHookedSort sentence) $ do
+        let SentenceSort { sentenceSortAttributes } = sentence
+        ModuleContext { attributesVerification } <- Reader.ask
+        hook <-
+            verifySortHookAttribute
+                attributesVerification
+                sentenceSortAttributes
+        let SentenceSort { sentenceSortName = name } = sentence
+            attrs = lookupSortAttributesHere name verifiedModule
+        ModuleContext { builtinVerifiers } <- Reader.ask
+        Builtin.sortDeclVerifier
+            builtinVerifiers
+            hook
+            (IndexedModule.eraseAttributes verifiedModule)
+            sentence
+            attrs
+            & either throwError return
+        return $ addIndexedModuleHook name hook verifiedModule
+
+verifySymbols
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifySymbols sentences verifiedModule =
+    Monad.foldM verifySymbol verifiedModule
+    $ mapMaybe project sentences
+  where
+    project sentence =
+        projectSentenceSymbol sentence <|> projectSentenceHookedSymbol sentence
+
+verifySymbol
+    :: VerifiedModule'
+    -> SentenceSymbol ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifySymbol verifiedModule sentence =
+    withSentenceSymbolContext sentence $ do
+        verified <-
+            liftSentenceVerifier verifiedModule
+            $ SentenceVerifier.verifySymbolSentence sentence
+        attrs <- parseAttributes' $ sentenceSymbolAttributes sentence
+        return $ addSymbol verified attrs verifiedModule
+  where
+    addSymbol verified attrs =
+        Lens.over
+            (field @"indexedModuleSymbolSentences")
+            (Map.insert name (attrs, verified))
+      where
+        Symbol { symbolConstructor = name } = sentenceSymbolSymbol verified
+
+verifyHookedSymbols
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyHookedSymbols sentences verifiedModule =
+    Monad.foldM verifyHookedSymbol verifiedModule
+    $ mapMaybe projectSentenceHookedSymbol sentences
+
+verifyHookedSymbol
+    :: VerifiedModule'
+    -> SentenceSymbol ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifyHookedSymbol verifiedModule sentence =
+    withSentenceHookContext (SentenceHookedSymbol sentence) $ do
+        let SentenceSymbol { sentenceSymbolAttributes } = sentence
+        ModuleContext { attributesVerification } <- Reader.ask
+        hook <-
+            verifySymbolHookAttribute
+                attributesVerification
+                sentenceSymbolAttributes
+        ModuleContext { builtinVerifiers } <- Reader.ask
+        Builtin.runSymbolVerifier
+            (Builtin.symbolVerifier builtinVerifiers hook)
+            (findIndexedSort verifiedModule)
+            sentence
+            & either throwError return
+        let Symbol { symbolConstructor = name } = sentenceSymbolSymbol sentence
+        return $ addIndexedModuleHook name hook verifiedModule
+
+verifyAxioms
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyAxioms sentences verifiedModule =
+    Monad.foldM verifyAxiom verifiedModule
+    $ mapMaybe projectSentenceAxiom sentences
+
+verifyAxiom
+    :: VerifiedModule'
+    -> SentenceAxiom ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifyAxiom verifiedModule sentence =
+    withSentenceAxiomContext sentence $ do
+        verified <-
+            liftSentenceVerifier verifiedModule
+            $ SentenceVerifier.verifyAxiomSentence sentence
+        attrs <- parseAttributes' $ sentenceAxiomAttributes sentence
+        return $ addAxiom verified attrs verifiedModule
+  where
+    addAxiom verified attrs =
+        Lens.over
+            (field @"indexedModuleAxioms")
+            ((attrs, verified) :)
+
+verifyClaims
+    :: [ParsedSentence]
+    -> VerifiedModule'
+    -> ModuleVerifier VerifiedModule'
+verifyClaims sentences verifiedModule =
+    Monad.foldM verifyClaim verifiedModule
+    $ mapMaybe projectSentenceClaim sentences
+
+verifyClaim
+    :: VerifiedModule'
+    -> SentenceClaim ParsedPattern
+    -> ModuleVerifier VerifiedModule'
+verifyClaim verifiedModule sentence =
+    withSentenceClaimContext sentence $ do
+        verified <-
+            liftSentenceVerifier verifiedModule
+            $ SentenceVerifier.verifyClaimSentence sentence
+        attrs <- parseAttributes' $ sentenceClaimAttributes sentence
+        return $ addClaim verified attrs verifiedModule
+  where
+    addClaim verified attrs =
+        Lens.over
+            (field @"indexedModuleClaims")
+            ((attrs, verified) :)
+
+liftSentenceVerifier
+    :: VerifiedModule'
+    -> SentenceVerifier.SentenceVerifier a
+    -> ModuleVerifier a
+liftSentenceVerifier verifiedModule sentenceVerifier = do
+    ModuleContext { attributesVerification, builtinVerifiers } <- Reader.ask
+    ModuleVerifier . Trans.lift
+        $ SentenceVerifier.runSentenceVerifier
+            sentenceVerifier
+            verifiedModule
+            attributesVerification
+            builtinVerifiers

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -52,23 +52,16 @@ verifyModule
     -> IndexedModule ParsedPattern Attribute.Symbol axiomAtts
     -> Either (Error VerifyError) (Module Verified.Sentence)
 verifyModule attributesVerification builtinVerifiers indexedModule =
-    withContext
-        (  "module '"
-        ++ getModuleNameForError (indexedModuleName indexedModule)
-        ++ "'"
-        )
-        (do
-            verifyAttributes
-                (snd (indexedModuleAttributes indexedModule))
+    withContext context $ do
+        verifyAttributes moduleAttributes attributesVerification
+        moduleSentences <-
+            SentenceVerifier.verifySentences
+                indexedModule
                 attributesVerification
-            moduleSentences <-
-                SentenceVerifier.verifySentences
-                    indexedModule
-                    attributesVerification
-                    builtinVerifiers
-                    (indexedModuleRawSentences indexedModule)
-            return Module { moduleName, moduleSentences, moduleAttributes }
-        )
+                builtinVerifiers
+                (indexedModuleRawSentences indexedModule)
+        return Module { moduleName, moduleSentences, moduleAttributes }
   where
     moduleName = indexedModuleName indexedModule
     (_, moduleAttributes) = indexedModuleAttributes indexedModule
+    context = "module '" ++ getModuleNameForError moduleName ++ "'"

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -18,28 +18,20 @@ import           Control.Lens
                  ( (%=) )
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
-import           Control.Monad.Reader
-                 ( ReaderT, runReaderT )
-import qualified Control.Monad.Reader as Reader
+import qualified Control.Monad.Reader.Class as Reader
 import qualified Control.Monad.State.Class as State
-import qualified Control.Monad.Trans as Trans
 import qualified Data.Foldable as Foldable
 import           Data.Function
-import qualified Data.Functor.Foldable as Recursive
 import           Data.Generics.Product
 import qualified Data.List as List
-import           Data.Map
-                 ( Map )
 import qualified Data.Map as Map
 import           Data.Maybe
-import           Data.Set
-                 ( Set )
 import qualified Data.Set as Set
 import           Data.Text
                  ( Text )
-import qualified GHC.Generics as GHC
 
 import           Kore.AST.Error
+import           Kore.ASTVerifier.AliasVerifier
 import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
@@ -59,7 +51,6 @@ import           Kore.IndexedModule.Resolvers
 import           Kore.Syntax
 import           Kore.Syntax.Definition
 import           Kore.Unparser
-import qualified Kore.Verified as Verified
 
 newIndexedModule :: Module ParsedSentence -> Verifier VerifiedModule'
 newIndexedModule module' = do
@@ -174,101 +165,6 @@ verifySort sentence =
         Lens.over
             (field @"indexedModuleSortDescriptions")
             (Map.insert (sentenceSortName verified) (attrs, verified))
-
-verifyAliases
-    :: [ParsedSentence]
-    -> SentenceVerifier ()
-verifyAliases sentences= do
-    let aliases =
-            Map.fromList . map (\sentence -> (aliasName sentence, sentence))
-            $ mapMaybe projectSentenceAlias sentences
-        aliasIds = Map.keysSet aliases
-    runReaderT
-        (Foldable.traverse_ verifyAlias aliasIds)
-        AliasContext { aliases, verifying = Set.empty }
-
-aliasName :: SentenceAlias patternType -> Id
-aliasName = aliasConstructor . sentenceAliasAlias
-
-type AliasVerifierT = ReaderT AliasContext
-
-data AliasContext =
-    AliasContext
-        { aliases   :: !(Map Id ParsedSentenceAlias)
-        , verifying :: !(Set Id)
-        }
-    deriving (GHC.Generic)
-
-type VerifiedAlias = (Attribute.Symbol, SentenceAlias Verified.Pattern)
-
-lookupVerifiedAlias
-    :: Id
-    -> AliasVerifierT SentenceVerifier (Maybe VerifiedAlias)
-lookupVerifiedAlias name = do
-    verifiedAliases <- State.gets indexedModuleAliasSentences
-    return $ Map.lookup name verifiedAliases
-
-lookupParsedAlias
-    :: MonadError (Error e) monad
-    => Id
-    -> AliasVerifierT monad ParsedSentenceAlias
-lookupParsedAlias name =
-    Reader.asks (Map.lookup name . aliases) >>= maybe notFound return
-  where
-    notFound = koreFail "Alias not found."
-
-verifyAlias :: Id -> AliasVerifierT SentenceVerifier ()
-verifyAlias name =
-    withLocationAndContext name aliasContext $ do
-        checkAliasCycle
-        lookupVerifiedAlias name >>= maybe notCached cached
-  where
-    aliasContext = "alias '" <> getId name <> "' declaration"
-    checkAliasCycle = do
-        isCycle <- Reader.asks (Set.member name . verifying)
-        koreFailWhen isCycle "Circular alias dependency."
-    cached _ = return ()
-    notCached = verifyUncachedAlias name
-
-verifyUncachedAlias :: Id -> AliasVerifierT SentenceVerifier ()
-verifyUncachedAlias name = do
-    sentence <- lookupParsedAlias name
-    verifyAliasDependencies sentence
-    verified <- SentenceVerifier.verifyAliasSentence sentence & Trans.lift
-    attrs <- parseAttributes' $ sentenceAliasAttributes verified
-    State.modify' $ addAlias verified attrs
-  where
-    addAlias verified attrs =
-        Lens.over
-            (field @"indexedModuleAliasSentences")
-            (Map.insert (aliasName verified) (attrs, verified))
-
-verifyAliasDependencies
-    :: SentenceAlias ParsedPattern
-    -> AliasVerifierT SentenceVerifier ()
-verifyAliasDependencies sentence = do
-    deps <- Recursive.fold collectAliasIds aliasPattern
-    Foldable.traverse_ verifyAlias deps
-  where
-    aliasPattern = sentenceAliasRightPattern sentence
-
-collectAliasIds
-    :: Monad monad
-    => Base ParsedPattern (AliasVerifierT monad (Set Id))
-    -> AliasVerifierT monad (Set Id)
-collectAliasIds base = do
-    _ :< patternF <- sequence base
-    let names = Foldable.fold patternF
-    AliasContext { aliases } <- Reader.ask
-    case patternF of
-        ApplicationF application | Map.member name aliases ->
-            return $ Set.insert name names
-          where
-            name =
-                symbolOrAliasConstructor
-                . applicationSymbolOrAlias
-                $ application
-        _ -> return names
 
 addIndexedModuleHook
     :: Id

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -266,9 +266,7 @@ verifySort verifiedModule sentence =
     addSort verified attrs =
         Lens.over
             (field @"indexedModuleSortDescriptions")
-            (Map.insert name (attrs, verified))
-      where
-        name = sentenceSortName verified
+            (Map.insert (sentenceSortName verified) (attrs, verified))
 
 verifyAliases
     :: [ParsedSentence]

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -318,12 +318,12 @@ verifyAlias
     -> Id
     -> AliasVerifierT ModuleVerifier VerifiedModule'
 verifyAlias verifiedModule name =
-    withContext aliasContext $ do
+    withLocationAndContext name aliasContext $ do
         checkAliasCycle
         lookupVerifiedAlias name verifiedModule
             >>= maybe notYetVerified alreadyVerified
   where
-    aliasContext = "alias '" ++ getIdForError name ++ "' declaration"
+    aliasContext = "alias '" <> getId name <> "' declaration"
     alreadyVerified _ = return verifiedModule
     checkAliasCycle = do
         isCycle <- Reader.asks (Set.member name . verifying)

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -332,7 +332,7 @@ verifyAlias verifiedModule name =
         sentence <- lookupParsedAlias name
         verifiedModule' <- verifyAliasDependencies verifiedModule sentence
         verified <-
-            Trans.lift . liftSentenceVerifier verifiedModule
+            Trans.lift . liftSentenceVerifier verifiedModule'
             $ SentenceVerifier.verifyAliasSentence sentence
         attrs <- parseAttributes' $ sentenceAliasAttributes verified
         return $ addAlias verified attrs verifiedModule'

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -35,8 +35,8 @@ import           Kore.ASTVerifier.AttributesVerifier
 import           Kore.ASTVerifier.Error
 import           Kore.ASTVerifier.SentenceVerifier
                  ( SentenceVerifier, verifyAxioms, verifyClaims,
-                 verifyHookedSorts, verifyHookedSymbols, verifySorts,
-                 verifySymbols )
+                 verifyHookedSorts, verifyHookedSymbols, verifyNonHooks,
+                 verifySorts, verifySymbols )
 import qualified Kore.ASTVerifier.SentenceVerifier as SentenceVerifier
 import           Kore.ASTVerifier.Verifier
 import           Kore.Attribute.Parser
@@ -134,20 +134,3 @@ parseAttributes'
     -> error attrs
 parseAttributes' =
     Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
-
-verifyNonHooks
-    :: [ParsedSentence]
-    -> SentenceVerifier ()
-verifyNonHooks sentences=
-    Foldable.traverse_ verifyNonHook nonHookSentences
-  where
-    nonHookSentences = mapMaybe project sentences
-    project (SentenceHookSentence _) = Nothing
-    project sentence = Just sentence
-
-verifyNonHook :: ParsedSentence -> SentenceVerifier ()
-verifyNonHook sentence =
-    withSentenceContext sentence $ do
-        VerifierContext { attributesVerification } <- Reader.ask
-        verifyNoHookAttribute attributesVerification
-            $ sentenceAttributes sentence

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -238,25 +238,39 @@ See also: 'uniqueDeclaredVariables', 'withDeclaredVariables'
 
  -}
 verifyAliasLeftPattern
-    :: Application SymbolOrAlias (ElementVariable Variable)
+    :: Alias
+    -> [Sort]
+    -> Application SymbolOrAlias (ElementVariable Variable)
     -> PatternVerifier
         ( DeclaredVariables
         , Application SymbolOrAlias (ElementVariable Variable)
         )
-verifyAliasLeftPattern leftPattern = do
-    _ :< verified <-
-        verifyApplyAlias snd (expectVariable . ElemVar  <$> leftPattern)
-        & runMaybeT
-        & (>>= maybe (error . noHead $ symbolOrAlias) return)
+verifyAliasLeftPattern alias aliasSorts leftPattern = do
+    koreFailWhen (declaredHead /= symbolOrAlias) aliasDeclarationMismatch
+    let expect = expectVariable . ElemVar <$> applicationChildren leftPattern
+    verified <- verifyPatternsWithSorts snd aliasSorts expect
     declaredVariables <- uniqueDeclaredVariables (fst <$> verified)
-    let verifiedLeftPattern = traverse extractElementVariable
-            leftPattern
-                { applicationChildren = fst <$> applicationChildren verified }
+    let verifiedLeftPattern =
+            traverse
+                extractElementVariable
+                leftPattern { applicationChildren = fst <$> verified }
     case verifiedLeftPattern of
         Just result -> return (declaredVariables, result)
         Nothing -> error "Impossible change from element var to set var"
   where
     symbolOrAlias = applicationSymbolOrAlias leftPattern
+    declaredHead =
+        SymbolOrAlias
+            { symbolOrAliasConstructor = aliasConstructor alias
+            , symbolOrAliasParams = SortVariableSort <$> aliasParams alias
+            }
+    aliasDeclarationMismatch =
+        (show . Pretty.vsep)
+            [ "Alias left-hand side:"
+            , Pretty.indent 4 $ unparse symbolOrAlias
+            , "does not match declaration:"
+            , Pretty.indent 4 $ unparse alias
+            ]
     expectVariable
         :: UnifiedVariable Variable
         -> PatternVerifier

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -60,9 +60,8 @@ import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValue
 import qualified Kore.Attribute.Symbol as Attribute.Symbol
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
-import           Kore.IndexedModule.Error
 import           Kore.IndexedModule.IndexedModule as IndexedModule
-import           Kore.IndexedModule.Resolvers
+import           Kore.IndexedModule.Resolvers as Resolvers
 import           Kore.Sort
 import           Kore.Syntax.Definition
 import qualified Kore.Verified as Verified
@@ -160,8 +159,9 @@ It is an error to use this before 'verifySorts'.
  -}
 lookupSortAttributes :: Id -> SentenceVerifier Attribute.Sort
 lookupSortAttributes name = do
-    sorts <- State.gets indexedModuleSortDescriptions
-    Map.lookup name sorts & maybe (koreFail $ noSort name) (return . fst)
+    verifiedModule <- State.get
+    (attrs, _) <- Resolvers.resolveSort verifiedModule name
+    return attrs
 
 runSentenceVerifier
     :: SentenceVerifier a

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -240,7 +240,7 @@ verifyHookedSort sentence@SentenceSort { sentenceSortAttributes } = do
     Builtin.sortDeclVerifier
         builtinVerifiers
         hook
-        (IndexedModule.eraseAttributes verifiedModule)
+        verifiedModule
         sentence
         attrs
         & either throwError return

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -379,7 +379,7 @@ verifyAliasSentence sentence = do
     context <- askPatternContext variables
     either throwError return . runPatternVerifier context $ do
         (declaredVariables, verifiedLeftPattern) <-
-            verifyAliasLeftPattern leftPattern
+            verifyAliasLeftPattern alias sentenceAliasSorts leftPattern
         verifiedRightPattern <-
             withDeclaredVariables declaredVariables
             $ verifyPattern (Just expectedSort) rightPattern
@@ -388,6 +388,7 @@ verifyAliasSentence sentence = do
             , sentenceAliasRightPattern = verifiedRightPattern
             }
   where
+    SentenceAlias { sentenceAliasAlias = alias } = sentence
     SentenceAlias { sentenceAliasLeftPattern = leftPattern } = sentence
     SentenceAlias { sentenceAliasRightPattern = rightPattern } = sentence
     SentenceAlias { sentenceAliasSorts } = sentence

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -277,17 +277,23 @@ verifyConstructor
     :: Verified.SentenceSymbol
     -> SentenceVerifier ()
 verifyConstructor verified = do
-    sortAttrs <- lookupSortAttributes (getSortId resultSort)
+    resultSortId <-
+        case resultSort of
+            SortVariableSort _ ->
+                koreFail (noConstructorWithVariableSort symbolName)
+            SortActualSort _ ->
+                return (getSortId resultSort)
+    attrs <- lookupSortAttributes resultSortId
     let
         isHookedSort =
             isJust
             . Attribute.getHook
             . Attribute.Sort.hook
-            $ sortAttrs
+            $ attrs
         hasDomainValues =
             Attribute.HasDomainValues.getHasDomainValues
             . Attribute.Sort.hasDomainValues
-            $ sortAttrs
+            $ attrs
     koreFailWhen isHookedSort
         (noConstructorInHookedSort symbolName resultSort)
     koreFailWhen hasDomainValues

--- a/kore/src/Kore/ASTVerifier/Verifier.hs
+++ b/kore/src/Kore/ASTVerifier/Verifier.hs
@@ -1,0 +1,137 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+module Kore.ASTVerifier.Verifier
+    ( Verifier
+    , VerifierContext (..)
+    , VerifierState (..)
+    , runVerifier
+    --
+    , VerifiedModule'
+    , ImplicitModule
+    , AttributesVerification'
+    --
+    , lookupVerifiedModule
+    , lookupParsedModule
+    , whileImporting
+    ) where
+
+import qualified Control.Lens as Lens
+import qualified Control.Monad.Reader as Reader
+import           Control.Monad.RWS.Strict
+                 ( MonadReader, MonadState, RWST, runRWST )
+import qualified Control.Monad.State.Strict as State
+import           Data.Generics.Product
+import           Data.Map
+                 ( Map )
+import qualified Data.Map as Map
+import qualified GHC.Generics as GHC
+
+import           Kore.AST.Error
+import           Kore.ASTVerifier.AttributesVerifier
+import           Kore.ASTVerifier.Error
+import qualified Kore.Attribute.Axiom as Attribute
+import qualified Kore.Attribute.Symbol as Attribute
+import qualified Kore.Builtin as Builtin
+import           Kore.Error
+import           Kore.IndexedModule.IndexedModule as IndexedModule
+import           Kore.Syntax.Definition
+import qualified Kore.Verified as Verified
+
+type ImplicitModule =
+    ImplicitIndexedModule
+        Verified.Pattern
+        Attribute.Symbol
+        Attribute.Axiom
+
+type AttributesVerification' =
+    AttributesVerification Attribute.Symbol Attribute.Axiom
+
+type VerifiedModule' = VerifiedModule Attribute.Symbol Attribute.Axiom
+
+data VerifierContext =
+    VerifierContext
+        { implicitModule         :: !(Maybe ImplicitModule)
+        , modules                :: !(Map ModuleName ParsedModule)
+        , importing              :: ![ModuleName]
+        , attributesVerification :: !AttributesVerification'
+        , builtinVerifiers       :: !Builtin.Verifiers
+        }
+    deriving (GHC.Generic)
+
+data VerifierState =
+    VerifierState
+        { verifiedModules :: !(Map ModuleName VerifiedModule')
+        }
+    deriving (GHC.Generic)
+
+newtype Verifier a =
+    Verifier
+        { getVerifier
+            ::  RWST VerifierContext () VerifierState
+                    (Either (Error VerifyError)) a
+        }
+    deriving (Functor, Applicative, Monad)
+
+deriving instance MonadReader VerifierContext Verifier
+
+deriving instance MonadState VerifierState Verifier
+
+deriving instance MonadError (Error VerifyError) Verifier
+
+runVerifier
+    :: Verifier a
+    -> Map ModuleName VerifiedModule'
+    -> Maybe ImplicitModule
+    -> Map ModuleName (Module ParsedSentence)
+    -> AttributesVerification'
+    -> Builtin.Verifiers
+    -> Either (Error VerifyError) (a, Map ModuleName VerifiedModule')
+runVerifier
+    moduleVerifier
+    alreadyVerifiedModules
+    implicitModule
+    modules
+    attributesVerification
+    builtinVerifiers
+  = do
+    (a, verifierState', ()) <-
+        runRWST
+            (getVerifier moduleVerifier)
+            verifierContext
+            verifierState
+    return (a, verifiedModules verifierState')
+  where
+    verifierState =
+        VerifierState { verifiedModules = alreadyVerifiedModules}
+    verifierContext =
+        VerifierContext
+            { implicitModule
+            , modules
+            , importing = []
+            , attributesVerification
+            , builtinVerifiers
+            }
+
+lookupVerifiedModule :: ModuleName -> Verifier (Maybe VerifiedModule')
+lookupVerifiedModule name = State.gets (Map.lookup name . verifiedModules)
+
+lookupParsedModule :: ModuleName -> Verifier (Module ParsedSentence)
+lookupParsedModule name =
+    Reader.asks (Map.lookup name . modules) >>= maybe notFound return
+  where
+    notFound =
+        koreFail ("Module '" ++ getModuleNameForError name ++ "' not found.")
+
+whileImporting :: ModuleName -> Verifier a -> Verifier a
+whileImporting name locally = do
+    VerifierContext { importing } <- Reader.ask
+    let failCycle =
+            koreFailWhen
+                (elem name importing)
+                "Circular module import dependency."
+        importing' = name : importing
+    foldr withModuleContext failCycle (reverse importing')
+    Reader.local (Lens.set (field @"importing") importing') locally

--- a/kore/src/Kore/ASTVerifier/Verifier.hs
+++ b/kore/src/Kore/ASTVerifier/Verifier.hs
@@ -53,7 +53,7 @@ type VerifiedModule' = VerifiedModule Attribute.Symbol Attribute.Axiom
 
 data VerifierContext =
     VerifierContext
-        { implicitModule         :: !(Maybe ImplicitModule)
+        { implicitModule         :: !ImplicitModule
         , modules                :: !(Map ModuleName ParsedModule)
         , importing              :: ![ModuleName]
         , attributesVerification :: !AttributesVerification'
@@ -84,7 +84,7 @@ deriving instance MonadError (Error VerifyError) Verifier
 runVerifier
     :: Verifier a
     -> Map ModuleName VerifiedModule'
-    -> Maybe ImplicitModule
+    -> ImplicitModule
     -> Map ModuleName (Module ParsedSentence)
     -> AttributesVerification'
     -> Builtin.Verifiers

--- a/kore/src/Kore/ASTVerifier/Verifier.hs
+++ b/kore/src/Kore/ASTVerifier/Verifier.hs
@@ -115,16 +115,30 @@ runVerifier
             , builtinVerifiers
             }
 
+{- | Find the named 'VerifiedModule' in the cache, if present.
+
+ -}
 lookupVerifiedModule :: ModuleName -> Verifier (Maybe VerifiedModule')
 lookupVerifiedModule name = State.gets (Map.lookup name . verifiedModules)
 
-lookupParsedModule :: ModuleName -> Verifier (Module ParsedSentence)
+{- | Find the named 'ParsedModule'.
+
+It is an error if the module is missing.
+
+ -}
+lookupParsedModule :: ModuleName -> Verifier ParsedModule
 lookupParsedModule name =
     Reader.asks (Map.lookup name . modules) >>= maybe notFound return
   where
     notFound =
         koreFail ("Module '" ++ getModuleNameForError name ++ "' not found.")
 
+{- | Add the 'ModuleName' to the import stack.
+
+It is an error if there is a dependency cycle among modules, i.e. if the
+'ModuleName' was already on the stack.
+
+ -}
 whileImporting :: ModuleName -> Verifier a -> Verifier a
 whileImporting name locally = do
     VerifierContext { importing } <- Reader.ask

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -90,9 +90,10 @@ import qualified Kore.AST.Error as Kore.Error
 import qualified Kore.ASTVerifier.AttributesVerifier as Verifier.Attributes
 import           Kore.ASTVerifier.Error
                  ( VerifyError )
+import qualified Kore.Attribute.Axiom as Attribute
+                 ( Axiom )
 import           Kore.Attribute.Hook
                  ( Hook (..) )
-import qualified Kore.Attribute.Null as Attribute
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Sort.Concat as Attribute.Sort
@@ -144,8 +145,8 @@ type Function = BuiltinAndAxiomSimplifier
 
 -- | Verify a sort declaration.
 type SortDeclVerifier =
-        VerifiedModule Attribute.Null Attribute.Null
-    -- ^ Indexed module, to look up symbol declarations
+        VerifiedModule Attribute.Symbol Attribute.Axiom
+    -- ^ Indexed module, to look up sort declarations
     ->  ParsedSentenceSort
     -- ^ Sort declaration to verify
     ->  Attribute.Sort

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -104,7 +104,7 @@ import           Kore.Error
                  ( Error )
 import qualified Kore.Error
 import           Kore.IndexedModule.IndexedModule
-                 ( KoreIndexedModule, VerifiedModule )
+                 ( IndexedModule, VerifiedModule )
 import           Kore.IndexedModule.MetadataTools
                  ( MetadataTools (MetadataTools), SmtMetadataTools )
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
@@ -144,7 +144,7 @@ type Function = BuiltinAndAxiomSimplifier
 
 -- | Verify a sort declaration.
 type SortDeclVerifier =
-        KoreIndexedModule Attribute.Null Attribute.Null
+        VerifiedModule Attribute.Null Attribute.Null
     -- ^ Indexed module, to look up symbol declarations
     ->  ParsedSentenceSort
     -- ^ Sort declaration to verify
@@ -320,7 +320,7 @@ Fail if the symbol is not defined or the attribute is missing.
 
  -}
 assertSymbolHook
-    :: KoreIndexedModule declAttrs axiomAttrs
+    :: IndexedModule patternType declAttrs axiomAttrs
     -> Id
     -- ^ Symbol identifier
     -> Text
@@ -350,7 +350,7 @@ Fail if the symbol is not defined.
 
  -}
 assertSymbolResultSort
-    :: KoreIndexedModule declAttrs axiomAttrs
+    :: IndexedModule patternType declAttrs axiomAttrs
     -> Id
     -- ^ Symbol identifier
     -> Sort

--- a/kore/src/Kore/IndexedModule/IndexedModule.hs
+++ b/kore/src/Kore/IndexedModule/IndexedModule.hs
@@ -30,12 +30,10 @@ module Kore.IndexedModule.IndexedModule
     , erasePatterns
     , mapPatterns
     , indexedModuleRawSentences
-    , indexModuleIfNeeded
     , SortDescription
     , getIndexedSentence
     , hookedObjectSymbolSentences
     , indexedModuleSubsorts
-    , indexModuleSentence
     , internalIndexedModuleSubsorts
     , indexedModulesInScope
     , toModule
@@ -56,8 +54,6 @@ import           Control.DeepSeq
                  ( NFData (..) )
 import qualified Control.Lens as Lens hiding
                  ( makeLenses )
-import           Control.Monad
-                 ( foldM )
 import           Control.Monad.Extra
                  ( unlessM )
 import           Control.Monad.State.Strict
@@ -66,7 +62,6 @@ import qualified Control.Monad.State.Strict as Monad.State
 import           Data.Default as Default
 import qualified Data.Foldable as Foldable
 import           Data.Function
-import qualified Data.List as List
 import           Data.Map.Strict
                  ( Map )
 import qualified Data.Map.Strict as Map
@@ -78,11 +73,7 @@ import           Data.Text
 import           GHC.Generics
                  ( Generic )
 
-import           Kore.AST.Error
-import           Kore.Attribute.Hook
 import qualified Kore.Attribute.Null as Attribute
-import           Kore.Attribute.Parser
-                 ( ParseAttributes )
 import qualified Kore.Attribute.Parser as Attribute.Parser
 import qualified Kore.Attribute.Sort as Attribute
                  ( Sort )
@@ -457,342 +448,6 @@ indexedModuleWithDefaultImports name defaultImport =
                 Nothing ->
                     []
         }
-
-
-{-|'indexModuleIfNeeded' transforms a 'Module' into an 'IndexedModule', unless
-the module is already in the 'IndexedModule' map.
--}
-indexModuleIfNeeded
-    ::  ( MonadError (Error e) error
-        , ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -- ^ Module containing the implicit Kore definitions
-    -> Map.Map ModuleName (Module sentence)
-    -- ^ Map containing all defined modules, used for resolving imports.
-    -> Map.Map ModuleName indexed
-    -- ^ Map containing all modules that were already indexed.
-    -> Module sentence
-    -- ^ Module to be indexed
-    -> error (Map.Map ModuleName indexed)
-    -- ^ If the module was indexed succesfully, the map returned on 'Right'
-    -- contains everything that the provided 'IndexedModule' map contained,
-    -- plus the current module, plus all the modules that were indexed when
-    -- resolving imports.
-indexModuleIfNeeded implicitModule nameToModule indexedModules koreModule =
-    fst <$>
-        internalIndexModuleIfNeeded
-            implicitModule Set.empty nameToModule indexedModules koreModule
-
-internalIndexModuleIfNeeded
-    ::  ( MonadError (Error e) error
-        , ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> Map.Map ModuleName indexed
-    -> Module sentence
-    -> error (Map.Map ModuleName indexed, indexed)
-internalIndexModuleIfNeeded
-    implicitModule importingModules nameToModule indexedModules koreModule
-  =
-    withContext
-        ("module '" ++ getModuleNameForError koreModuleName ++ "'")
-        (do
-            koreFailWhen
-                (koreModuleName `Set.member` importingModules)
-                "Circular module import dependency."
-            case Map.lookup koreModuleName indexedModules of
-                Just indexedModule -> return (indexedModules, indexedModule)
-                Nothing -> do
-                    parsedModuleAtts <- parseAttributes moduleAtts
-                    let
-                        indexedModulesAndStartingIndexedModule =
-                            ( indexedModules
-                            , (indexedModuleWithDefaultImports
-                                    (moduleName koreModule) implicitModule)
-                                { indexedModuleAttributes =
-                                    (parsedModuleAtts, moduleAtts)
-                                }
-                            )
-                    (newIndex, newModule) <-
-                        foldM
-                            (indexModuleSentence
-                                implicitModule
-                                importingModulesWithCurrentOne
-                                nameToModule
-                            )
-                            indexedModulesAndStartingIndexedModule
-                            (List.sort $ moduleSentences koreModule)
-                    -- Parse subsorts to fail now if subsort attributes are
-                    -- malformed, so indexedModuleSubsorts can appear total
-                    -- TODO: consider making subsorts an IndexedModule field
-                    _ <- internalIndexedModuleSubsorts newModule
-                    return
-                        ( Map.insert koreModuleName newModule newIndex
-                        , newModule
-                        )
-        )
-  where
-    moduleAtts = moduleAttributes koreModule
-    koreModuleName = moduleName koreModule
-    importingModulesWithCurrentOne = Set.insert koreModuleName importingModules
-
-indexModuleSentence
-    ::  ( MonadError (Error e) error
-        , ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> (Map.Map ModuleName indexed, indexed)
-    -> Sentence patternType
-    -> error (Map.Map ModuleName indexed, indexed)
-indexModuleSentence
-    implicitModule
-    importingModules
-    nameToModule
-    ( indexedModules
-    , indexedModule@IndexedModule
-        { indexedModuleAliasSentences
-        , indexedModuleSymbolSentences
-        , indexedModuleAxioms
-        , indexedModuleClaims
-        , indexedModuleImports
-        , indexedModuleSortDescriptions
-        , indexedModuleHookedIdentifiers
-        , indexedModuleHooks
-        }
-    )
-    sentence
-  =
-    withSentenceContext sentence indexModuleMetaSentence0
-  where
-    indexModuleMetaSentence0 =
-        case sentence of
-            SentenceAliasSentence s  -> indexSentenceAlias s
-            SentenceSymbolSentence s -> indexSentenceSymbol s
-            SentenceAxiomSentence s  -> indexSentenceAxiom s
-            SentenceClaimSentence s  -> indexSentenceClaim s
-            SentenceImportSentence s -> indexSentenceImport s
-            SentenceSortSentence s   -> indexSentenceSort s
-            SentenceHookSentence s   -> indexSentenceHook s
-
-    indexSentenceAlias
-        _sentence@SentenceAlias
-            { sentenceAliasAlias = Alias { aliasConstructor }
-            , sentenceAliasAttributes
-            }
-      = do
-        atts <- parseAttributes sentenceAliasAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleAliasSentences =
-                    Map.insert aliasConstructor (atts, _sentence)
-                        indexedModuleAliasSentences
-                }
-            )
-
-    indexSentenceSymbol
-        _sentence@SentenceSymbol
-            { sentenceSymbolSymbol = Symbol { symbolConstructor }
-            , sentenceSymbolAttributes
-            }
-      = do
-        atts <- parseAttributes sentenceSymbolAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSymbolSentences =
-                    Map.insert
-                        symbolConstructor
-                        (atts, _sentence)
-                        indexedModuleSymbolSentences
-                }
-            )
-
-    indexSentenceAxiom
-        _sentence@SentenceAxiom { sentenceAxiomAttributes }
-      = do
-        atts <- parseAttributes sentenceAxiomAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleAxioms =
-                    (atts, _sentence) : indexedModuleAxioms
-                }
-            )
-
-    indexSentenceClaim
-        _sentence@(SentenceClaim SentenceAxiom { sentenceAxiomAttributes })
-      = do
-        atts <- parseAttributes sentenceAxiomAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleClaims =
-                    (atts, _sentence) : indexedModuleClaims
-                }
-            )
-
-    indexSentenceImport
-        SentenceImport
-            { sentenceImportModuleName = importedModuleName
-            , sentenceImportAttributes = attributes
-            }
-      = do
-        (newIndexedModules, importedModule) <-
-            indexImportedModule
-                implicitModule
-                importingModules
-                nameToModule
-                indexedModules
-                importedModuleName
-        atts <- parseAttributes attributes
-        return
-            ( newIndexedModules
-            , indexedModule
-                { indexedModuleImports =
-                    (:) (atts, attributes, importedModule)
-                        indexedModuleImports
-                }
-            )
-
-    indexSentenceSort
-        _sentence@SentenceSort
-            { sentenceSortAttributes
-            , sentenceSortName
-            }
-      = do
-        atts <- parseAttributes sentenceSortAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSortDescriptions =
-                    Map.insert sentenceSortName (atts, _sentence)
-                        indexedModuleSortDescriptions
-                }
-            )
-
-    indexSentenceHook
-        (SentenceHookedSort _sentence@SentenceSort
-            { sentenceSortName
-            , sentenceSortAttributes
-            }
-        )
-      = do
-        (indexedModules', indexedModule') <-
-            indexModuleSentence
-                implicitModule
-                importingModules
-                nameToModule
-                (indexedModules, indexedModule)
-                (SentenceSortSentence _sentence)
-        hook <- getHookAttribute sentenceSortAttributes
-        return
-            ( indexedModules'
-            , indexedModule'
-                { indexedModuleHookedIdentifiers =
-                    Set.insert sentenceSortName indexedModuleHookedIdentifiers
-                , indexedModuleHooks =
-                    Map.alter
-                        (Just . maybe [sentenceSortName] (sentenceSortName :))
-                        hook
-                        indexedModuleHooks
-                }
-            )
-
-    indexSentenceHook
-        (SentenceHookedSymbol _sentence@SentenceSymbol
-            { sentenceSymbolAttributes
-            , sentenceSymbolSymbol = Symbol { symbolConstructor }
-            }
-        )
-      = do
-        atts <- parseAttributes sentenceSymbolAttributes
-        hook <- getHookAttribute sentenceSymbolAttributes
-        return
-            ( indexedModules
-            , indexedModule
-                { indexedModuleSymbolSentences =
-                    Map.insert symbolConstructor (atts, _sentence)
-                        indexedModuleSymbolSentences
-                , indexedModuleHookedIdentifiers =
-                    Set.insert symbolConstructor indexedModuleHookedIdentifiers
-                , indexedModuleHooks =
-                    Map.alter
-                        (Just . maybe [symbolConstructor] (symbolConstructor :))
-                        hook
-                        indexedModuleHooks
-                }
-            )
-
-indexImportedModule
-    ::  ( MonadError (Error e) error
-        , ParseAttributes declAttrs
-        , ParseAttributes axiomAttrs
-        , Ord sentence
-        , sentence ~ Sentence patternType
-        , indexed ~ IndexedModule patternType declAttrs axiomAttrs
-        )
-    => Maybe (ImplicitIndexedModule patternType declAttrs axiomAttrs)
-    -> Set.Set ModuleName
-    -> Map.Map ModuleName (Module sentence)
-    -> Map.Map ModuleName indexed
-    -> ModuleName
-    -> error (Map.Map ModuleName indexed, indexed)
-indexImportedModule
-    implicitModule
-    importingModules
-    nameToModule
-    indexedModules
-    importedModuleName
-  =
-    case Map.lookup importedModuleName indexedModules of
-        Just indexedModule -> return (indexedModules, indexedModule)
-        Nothing -> do
-            koreModule <-
-                case Map.lookup importedModuleName nameToModule of
-                    Nothing ->
-                        koreFail
-                            (  "Module '"
-                            ++ getModuleNameForError importedModuleName
-                            ++ "' imported but not found."
-                            )
-                    Just m -> return m
-            internalIndexModuleIfNeeded
-                implicitModule
-                importingModules
-                nameToModule
-                indexedModules
-                koreModule
-
-{- | Parse attributes in the context of indexing a module.
-
-'AttributeParserError's are cast to 'IndexModuleError'.
-
-See also: 'parseAttributes'
--}
-parseAttributes
-    :: MonadError (Error e) error
-    => ParseAttributes a
-    => Attributes
-    -> error a
-parseAttributes = Attribute.Parser.liftParser . Attribute.Parser.parseAttributes
 
 {- | Retrieve those object-level symbol sentences that are hooked.
 

--- a/kore/src/Kore/IndexedModule/Resolvers.hs
+++ b/kore/src/Kore/IndexedModule/Resolvers.hs
@@ -266,11 +266,12 @@ resolveHooks indexedModule builtinName =
 
  -}
 findIndexedSort
-    :: IndexedModule patternType declAtts axiomAtts
+    :: MonadError (Error e) error
+    => IndexedModule patternType declAtts axiomAtts
     -- ^ indexed module
     -> Id
     -- ^ sort identifier
-    -> Either (Error e) (SentenceSort patternType)
+    -> error (SentenceSort patternType)
 findIndexedSort indexedModule sort =
     fmap getIndexedSentence (resolveSort indexedModule sort)
 

--- a/kore/src/Kore/Syntax/Sentence.hs
+++ b/kore/src/Kore/Syntax/Sentence.hs
@@ -17,9 +17,18 @@ module Kore.Syntax.Sentence
     , coerceSentenceSort
     , SentenceAxiom (..)
     , SentenceClaim (..)
+    , sentenceClaimAttributes
     , SentenceHook (..)
     , coerceSentenceHook
     , Sentence (..)
+    , projectSentenceImport
+    , projectSentenceSort
+    , projectSentenceSymbol
+    , projectSentenceHookedSort
+    , projectSentenceHookedSymbol
+    , projectSentenceAlias
+    , projectSentenceAxiom
+    , projectSentenceClaim
     , sentenceAttributes
     , eraseSentenceAnnotations
     -- * Injections and projections
@@ -48,7 +57,10 @@ module Kore.Syntax.Sentence
 
 import           Control.DeepSeq
                  ( NFData (..) )
+import qualified Control.Monad as Monad
 import           Data.Coerce
+import           Data.Generics.Sum.Typed
+                 ( projectTyped )
 import           Data.Hashable
                  ( Hashable (..) )
 import qualified Data.Text.Prettyprint.Doc as Pretty
@@ -478,6 +490,9 @@ newtype SentenceClaim (patternType :: *) =
     SentenceClaim { getSentenceClaim :: SentenceAxiom patternType }
     deriving (Eq, Foldable, Functor, GHC.Generic, Ord, Show, Traversable)
 
+sentenceClaimAttributes :: SentenceClaim patternType -> Attributes
+sentenceClaimAttributes = sentenceAxiomAttributes . getSentenceClaim
+
 instance Hashable patternType => Hashable (SentenceClaim patternType)
 
 instance NFData patternType => NFData (SentenceClaim patternType)
@@ -560,6 +575,51 @@ instance Debug patternType => Debug (Sentence patternType)
 instance Unparse patternType => Unparse (Sentence patternType) where
      unparse = unparseGeneric
      unparse2 = unparse2Generic
+
+projectSentenceImport
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceImport ParsedPattern)
+projectSentenceImport = projectTyped
+
+projectSentenceSort
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceSort ParsedPattern)
+projectSentenceSort = projectTyped
+
+projectSentenceSymbol
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceSymbol ParsedPattern)
+projectSentenceSymbol = projectTyped
+
+projectSentenceHook
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceHook ParsedPattern)
+projectSentenceHook = projectTyped
+
+projectSentenceHookedSort
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceSort ParsedPattern)
+projectSentenceHookedSort = projectSentenceHook Monad.>=> projectTyped
+
+projectSentenceHookedSymbol
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceSymbol ParsedPattern)
+projectSentenceHookedSymbol = projectSentenceHook Monad.>=> projectTyped
+
+projectSentenceAlias
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceAlias ParsedPattern)
+projectSentenceAlias = projectTyped
+
+projectSentenceAxiom
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceAxiom ParsedPattern)
+projectSentenceAxiom = projectTyped
+
+projectSentenceClaim
+    :: Sentence ParsedPattern
+    -> Maybe (SentenceClaim ParsedPattern)
+projectSentenceClaim = projectTyped
 
 {- | The attributes associated with a sentence.
 

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -11,7 +11,7 @@ import Data.Text
 
 import           Kore.ASTVerifier.DefinitionVerifier
 import           Kore.ASTVerifier.Error
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Debug
@@ -129,7 +129,7 @@ expectFailureWithError description expectedError unverifiedDefinition =
         )
 
 attributesVerificationForTests
-    :: AttributesVerification Attribute.Symbol Attribute.Null
+    :: AttributesVerification Attribute.Symbol Attribute.Axiom
 attributesVerificationForTests = defaultAttributesVerification Proxy Proxy
 
 printDefinition :: ParsedDefinition -> String

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/SortUsage.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/SortUsage.hs
@@ -13,7 +13,6 @@ import           Data.Maybe
 import qualified Data.Text as Text
 
 import           Kore.ASTVerifier.Error
-                 ( noConstructorWithDomainValuesMessage )
 import qualified Kore.Attribute.Constructor as Attribute.Constructor
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
 import qualified Kore.Builtin as Builtin
@@ -80,7 +79,7 @@ test_sortUsage =
                 [ "module 'MODULE'"
                 , "symbol 'a' declaration (<test data>)"
                 ]
-            , errorError   = noConstructorWithDomainValuesMessage
+            , errorError   = noConstructorWithDomainValues
                 (testId "a")
                 (simpleSort (SortName "mySort"))
             }

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -1140,7 +1140,7 @@ pairSymbolDecl =
                     , symbolParams = [leftSortVariable, rightSortVariable]
                     }
             , sentenceSymbolSorts = [leftSort, rightSort]
-            , sentenceSymbolResultSort = rightSort
+            , sentenceSymbolResultSort = pairSort leftSort rightSort
             , sentenceSymbolAttributes =
                 Attributes
                     [ constructorAttribute

--- a/kore/test/Test/Kore/IndexedModule/Resolvers.hs
+++ b/kore/test/Test/Kore/IndexedModule/Resolvers.hs
@@ -11,7 +11,7 @@ import qualified Data.Map as Map
 import qualified Data.Ord
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
@@ -150,7 +150,7 @@ testDefinition =
             ]
         }
 
-indexedModules :: Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Null)
+indexedModules :: Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom)
 Right indexedModules =
     verifyAndIndexDefinition
         DoNotVerifyAttributes
@@ -158,7 +158,7 @@ Right indexedModules =
         testDefinition
 
 testIndexedModule, testIndexedObjectModule
-    :: VerifiedModule Attribute.Symbol Attribute.Null
+    :: VerifiedModule Attribute.Symbol Attribute.Axiom
 Just testIndexedModule = Map.lookup testMainModuleName indexedModules
 Just testIndexedObjectModule = Map.lookup testObjectModuleName indexedModules
 

--- a/kore/test/Test/Kore/Parser/Regression.hs
+++ b/kore/test/Test/Kore/Parser/Regression.hs
@@ -27,7 +27,7 @@ import           System.FilePath
                  ( addExtension, splitFileName, (</>) )
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import           Kore.Error
@@ -83,7 +83,7 @@ verify definition =
     verifyDefinition attrVerify Builtin.koreVerifiers definition
     & bimap printError (const definition)
   where
-    attrVerify :: AttributesVerification Attribute.Symbol Attribute.Null
+    attrVerify :: AttributesVerification Attribute.Symbol Attribute.Axiom
     attrVerify = defaultAttributesVerification Proxy Proxy
 
 runParser :: String -> VerifyRequest -> IO ByteString

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -18,7 +18,7 @@ import           Data.Text
 import qualified Data.Text as Text
 
 import           Kore.ASTVerifier.DefinitionVerifier
-import qualified Kore.Attribute.Null as Attribute
+import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Pattern as Attribute
 import           Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Attribute.Symbol as Attribute
@@ -330,8 +330,8 @@ extractIndexedModule
     :: Text
     -> Either
         (Error a)
-        (Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Null))
-    -> VerifiedModule Attribute.Symbol Attribute.Null
+        (Map.Map ModuleName (VerifiedModule Attribute.Symbol Attribute.Axiom))
+    -> VerifiedModule Attribute.Symbol Attribute.Axiom
 extractIndexedModule name eModules =
     case eModules of
         Left err -> error (printError err)

--- a/src/test/resources/test-hooks-ctor.kore.golden
+++ b/src/test/resources/test-hooks-ctor.kore.golden
@@ -1,1 +1,1 @@
-Error in module 'TEST-HOOKS-CTOR' -> symbol 'sym' declaration (../src/test/resources//test-hooks-ctor.kore 8:10): Cannot define constructor 'sym' for hooked sort 'S'.
+Error in module 'TEST-HOOKS-CTOR' -> symbol 'sym' declaration (../src/test/resources//test-hooks-ctor.kore 8:10): Cannot define constructor 'sym' for hooked sort 'S{}'.


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

@ana-pantilie 
I fixed the problems with #916, but it looks like you had pushed some changes, and I can't tell anymore which changes are mine or yours, so I'm opening a new pull request; otherwise I'm afraid I might overwrite something you did. The tests pass and you can use a `VerifiedModule` in the pattern verifier now, which should unblock you on #873. I haven't tracked down all the dead code in `Kore.IndexedModule.IndexedModule` yet, but I can do that in another pull request, if you want to review this one.
