### PR TITLE
Makefile: Fix indentation of .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include include.mk
 
 .PHONY: all clean docs haddock jenkins k-frontend \
         test test-kore test-k \
-				kore-exec kore-repl
+        kore-exec kore-repl
 
 kore: kore-exec kore-repl
 


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

Fix some funny indentation introduced in #909.