### PR TITLE
Child and top-level predicates

### DIFF
--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -32,6 +32,7 @@ import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Predicate
     ( Predicate
     )
+import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike
 import qualified Kore.Proof.Value as Value
@@ -71,14 +72,14 @@ definitionEvaluation
     :: [EqualityRule Variable]
     -> BuiltinAndAxiomSimplifier
 definitionEvaluation rules =
-    BuiltinAndAxiomSimplifier (\_ _ _ term _ -> evaluateAxioms rules term)
+    BuiltinAndAxiomSimplifier (\_ _ _ term predicate -> evaluateAxioms rules term (Predicate.toPredicate predicate))
 
 -- | Create an evaluator from a single simplification rule.
 simplificationEvaluation
     :: EqualityRule Variable
     -> BuiltinAndAxiomSimplifier
 simplificationEvaluation rule =
-    BuiltinAndAxiomSimplifier (\_ _ _ term _ -> evaluateAxioms [rule] term)
+    BuiltinAndAxiomSimplifier (\_ _ _ term predicate -> evaluateAxioms [rule] term (Predicate.toPredicate predicate))
 
 {- | Creates an evaluator for a function from all the rules that define it.
 
@@ -104,8 +105,8 @@ totalDefinitionEvaluation rules =
         -> TermLike variable
         -> Predicate variable
         -> simplifier (AttemptedAxiom variable)
-    totalDefinitionEvaluationWorker _ _ _ term _ = do
-        result <- evaluateAxioms rules term
+    totalDefinitionEvaluationWorker _ _ _ term predicate = do
+        result <- evaluateAxioms rules term (Predicate.toPredicate predicate)
         if AttemptedAxiom.hasRemainders result
             then return AttemptedAxiom.NotApplicable
             else return result

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -72,14 +72,20 @@ definitionEvaluation
     :: [EqualityRule Variable]
     -> BuiltinAndAxiomSimplifier
 definitionEvaluation rules =
-    BuiltinAndAxiomSimplifier (\_ _ _ term predicate -> evaluateAxioms rules term (Predicate.toPredicate predicate))
+    BuiltinAndAxiomSimplifier
+        (\_ _ _ term predicate ->
+            evaluateAxioms rules term (Predicate.toPredicate predicate)
+        )
 
 -- | Create an evaluator from a single simplification rule.
 simplificationEvaluation
     :: EqualityRule Variable
     -> BuiltinAndAxiomSimplifier
 simplificationEvaluation rule =
-    BuiltinAndAxiomSimplifier (\_ _ _ term predicate -> evaluateAxioms [rule] term (Predicate.toPredicate predicate))
+    BuiltinAndAxiomSimplifier
+        (\_ _ _ term predicate ->
+            evaluateAxioms [rule] term (Predicate.toPredicate predicate)
+        )
 
 {- | Creates an evaluator for a function from all the rules that define it.
 

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -89,7 +89,7 @@ instance
     )
     => Evaluable (Syntax.Predicate variable)
   where
-    evaluate predicate = do
+    evaluate predicate =
         case predicate of
             Syntax.Predicate.PredicateTrue -> return (Just True)
             Syntax.Predicate.PredicateFalse -> return (Just False)

--- a/kore/src/Kore/Step/Simplification/Conditional.hs
+++ b/kore/src/Kore/Step/Simplification/Conditional.hs
@@ -1,0 +1,51 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+module Kore.Step.Simplification.Conditional
+    ( simplifyPredicate
+    ) where
+
+import qualified Control.Monad.Trans.Class as Monad.Trans
+
+import Branch
+import Kore.Internal.Pattern
+    ( Conditional (..)
+    )
+import qualified Kore.Internal.Pattern as Pattern
+import Kore.Logger
+    ( LogMessage
+    , WithLog
+    )
+import qualified Kore.Step.Condition.Evaluator as Predicate
+    ( simplify
+    )
+import Kore.Step.Simplification.Simplify
+    ( MonadSimplify
+    , SimplifierVariable
+    )
+import Kore.Step.Substitution
+    ( mergePredicatesAndSubstitutions
+    )
+
+{-| Simplifies the predicate inside a 'Conditional'.
+-}
+simplifyPredicate
+    ::  ( SimplifierVariable variable
+        , MonadSimplify simplifier
+        , WithLog LogMessage simplifier
+        )
+    => Conditional variable term
+    -- ^ Contains the condition to be evaluated.
+    -> BranchT simplifier (Conditional variable term)
+simplifyPredicate Conditional {term, predicate, substitution} = do
+    evaluated <- Monad.Trans.lift $ Predicate.simplify predicate
+    let Conditional { predicate = evaluatedPredicate } = evaluated
+        Conditional { substitution = evaluatedSubstitution } = evaluated
+    merged <-
+        mergePredicatesAndSubstitutions
+            [evaluatedPredicate]
+            [substitution, evaluatedSubstitution]
+    -- TODO(virgil): Do I need to re-evaluate the predicate?
+    return $ Pattern.withCondition term merged

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -8,11 +8,26 @@ module Kore.Step.Simplification.OrPattern
     ) where
 
 import qualified Branch as BranchT
+import Kore.Internal.Conditional
+    ( Conditional (Conditional)
+    )
+import qualified Kore.Internal.Conditional as Conditional
+    ( Conditional (..)
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrPattern
     ( OrPattern
     )
-import qualified Kore.Step.Simplification.Pattern as Pattern
+import Kore.Internal.Pattern
+    ( Pattern
+    )
+import Kore.Predicate.Predicate
+    ( makeAndPredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+    ( Predicate
+    )
+import qualified Kore.Step.Simplification.Conditional as Conditional
     ( simplifyPredicate
     )
 import Kore.Step.Simplification.Simplify
@@ -24,10 +39,27 @@ import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
     )
 
 simplifyPredicatesWithSmt
-    :: (MonadSimplify simplifier, SimplifierVariable variable)
-    => OrPattern variable -> simplifier (OrPattern variable)
-simplifyPredicatesWithSmt unsimplified = do
+    ::  forall variable simplifier
+    .   (MonadSimplify simplifier, SimplifierVariable variable)
+    => Syntax.Predicate variable
+    -> OrPattern variable
+    -> simplifier (OrPattern variable)
+simplifyPredicatesWithSmt predicate' unsimplified = do
     simplifiedOrs <- traverse
-        (BranchT.gather . Pattern.simplifyPredicate)
+        (BranchT.gather . Conditional.simplifyPredicate)
         (MultiOr.extractPatterns unsimplified)
-    SMT.Evaluator.filterMultiOr (MultiOr.make (concat simplifiedOrs))
+    let newOrs :: [Conditional variable (Pattern variable)]
+        newOrs = addPredicate . conditionalAsTerm <$> concat simplifiedOrs
+    newSimplifiedOrs <- traverse
+        (BranchT.gather . Conditional.simplifyPredicate)
+        newOrs
+    filteredOrs <-
+        SMT.Evaluator.filterMultiOr
+            (MultiOr.make (concat newSimplifiedOrs))
+    return (Conditional.term <$> filteredOrs)
+  where
+    conditionalAsTerm :: Pattern variable -> Conditional variable (Pattern variable)
+    conditionalAsTerm c = c {Conditional.term = c}
+
+    addPredicate :: Conditional variable term -> Conditional variable term
+    addPredicate c@Conditional {predicate} = c {Conditional.predicate = makeAndPredicate predicate predicate'}

--- a/kore/src/Kore/Step/Simplification/Predicate.hs
+++ b/kore/src/Kore/Step/Simplification/Predicate.hs
@@ -11,6 +11,7 @@ module Kore.Step.Simplification.Predicate
     ( create
     , simplify
     , simplifyPartial
+    , simplifyPredicate
     ) where
 
 import qualified Control.Monad.Trans as Monad.Trans

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -9,6 +9,7 @@ module Kore.Step.Simplification.Simplify
     , MonadSimplify (..)
     , simplifyTerm
     , simplifyConditionalTerm
+    , simplifyConditionalTermToOr
     , TermSimplifier
     -- * Predicate simplifiers
     , PredicateSimplifier (..)
@@ -246,11 +247,21 @@ simplifyTerm
         )
     => TermLike variable
     -> simplifier (OrPattern variable)
-simplifyTerm termLike = do
-    TermLikeSimplifier simplify <- askSimplifierTermLike
-    results <- gather $ simplify Predicate.top termLike
-    return (OrPattern.fromPatterns results)
+simplifyTerm = simplifyConditionalTermToOr Predicate.top
 
+{- | Use a 'TermLikeSimplifier' to simplify a pattern subject to conditions.
+ -}
+simplifyConditionalTermToOr
+    :: forall variable simplifier
+    .   ( SimplifierVariable variable
+        , MonadSimplify simplifier
+        )
+    => Predicate variable
+    -> TermLike variable
+    -> simplifier (OrPattern variable)
+simplifyConditionalTermToOr predicate termLike = do
+    results <- gather $ simplifyConditionalTerm predicate termLike
+    return (OrPattern.fromPatterns results)
 
 {- | Use a 'TermLikeSimplifier' to simplify a pattern subject to conditions.
  -}

--- a/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
@@ -1,0 +1,131 @@
+module Test.Kore.Step.Simplification.OrPattern where
+
+import Test.Tasty
+    ( TestTree
+    )
+import Test.Tasty.HUnit
+    ( testCase
+    )
+
+import Kore.Internal.Conditional
+    ( Conditional (Conditional)
+    )
+import qualified Kore.Internal.Conditional as Conditional.DoNotUse
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+    ( fromPatterns
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+    ( bottom
+    , top
+    )
+import Kore.Internal.TermLike
+    ( TermLike
+    , mkElemVar
+    )
+import Kore.Predicate.Predicate
+    ( makeAndPredicate
+    , makeEqualsPredicate
+    , makeTruePredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+    ( Predicate
+    )
+import Kore.Step.Simplification.OrPattern
+import Kore.Syntax.Variable
+    ( Variable
+    )
+
+import Test.Kore.Comparators ()
+import qualified Test.Kore.Step.MockSymbols as Mock
+import qualified Test.Kore.Step.Simplification as Test
+import Test.Tasty.HUnit.Extensions
+
+test_orPatternSimplification :: [TestTree]
+test_orPatternSimplification =
+    [ testCase "Identity for top" $ do
+        actual <- runSimplifyPredicates makeTruePredicate OrPattern.top
+        assertEqualWithExplanation "" OrPattern.top actual
+    , testCase "Identity for bottom" $ do
+        actual <- runSimplifyPredicates makeTruePredicate OrPattern.bottom
+        assertEqualWithExplanation "" OrPattern.bottom actual
+    , testCase "Filters with SMT" $ do
+        let expected = OrPattern.fromPatterns
+                [ Conditional
+                    { term = Mock.a
+                    , predicate = positive x
+                    , substitution = mempty
+                    }
+                ]
+        actual <- runSimplifyPredicates
+            makeTruePredicate
+            ( OrPattern.fromPatterns
+                [ Conditional
+                    { term = Mock.a
+                    , predicate = positive x
+                    , substitution = mempty
+                    }
+                , Conditional
+                    { term = Mock.b
+                    , predicate = makeAndPredicate (positive x) (negative x)
+                    , substitution = mempty
+                    }
+                ]
+            )
+        assertEqualWithExplanation "" expected actual
+    , testCase "Filters with SMT and additional predicate" $ do
+        let expected = OrPattern.fromPatterns
+                [ Conditional
+                    { term = Mock.a
+                    , predicate = makeTruePredicate
+                    , substitution = mempty
+                    }
+                ]
+        actual <- runSimplifyPredicates
+            (positive x)
+            ( OrPattern.fromPatterns
+                [ Conditional
+                    { term = Mock.a
+                    , predicate = makeTruePredicate
+                    , substitution = mempty
+                    }
+                , Conditional
+                    { term = Mock.b
+                    , predicate = negative x
+                    , substitution = mempty
+                    }
+                ]
+            )
+        assertEqualWithExplanation "" expected actual
+    ]
+  where
+    x :: TermLike Variable
+    x = mkElemVar Mock.x
+
+positive :: TermLike Variable -> Syntax.Predicate Variable
+positive u =
+    makeEqualsPredicate
+        (Mock.lessInt
+            (Mock.fTestInt u)  -- wrap the given term for sort agreement
+            (Mock.builtinInt 0)
+        )
+        (Mock.builtinBool False)
+
+negative :: TermLike Variable -> Syntax.Predicate Variable
+negative u =
+    makeEqualsPredicate
+        (Mock.greaterEqInt
+            (Mock.fTestInt u)  -- wrap the given term for sort agreement
+            (Mock.builtinInt 0)
+        )
+        (Mock.builtinBool False)
+
+runSimplifyPredicates
+    :: Syntax.Predicate Variable
+    -> OrPattern Variable
+    -> IO (OrPattern Variable)
+runSimplifyPredicates predicate orPattern =
+    Test.runSimplifier Mock.env
+    $ simplifyPredicatesWithSmt predicate orPattern


### PR DESCRIPTION
@traiansf  said that child predicates (without the top-level predicate) reduce the SDIV time from >20 min (timeout) to ~9 min

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

