### PR TITLE
Fix instance Hashable Id

### DIFF
--- a/kore/src/Kore/Syntax/Id.hs
+++ b/kore/src/Kore/Syntax/Id.hs
@@ -21,7 +21,6 @@ module Kore.Syntax.Id
 import           Control.DeepSeq
                  ( NFData )
 import           Data.Hashable
-                 ( Hashable )
 import           Data.String
                  ( IsString (..) )
 import           Data.Text
@@ -54,8 +53,12 @@ instance Ord Id where
 -- | 'Eq' ignores the 'AstLocation'
 instance Eq Id where
     first == second = compare first second == EQ
+    {-# INLINE (==) #-}
 
-instance Hashable Id
+-- | 'Hashable' ignores the 'AstLocation'
+instance Hashable Id where
+    hashWithSalt salt (Id text _) = hashWithSalt salt text
+    {-# INLINE hashWithSalt #-}
 
 instance NFData Id
 

--- a/kore/test/Test/Kore/Syntax/Id.hs
+++ b/kore/test/Test/Kore/Syntax/Id.hs
@@ -1,0 +1,21 @@
+module Test.Kore.Syntax.Id
+    ( test_Id
+    ) where
+
+import Test.Tasty
+
+import Data.Function
+import Data.Hashable
+
+import Kore.Syntax.Id
+
+import Test.Kore
+       ( testId )
+import Test.Kore.Comparators ()
+import Test.Terse
+
+test_Id :: [TestTree]
+test_Id =
+    [ equals (testId "x") (noLocationId "x") "Eq"
+    , on equals hash (testId "x") (noLocationId "x") "Hashable"
+    ]


### PR DESCRIPTION
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

The `Hashable` instance of `Id` accidentally included the `AstLocation`.