### PR TITLE
Jenkinsfile: Extend the KEVM Integration timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 
         stage('KEVM Integration') {
           options {
-            timeout(time: 16, unit: 'MINUTES')
+            timeout(time: 48, unit: 'MINUTES')
           }
           steps {
             sh '''


### PR DESCRIPTION
The timeout served its purpose: we immediately observed the slow-down due to
recent changes in the KEVM semantics. Now we will temporarily increase the
timeout so that other work is not blocked while we work on this.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

