### PR TITLE
Prototype: Function memoization

### DIFF
--- a/kore/src/Data/Map/Dynamic.hs
+++ b/kore/src/Data/Map/Dynamic.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Data.Map.Dynamic
+    ( DynamicMap
+    -- * Construction
+    , empty
+    , singleton
+    -- * Basic interface
+    , null
+    , size
+    , member
+    , lookup
+    , insert
+    , delete
+    ) where
+
+import           Data.Dynamic
+import           Data.Function
+import           Data.Hashable
+import           Data.HashMap.Strict
+                 ( HashMap )
+import qualified Data.HashMap.Strict as HashMap
+import           Data.Maybe
+import           Data.Proxy
+import           Prelude hiding
+                 ( lookup, null )
+import           Type.Reflection
+
+{- | Dynamic keys.
+ -}
+data Key where
+    Key
+        ::  forall key value
+        .   (Eq key, Hashable key)
+        => !(TypeRep key)
+        -> !(TypeRep value)
+        -> !key
+        -> Key
+
+instance Eq Key where
+    (==) (Key repKey1 repValue1 key1) (Key repKey2 repValue2 key2) =
+        do
+            HRefl <- eqTypeRep repKey1   repKey2
+            HRefl <- eqTypeRep repValue1 repValue2
+            return (key1 == key2)
+        & fromMaybe False
+
+instance Hashable Key where
+    hashWithSalt salt (Key repKey repValue key) =
+        salt `hashWithSalt` repKey `hashWithSalt` repValue `hashWithSalt` key
+
+newtype DynamicMap = DynamicMap { getDynamicMap :: HashMap Key Dynamic }
+
+empty :: DynamicMap
+empty = DynamicMap HashMap.empty
+
+singleton
+    :: forall key value
+    .  (Eq key, Hashable key, Typeable key, Typeable value)
+    => key -> value -> DynamicMap
+singleton key value =
+    DynamicMap (HashMap.singleton (Key repKey repValue key) (toDyn value))
+  where
+    repKey = typeRep @key
+    repValue = typeRep @value
+
+null :: DynamicMap -> Bool
+null = HashMap.null . getDynamicMap
+
+size :: DynamicMap -> Int
+size = HashMap.size . getDynamicMap
+
+member
+    :: forall key value
+    .  (Eq key, Hashable key, Typeable key, Typeable value)
+    => key -> Proxy value -> DynamicMap -> Bool
+member key Proxy =
+    HashMap.member (Key repKey repValue key) . getDynamicMap
+  where
+    repKey = typeRep @key
+    repValue = typeRep @value
+
+lookup
+    :: forall key value
+    .  (Eq key, Hashable key, Typeable key, Typeable value)
+    => key -> DynamicMap -> Maybe value
+lookup key dynamicMap = do
+    unwrapValue <$> HashMap.lookup key' (getDynamicMap dynamicMap)
+  where
+    key' = Key (typeRep @key) (typeRep @value) key
+    -- Unwrap a Dynamic value; throws an error if the wrapped value
+    -- has the wrong type. The type is assured by 'insert'.
+    unwrapValue = fromJust . fromDynamic
+
+insert
+    :: forall key value
+    .  (Eq key, Hashable key, Typeable key, Typeable value)
+    => key -> value -> DynamicMap -> DynamicMap
+insert key value =
+    DynamicMap . HashMap.insert key' (toDyn value) . getDynamicMap
+  where
+    key' = Key (typeRep @key) (typeRep @value) key
+
+delete
+    :: forall key value
+    .  (Eq key, Hashable key, Typeable key, Typeable value)
+    => key -> Proxy value -> DynamicMap -> DynamicMap
+delete key Proxy =
+    DynamicMap . HashMap.delete key' . getDynamicMap
+  where
+    key' = Key (typeRep @key) (typeRep @value) key

--- a/kore/src/Kore/Attribute/Symbol.hs
+++ b/kore/src/Kore/Attribute/Symbol.hs
@@ -40,6 +40,9 @@ module Kore.Attribute.Symbol
     , smthookAttribute
     , Smtlib (..)
     , smtlibAttribute
+    -- * Memoized functions
+    , Memo (..)
+    , memoAttribute
     -- * Derived attributes
     , isNonSimplifiable
     , isFunctional
@@ -69,6 +72,7 @@ import Kore.Attribute.Smthook
 import Kore.Attribute.Smtlib
 import Kore.Attribute.SortInjection
 import Kore.Attribute.Symbol.Anywhere
+import Kore.Attribute.Symbol.Memo
 import Kore.Debug
 
 {- | Symbol attributes used during Kore execution.
@@ -96,6 +100,7 @@ data Symbol =
       -- ^ The builtin sort or symbol hooked to a sort or symbol
     , smtlib        :: !Smtlib
     , smthook       :: !Smthook
+    , memo          :: !Memo
     }
     deriving (Eq, Ord, GHC.Generic, Show)
 
@@ -118,6 +123,7 @@ instance ParseAttributes Symbol where
         >=> typed @Hook (parseAttribute attr)
         >=> typed @Smtlib (parseAttribute attr)
         >=> typed @Smthook (parseAttribute attr)
+        >=> typed @Memo (parseAttribute attr)
 
     toAttributes =
         mconcat . sequence
@@ -130,6 +136,7 @@ instance ParseAttributes Symbol where
             , toAttributes . hook
             , toAttributes . smtlib
             , toAttributes . smthook
+            , toAttributes . memo
             ]
 
 type StepperAttributes = Symbol
@@ -137,15 +144,16 @@ type StepperAttributes = Symbol
 defaultSymbolAttributes :: Symbol
 defaultSymbolAttributes =
     Symbol
-        { function       = def
-        , functional     = def
-        , constructor    = def
-        , injective      = def
-        , sortInjection  = def
-        , anywhere       = def
-        , hook           = def
-        , smtlib         = def
-        , smthook        = def
+        { function      = def
+        , functional    = def
+        , constructor   = def
+        , injective     = def
+        , sortInjection = def
+        , anywhere      = def
+        , hook          = def
+        , smtlib        = def
+        , smthook       = def
+        , memo          = def
         }
 
 -- | See also: 'defaultSymbolAttributes'

--- a/kore/src/Kore/Attribute/Symbol/Memo.hs
+++ b/kore/src/Kore/Attribute/Symbol/Memo.hs
@@ -1,0 +1,68 @@
+{- |
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+
+ -}
+
+module Kore.Attribute.Symbol.Memo
+    ( Memo (..)
+    , memoId, memoSymbol, memoAttribute
+    ) where
+
+import qualified Control.Monad as Monad
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Attribute.Parser as Parser
+import Kore.Debug
+
+-- | @Memo@ represents the @memo@ attribute for symbols.
+newtype Memo = Memo { isMemo :: Bool }
+    deriving (GHC.Generic, Eq, Ord, Show)
+
+instance Semigroup Memo where
+    (<>) (Memo a) (Memo b) = Memo (a || b)
+
+instance Monoid Memo where
+    mempty = Memo False
+
+instance Default Memo where
+    def = mempty
+
+instance NFData Memo
+
+instance SOP.Generic Memo
+
+instance SOP.HasDatatypeInfo Memo
+
+instance Debug Memo
+
+-- | Kore identifier representing the @memo@ attribute symbol.
+memoId :: Id
+memoId = "memo"
+
+-- | Kore symbol representing the @memo@ attribute.
+memoSymbol :: SymbolOrAlias
+memoSymbol =
+    SymbolOrAlias
+        { symbolOrAliasConstructor = memoId
+        , symbolOrAliasParams = []
+        }
+
+-- | Kore pattern representing the @memo@ attribute.
+memoAttribute :: AttributePattern
+memoAttribute = attributePattern_ memoSymbol
+
+instance ParseAttributes Memo where
+    parseAttribute = withApplication' parseApplication
+      where
+        parseApplication params args Memo { isMemo } = do
+            Parser.getZeroParams params
+            Parser.getZeroArguments args
+            Monad.when isMemo failDuplicate'
+            return Memo { isMemo = True }
+        withApplication' = Parser.withApplication memoId
+        failDuplicate' = Parser.failDuplicate memoId
+
+    toAttributes Memo { isMemo } =
+        Attributes [memoAttribute | isMemo]

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -672,11 +672,8 @@ reject the definition.
 -}
 unifyEqualsNormalized
     :: forall normalized unifier variable
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
+    .   ( SimplifierVariable variable
         , Traversable (Domain.Value normalized)
-        , FreshVariable variable
         , TermWrapper normalized
         , MonadUnify unifier
         )
@@ -747,11 +744,8 @@ Currently allows at most one opaque term in the two arguments taken together.
 -}
 unifyEqualsNormalizedAc
     ::  forall normalized variable unifier
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
+    .   ( SimplifierVariable variable
         , Traversable (Domain.Value normalized)
-        , FreshVariable variable
         , TermWrapper normalized
         , MonadUnify unifier
         )

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -529,13 +529,8 @@ multiple sorts are hooked to the same builtin domain, the verifier should
 reject the definition.
 -}
 unifyEquals
-    ::  forall variable unifier
-    .   ( SortedVariable variable
-        , FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
+    :: forall variable unifier
+    .  (SimplifierVariable variable, MonadUnify unifier)
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -83,8 +83,6 @@ import           Kore.Unification.Unify
 import qualified Kore.Unification.Unify as Monad.Unify
 import           Kore.Unparser
                  ( Unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {- | Builtin name of the @Set@ sort.
  -}
@@ -507,13 +505,8 @@ internalize tools termLike
     reject the definition.
  -}
 unifyEquals
-    ::  forall variable unifier
-    .   ( SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        )
+    :: forall variable unifier
+    .  (SimplifierVariable variable, MonadUnify unifier)
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Goal.hs
+++ b/kore/src/Kore/Goal.hs
@@ -36,7 +36,7 @@ import qualified Kore.Step.Result as Result
 import           Kore.Step.Rule
                  ( OnePathRule (..), RewriteRule (..), RulePattern (..) )
 import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+                 ( MonadSimplify, SimplifierVariable )
 import           Kore.Step.Simplification.Pattern
                  ( simplifyAndRemoveTopExists )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
@@ -49,8 +49,6 @@ import qualified Kore.Unification.Procedure as Unification
 import qualified Kore.Unification.Unify as Monad.Unify
 import           Kore.Unparser
                  ( Unparse, unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 import           Kore.Variables.UnifiedVariable
 
 {- | The state of the all-path reachability proof strategy for @goal@.
@@ -297,12 +295,9 @@ removalPredicate destination config =
                 (Pattern.toTermLike config)
 
 instance
-    ( SortedVariable variable
-    , Debug variable
-    , Unparse variable
-    , Show variable
-    , FreshVariable variable
-    ) => Goal (OnePathRule variable) where
+    (SimplifierVariable variable , Debug variable)
+    => Goal (OnePathRule variable)
+  where
 
     newtype Rule (OnePathRule variable) =
         Rule { unRule :: RewriteRule variable }
@@ -430,11 +425,8 @@ instance Debug variable => Debug (Rule (OnePathRule variable))
 removeDestSimplifyRemainder
     :: forall variable m
     .  MonadSimplify m
-    => SortedVariable variable
+    => SimplifierVariable variable
     => Debug variable
-    => Unparse variable
-    => Show variable
-    => FreshVariable variable
     => OnePathRule variable
     -> Strategy.TransitionT (Rule (OnePathRule variable)) m (ProofState (OnePathRule variable))
 removeDestSimplifyRemainder remainder = do

--- a/kore/src/Kore/Internal/Symbol.hs
+++ b/kore/src/Kore/Internal/Symbol.hs
@@ -14,6 +14,7 @@ module Kore.Internal.Symbol
     , isFunction
     , isTotal
     , isInjective
+    , isMemo
     , symbolHook
     , constructor
     , functional
@@ -149,6 +150,9 @@ isFunction = Attribute.isFunction . symbolAttributes
 
 isTotal :: Symbol -> Bool
 isTotal = Attribute.isTotal . symbolAttributes
+
+isMemo :: Symbol -> Bool
+isMemo = Attribute.isMemo . Attribute.memo . symbolAttributes
 
 symbolHook :: Symbol -> Attribute.Hook
 symbolHook = Attribute.hook . symbolAttributes

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -698,9 +698,7 @@ because the entire tree must be traversed to inspect for variables before
 deciding if the result is @Nothing@ or @Just _@.
 
  -}
-asConcrete
-    :: TermLike variable
-    -> Maybe (TermLike Concrete)
+asConcrete :: TermLike variable -> Maybe (TermLike Concrete)
 asConcrete = traverseVariables (\case { _ -> Nothing })
 
 isConcrete :: TermLike variable -> Bool

--- a/kore/src/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/src/Kore/Step/Axiom/Evaluate.hs
@@ -37,17 +37,11 @@ import           Kore.Step.Step
                  ( UnificationProcedure (..) )
 import qualified Kore.Step.Step as Step
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
 import           Kore.Variables.Fresh
 
 evaluateAxioms
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => [EqualityRule Variable]
     -> TermLike variable
     -> simplifier (AttemptedAxiom variable)

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -39,15 +39,14 @@ import           Kore.Step.Simplification.Data
                  ( AttemptedAxiom,
                  AttemptedAxiomResults (AttemptedAxiomResults),
                  BuiltinAndAxiomSimplifier (..), BuiltinAndAxiomSimplifierMap,
-                 MonadSimplify, PredicateSimplifier, TermLikeSimplifier )
+                 MonadSimplify, PredicateSimplifier, SimplifierVariable,
+                 TermLikeSimplifier )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiomResults
                  ( AttemptedAxiomResults (..) )
 import qualified Kore.Step.Simplification.Data as AttemptedAxiom
                  ( AttemptedAxiom (..), hasRemainders )
 import           Kore.Unparser
-                 ( Unparse, unparse )
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
+                 ( unparse )
 
 {-|Describes whether simplifiers are allowed to return multiple results or not.
 -}
@@ -92,13 +91,8 @@ totalDefinitionEvaluation rules =
     BuiltinAndAxiomSimplifier totalDefinitionEvaluationWorker
   where
     totalDefinitionEvaluationWorker
-        ::  forall variable simplifier
-        .   ( FreshVariable variable
-            , SortedVariable variable
-            , Show variable
-            , Unparse variable
-            , MonadSimplify simplifier
-            )
+        :: forall variable simplifier
+        .  (SimplifierVariable variable, MonadSimplify simplifier)
         => PredicateSimplifier
         -> TermLikeSimplifier
         -> BuiltinAndAxiomSimplifierMap
@@ -147,12 +141,7 @@ builtinEvaluation evaluator =
 
 evaluateBuiltin
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => BuiltinAndAxiomSimplifier
     -> PredicateSimplifier
     -> TermLikeSimplifier
@@ -193,12 +182,7 @@ evaluateBuiltin
 
 applyFirstSimplifierThatWorks
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => [BuiltinAndAxiomSimplifier]
     -> AcceptsMultipleResults
     -> PredicateSimplifier

--- a/kore/src/Kore/Step/Condition/Evaluator.hs
+++ b/kore/src/Kore/Step/Condition/Evaluator.hs
@@ -14,31 +14,21 @@ module Kore.Step.Condition.Evaluator
 import           Kore.Internal.Predicate
                  ( Predicate )
 import qualified Kore.Internal.Predicate as Predicate
-import           Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import           Kore.Step.Simplification.Data
-                 ( MonadSimplify, simplifyPredicate )
+                 ( MonadSimplify, SimplifierVariable, simplifyPredicate )
 import qualified Kore.Step.Simplification.Data as BranchT
                  ( gather )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {- | Attempt to simplify a predicate. -}
 simplify
-    ::  forall variable m .
-        ( FreshVariable variable
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify m
-        )
+    ::  forall variable simplifier
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => Syntax.Predicate variable
     -- ^ The condition to be evaluated.
-    -> m (Predicate variable)
+    -> simplifier (Predicate variable)
     -- TODO (virgil): use a BranchT m here and stop converting substitutions
     -- to predicates. Even better, delete this one and use Predicate.simplify.
 simplify predicate = do

--- a/kore/src/Kore/Step/Merging/OrPattern.hs
+++ b/kore/src/Kore/Step/Merging/OrPattern.hs
@@ -35,10 +35,7 @@ import           Kore.Variables.Fresh
 to the given OrPattern.
 -}
 mergeWithPredicate
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )

--- a/kore/src/Kore/Step/Merging/Pattern.hs
+++ b/kore/src/Kore/Step/Merging/Pattern.hs
@@ -30,11 +30,7 @@ import           Kore.Variables.Fresh
 with the given pattern.
 -}
 mergeWithPredicate
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -65,11 +61,7 @@ mergeWithPredicate
         evaluatedCondition
 
 mergeWithEvaluatedCondition
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -32,13 +32,11 @@ import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import qualified Kore.Step.Simplification.AndPredicates as AndPredicates
 import qualified Kore.Step.Simplification.Ceil as Ceil
 import           Kore.Step.Simplification.Data
-                 ( MonadSimplify (..) )
+                 ( MonadSimplify (..), SimplifierVariable )
 import           Kore.Unification.Substitution
                  ( Substitution )
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 import           Kore.Variables.Target
                  ( Target )
 import qualified Kore.Variables.Target as Target
@@ -167,16 +165,11 @@ substitutionConditions subst =
         Syntax.Predicate.makeEqualsPredicate (mkVar x) t
 
 ceilChildOfApplicationOrTop
-    :: forall variable m
-    .  ( FreshVariable variable
-       , SortedVariable variable
-       , Show variable
-       , Unparse variable
-       , MonadSimplify m
-       )
+    :: forall variable simplifier
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> TermLike variable
-    -> m (Predicate variable)
+    -> simplifier (Predicate variable)
 ceilChildOfApplicationOrTop predicate patt =
     case patt of
         App_ _ children -> do

--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -38,7 +38,6 @@ import           Kore.Step.Simplification.Data hiding
                  ( And )
 import qualified Kore.Step.Substitution as Substitution
 import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 {-|'simplify' simplifies an 'And' of 'OrPattern'.
 
@@ -77,12 +76,7 @@ Also, we have
     the same for two string literals and two chars
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => And Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify And { andFirst = first, andSecond = second } =
@@ -106,12 +100,7 @@ to carry around.
 
 -}
 simplifyEvaluated
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
@@ -129,12 +118,7 @@ simplifyEvaluated first second
     return (OrPattern.fromPatterns result)
 
 simplifyEvaluatedMultiple
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => [OrPattern variable]
     -> simplifier (OrPattern variable)
 simplifyEvaluatedMultiple [] = return OrPattern.top
@@ -146,10 +130,7 @@ simplifyEvaluatedMultiple (pat : patterns) =
 See the comment for 'simplify' to find more details.
 -}
 makeEvaluate
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , HasCallStack
         , MonadSimplify simplifier
         )
@@ -163,10 +144,7 @@ makeEvaluate first second
   | otherwise = makeEvaluateNonBool first second
 
 makeEvaluateNonBool
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , HasCallStack
         , MonadSimplify simplifier
         )

--- a/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -26,21 +26,14 @@ import           Kore.Internal.OrPredicate
 import           Kore.Internal.Pattern
                  ( Predicate )
 import           Kore.Step.Simplification.Data
-                 ( BranchT, MonadSimplify )
+                 ( BranchT, MonadSimplify, SimplifierVariable )
 import qualified Kore.Step.Simplification.Data as BranchT
                  ( gather )
 import qualified Kore.Step.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 simplifyEvaluatedMultiPredicate
     :: forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => MultiAnd (OrPredicate variable)
     -> simplifier (OrPredicate variable)
 simplifyEvaluatedMultiPredicate predicates = do

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -98,12 +98,7 @@ See also: 'termAnd'
 
  -}
 termEquals
-    ::  ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => GHC.HasCallStack
     => TermLike variable
     -> TermLike variable
@@ -116,13 +111,8 @@ termEquals first second = MaybeT $ do
             MultiOr.make (map Predicate.eraseConditionalTerm results)
 
 termEqualsAnd
-    ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: forall variable simplifier
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => GHC.HasCallStack
     => TermLike variable
     -> TermLike variable
@@ -175,11 +165,7 @@ termEqualsAnd
                 }
 
 maybeTermEquals
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -208,11 +194,7 @@ the special cases handled by this.
 -- signature.
 termUnification
     ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -258,12 +240,7 @@ See also: 'termUnification'
 -- signature.
 termAnd
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => GHC.HasCallStack
     => TermLike variable
     -> TermLike variable
@@ -293,11 +270,7 @@ termAnd p1 p2 =
         andPattern = Pattern.fromTermLike (mkAnd first second)
 
 maybeTermAnd
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -312,11 +285,7 @@ maybeTermAnd = maybeTransformTerm andFunctions
 
 andFunctions
     ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         , GHC.HasCallStack
@@ -337,11 +306,7 @@ andFunctions =
 
 equalsFunctions
     ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         , GHC.HasCallStack
@@ -362,12 +327,7 @@ equalsFunctions =
 
 andEqualsFunctions
     ::  forall variable unifier
-    .   ( Eq variable
-        , FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         , GHC.HasCallStack
@@ -542,10 +502,7 @@ equalAndEquals _ _ = empty
 
 -- | Unify two patterns where the first is @\\bottom@.
 bottomTermEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    ::  ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -586,10 +543,7 @@ See also: 'bottomTermEquals'
 
  -}
 termBottomEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    ::  ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -597,7 +551,8 @@ termBottomEquals
     -> TermLike variable
     -> TermLike variable
     -> MaybeT unifier (Pattern variable)
-termBottomEquals predicate first second = bottomTermEquals predicate second first
+termBottomEquals predicate first second =
+    bottomTermEquals predicate second first
 
 {- | Unify a variable with a function pattern.
 
@@ -605,10 +560,7 @@ See also: 'isFunctionPattern'
 
  -}
 variableFunctionAndEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    ::  ( SimplifierVariable variable
         , MonadUnify unifier
         , Logger.WithLog Logger.LogMessage unifier
         )
@@ -667,12 +619,7 @@ See also: 'variableFunctionAndEquals'
 
  -}
 functionVariableAndEquals
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadUnify unifier
-        )
+    :: (SimplifierVariable variable, MonadUnify unifier)
     => GHC.HasCallStack
     => Predicate variable
     -> SimplificationType

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs-boot
@@ -9,23 +9,13 @@ import Kore.Internal.TermLike
 import Kore.Logger
        ( LogMessage, WithLog )
 import Kore.Step.Simplification.Data
-       ( BranchT, MonadSimplify )
-import Kore.Syntax.Variable
-       ( SortedVariable )
+       ( BranchT, MonadSimplify, SimplifierVariable )
 import Kore.Unification.Unify
        ( MonadUnify )
-import Kore.Unparser
-import Kore.Variables.Fresh
-       ( FreshVariable )
 
 termAnd
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => GHC.HasCallStack
     => TermLike variable
     -> TermLike variable
@@ -33,11 +23,7 @@ termAnd
 
 termUnification
     ::  forall variable unifier
-    .   ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )

--- a/kore/src/Kore/Step/Simplification/Application.hs
+++ b/kore/src/Kore/Step/Simplification/Application.hs
@@ -29,8 +29,6 @@ import qualified Kore.Step.Simplification.Data as BranchT
                  ( gather )
 import           Kore.Step.Substitution
                  ( mergePredicatesAndSubstitutions )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 type ExpandedApplication variable =
     Conditional variable (Application Symbol (TermLike variable))
@@ -46,12 +44,7 @@ predicates ans substitutions, applying functions on the Application(terms),
 then merging everything into an Pattern.
 -}
 simplify
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Application Symbol (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -71,12 +64,7 @@ simplify predicate application = do
       = application
 
 makeAndEvaluateApplications
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Symbol
     -> [Pattern variable]
@@ -85,12 +73,7 @@ makeAndEvaluateApplications =
     makeAndEvaluateSymbolApplications
 
 makeAndEvaluateSymbolApplications
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Symbol
     -> [Pattern variable]
@@ -104,12 +87,7 @@ makeAndEvaluateSymbolApplications predicate symbol children = do
     return (MultiOr.mergeAll orResults)
 
 evaluateApplicationFunction
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -- ^ The predicate from the configuration
     -> ExpandedApplication variable
@@ -125,12 +103,7 @@ evaluateApplicationFunction
         term
 
 makeExpandedApplication
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Symbol
     -> [Pattern variable]
     -> BranchT simplifier (ExpandedApplication variable)

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -54,9 +54,6 @@ import           Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Equals as Equals
 import qualified Kore.Step.Simplification.Not as Not
 import           Kore.TopBottom
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {-| Simplify a 'Ceil' of 'OrPattern'.
 
@@ -67,12 +64,7 @@ A ceil(or) is equal to or(ceil). We also take into account that
 * ceil transforms terms into predicates
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate.Predicate variable
     -> Ceil Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -99,10 +91,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -116,12 +105,7 @@ simplifyEvaluated predicate child =
 for details.
 -}
 makeEvaluate
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -134,11 +118,7 @@ makeEvaluate predicate child
   | otherwise              = makeEvaluateNonBoolCeil predicate child
 
 makeEvaluateNonBoolCeil
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -166,10 +146,7 @@ makeEvaluateNonBoolCeil predicate patt@Conditional {term}
 -- signature.
 makeEvaluateTerm
     ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    .   ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -240,10 +217,7 @@ makeEvaluateTerm
 -}
 makeEvaluateBuiltin
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Unparse variable
-        , Show variable
+    .   ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -292,13 +266,9 @@ makeEvaluateBuiltin _ (Domain.BuiltinString _) = return OrPredicate.top
 
 makeEvaluateNormalizedAc
     :: forall normalized variable simplifier
-    .   ( FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadSimplify simplifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
         , Traversable (Domain.Value normalized)
-        , Unparse variable
         , Domain.AcWrapper normalized
         )
     =>  Predicate.Predicate variable

--- a/kore/src/Kore/Step/Simplification/Ceil.hs-boot
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs-boot
@@ -16,21 +16,10 @@ import Kore.Internal.TermLike
 import Kore.Logger
        ( LogMessage, WithLog )
 import Kore.Step.Simplification.Data
-       ( MonadSimplify )
-import Kore.Syntax.Variable
-       ( SortedVariable )
-import Kore.Unparser
-       ( Unparse )
-import Kore.Variables.Fresh
-       ( FreshVariable )
+       ( MonadSimplify, SimplifierVariable )
 
 makeEvaluate
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -40,10 +29,7 @@ makeEvaluate
 
 makeEvaluateTerm
     ::  forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
+    .   ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -52,8 +52,6 @@ import qualified Kore.Step.Simplification.Not as Not
 import qualified Kore.Step.Simplification.Or as Or
                  ( simplifyEvaluated )
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 {-|'simplify' simplifies an 'Equals' pattern made of 'OrPattern's.
 
@@ -131,12 +129,7 @@ Normalization of the compared terms is not implemented yet, so
 Equals(a and b, b and a) will not be evaluated to Top.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -157,12 +150,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> OrPattern variable
     -> OrPattern variable
@@ -191,12 +179,7 @@ simplifyEvaluated predicate first second
 
 makeEvaluateFunctionalOr
     :: forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Pattern variable
     -> [Pattern variable]
@@ -236,12 +219,7 @@ makeEvaluateFunctionalOr predicate first seconds = do
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Pattern variable
     -> Pattern variable
     -> Predicate variable
@@ -290,12 +268,7 @@ makeEvaluate
 -- Do not export this. This not valid as a standalone function, it
 -- assumes that some extra conditions will be added on the outside
 makeEvaluateTermsAssumesNoBottom
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> simplifier (OrPattern variable)
@@ -317,12 +290,7 @@ makeEvaluateTermsAssumesNoBottom firstTerm secondTerm = do
 -- assumes that some extra conditions will be added on the outside
 makeEvaluateTermsAssumesNoBottomMaybe
     :: forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> MaybeT simplifier (OrPattern variable)
@@ -341,12 +309,7 @@ because it returns an 'or').
 See 'simplify' for detailed documentation.
 -}
 makeEvaluateTermsToPredicate
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> Predicate variable

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -82,12 +82,7 @@ The simplification of exists x . (pat and pred and subst) is equivalent to:
     (pat' and (pred' and (exists x . predX and substX)) and subst')
 -}
 simplify
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Exists Sort variable (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify Exists { existsVariable, existsChild } =
@@ -107,12 +102,7 @@ even more useful to carry around.
 
 -}
 simplifyEvaluated
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => ElementVariable variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
@@ -128,12 +118,7 @@ simplifyEvaluated variable simplified
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => ElementVariable variable
     -> Pattern variable
     -> simplifier (OrPattern variable)
@@ -226,12 +211,7 @@ See also: 'quantifyPattern'
 
  -}
 makeEvaluateBoundLeft
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => ElementVariable variable  -- ^ quantified variable
     -> TermLike variable  -- ^ substituted term
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/kore/src/Kore/Step/Simplification/Iff.hs
@@ -24,8 +24,6 @@ import           Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.Not as Not
                  ( makeEvaluate, simplifyEvaluated )
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {-|'simplify' simplifies an 'Iff' pattern with 'OrPattern'
 children.
@@ -34,12 +32,7 @@ Right now this has special cases only for top and bottom children
 and for children with top terms.
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Iff Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify Iff { iffFirst = first, iffSecond = second } =
@@ -63,12 +56,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/kore/src/Kore/Step/Simplification/Implies.hs
@@ -23,8 +23,6 @@ import           Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.Not as Not
                  ( makeEvaluate, simplifyEvaluated )
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {-|'simplify' simplifies an 'Implies' pattern with 'OrPattern'
 children.
@@ -40,12 +38,7 @@ Right now this uses the following simplifications:
 and it has a special case for children with top terms.
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Implies Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify Implies { impliesFirst = first, impliesSecond = second } =
@@ -70,12 +63,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
@@ -89,12 +77,7 @@ simplifyEvaluated first second
     return (MultiOr.flatten results)
 
 simplifyEvaluateHalfImplies
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable
     -> Pattern variable
     -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -24,7 +24,6 @@ import qualified Kore.Step.Simplification.Ceil as Ceil
                  ( makeEvaluate, simplifyEvaluated )
 import           Kore.Step.Simplification.Data
 import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 {-|'simplify' simplifies an 'In' pattern with 'OrPattern'
 children.
@@ -39,12 +38,7 @@ Right now this uses the following simplifications:
 TODO(virgil): It does not have yet a special case for children with top terms.
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> In Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -66,12 +60,7 @@ carry around.
 -}
 simplifyEvaluatedIn
     :: forall variable simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> OrPattern variable
     -> OrPattern variable
@@ -88,12 +77,7 @@ simplifyEvaluatedIn predicate first second
                             (makeEvaluateIn predicate <$> first <*> second)
 
 makeEvaluateIn
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> Pattern variable
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/Not.hs
+++ b/kore/src/Kore/Step/Simplification/Not.hs
@@ -34,8 +34,6 @@ import qualified Kore.Predicate.Predicate as Predicate
 import qualified Kore.Step.Simplification.And as And
 import           Kore.Step.Simplification.Data
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {-|'simplify' simplifies a 'Not' pattern with an 'OrPattern'
 child.
@@ -47,12 +45,7 @@ Right now this uses the following:
 
 -}
 simplify
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Not Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify Not { notChild } = simplifyEvaluated notChild
@@ -76,12 +69,7 @@ to carry around.
 
 -}
 simplifyEvaluated
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable
     -> simplifier (OrPattern variable)
 simplifyEvaluated simplified =
@@ -197,12 +185,7 @@ scatterAnd = scatter . distributeAnd
 {- | Conjoin and simplify a 'MultiAnd' of 'Pattern'.
  -}
 mkMultiAndPattern
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => MultiAnd (Pattern variable)
     -> BranchT simplifier (Pattern variable)
 mkMultiAndPattern patterns =

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -11,26 +11,16 @@ import qualified Kore.Internal.MultiOr as MultiOr
 import           Kore.Internal.OrPattern
                  ( OrPattern )
 import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+                 ( MonadSimplify, SimplifierVariable )
 import qualified Kore.Step.Simplification.Data as BranchT
                  ( gather )
 import qualified Kore.Step.Simplification.Pattern as Pattern
                  ( simplifyPredicate )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
                  ( filterMultiOr )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 simplifyPredicatesWithSmt
-    ::  ( FreshVariable variable
-        , MonadSimplify simplifier
-        , Ord variable
-        , Show variable
-        , SortedVariable variable
-        , Unparse variable
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => OrPattern variable -> simplifier (OrPattern variable)
 simplifyPredicatesWithSmt unsimplified = do
     simplifiedOrs <- traverse

--- a/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -25,22 +25,15 @@ import qualified Kore.Step.Condition.Evaluator as Predicate
                  ( simplify )
 import qualified Kore.Step.Merging.Pattern as Pattern
 import           Kore.Step.Simplification.Data
-                 ( BranchT, MonadSimplify )
+                 ( BranchT, MonadSimplify, SimplifierVariable )
 import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as BranchT
                  ( gather )
 import           Kore.Step.Substitution
                  ( mergePredicatesAndSubstitutions )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 simplifyAndRemoveTopExists
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -58,10 +51,7 @@ simplifyAndRemoveTopExists patt = do
 {-| Simplifies an 'Pattern', returning an 'OrPattern'.
 -}
 simplify
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )
@@ -79,10 +69,7 @@ simplify pattern'@Conditional { term } = do
 {-| Simplifies the predicate inside an 'Pattern'.
 -}
 simplifyPredicate
-    ::  ( Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , MonadSimplify simplifier
         , WithLog LogMessage simplifier
         )

--- a/kore/src/Kore/Step/Simplification/Predicate.hs
+++ b/kore/src/Kore/Step/Simplification/Predicate.hs
@@ -29,15 +29,11 @@ import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import           Kore.Step.Simplification.Data
 import           Kore.Step.Substitution
                  ( mergePredicatesAndSubstitutions )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
 import qualified Kore.TopBottom as TopBottom
 import           Kore.Unification.Substitution
                  ( Substitution )
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 {- | Create a 'PredicateSimplifier' using 'simplify'.
 -}
@@ -51,13 +47,7 @@ result. The result is re-simplified once.
 
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Int
     -> Predicate variable
     -> BranchT simplifier (Predicate variable)
@@ -130,13 +120,7 @@ See also: 'simplify'
 
 -}
 simplifyPartial
-    ::  ( FreshVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Syntax.Predicate variable
     -> BranchT simplifier (Predicate variable)
 simplifyPartial

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -25,15 +25,12 @@ import           Kore.Predicate.Predicate
                  ( pattern PredicateTrue )
 import           Kore.Step.Rule
 import           Kore.Step.Simplification.Data
-                 ( MonadSimplify )
+                 ( MonadSimplify, SimplifierVariable )
 import qualified Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Pattern as Pattern
 import qualified Kore.Step.Simplification.Predicate as Predicate
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
 import qualified Kore.Unification.Substitution as Substitution
-import           Kore.Unparser
-                 ( Unparse )
-import           Kore.Variables.Fresh
 
 {- | Simplify a 'Map' of 'EqualityRule's using only matching logic rules.
 
@@ -41,26 +38,16 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyFunctionAxioms
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  Map identifier [EqualityRule variable]
-    ->  simplifier (Map identifier [EqualityRule variable])
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    => Map identifier [EqualityRule variable]
+    -> simplifier (Map identifier [EqualityRule variable])
 simplifyFunctionAxioms =
     (traverse . traverse) simplifyEqualityRule
 
 simplifyEqualityRule
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  EqualityRule variable
-    ->  simplifier (EqualityRule variable)
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    => EqualityRule variable
+    -> simplifier (EqualityRule variable)
 simplifyEqualityRule (EqualityRule rule) =
     EqualityRule <$> simplifyRulePattern rule
 
@@ -70,14 +57,9 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyRewriteRule
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  RewriteRule variable
-    ->  simplifier (RewriteRule variable)
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    => RewriteRule variable
+    -> simplifier (RewriteRule variable)
 simplifyRewriteRule (RewriteRule rule) =
     RewriteRule <$> simplifyRulePattern rule
 
@@ -88,14 +70,9 @@ narrowly-defined criteria.
 
  -}
 simplifyRulePattern
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  RulePattern variable
-    ->  simplifier (RulePattern variable)
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    => RulePattern variable
+    -> simplifier (RulePattern variable)
 simplifyRulePattern rule = do
     let RulePattern { left } = rule
     simplifiedLeft <- simplifyPattern left
@@ -129,14 +106,9 @@ simplifyRulePattern rule = do
 
 -- | Simplify a 'TermLike' using only matching logic rules.
 simplifyPattern
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , MonadSimplify simplifier
-        )
-    =>  TermLike variable
-    ->  simplifier (OrPattern variable)
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    => TermLike variable
+    -> simplifier (OrPattern variable)
 simplifyPattern termLike =
     Simplifier.localSimplifierTermLike (const Simplifier.create)
     $ Simplifier.localSimplifierPredicate (const Predicate.create)

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -66,8 +66,6 @@ import qualified Kore.Step.Simplification.Top as Top
                  ( simplify )
 import qualified Kore.Step.Simplification.Variable as Variable
                  ( simplify )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 -- TODO(virgil): Add a Simplifiable class and make all pattern types
 -- instances of that.
@@ -75,12 +73,7 @@ import           Kore.Variables.Fresh
 {-|'simplify' simplifies a `TermLike`, returning a 'Pattern'.
 -}
 simplify
-    ::  ( SortedVariable variable
-        , Show variable
-        , Ord variable
-        , Unparse variable
-        , FreshVariable variable
-        )
+    :: SimplifierVariable variable
     => TermLike variable
     -> Predicate variable
     -> Simplifier (Pattern variable)
@@ -92,12 +85,7 @@ simplify patt predicate = do
 'OrPattern'.
 -}
 simplifyToOr
-    ::  ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Predicate variable
     -> TermLike variable
     -> simplifier (OrPattern variable)
@@ -109,13 +97,8 @@ simplifyToOr term predicate =
     simplifier = termLikeSimplifier simplifyToOr
 
 simplifyInternal
-    ::  forall variable simplifier
-    .   ( SortedVariable variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    :: forall variable simplifier
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> Predicate variable
     -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -73,6 +73,8 @@ import           Kore.Step.Rule
                  ( RewriteRule (..), RulePattern (RulePattern) )
 import qualified Kore.Step.Rule as Rule
 import qualified Kore.Step.Rule as RulePattern
+import           Kore.Step.Simplification.Data
+                 ( SimplifierVariable )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
 import qualified Kore.Step.Substitution as Substitution
 import qualified Kore.TopBottom as TopBottom
@@ -82,7 +84,6 @@ import           Kore.Unification.Unify
 import qualified Kore.Unification.Unify as Monad.Unify
                  ( gather, scatter )
 import           Kore.Unparser
-import           Kore.Variables.Fresh
 import           Kore.Variables.Target
                  ( Target )
 import qualified Kore.Variables.Target as Target
@@ -95,14 +96,8 @@ import           Kore.Variables.UnifiedVariable
 
 newtype UnificationProcedure =
     UnificationProcedure
-        ( forall variable unifier
-        .   ( SortedVariable variable
-            , Ord variable
-            , Show variable
-            , Unparse variable
-            , FreshVariable variable
-            , MonadUnify unifier
-            )
+        (  forall variable unifier
+        .  (SimplifierVariable variable, MonadUnify unifier)
         => TermLike variable
         -> TermLike variable
         -> unifier (Predicate variable)
@@ -200,11 +195,7 @@ unification. The substitution is not applied to the renamed rule.
  -}
 unifyRule
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -238,11 +229,7 @@ unifyRule
 
 unifyRules
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -266,11 +253,7 @@ The rule is considered to apply if the result is not @\\bottom@.
  -}
 applyInitialConditions
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -309,11 +292,7 @@ See also: 'applyInitialConditions'
  -}
 finalizeAppliedRule
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -350,11 +329,7 @@ finalizeAppliedRule renamedRule appliedConditions =
  -}
 applyRemainder
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -383,11 +358,7 @@ toConfigurationVariables
 toConfigurationVariables = Pattern.mapVariables Target.NonTarget
 
 finalizeRule
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    ::  ( SimplifierVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -409,11 +380,7 @@ finalizeRule initialCondition unifiedRule =
 
 finalizeRulesParallel
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Log.WithLog Log.LogMessage unifier
         )
@@ -436,11 +403,7 @@ finalizeRulesParallel initial unifiedRules = do
 
 finalizeRulesSequence
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , Log.WithLog Log.LogMessage unifier
         )
@@ -560,11 +523,7 @@ See also: 'applyRewriteRule'
  -}
 applyRulesParallel
     ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -591,11 +550,7 @@ See also: 'applyRewriteRule'
  -}
 applyRewriteRulesParallel
     ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -615,11 +570,7 @@ See also: 'applyRewriteRule'
  -}
 applyRulesSequence
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -646,11 +597,7 @@ See also: 'applyRewriteRulesParallel'
  -}
 applyRewriteRulesSequence
     ::  forall unifier variable
-    .   ( Ord     variable
-        , Show    variable
-        , Unparse variable
-        , FreshVariable  variable
-        , SortedVariable variable
+    .   ( SimplifierVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -36,8 +36,6 @@ import qualified Kore.Predicate.Predicate as Syntax
 import qualified Kore.Predicate.Predicate as Syntax.Predicate
 import           Kore.Step.Simplification.Data as Simplifier
 import qualified Kore.Step.Simplification.Data as Branch
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
 import qualified Kore.TopBottom as TopBottom
 import           Kore.Unification.Error
                  ( substitutionToUnifyOrSubError )
@@ -51,8 +49,6 @@ import           Kore.Unification.UnifierImpl
 import           Kore.Unification.Unify
                  ( MonadUnify )
 import qualified Kore.Unification.Unify as Monad.Unify
-import           Kore.Unparser
-import           Kore.Variables.Fresh
 
 newtype PredicateMerger variable m =
     PredicateMerger
@@ -64,12 +60,7 @@ newtype PredicateMerger variable m =
 -- | Normalize the substitution and predicate of 'expanded'.
 normalize
     :: forall variable term simplifier
-    .   ( FreshVariable variable
-        , SortedVariable variable
-        , Unparse variable
-        , Show variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => Conditional variable term
     -> BranchT simplifier (Conditional variable term)
 normalize Conditional { term, predicate, substitution } = do
@@ -94,11 +85,7 @@ normalize Conditional { term, predicate, substitution } = do
 
 normalizeExcept
     ::  forall unifier variable
-    .   ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -152,11 +139,7 @@ hs-boot: Please remember to update the hs-boot file when changing the signature.
 -}
 mergePredicatesAndSubstitutions
     ::  forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , Ord variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadSimplify simplifier
         , HasCallStack
         , WithLog LogMessage simplifier
@@ -182,11 +165,7 @@ mergePredicatesAndSubstitutions predicates substitutions = do
 
 mergePredicatesAndSubstitutionsExcept
     ::  forall variable unifier
-    .   ( Show variable
-        , SortedVariable variable
-        , Ord variable
-        , Unparse variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , HasCallStack
         , MonadUnify unifier
         , WithLog LogMessage unifier
@@ -210,10 +189,7 @@ can't handle.
 -}
 createPredicatesAndSubstitutionsMergerExcept
     ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -236,12 +212,7 @@ unifications it can't handle.
 -}
 createPredicatesAndSubstitutionsMerger
     :: forall variable simplifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
-        , MonadSimplify simplifier
-        )
+    .  (SimplifierVariable variable, MonadSimplify simplifier)
     => PredicateMerger variable (BranchT simplifier)
 createPredicatesAndSubstitutionsMerger =
     PredicateMerger worker
@@ -262,11 +233,7 @@ over the base monad.
 -}
 createLiftedPredicatesAndSubstitutionsMerger
     ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , Ord variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )

--- a/kore/src/Kore/Step/Substitution.hs-boot
+++ b/kore/src/Kore/Step/Substitution.hs-boot
@@ -9,22 +9,15 @@ import           Kore.Logger
                  ( LogMessage, WithLog )
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
+import           Kore.Step.Simplification.Data
+                 ( SimplifierVariable )
 import           Kore.Unification.Substitution
                  ( Substitution )
 import           Kore.Unification.Unify
                  ( MonadUnify )
-import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 mergePredicatesAndSubstitutionsExcept
-    ::  ( Show variable
-        , SortedVariable variable
-        , Ord variable
-        , Unparse variable
-        , FreshVariable variable
+    ::  ( SimplifierVariable variable
         , HasCallStack
         , MonadUnify unifier
         , WithLog LogMessage unifier

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -28,30 +28,22 @@ import           Kore.Step.Simplification.AndTerms
                  ( termUnification )
 import qualified Kore.Step.Simplification.Ceil as Ceil
                  ( makeEvaluateTerm )
+import           Kore.Step.Simplification.Data
+                 ( SimplifierVariable )
 import qualified Kore.Step.Simplification.Data as BranchT
 import           Kore.Step.Substitution
                  ( createPredicatesAndSubstitutionsMerger )
-import           Kore.Syntax.Variable
-                 ( SortedVariable )
 import           Kore.Unification.Unify
                  ( MonadUnify )
 import qualified Kore.Unification.Unify as Monad.Unify
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 
 -- |'unificationProcedure' atempts to simplify @t1 = t2@, assuming @t1@ and @t2@
 -- are terms (functional patterns) to a substitution.
 -- If successful, it also produces a proof of how the substitution was obtained.
 -- If failing, it gives a 'UnificationError' reason for the failure.
 unificationProcedure
-    ::  ( SortedVariable variable
-        , Ord variable
-        , Show variable
-        , Unparse variable
-        , FreshVariable variable
-        , MonadUnify unifier
-        )
+    :: (SimplifierVariable variable, MonadUnify unifier)
     => TermLike variable
     -> TermLike variable
     -> unifier (Predicate variable)

--- a/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/kore/src/Kore/Unification/UnifierImpl.hs
@@ -31,14 +31,14 @@ import           Kore.Logger
                  ( LogMessage, WithLog )
 import qualified Kore.Predicate.Predicate as Predicate
                  ( isFalse, makeAndPredicate )
+import           Kore.Step.Simplification.Data
+                 ( SimplifierVariable )
 import           Kore.Unification.Substitution
                  ( Substitution )
 import qualified Kore.Unification.Substitution as Substitution
 import           Kore.Unification.Unify
                  ( MonadUnify )
 import           Kore.Unparser
-import           Kore.Variables.Fresh
-                 ( FreshVariable )
 import           Kore.Variables.UnifiedVariable
                  ( UnifiedVariable (..) )
 
@@ -49,10 +49,7 @@ import {-# SOURCE #-} Kore.Step.Substitution
 
 simplifyAnds
     ::  forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )
@@ -102,10 +99,7 @@ groupSubstitutionByVariable =
 -- x = ((t1 /\ t2) /\ (..)) /\ tn
 -- then recursively reducing that to finally get x = t /\ subst
 solveGroupedSubstitution
-    :: ( Show variable
-       , Unparse variable
-       , SortedVariable variable
-       , FreshVariable variable
+    :: ( SimplifierVariable variable
        , MonadUnify unifier
        , WithLog LogMessage unifier
        )
@@ -131,10 +125,7 @@ solveGroupedSubstitution var patterns = do
 -- stabilizes.
 normalizeSubstitutionDuplication
     :: forall variable unifier
-    .   ( Show variable
-        , Unparse variable
-        , SortedVariable variable
-        , FreshVariable variable
+    .   ( SimplifierVariable variable
         , MonadUnify unifier
         , WithLog LogMessage unifier
         )

--- a/kore/test/Test/Kore/AllPath.hs
+++ b/kore/test/Test/Kore/AllPath.hs
@@ -347,6 +347,8 @@ instance MonadSimplify AllPathIdentity where
     localSimplifierPredicate = undefined
     askSimplifierAxioms = undefined
     localSimplifierAxioms = undefined
+    simplifierMemo = undefined
+    simplifierRecall = undefined
 
 -- | 'Goal.transitionRule' instantiated with our unit test rules.
 transitionRule


### PR DESCRIPTION
DO NOT MERGE. This is a prototype implementation of the `memo` attribute and machinery to memoize function evaluation. Memoizing certain expensive functions in KEVM reduces runtime by as much as 70%. Certain implementation details of the backend make memoization relatively expensive compared to evaluating small functions, so the attribute should be applied judiciously.

DO NOT MERGE. I will pick off and clean up parts of this to be merged as smaller pull requests.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`
