### PR TITLE
Refactor Goal.hs

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -55,8 +55,6 @@ import qualified Kore.Internal.Predicate as Predicate
 import           Kore.Internal.TermLike
 import qualified Kore.Logger as Log
 import qualified Kore.ModelChecker.Bounded as Bounded
-import           Kore.OnePath.Verification
-                 ( Claim, defaultStrategy, verify )
 import           Kore.Predicate.Predicate
                  ( makeMultipleOrPredicate, unwrapPredicate )
 import           Kore.Profiler.Data
@@ -88,6 +86,8 @@ import qualified Kore.Step.Simplification.Rule as Rule
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
                  ( create )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.OnePath.Verification
+                 ( Claim, defaultStrategy, verify )
 import           SMT
                  ( MonadSMT, SMT )
 

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -39,7 +39,6 @@ import           Kore.Attribute.Symbol
                  ( StepperAttributes )
 import qualified Kore.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
-import qualified Kore.Goal as Goal
 import           Kore.IndexedModule.IndexedModule
                  ( VerifiedModule )
 import qualified Kore.IndexedModule.IndexedModule as IndexedModule
@@ -86,6 +85,7 @@ import qualified Kore.Step.Simplification.Rule as Rule
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
                  ( create )
 import qualified Kore.Step.Strategy as Strategy
+import qualified Kore.Strategies.Goal as Goal
 import           Kore.Strategies.OnePath.Verification
                  ( Claim, defaultStrategy, verify )
 import           SMT

--- a/kore/src/Kore/Goal.hs
+++ b/kore/src/Kore/Goal.hs
@@ -6,79 +6,28 @@ module Kore.Goal where
 
 import           Control.Applicative
                  ( Alternative (..) )
-import qualified Control.Monad.Trans as Monad.Trans
-import           Data.Coerce
-                 ( Coercible, coerce )
-import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
-import           Data.Hashable
 import           Data.Maybe
                  ( mapMaybe )
-import qualified Data.Set as Set
-import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Generics.SOP as SOP
 import           GHC.Generics as GHC
 
-import qualified Kore.Attribute.Axiom as Attribute
-import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import qualified Kore.Attribute.Trusted as Trusted
 import           Kore.Debug
-import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.Pattern
-                 ( Pattern )
-import qualified Kore.Internal.Pattern as Pattern
 import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( Predicate )
-import qualified Kore.Predicate.Predicate as Predicate
-import qualified Kore.Step.Result as Result
+import           Kore.ProofState
 import           Kore.Step.Rule
-                 ( OnePathRule (..), RewriteRule (..), RulePattern (..) )
+                 ( OnePathRule (..), RewriteRule (..) )
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
-import           Kore.Step.Simplification.Pattern
-                 ( simplifyAndRemoveTopExists )
-import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
-import qualified Kore.Step.Step as Step
 import           Kore.Step.Strategy
                  ( Strategy )
 import qualified Kore.Step.Strategy as Strategy
-import           Kore.TopBottom
-import qualified Kore.Unification.Procedure as Unification
-import qualified Kore.Unification.Unify as Monad.Unify
+import qualified Kore.Strategies.OnePath.Actions as OnePath
 import           Kore.Unparser
-                 ( Unparse, unparse )
+                 ( Unparse )
 import           Kore.Variables.Fresh
                  ( FreshVariable )
-import           Kore.Variables.UnifiedVariable
-
-{- | The state of the all-path reachability proof strategy for @goal@.
- -}
-data ProofState goal
-    = Goal goal
-    -- ^ The indicated goal is being proven.
-    | GoalRem goal
-    -- ^ The indicated goal remains after rewriting.
-    | Proven
-    -- ^ The parent goal was proven.
-    deriving (Eq, Show, Ord, Functor, Generic)
-
-instance Hashable goal => Hashable (ProofState goal)
-
-{- | Extract the unproven goals of a 'ProofState'.
-
-Returns 'Nothing' if there is no remaining unproven goal.
-
- -}
-extractUnproven :: ProofState goal -> Maybe goal
-extractUnproven (Goal t)    = Just t
-extractUnproven (GoalRem t) = Just t
-extractUnproven Proven      = Nothing
-
-extractGoalRem :: ProofState goal -> Maybe goal
-extractGoalRem (GoalRem t) = Just t
-extractGoalRem _           = Nothing
 
 {- | The final nodes of an execution graph which were not proven.
 
@@ -97,28 +46,6 @@ unprovenNodes executionGraph =
  -}
 proven :: Strategy.ExecutionGraph (ProofState goal) rule -> Bool
 proven = Foldable.null . unprovenNodes
-
-data ProofStateTransformer goal a =
-    ProofStateTransformer
-        { goalTransformer :: goal -> a
-        , goalRemTransformer :: goal -> a
-        , provenValue :: a
-        }
-
-{- | Catamorphism for 'ProofState'
--}
-proofState
-    :: ProofStateTransformer goal a
-    -> ProofState goal
-    -> a
-proofState
-    ProofStateTransformer
-        {goalTransformer, goalRemTransformer, provenValue}
-  =
-    \case
-        Goal goal -> goalTransformer goal
-        GoalRem goal -> goalRemTransformer goal
-        Proven -> provenValue
 
 {- | The primitive transitions of the all-path reachability proof strategy.
  -}
@@ -152,14 +79,14 @@ class Goal goal where
 
     isTrusted :: goal -> Bool
 
-    -- | Apply 'Rule's in to the goal in parallel.
+    -- | Apply 'Rule's to the goal in parallel.
     derivePar
         :: MonadSimplify m
         => [Rule goal]
         -> goal
         -> Strategy.TransitionT (Rule goal) m (ProofState goal)
 
-    -- | Apply 'Rule's in to the goal in sequence.
+    -- | Apply 'Rule's to the goal in sequence.
     deriveSeq
         :: MonadSimplify m
         => [Rule goal]
@@ -257,45 +184,6 @@ onePathFollowupStep claims axioms =
         , TriviallyValid
         ]
 
-{- | The predicate to remove the destination from the present configuration.
- -}
-removalPredicate
-    ::  ( Ord variable
-        , Show variable
-        , Unparse variable
-        , SortedVariable variable
-        )
-    => Pattern variable
-    -- ^ Destination
-    -> Pattern variable
-    -- ^ Current configuration
-    -> Predicate variable
-removalPredicate destination config =
-    let
-        -- The variables of the destination that are missing from the
-        -- configuration. These are the variables which should be existentially
-        -- quantified in the removal predicate.
-        configVariables =
-            FreeVariables.getFreeVariables $ Pattern.freeVariables config
-        destinationVariables =
-            FreeVariables.getFreeVariables $ Pattern.freeVariables destination
-        extraVariables = Set.toList
-            $ Set.difference destinationVariables configVariables
-        extraElementVariables = [v | ElemVar v <- extraVariables]
-        extraNonElemVariables = filter (not . isElemVar) extraVariables
-        quantifyPredicate = Predicate.makeMultipleExists extraElementVariables
-    in
-        if not (null extraNonElemVariables)
-        then error
-            ("Cannot quantify non-element variables: "
-                ++ show (unparse <$> extraNonElemVariables))
-        else Predicate.makeNotPredicate
-            $ quantifyPredicate
-            $ Predicate.makeCeilPredicate
-            $ mkAnd
-                (Pattern.toTermLike destination)
-                (Pattern.toTermLike config)
-
 instance
     ( SortedVariable variable
     , Debug variable
@@ -308,170 +196,20 @@ instance
         Rule { unRule :: RewriteRule variable }
         deriving (GHC.Generic, Show, Unparse)
 
-    isTrusted =
-        Trusted.isTrusted
-        . Attribute.trusted
-        . attributes
-        . coerce
+    isTrusted = OnePath.isTrusted
 
-    removeDestination goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            removal = removalPredicate destination configuration
-            result = Conditional.andPredicate configuration removal
-        pure $ makeRuleFromPatterns result destination
+    removeDestination = OnePath.removeDestination
 
-    simplify goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-        configs <-
-            Monad.Trans.lift
-            $ simplifyAndRemoveTopExists configuration
-        filteredConfigs <- SMT.Evaluator.filterMultiOr configs
-        if null filteredConfigs
-           then pure $ makeRuleFromPatterns Pattern.bottom destination
-           else do
-               let simplifiedRules =
-                       fmap (flip makeRuleFromPatterns destination) filteredConfigs
-               Foldable.asum (pure <$> simplifiedRules)
+    simplify = OnePath.simplify
 
+    isTriviallyValid = OnePath.isTriviallyValid
 
-    isTriviallyValid =
-        isBottom . left . coerce
+    derivePar = OnePath.derivePar
 
-    derivePar rules goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            rewrites = unRule <$> rules
-        eitherResults <-
-            Monad.Trans.lift
-            . Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesParallel
-                (Step.UnificationProcedure Unification.unificationProcedure)
-                rewrites
-                configuration
-        case eitherResults of
-            Left err ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , Pretty.indent 4 (Pretty.pretty err)
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse configuration)
-                ,   "We decided to end the execution because we don't \
-                    \understand this case well enough at the moment."
-                ]
-            Right results -> do
-                let mapRules =
-                        Result.mapRules
-                        $ Rule
-                        . RewriteRule
-                        . Step.unwrapRule
-                        . Step.withoutUnification
-                    traverseConfigs =
-                        Result.traverseConfigs
-                            (pure . Goal)
-                            removeDestSimplifyRemainder
-                let onePathResults =
-                        Result.mapConfigs
-                            (flip makeRuleFromPatterns $ destination)
-                            (flip makeRuleFromPatterns $ destination)
-                            (Result.mergeResults results)
-                results' <-
-                    traverseConfigs (mapRules onePathResults)
-                Result.transitionResults results'
-
-    deriveSeq rules goal = do
-        let destination = getDestination goal
-            configuration = getConfiguration goal
-            rewrites = unRule <$> rules
-        eitherResults <-
-            Monad.Trans.lift
-            . Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesSequence
-                (Step.UnificationProcedure Unification.unificationProcedure)
-                configuration
-                rewrites
-        case eitherResults of
-            Left err ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , Pretty.indent 4 (Pretty.pretty err)
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse configuration)
-                ,   "We decided to end the execution because we don't \
-                    \understand this case well enough at the moment."
-                ]
-            Right results -> do
-                let mapRules =
-                        Result.mapRules
-                        $ Rule
-                        . RewriteRule
-                        . Step.unwrapRule
-                        . Step.withoutUnification
-                    traverseConfigs =
-                        Result.traverseConfigs
-                            (pure . Goal)
-                            removeDestSimplifyRemainder
-                let onePathResults =
-                        Result.mapConfigs
-                            (flip makeRuleFromPatterns $ destination)
-                            (flip makeRuleFromPatterns $ destination)
-                            (Result.mergeResults results)
-                results' <-
-                    traverseConfigs (mapRules onePathResults)
-                Result.transitionResults results'
+    deriveSeq = OnePath.deriveSeq
 
 instance SOP.Generic (Rule (OnePathRule variable))
 
 instance SOP.HasDatatypeInfo (Rule (OnePathRule variable))
 
 instance Debug variable => Debug (Rule (OnePathRule variable))
-
-removeDestSimplifyRemainder
-    :: forall variable m
-    .  MonadSimplify m
-    => SortedVariable variable
-    => Debug variable
-    => Unparse variable
-    => Show variable
-    => FreshVariable variable
-    => OnePathRule variable
-    -> Strategy.TransitionT (Rule (OnePathRule variable)) m (ProofState (OnePathRule variable))
-removeDestSimplifyRemainder remainder = do
-    result <- removeDestination remainder >>= simplify
-    if isTriviallyValid result
-       then pure Proven
-       else pure . GoalRem $ result
-
-getConfiguration
-    :: forall rule variable
-    .  Ord variable
-    => Coercible rule (RulePattern variable)
-    => rule
-    -> Pattern variable
-getConfiguration (coerce -> RulePattern { left, requires }) =
-    Pattern.withCondition left (Conditional.fromPredicate requires)
-
-getDestination
-    :: forall rule variable
-    .  Ord variable
-    => Coercible rule (RulePattern variable)
-    => rule
-    -> Pattern variable
-getDestination (coerce -> RulePattern { right, ensures }) =
-    Pattern.withCondition right (Conditional.fromPredicate ensures)
-
-makeRuleFromPatterns
-    :: forall rule variable
-    .  Ord variable
-    => SortedVariable variable
-    => Unparse variable
-    => Show variable
-    => Coercible (RulePattern variable) rule
-    => Pattern variable
-    -> Pattern variable
-    -> rule
-makeRuleFromPatterns configuration destination =
-    let (left, Conditional.toPredicate -> requires) = Pattern.splitTerm configuration
-        (right, Conditional.toPredicate -> ensures) = Pattern.splitTerm destination
-    in coerce RulePattern { left, right, requires, ensures, attributes = Default.def }

--- a/kore/src/Kore/ProofState.hs
+++ b/kore/src/Kore/ProofState.hs
@@ -1,0 +1,63 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+-}
+module Kore.ProofState
+    ( extractGoalRem
+    , extractUnproven
+    , ProofState (..)
+    , proofState
+    , ProofStateTransformer (..)
+    ) where
+
+import Data.Hashable
+import GHC.Generics as GHC
+
+{- | The state of the all-path reachability proof strategy for @goal@.
+ -}
+data ProofState goal
+    = Goal goal
+    -- ^ The indicated goal is being proven.
+    | GoalRem goal
+    -- ^ The indicated goal remains after rewriting.
+    | Proven
+    -- ^ The parent goal was proven.
+    deriving (Eq, Show, Ord, Functor, Generic)
+
+instance Hashable goal => Hashable (ProofState goal)
+
+{- | Extract the unproven goals of a 'ProofState'.
+
+Returns 'Nothing' if there is no remaining unproven goal.
+
+ -}
+extractUnproven :: ProofState goal -> Maybe goal
+extractUnproven (Goal t)    = Just t
+extractUnproven (GoalRem t) = Just t
+extractUnproven Proven      = Nothing
+
+extractGoalRem :: ProofState goal -> Maybe goal
+extractGoalRem (GoalRem t) = Just t
+extractGoalRem _           = Nothing
+
+data ProofStateTransformer goal a =
+    ProofStateTransformer
+        { goalTransformer :: goal -> a
+        , goalRemTransformer :: goal -> a
+        , provenValue :: a
+        }
+
+{- | Catamorphism for 'ProofState'
+-}
+proofState
+    :: ProofStateTransformer goal a
+    -> ProofState goal
+    -> a
+proofState
+    ProofStateTransformer
+        {goalTransformer, goalRemTransformer, provenValue}
+  =
+    \case
+        Goal goal -> goalTransformer goal
+        GoalRem goal -> goalRemTransformer goal
+        Proven -> provenValue

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -45,7 +45,6 @@ import           Text.Megaparsec
 import qualified Kore.Attribute.Axiom as Attribute
 import           Kore.Goal
 import qualified Kore.Logger as Logger
-import           Kore.OnePath.Verification
 import           Kore.Repl.Data
 import           Kore.Repl.Interpreter
 import           Kore.Repl.Parser
@@ -54,6 +53,7 @@ import qualified Kore.Step.Rule as Rule
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.OnePath.Verification
 import           Kore.Syntax.Variable
 import           Kore.Unification.Procedure
                  ( unificationProcedure )

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -43,7 +43,6 @@ import           Text.Megaparsec
                  ( parseMaybe )
 
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Goal
 import qualified Kore.Logger as Logger
 import           Kore.Repl.Data
 import           Kore.Repl.Interpreter
@@ -53,6 +52,7 @@ import qualified Kore.Step.Rule as Rule
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Verification
 import           Kore.Syntax.Variable
 import           Kore.Unification.Procedure

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -62,7 +62,6 @@ import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified GHC.Generics as GHC
 import           Numeric.Natural
 
-import           Kore.Goal
 import qualified Kore.Internal.Predicate as IPredicate
 import           Kore.Internal.TermLike
                  ( TermLike )
@@ -72,6 +71,7 @@ import           Kore.Profiler.Data
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Verification
                  ( CommonProofState )
 import           Kore.Syntax.Variable

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -67,13 +67,13 @@ import qualified Kore.Internal.Predicate as IPredicate
 import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Logger.Output as Logger
-import           Kore.OnePath.Verification
-                 ( CommonProofState )
 import           Kore.Profiler.Data
                  ( MonadProfiler )
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.OnePath.Verification
+                 ( CommonProofState )
 import           Kore.Syntax.Variable
                  ( Variable )
 import           Kore.Unification.Error

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -94,8 +94,6 @@ import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Logger
-import           Kore.OnePath.Verification
-                 ( Claim, CommonProofState )
 import           Kore.Repl.Data
 import           Kore.Repl.Parser
 import           Kore.Repl.State
@@ -107,6 +105,8 @@ import qualified Kore.Step.Rule as Axiom
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.OnePath.Verification
+                 ( Claim, CommonProofState )
 import           Kore.Syntax.Application
 import qualified Kore.Syntax.Id as Id
                  ( Id (..) )

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -94,6 +94,9 @@ import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Logger
+import           Kore.ProofState
+                 ( ProofStateTransformer (ProofStateTransformer), proofState )
+import qualified Kore.ProofState as ProofState.DoNotUse
 import           Kore.Repl.Data
 import           Kore.Repl.Parser
 import           Kore.Repl.State

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -84,7 +84,6 @@ import qualified Kore.Attribute.Axiom as Attribute
                  ( Axiom (..), RuleIndex (..), sourceLocation )
 import qualified Kore.Attribute.Label as AttrLabel
 import           Kore.Attribute.RuleIndex
-import           Kore.Goal
 import           Kore.Internal.Conditional
                  ( Conditional (..) )
 import qualified Kore.Internal.Pattern as Pattern
@@ -94,9 +93,6 @@ import           Kore.Internal.TermLike
                  ( TermLike )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Logger
-import           Kore.ProofState
-                 ( ProofStateTransformer (ProofStateTransformer), proofState )
-import qualified Kore.ProofState as ProofState.DoNotUse
 import           Kore.Repl.Data
 import           Kore.Repl.Parser
 import           Kore.Repl.State
@@ -108,8 +104,12 @@ import qualified Kore.Step.Rule as Axiom
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Verification
                  ( Claim, CommonProofState )
+import           Kore.Strategies.ProofState
+                 ( ProofStateTransformer (ProofStateTransformer), proofState )
+import qualified Kore.Strategies.ProofState as ProofState.DoNotUse
 import           Kore.Syntax.Application
 import qualified Kore.Syntax.Id as Id
                  ( Id (..) )

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -85,6 +85,10 @@ import           Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger.Output as Logger
 import           Kore.Predicate.Predicate as Predicate
+import           Kore.ProofState
+                 ( ProofState (Goal),
+                 ProofStateTransformer (ProofStateTransformer), proofState )
+import qualified Kore.ProofState as ProofState.DoNotUse
 import           Kore.Repl.Data
 import           Kore.Step.Rule
                  ( RewriteRule (..), RulePattern (..) )

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -74,7 +74,6 @@ import           Control.Monad.Reader
                  ( MonadReader, asks )
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Label as AttrLabel
-import           Kore.Goal
 import           Kore.Internal.Conditional
                  ( Conditional (..) )
 import           Kore.Internal.Pattern
@@ -85,10 +84,6 @@ import           Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger.Output as Logger
 import           Kore.Predicate.Predicate as Predicate
-import           Kore.ProofState
-                 ( ProofState (Goal),
-                 ProofStateTransformer (ProofStateTransformer), proofState )
-import qualified Kore.ProofState as ProofState.DoNotUse
 import           Kore.Repl.Data
 import           Kore.Step.Rule
                  ( RewriteRule (..), RulePattern (..) )
@@ -96,7 +91,12 @@ import           Kore.Step.Rule as Rule
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Verification
+import           Kore.Strategies.ProofState
+                 ( ProofState (Goal),
+                 ProofStateTransformer (ProofStateTransformer), proofState )
+import qualified Kore.Strategies.ProofState as ProofState.DoNotUse
 import           Kore.Syntax.Variable
                  ( Variable )
 

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -84,7 +84,6 @@ import           Kore.Internal.TermLike
                  ( Sort, TermLike )
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger.Output as Logger
-import           Kore.OnePath.Verification
 import           Kore.Predicate.Predicate as Predicate
 import           Kore.Repl.Data
 import           Kore.Step.Rule
@@ -93,6 +92,7 @@ import           Kore.Step.Rule as Rule
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify )
 import qualified Kore.Step.Strategy as Strategy
+import           Kore.Strategies.OnePath.Verification
 import           Kore.Syntax.Variable
                  ( Variable )
 

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -2,7 +2,7 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-module Kore.Goal where
+module Kore.Strategies.Goal where
 
 import           Control.Applicative
                  ( Alternative (..) )
@@ -15,7 +15,6 @@ import           GHC.Generics as GHC
 import           Kore.Debug
 import qualified Kore.Internal.MultiOr as MultiOr
 import           Kore.Internal.TermLike
-import           Kore.ProofState
 import           Kore.Step.Rule
                  ( OnePathRule (..), RewriteRule (..) )
 import           Kore.Step.Simplification.Data
@@ -24,6 +23,7 @@ import           Kore.Step.Strategy
                  ( Strategy )
 import qualified Kore.Step.Strategy as Strategy
 import qualified Kore.Strategies.OnePath.Actions as OnePath
+import           Kore.Strategies.ProofState
 import           Kore.Unparser
                  ( Unparse )
 import           Kore.Variables.Fresh

--- a/kore/src/Kore/Strategies/OnePath/Actions.hs
+++ b/kore/src/Kore/Strategies/OnePath/Actions.hs
@@ -1,0 +1,328 @@
+{-|
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+
+module Kore.Strategies.OnePath.Actions
+    ( derivePar
+    , deriveSeq
+    , getConfiguration
+    , getDestination
+    , isTriviallyValid
+    , isTrusted
+    , makeRuleFromPatterns
+    , removeDestination
+    , simplify
+    ) where
+
+import qualified Control.Monad.Trans as Monad.Trans
+import           Data.Coerce
+                 ( Coercible, coerce )
+import qualified Data.Default as Default
+import qualified Data.Foldable as Foldable
+import qualified Data.Set as Set
+import qualified Data.Text.Prettyprint.Doc as Pretty
+
+import qualified Kore.Attribute.Axiom as Attribute.Axiom
+import qualified Kore.Attribute.Pattern.FreeVariables as Attribute.FreeVariables
+import qualified Kore.Attribute.Trusted as Attribute.Trusted
+import           Kore.Debug
+                 ( Debug )
+import qualified Kore.Internal.Conditional as Conditional
+import           Kore.Internal.Pattern
+                 ( Pattern )
+import qualified Kore.Internal.Pattern as Pattern
+import           Kore.Internal.TermLike
+                 ( mkAnd )
+import qualified Kore.Predicate.Predicate as Syntax
+                 ( Predicate )
+import qualified Kore.Predicate.Predicate as Predicate
+import qualified Kore.ProofState as Goal
+import qualified Kore.Step.Result as Result
+import           Kore.Step.Rule
+                 ( OnePathRule (OnePathRule), RewriteRule (RewriteRule),
+                 RulePattern (RulePattern) )
+import qualified Kore.Step.Rule as RulePattern
+                 ( RulePattern (..) )
+import           Kore.Step.Simplification.Data
+                 ( MonadSimplify )
+import           Kore.Step.Simplification.Pattern
+                 ( simplifyAndRemoveTopExists )
+import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
+import qualified Kore.Step.Step as Step
+import qualified Kore.Step.Strategy as Strategy
+import           Kore.Syntax.Variable
+                 ( SortedVariable )
+import           Kore.TopBottom
+                 ( isBottom )
+import qualified Kore.Unification.Procedure as Unification
+import qualified Kore.Unification.Unify as Monad.Unify
+import           Kore.Unparser
+                 ( Unparse, unparse )
+import           Kore.Variables.Fresh
+                 ( FreshVariable )
+import           Kore.Variables.UnifiedVariable
+                 ( UnifiedVariable (ElemVar), isElemVar )
+
+isTrusted :: OnePathRule variable -> Bool
+isTrusted =
+    Attribute.Trusted.isTrusted
+    . Attribute.Axiom.trusted
+    . RulePattern.attributes
+    . coerce
+
+removeDestination
+    ::  ( MonadSimplify m
+        , Ord variable
+        , Show variable
+        , SortedVariable variable
+        , Unparse variable
+        , goal ~ OnePathRule variable
+        )
+    => goal
+    -> Strategy.TransitionT rule m (OnePathRule variable)
+removeDestination goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+        removal = removalPredicate destination configuration
+        result = Conditional.andPredicate configuration removal
+    pure $ makeRuleFromPatterns result destination
+
+simplify
+    ::  ( FreshVariable variable
+        , MonadSimplify m
+        , Ord variable
+        , Show variable
+        , SortedVariable variable
+        , Unparse variable
+        , goal ~ OnePathRule variable
+        )
+    => goal
+    -> Strategy.TransitionT rule m goal
+simplify goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+    configs <-
+        Monad.Trans.lift
+        $ simplifyAndRemoveTopExists configuration
+    filteredConfigs <- SMT.Evaluator.filterMultiOr configs
+    if null filteredConfigs
+        then pure $ makeRuleFromPatterns Pattern.bottom destination
+        else do
+            let simplifiedRules =
+                    fmap (`makeRuleFromPatterns` destination) filteredConfigs
+            Foldable.asum (pure <$> simplifiedRules)
+
+isTriviallyValid :: OnePathRule variable -> Bool
+isTriviallyValid = isBottom . RulePattern.left . coerce
+
+-- | Apply 'Rule's to the goal in parallel.
+derivePar
+    :: forall goal m rule variable
+    .   ( Coercible (RewriteRule variable) rule
+        , Debug variable
+        , FreshVariable variable
+        , MonadSimplify m
+        , Ord variable
+        , Show variable
+        , SortedVariable variable
+        , Unparse variable
+        , goal ~ OnePathRule variable
+        )
+    => [rule]
+    -> goal
+    -> Strategy.TransitionT rule m (Goal.ProofState goal)
+derivePar rules goal = do
+    let destination = getDestination goal
+        configuration :: Pattern variable
+        configuration = getConfiguration goal
+        rewrites = coerce <$> rules
+    eitherResults <-
+        Monad.Trans.lift
+        . Monad.Unify.runUnifierT
+        $ Step.applyRewriteRulesParallel
+            (Step.UnificationProcedure Unification.unificationProcedure)
+            rewrites
+            configuration
+    case eitherResults of
+        Left err ->
+            (error . show . Pretty.vsep)
+            [ "Not implemented error:"
+            , Pretty.indent 4 (Pretty.pretty err)
+            , "while applying a \\rewrite axiom to the pattern:"
+            , Pretty.indent 4 (unparse configuration)
+            ,   "We decided to end the execution because we don't \
+                \understand this case well enough at the moment."
+            ]
+        Right results -> do
+            let mapRules =
+                    Result.mapRules
+                    $ coerce
+                    . RewriteRule
+                    . Step.unwrapRule
+                    . Step.withoutUnification
+                traverseConfigs =
+                    Result.traverseConfigs
+                        (pure . Goal.Goal)
+                        removeDestSimplifyRemainder
+            let onePathResults =
+                    Result.mapConfigs
+                        (`makeRuleFromPatterns` destination)
+                        (`makeRuleFromPatterns` destination)
+                        (Result.mergeResults results)
+            results' <-
+                traverseConfigs (mapRules onePathResults)
+            Result.transitionResults results'
+
+-- | Apply 'Rule's to the goal in sequence.
+deriveSeq
+    :: forall goal m rule variable
+    .   ( Coercible (RewriteRule variable) rule
+        , Debug variable
+        , FreshVariable variable
+        , MonadSimplify m
+        , Ord variable
+        , Show variable
+        , SortedVariable variable
+        , Unparse variable
+        , goal ~ OnePathRule variable
+        )
+    => [rule]
+    -> goal
+    -> Strategy.TransitionT rule m (Goal.ProofState goal)
+deriveSeq rules goal = do
+    let destination = getDestination goal
+        configuration = getConfiguration goal
+        rewrites = coerce <$> rules
+    eitherResults <-
+        Monad.Trans.lift
+        . Monad.Unify.runUnifierT
+        $ Step.applyRewriteRulesSequence
+            (Step.UnificationProcedure Unification.unificationProcedure)
+            configuration
+            rewrites
+    case eitherResults of
+        Left err ->
+            (error . show . Pretty.vsep)
+            [ "Not implemented error:"
+            , Pretty.indent 4 (Pretty.pretty err)
+            , "while applying a \\rewrite axiom to the pattern:"
+            , Pretty.indent 4 (unparse configuration)
+            ,   "We decided to end the execution because we don't \
+                \understand this case well enough at the moment."
+            ]
+        Right results -> do
+            let mapRules =
+                    Result.mapRules
+                    $ coerce
+                    . RewriteRule
+                    . Step.unwrapRule
+                    . Step.withoutUnification
+                traverseConfigs =
+                    Result.traverseConfigs
+                        (pure . Goal.Goal)
+                        removeDestSimplifyRemainder
+            let onePathResults =
+                    Result.mapConfigs
+                        (`makeRuleFromPatterns` destination)
+                        (`makeRuleFromPatterns` destination)
+                        (Result.mergeResults results)
+            results' <-
+                traverseConfigs (mapRules onePathResults)
+            Result.transitionResults results'
+
+makeRuleFromPatterns
+    :: forall rule variable
+    .  Ord variable
+    => SortedVariable variable
+    => Unparse variable
+    => Show variable
+    => Coercible (RulePattern variable) rule
+    => Pattern variable
+    -> Pattern variable
+    -> rule
+makeRuleFromPatterns configuration destination =
+    let (left, Conditional.toPredicate -> requires) =
+            Pattern.splitTerm configuration
+        (right, Conditional.toPredicate -> ensures) =
+            Pattern.splitTerm destination
+    in coerce RulePattern
+        { left, right, requires, ensures, attributes = Default.def }
+
+{- | The predicate to remove the destination from the present configuration.
+ -}
+removalPredicate
+    ::  ( Ord variable
+        , Show variable
+        , Unparse variable
+        , SortedVariable variable
+        )
+    => Pattern variable
+    -- ^ Destination
+    -> Pattern variable
+    -- ^ Current configuration
+    -> Syntax.Predicate variable
+removalPredicate destination config =
+    let
+        -- The variables of the destination that are missing from the
+        -- configuration. These are the variables which should be existentially
+        -- quantified in the removal predicate.
+        configVariables =
+            Attribute.FreeVariables.getFreeVariables
+            $ Pattern.freeVariables config
+        destinationVariables =
+            Attribute.FreeVariables.getFreeVariables
+            $ Pattern.freeVariables destination
+        extraVariables = Set.toList
+            $ Set.difference destinationVariables configVariables
+        extraElementVariables = [v | ElemVar v <- extraVariables]
+        extraNonElemVariables = filter (not . isElemVar) extraVariables
+        quantifyPredicate = Predicate.makeMultipleExists extraElementVariables
+    in
+        if not (null extraNonElemVariables)
+        then error
+            ("Cannot quantify non-element variables: "
+                ++ show (unparse <$> extraNonElemVariables))
+        else Predicate.makeNotPredicate
+            $ quantifyPredicate
+            $ Predicate.makeCeilPredicate
+            $ mkAnd
+                (Pattern.toTermLike destination)
+                (Pattern.toTermLike config)
+
+getConfiguration
+    :: forall rule variable
+    .  Ord variable
+    => Coercible rule (RulePattern variable)
+    => rule
+    -> Pattern variable
+getConfiguration (coerce -> RulePattern { left, requires }) =
+    Pattern.withCondition left (Conditional.fromPredicate requires)
+
+getDestination
+    :: forall rule variable
+    .  Ord variable
+    => Coercible rule (RulePattern variable)
+    => rule
+    -> Pattern variable
+getDestination (coerce -> RulePattern { right, ensures }) =
+    Pattern.withCondition right (Conditional.fromPredicate ensures)
+
+removeDestSimplifyRemainder
+    :: forall variable m rule
+    .  MonadSimplify m
+    => SortedVariable variable
+    => Debug variable
+    => Unparse variable
+    => Show variable
+    => FreshVariable variable
+    => OnePathRule variable
+    -> Strategy.TransitionT
+        rule
+        m
+        (Goal.ProofState (OnePathRule variable))
+removeDestSimplifyRemainder remainder = do
+    result <- removeDestination remainder >>= simplify
+    if isTriviallyValid result
+       then pure Goal.Proven
+       else pure . Goal.GoalRem $ result

--- a/kore/src/Kore/Strategies/OnePath/Actions.hs
+++ b/kore/src/Kore/Strategies/OnePath/Actions.hs
@@ -37,7 +37,6 @@ import           Kore.Internal.TermLike
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
 import qualified Kore.Predicate.Predicate as Predicate
-import qualified Kore.ProofState as Goal
 import qualified Kore.Step.Result as Result
 import           Kore.Step.Rule
                  ( OnePathRule (OnePathRule), RewriteRule (RewriteRule),
@@ -51,6 +50,7 @@ import           Kore.Step.Simplification.Pattern
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
 import qualified Kore.Step.Step as Step
 import qualified Kore.Step.Strategy as Strategy
+import qualified Kore.Strategies.ProofState as Goal
 import           Kore.Syntax.Variable
                  ( SortedVariable )
 import           Kore.TopBottom

--- a/kore/src/Kore/Strategies/OnePath/Verification.hs
+++ b/kore/src/Kore/Strategies/OnePath/Verification.hs
@@ -8,7 +8,7 @@ Maintainer  : virgil.serbanuta@runtimeverification.com
 This should be imported qualified.
 -}
 
-module Kore.OnePath.Verification
+module Kore.Strategies.OnePath.Verification
     ( Claim
     , CommonProofState
     , defaultStrategy

--- a/kore/src/Kore/Strategies/OnePath/Verification.hs
+++ b/kore/src/Kore/Strategies/OnePath/Verification.hs
@@ -31,11 +31,8 @@ import           Data.Limit
 import qualified Data.Limit as Limit
 
 import           Kore.Debug
-import           Kore.Goal
 import           Kore.Internal.Pattern
                  ( Pattern )
-import           Kore.ProofState
-                 ( ProofState (Goal) )
 import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Simplification.Data
@@ -43,8 +40,11 @@ import           Kore.Step.Strategy
 import           Kore.Step.Transition
                  ( runTransitionT )
 import qualified Kore.Step.Transition as Transition
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Actions
                  ( getConfiguration, getDestination, makeRuleFromPatterns )
+import           Kore.Strategies.ProofState
+                 ( ProofState (Goal) )
 import           Kore.Syntax.Variable
                  ( Variable )
 import           Kore.Unparser

--- a/kore/src/Kore/Strategies/OnePath/Verification.hs
+++ b/kore/src/Kore/Strategies/OnePath/Verification.hs
@@ -34,6 +34,8 @@ import           Kore.Debug
 import           Kore.Goal
 import           Kore.Internal.Pattern
                  ( Pattern )
+import           Kore.ProofState
+                 ( ProofState (Goal) )
 import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Simplification.Data
@@ -41,6 +43,8 @@ import           Kore.Step.Strategy
 import           Kore.Step.Transition
                  ( runTransitionT )
 import qualified Kore.Step.Transition as Transition
+import           Kore.Strategies.OnePath.Actions
+                 ( getConfiguration, getDestination, makeRuleFromPatterns )
 import           Kore.Syntax.Variable
                  ( Variable )
 import           Kore.Unparser

--- a/kore/src/Kore/Strategies/ProofState.hs
+++ b/kore/src/Kore/Strategies/ProofState.hs
@@ -2,7 +2,7 @@
 Copyright   : (c) Runtime Verification, 2019
 License     : NCSA
 -}
-module Kore.ProofState
+module Kore.Strategies.ProofState
     ( extractGoalRem
     , extractUnproven
     , ProofState (..)

--- a/kore/test/Test/Kore/AllPath.hs
+++ b/kore/test/Test/Kore/AllPath.hs
@@ -21,6 +21,7 @@ import           Kore.Logger
                  ( LogMessage (..), WithLog (..) )
 import           Kore.Profiler.Data
                  ( Configuration (..), MonadProfiler (..) )
+import qualified Kore.ProofState as Goal
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify (..) )
 import qualified Kore.Step.Strategy as Strategy

--- a/kore/test/Test/Kore/AllPath.hs
+++ b/kore/test/Test/Kore/AllPath.hs
@@ -15,19 +15,19 @@ import qualified Data.Sequence as Seq
 import           GHC.Stack
                  ( HasCallStack )
 
-import qualified Kore.Goal as Goal
 import qualified Kore.Internal.MultiOr as MultiOr
 import           Kore.Logger
                  ( LogMessage (..), WithLog (..) )
 import           Kore.Profiler.Data
                  ( Configuration (..), MonadProfiler (..) )
-import qualified Kore.ProofState as Goal
 import           Kore.Step.Simplification.Data
                  ( MonadSimplify (..) )
 import qualified Kore.Step.Strategy as Strategy
 import           Kore.Step.Transition
                  ( runTransitionT )
 import qualified Kore.Step.Transition as Transition
+import qualified Kore.Strategies.Goal as Goal
+import qualified Kore.Strategies.ProofState as Goal
 import           SMT
                  ( MonadSMT (..) )
 

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -35,13 +35,13 @@ import qualified Kore.Attribute.Pattern.Functional as Attribute.Pattern
 import qualified Kore.Attribute.Source as Attribute
 import           Kore.Domain.Builtin as Domain
 import           Kore.Error
-import           Kore.Goal
 import           Kore.Internal.MultiOr
 import           Kore.Internal.Pattern
                  ( Conditional (..) )
 import           Kore.Internal.TermLike as TermLike
 import           Kore.Predicate.Predicate
 import           Kore.Proof.Functional
+import           Kore.ProofState
 import           Kore.Step.Axiom.Identifier
                  ( AxiomIdentifier )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -41,7 +41,6 @@ import           Kore.Internal.Pattern
 import           Kore.Internal.TermLike as TermLike
 import           Kore.Predicate.Predicate
 import           Kore.Proof.Functional
-import           Kore.ProofState
 import           Kore.Step.Axiom.Identifier
                  ( AxiomIdentifier )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
@@ -70,6 +69,7 @@ import qualified Kore.Step.SMT.AST as SMT.SymbolReference
                  ( SymbolReference (..) )
 import qualified Kore.Step.SMT.AST as SMT.IndirectSymbolDeclaration
                  ( IndirectSymbolDeclaration (..) )
+import           Kore.Strategies.ProofState
 import           Kore.Syntax as Syntax
 import           Kore.Syntax.Sentence as Syntax
 import           Kore.Unification.Error

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -20,7 +20,6 @@ import           Data.Limit
                  ( Limit (..) )
 import qualified Data.Limit as Limit
 
-import           Kore.Goal
 import           Kore.Internal.Conditional
                  ( Conditional (Conditional) )
 import qualified Kore.Internal.Conditional as Conditional.DoNotUse
@@ -34,7 +33,6 @@ import           Kore.Predicate.Predicate
                  makeTruePredicate )
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
-import           Kore.ProofState
 import           Kore.Step.Rule
                  ( OnePathRule (..), RewriteRule (RewriteRule),
                  RulePattern (RulePattern) )
@@ -44,8 +42,10 @@ import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
 import           Kore.Step.Strategy
                  ( ExecutionGraph (..), Strategy, pickFinal, runStrategy )
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Actions
                  ( makeRuleFromPatterns )
+import           Kore.Strategies.ProofState
 import           Kore.Syntax.Variable
                  ( Variable (..) )
 import qualified Kore.Unification.Substitution as Substitution

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -34,6 +34,7 @@ import           Kore.Predicate.Predicate
                  makeTruePredicate )
 import qualified Kore.Predicate.Predicate as Syntax
                  ( Predicate )
+import           Kore.ProofState
 import           Kore.Step.Rule
                  ( OnePathRule (..), RewriteRule (RewriteRule),
                  RulePattern (RulePattern) )
@@ -42,9 +43,9 @@ import           Kore.Step.Rule as RulePattern
 import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
 import           Kore.Step.Strategy
-                 ( Strategy, pickFinal, runStrategy )
-import           Kore.Step.Strategy
-                 ( ExecutionGraph (..) )
+                 ( ExecutionGraph (..), Strategy, pickFinal, runStrategy )
+import           Kore.Strategies.OnePath.Actions
+                 ( makeRuleFromPatterns )
 import           Kore.Syntax.Variable
                  ( Variable (..) )
 import qualified Kore.Unification.Substitution as Substitution

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -31,7 +31,6 @@ import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Data.Map.Strict as StrictMap
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Builtin.Int as Int
-import           Kore.Goal
 import           Kore.Internal.Predicate
                  ( Predicate )
 import qualified Kore.Internal.Predicate as Predicate
@@ -46,6 +45,7 @@ import           Kore.Step.Simplification.AndTerms
                  ( cannotUnifyDistinctDomainValues )
 import           Kore.Step.Simplification.Data
                  ( Simplifier, evalSimplifier )
+import           Kore.Strategies.Goal
 import           Kore.Strategies.OnePath.Verification
                  ( verifyClaimStep )
 import           Kore.Syntax.Variable

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -38,8 +38,6 @@ import qualified Kore.Internal.Predicate as Predicate
 import           Kore.Internal.TermLike
                  ( TermLike, elemVarS, mkBottom_, mkElemVar )
 import qualified Kore.Logger.Output as Logger
-import           Kore.OnePath.Verification
-                 ( verifyClaimStep )
 import           Kore.Repl.Data
 import           Kore.Repl.Interpreter
 import           Kore.Repl.State
@@ -48,6 +46,8 @@ import           Kore.Step.Simplification.AndTerms
                  ( cannotUnifyDistinctDomainValues )
 import           Kore.Step.Simplification.Data
                  ( Simplifier, evalSimplifier )
+import           Kore.Strategies.OnePath.Verification
+                 ( verifyClaimStep )
 import           Kore.Syntax.Variable
                  ( SortedVariable, Variable )
 import           Kore.Unification.Procedure

--- a/kore/test/Test/Kore/Strategies/OnePath/Verification.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Verification.hs
@@ -17,7 +17,6 @@ import Numeric.Natural
        ( Natural )
 
 import qualified Kore.Attribute.Axiom as Attribute
-import           Kore.Goal
 import           Kore.Internal.Pattern
                  ( Conditional (Conditional) )
 import           Kore.Internal.Pattern as Conditional
@@ -33,6 +32,7 @@ import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
+import           Kore.Strategies.Goal
 import qualified Kore.Strategies.OnePath.Verification as OnePath
 import qualified SMT
 

--- a/kore/test/Test/Kore/Strategies/OnePath/Verification.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Verification.hs
@@ -1,4 +1,4 @@
-module Test.Kore.OnePath.Verification
+module Test.Kore.Strategies.OnePath.Verification
     ( test_onePathVerification
     ) where
 
@@ -24,7 +24,6 @@ import           Kore.Internal.Pattern as Conditional
                  ( Conditional (..) )
 import           Kore.Internal.Pattern as Pattern
 import           Kore.Internal.TermLike
-import qualified Kore.OnePath.Verification as OnePath
 import           Kore.Predicate.Predicate
                  ( makeEqualsPredicate, makeNotPredicate, makeTruePredicate )
 import           Kore.Step.Rule
@@ -34,6 +33,7 @@ import           Kore.Step.Rule as RulePattern
                  ( RulePattern (..) )
 import           Kore.Step.Simplification.Data
                  ( evalSimplifier )
+import qualified Kore.Strategies.OnePath.Verification as OnePath
 import qualified SMT
 
 import           Test.Kore


### PR DESCRIPTION
@ttuegel Would this improve the current code? I was trying to understand Goal.hs and it seemed to me that it contained things that shouldn't be in there so I extracted them, what do you think about it?

I also moved OnePath one level down in the module hierarchy, hoping that it will make more sense to put AllPath, OnePath, and whatever else we may add (chain-of-rules execution maybe) in their own directory.

I don't need this refactoring, so I can just drop the PR if it does not make sense.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
- [ ] Style conformance: `stylish-haskell`

---

