### PR TITLE
No Literate Haskell

### DIFF
--- a/kore/src/Kore/Step/Simplification/Or.hs
+++ b/kore/src/Kore/Step/Simplification/Or.hs
@@ -9,17 +9,20 @@ module Kore.Step.Simplification.Or
     ) where
 
 import Control.Applicative
-       ( Alternative (..) )
+    ( Alternative (..)
+    )
 
-import           Kore.Internal.Conditional as Conditional
+import Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
-import           Kore.Internal.OrPattern
-                 ( OrPattern )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import           Kore.Internal.Pattern as Pattern
-import           Kore.Internal.TermLike
-import           Kore.Predicate.Predicate
-                 ( makeOrPredicate )
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import Kore.Predicate.Predicate
+    ( makeOrPredicate
+    )
 
 -- * Driver
 

--- a/kore/src/Kore/Step/Simplification/Or.hs
+++ b/kore/src/Kore/Step/Simplification/Or.hs
@@ -1,81 +1,74 @@
-% Or Simplification
-
-== Header
-
-\begin{code}
-{-|
-Module      : Kore.Step.Simplification.Or
-Description : Tools for Or pattern simplification.
+{- |
 Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
-Maintainer  : virgil.serbanuta@runtimeverification.com
-Stability   : experimental
-Portability : portable
+
 -}
 module Kore.Step.Simplification.Or
     ( simplifyEvaluated
     , simplify
     ) where
 
-import           Control.Applicative
-                 ( Alternative (..) )
+import Control.Applicative
+       ( Alternative (..) )
 
-import           Kore.Predicate.Predicate
-                 ( makeOrPredicate )
 import           Kore.Internal.Conditional as Conditional
-import           Kore.Internal.Pattern as Pattern
-import qualified Kore.Internal.OrPattern as OrPattern
+import qualified Kore.Internal.MultiOr as MultiOr
 import           Kore.Internal.OrPattern
                  ( OrPattern )
-import qualified Kore.Internal.MultiOr as MultiOr
+import qualified Kore.Internal.OrPattern as OrPattern
+import           Kore.Internal.Pattern as Pattern
 import           Kore.Internal.TermLike
-\end{code}
+import           Kore.Predicate.Predicate
+                 ( makeOrPredicate )
 
-== Driver
+-- * Driver
 
-\begin{code}
-{-|'simplify' simplifies an 'Or' pattern with 'OrPattern'
-children by merging the two children.
+{- | 'simplify' simplifies an 'Or' pattern into an 'OrPattern'.
+
+'simplify' is the driver responsible for breaking down an @\\or@ pattern and
+merging its children.
+
 -}
 simplify
     :: InternalVariable variable
     => Or Sort (OrPattern variable)
     -> OrPattern variable
-\end{code}
-
-`simplify` is a driver responsible for breaking down an `\or` pattern and
-simplifying its children.
-
-\begin{code}
 simplify Or { orFirst = first, orSecond = second } =
     simplifyEvaluated first second
 
-{-| simplifies an 'Or' given its two 'OrPattern' children.
+{- | Simplify an 'Or' given its two 'OrPattern' children.
 
-See 'simplify' for detailed documentation.
+See also: 'simplify'
+
 -}
 simplifyEvaluated
     :: InternalVariable variable
     => OrPattern variable
     -> OrPattern variable
     -> OrPattern variable
-\end{code}
 
-**TODO** (virgil): Preserve pattern sorts under simplification.
-One way to preserve the required sort annotations is to make `simplifyEvaluated`
+{-
+
+__TODO__ (virgil): Preserve pattern sorts under simplification.
+One way to preserve the required sort annotations is to make 'simplifyEvaluated'
 take an argument of type
-``` haskell
+
+@
 CofreeF (Or Sort) (Attribute.Pattern variable) (OrPattern variable)
-```
-instead of two `OrPattern` arguments. The type of `makeEvaluate` may
-be changed analogously. The `Attribute.Pattern` annotation will eventually cache
+@
+
+instead of two 'OrPattern' arguments. The type of 'makeEvaluate' may
+be changed analogously. The 'Attribute.Pattern' annotation will eventually cache
 information besides the pattern sort, which will make it even more useful to
 carry around.
 
-**TODO** (virgil): This should do all possible mergings, not just the first term
-with the second.
+-}
 
-\begin{code}
+{-
+__TODO__ (virgil): This should do all possible mergings, not just the first term
+with the second.
+-}
+
 simplifyEvaluated first second
 
   | (head1 : tail1) <- MultiOr.extractPatterns first
@@ -89,47 +82,42 @@ simplifyEvaluated first second
   where
     simplifySinglePatterns first' second' =
         disjoinPredicates first' second' <|> topAnnihilates first' second'
-\end{code}
 
-== Disjoin predicates
+-- * Disjoin predicates
 
-\begin{code}
 {- | Merge two configurations by the disjunction of their predicates.
 
 This simplification case is only applied if the configurations have the same
 'term'.
 
- -}
-disjoinPredicates
-    :: InternalVariable variable
-    => Pattern variable
-    -- ^ Configuration
-    -> Pattern variable
-    -- ^ Disjunction
-    -> Maybe (Pattern variable)
-\end{code}
-
 When two configurations have the same substitution, it may be possible to
 simplify the pair by disjunction of their predicates.
-```
+
+@
 (             t₁, p₁, s) ∨ (             t₂, p₂, s)
 ([t₂ ∨ ¬t₂] ∧ t₁, p₁, s) ∨ ([t₁ ∨ ¬t₁] ∧ t₂, p₂, s)
 
 (t₁ ∧ t₂, p₁ ∨ p₂, s) ∨ (¬t₂ ∧ t₁, p₁, s) ∨ (¬t₁ ∧ t₂, p₂, s)
-```
+@
+
 It is useful to apply the above equality when
-```
+
+@
 ¬t₂ ∧ t₁ = ¬t₁ ∧ t₂ = ⊥
 t₁ = t₂
-```
+@
+
 so that
-```
+
+@
 (t₁, p₁, s) ∨ (t₂, p₂, s) = (t₁ ∧ t₂, p₁ ∨ p₂, s)
   where
     t₁ = t₂.
-```
+@
 
-**Note**: [Weakening predicates]
+ -}
+
+{- __NOTE__: [Weakening predicates]
 
 Phillip: It is not clear that we should *ever* apply this simplification.  We
 attempt to refute the conditions on configurations using an external solver to
@@ -149,8 +137,14 @@ be split into many other configurations. Or it may be worse, I don't know.
 
 To make it short: I agree with this, but I wanted to say the above in case it's
 useful.
-
-\begin{code}
+-}
+disjoinPredicates
+    :: InternalVariable variable
+    => Pattern variable
+    -- ^ Configuration
+    -> Pattern variable
+    -- ^ Disjunction
+    -> Maybe (Pattern variable)
 disjoinPredicates
     predicated1@Conditional
         { term = term1
@@ -167,12 +161,36 @@ disjoinPredicates
     Just (predicated1 { predicate = makeOrPredicate predicate1 predicate2 })
   | otherwise =
     Nothing
-\end{code}
 
-== `\top` annihilates `\or`
+-- * Top annihilates Or
 
-\begin{code}
 {- | 'Top' patterns are the annihilator of 'Or'.
+
+@⊤@ is the annihilator of @∨@; when two configurations have the same
+substitution, it may be possible to use this property to simplify the pair by
+annihilating the lesser term.
+
+@
+(⊤,              p₁, s) ∨ (t₂,              p₂, s)
+(⊤, [p₂ ∨ ¬p₂] ∧ p₁, s) ∨ (t₂, [p₁ ∨ ¬p₁] ∧ p₂, s)
+
+(⊤, p₁ ∧ p₂, s) ∨ (⊤, p₁ ∧ ¬p₂, s) ∨ (t₂, ¬p₁ ∧ p₂, s)
+@
+
+It is useful to apply the above equality when
+
+@
+¬p₂ ∧ p₁ = ¬p₁ ∧ p₂ = ⊥
+p₁ = p₂
+@
+
+so that
+
+@
+(⊤, p₁, s) ∨ (t₂, p₂, s) = (⊤, p₁ ∧ p₂, s)
+  where
+    p₁ = p₂.
+@
  -}
 topAnnihilates
     :: InternalVariable variable
@@ -181,30 +199,6 @@ topAnnihilates
     -> Pattern variable
     -- ^ Disjunction
     -> Maybe (Pattern variable)
-\end{code}
-
-`⊤` is the annihilator of `∨`; when two configurations have the same
-substitution, it may be possible to use this property to simplify the pair by
-annihilating the lesser term.
-```
-(⊤,              p₁, s) ∨ (t₂,              p₂, s)
-(⊤, [p₂ ∨ ¬p₂] ∧ p₁, s) ∨ (t₂, [p₁ ∨ ¬p₁] ∧ p₂, s)
-
-(⊤, p₁ ∧ p₂, s) ∨ (⊤, p₁ ∧ ¬p₂, s) ∨ (t₂, ¬p₁ ∧ p₂, s)
-```
-It is useful to apply the above equality when
-```
-¬p₂ ∧ p₁ = ¬p₁ ∧ p₂ = ⊥
-p₁ = p₂
-```
-so that
-```
-(⊤, p₁, s) ∨ (t₂, p₂, s) = (⊤, p₁ ∧ p₂, s)
-  where
-    p₁ = p₂.
-```
-
-\begin{code}
 topAnnihilates
     predicated1@Conditional
         { term = term1
@@ -232,4 +226,3 @@ topAnnihilates
 
   | otherwise =
     Nothing
-\end{code}


### PR DESCRIPTION
When I made this module literate, I didn't realize that Emacs is the only editor
which really supports Literate Haskell. Worse, stylish-haskell doesn't support
Literate Haskell either.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
