### PR TITLE
Clarify the onepath strategy

### DIFF
--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -842,7 +842,8 @@ tryAxiomClaimWorker mode ref = do
                     ProofStateTransformer
                         { provenValue        = putStrLn' "Cannot unify bottom"
                         , goalTransformer    = runUnifier' first . term
-                        , goalRemTransformer = runUnifier' first . term
+                        , goalRemainderTransformer = runUnifier' first . term
+                        , goalRewrittenTransformer = runUnifier' first . term
                         }
                     second
 
@@ -1131,9 +1132,11 @@ unparseStrategy
 unparseStrategy omitList =
     proofState ProofStateTransformer
         { goalTransformer = makeKoreReplOutput . unparseToString . fmap hide
-        , goalRemTransformer = \pat ->
+        , goalRemainderTransformer = \pat ->
             makeAuxReplOutput "Stuck: \n"
             <> makeKoreReplOutput (unparseToString $ fmap hide pat)
+        , goalRewrittenTransformer =
+            makeKoreReplOutput . unparseToString . fmap hide
         , provenValue = makeAuxReplOutput "Reached bottom"
         }
   where

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -507,7 +507,8 @@ getNodeState graph node =
         fmap (\nodeState -> (nodeState, node))
         . proofState ProofStateTransformer
             { goalTransformer = const . Just $ UnevaluatedNode
-            , goalRemTransformer = const . Just $ StuckNode
+            , goalRemainderTransformer = const . Just $ StuckNode
+            , goalRewrittenTransformer = const . Just $ UnevaluatedNode
             , provenValue = Nothing
             }
         . Graph.lab'
@@ -521,7 +522,8 @@ nodeToPattern
 nodeToPattern graph node =
     proofState ProofStateTransformer
         { goalTransformer = Just . toTermLike
-        , goalRemTransformer = Just . toTermLike
+        , goalRemainderTransformer = Just . toTermLike
+        , goalRewrittenTransformer = Just . toTermLike
         , provenValue = Nothing
         }
     . Graph.lab'

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -131,16 +131,26 @@ transitionRule = transitionRuleWorker
 
     transitionRuleWorker (DerivePar rules) (Goal g) =
         -- TODO (virgil): Wrap the results in GoalRemainder/GoalRewritten here.
+        --
+        -- Note that in most transitions it is obvious what is being transformed
+        -- into what, e.g. that a `ResetGoal` transition transforms
+        -- `GoalRewritten` into `Goal`. However, here we're taking a `Goal`
+        -- and transforming it into `GoalRewritten` and `GoalRemainder` in an
+        -- opaque way. I think that there's no good reason for wrapping the
+        -- results in `derivePar` as opposed to here.
         derivePar rules g
     transitionRuleWorker (DerivePar rules) (GoalRemainder g) =
         -- TODO (virgil): Wrap the results in GoalRemainder/GoalRewritten here.
+        -- See above for an explanation.
         derivePar rules g
 
     transitionRuleWorker (DeriveSeq rules) (Goal g) =
         -- TODO (virgil): Wrap the results in GoalRemainder/GoalRewritten here.
+        -- See above for an explanation.
         deriveSeq rules g
     transitionRuleWorker (DeriveSeq rules) (GoalRemainder g) =
         -- TODO (virgil): Wrap the results in GoalRemainder/GoalRewritten here.
+        -- See above for an explanation.
         deriveSeq rules g
 
     transitionRuleWorker _ state = return state

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -168,23 +168,30 @@ allPathStrategy claims axioms =
         (Strategy.sequence . map Strategy.apply)
             [ CheckProven
             , CheckGoalRemainder
-            , ResetGoal
             , RemoveDestination
             , TriviallyValid
             , DerivePar axioms
+            , RemoveDestination
+            , Simplify
+            , TriviallyValid
+            , ResetGoal
             , TriviallyValid
             ]
     nextStep =
         (Strategy.sequence . map Strategy.apply)
             [ CheckProven
             , CheckGoalRemainder
-            , ResetGoal
             , RemoveDestination
             , TriviallyValid
             , DeriveSeq claims
             , RemoveDestination
             , Simplify
+            , TriviallyValid
             , DerivePar axioms
+            , RemoveDestination
+            , Simplify
+            , TriviallyValid
+            , ResetGoal
             , TriviallyValid
             ]
 
@@ -200,6 +207,8 @@ onePathFirstStep axioms =
         , TriviallyValid
         , DeriveSeq axioms
         , RemoveDestination
+        , Simplify
+        , TriviallyValid
         , ResetGoal
         , Simplify
         , TriviallyValid
@@ -210,6 +219,10 @@ onePathFollowupStep claims axioms =
     (Strategy.sequence . map Strategy.apply)
         [ CheckProven
         , CheckGoalRemainder
+        , Simplify
+        , TriviallyValid
+        , RemoveDestination
+        , Simplify
         , TriviallyValid
         , DeriveSeq claims
         , RemoveDestination
@@ -217,6 +230,8 @@ onePathFollowupStep claims axioms =
         , TriviallyValid
         , DeriveSeq axioms
         , RemoveDestination
+        , Simplify
+        , TriviallyValid
         , ResetGoal
         , Simplify
         , TriviallyValid

--- a/kore/src/Kore/Strategies/OnePath/Actions.hs
+++ b/kore/src/Kore/Strategies/OnePath/Actions.hs
@@ -175,8 +175,8 @@ derivePar rules goal = do
                     . Step.withoutUnification
                 traverseConfigs =
                     Result.traverseConfigs
-                        (pure . Goal.Goal)
-                        removeDestSimplifyRemainder
+                        (pure . Goal.GoalRewritten)
+                        (pure . Goal.GoalRemainder)
             let onePathResults =
                     Result.mapConfigs
                         (`makeRuleFromPatterns` destination)
@@ -232,8 +232,8 @@ deriveSeq rules goal = do
                     . Step.withoutUnification
                 traverseConfigs =
                     Result.traverseConfigs
-                        (pure . Goal.Goal)
-                        removeDestSimplifyRemainder
+                        (pure . Goal.GoalRewritten)
+                        (pure . Goal.GoalRemainder)
             let onePathResults =
                     Result.mapConfigs
                         (`makeRuleFromPatterns` destination)
@@ -312,22 +312,3 @@ getDestination
     -> Pattern variable
 getDestination (coerce -> RulePattern { right, ensures }) =
     Pattern.withCondition right (Conditional.fromPredicate ensures)
-
-removeDestSimplifyRemainder
-    :: forall variable m rule
-    .  MonadSimplify m
-    => SortedVariable variable
-    => Debug variable
-    => Unparse variable
-    => Show variable
-    => FreshVariable variable
-    => OnePathRule variable
-    -> Strategy.TransitionT
-        rule
-        m
-        (Goal.ProofState (OnePathRule variable))
-removeDestSimplifyRemainder remainder = do
-    result <- removeDestination remainder >>= simplify
-    if isTriviallyValid result
-       then pure Goal.Proven
-       else pure . Goal.GoalRem $ result

--- a/kore/test/Test/Kore/AllPath.hs
+++ b/kore/test/Test/Kore/AllPath.hs
@@ -133,7 +133,7 @@ test_transitionRule_RemoveDestination :: [TestTree]
 test_transitionRule_RemoveDestination =
     [ unmodified Goal.Proven
     , unmodified (Goal.GoalRemainder (A, B))
-    , Goal.Goal (B, B) `becomes` (Goal.GoalRemainder (Bot, B), mempty)
+    , Goal.Goal (B, B) `becomes` (Goal.Goal (Bot, B), mempty)
     ]
   where
     run = runTransitionRule Goal.RemoveDestination
@@ -158,7 +158,7 @@ test_transitionRule_TriviallyValid =
 test_transitionRule_DerivePar :: [TestTree]
 test_transitionRule_DerivePar =
     [ unmodified Goal.Proven
-    , unmodified (Goal.Goal    (A, B))
+    , unmodified (Goal.GoalRewritten (A, B))
     , [Rule (A, C)]
         `derives`
         [ (Goal.Goal    (C,   C), Seq.singleton $ Rule (A, C))

--- a/kore/test/Test/Kore/Comparators.hs
+++ b/kore/test/Test/Kore/Comparators.hs
@@ -1937,13 +1937,24 @@ instance
     (EqualWithExplanation goal, Show goal)
     => SumEqualWithExplanation (ProofState goal)
   where
-    sumConstructorPair Proven          Proven          =
+    sumConstructorPair Proven                 Proven          =
         SumConstructorSameNoArguments
-    sumConstructorPair (Goal goal1)    (Goal goal2)    =
+    sumConstructorPair expect@Proven          actual          =
+        SumConstructorDifferent (show expect) (show actual)
+
+    sumConstructorPair (Goal goal1)           (Goal goal2)    =
         SumConstructorSameWithArguments (EqWrap "Goal" goal1 goal2)
-    sumConstructorPair (GoalRem goal1) (GoalRem goal2) =
-        SumConstructorSameWithArguments (EqWrap "GoalRem" goal1 goal2)
-    sumConstructorPair expect           actual           =
+    sumConstructorPair expect@(Goal _)        actual          =
+        SumConstructorDifferent (show expect) (show actual)
+
+    sumConstructorPair (GoalRemainder goal1)        (GoalRemainder goal2) =
+        SumConstructorSameWithArguments (EqWrap "GoalRemainder" goal1 goal2)
+    sumConstructorPair expect@(GoalRemainder _)     actual                =
+        SumConstructorDifferent (show expect) (show actual)
+
+    sumConstructorPair (GoalRewritten goal1)        (GoalRewritten goal2) =
+        SumConstructorSameWithArguments (EqWrap "GoalRewritten" goal1 goal2)
+    sumConstructorPair expect@(GoalRewritten _)     actual                =
         SumConstructorDifferent (show expect) (show actual)
 
 -- SMT.AST

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -199,148 +199,147 @@ test_onePathStrategy =
                 [ _actual
                 ]
             )
-     , testCase "Differentiated axioms" $ do
-         -- Target: constr11(a)
-         -- Coinductive axiom: constr11(a) => g(a)
-         -- Coinductive axiom: constr11(b) => f(b)
-         -- Normal axiom: constr11(a) => g(a)
-         -- Normal axiom: constr11(b) => g(b)
-         -- Normal axiom: constr11(c) => f(c)
-         -- Normal axiom: constr11(x) => h(x)
-         -- Normal axiom: constr10(x) => constr11(x)
-         -- Start pattern: constr10(x)
-         -- Expected:
-         --   (f(b) and x=b)
-         --   or (f(c) and x=c)
-         --   or (h(x) and x!=a and x!=b and x!=c )
-         actual <-
-             runOnePathSteps
+    , testCase "Differentiated axioms" $ do
+        -- Target: constr11(a)
+        -- Coinductive axiom: constr11(a) => g(a)
+        -- Coinductive axiom: constr11(b) => f(b)
+        -- Normal axiom: constr11(a) => g(a)
+        -- Normal axiom: constr11(b) => g(b)
+        -- Normal axiom: constr11(c) => f(c)
+        -- Normal axiom: constr11(x) => h(x)
+        -- Normal axiom: constr10(x) => constr11(x)
+        -- Start pattern: constr10(x)
+        -- Expected:
+        --   (f(b) and x=b)
+        --   or (f(c) and x=c)
+        --   or (h(x) and x!=a and x!=b and x!=c )
+        actual <-
+            runOnePathSteps
+            (Limit 2)
+            (makeOnePathRule
+                (Mock.functionalConstr10 (TermLike.mkElemVar Mock.x))
+                (Mock.functionalConstr11 Mock.a)
+            )
+            [ simpleRewrite (Mock.functionalConstr11 Mock.a) (Mock.g Mock.a)
+            , simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.f Mock.b)
+            ]
+            [ simpleRewrite (Mock.functionalConstr11 Mock.a) (Mock.g Mock.a)
+            , simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.g Mock.b)
+            , simpleRewrite (Mock.functionalConstr11 Mock.c) (Mock.f Mock.c)
+            , simpleRewrite
+                (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
+                (Mock.h (TermLike.mkElemVar Mock.y))
+            , simpleRewrite
+                (Mock.functionalConstr10 (TermLike.mkElemVar Mock.y))
+                (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
+            ]
+        let expected =
+                [ Goal $ makeRuleFromPatterns
+                ( Conditional
+                    { term = Mock.f Mock.b
+                    , predicate = makeTruePredicate
+                    , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.b)]
+                    }
+                )
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+                , Goal $ makeRuleFromPatterns
+                ( Conditional
+                    { term = Mock.f Mock.c
+                    , predicate = makeTruePredicate
+                    , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.c)]
+                    }
+                )
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+                , Goal $ makeRuleFromPatterns
+                ( Conditional
+                    { term = Mock.h (TermLike.mkElemVar Mock.x)
+                    , predicate =  -- TODO(virgil): Better and simplification.
+                        makeAndPredicate
+                            (makeAndPredicate
+                                (makeNotPredicate
+                                    (makeEqualsPredicate
+                                        (TermLike.mkElemVar Mock.x) Mock.a
+                                    )
+                                )
+                                (makeNotPredicate
+                                    (makeEqualsPredicate
+                                        (TermLike.mkElemVar Mock.x) Mock.b
+                                    )
+                                )
+                            )
+                            (makeNotPredicate
+                                (makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.c)
+                            )
+                    , substitution = mempty
+                    }
+                )
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+                ]
+        assertEqualWithExplanation ""
+            expected
+            actual
+    , testCase "zzzStuck pattern" $ do
+        -- Target: constr11(a)
+        -- Coinductive axiom: constr11(b) => f(b)
+        -- Normal axiom: constr11(c) => f(c)
+        -- Normal axiom: constr10(x) => constr11(x)
+        -- Start pattern: constr10(x)
+        -- Expected:
+        --   Bottom
+        --   or (f(b) and x=b)
+        --   or (f(c) and x=c)
+        --   Stuck (functionalConstr11(x) and x!=a and x!=b and x!=c )
+        [ _actual1, _actual2, _actual3 ] <-
+            runOnePathSteps
                 (Limit 2)
                 (makeOnePathRule
                     (Mock.functionalConstr10 (TermLike.mkElemVar Mock.x))
                     (Mock.functionalConstr11 Mock.a)
                 )
-                [ simpleRewrite (Mock.functionalConstr11 Mock.a) (Mock.g Mock.a)
-                , simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.f Mock.b)
+                [ simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.f Mock.b)
                 ]
-                [ simpleRewrite (Mock.functionalConstr11 Mock.a) (Mock.g Mock.a)
-                , simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.g Mock.b)
-                , simpleRewrite (Mock.functionalConstr11 Mock.c) (Mock.f Mock.c)
-                , simpleRewrite
-                    (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
-                    (Mock.h (TermLike.mkElemVar Mock.y))
+                [ simpleRewrite (Mock.functionalConstr11 Mock.c) (Mock.f Mock.c)
                 , simpleRewrite
                     (Mock.functionalConstr10 (TermLike.mkElemVar Mock.y))
                     (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
                 ]
-         let expected =
-                 [ Goal $ makeRuleFromPatterns
-                    ( Conditional
-                        { term = Mock.f Mock.b
-                        , predicate = makeTruePredicate
-                        , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.b)]
-                        }
-                    )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
-                 , Goal $ makeRuleFromPatterns
-                    ( Conditional
-                        { term = Mock.f Mock.c
-                        , predicate = makeTruePredicate
-                        , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.c)]
-                        }
-                    )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
-                 , Goal $ makeRuleFromPatterns
-                    ( Conditional
-                        { term = Mock.h (TermLike.mkElemVar Mock.x)
-                        , predicate =  -- TODO(virgil): Better and simplification.
-                            makeAndPredicate
-                                (makeAndPredicate
-                                    (makeNotPredicate
-                                        (makeEqualsPredicate
-                                            (TermLike.mkElemVar Mock.x) Mock.a
-                                        )
-                                    )
-                                    (makeNotPredicate
-                                        (makeEqualsPredicate
-                                            (TermLike.mkElemVar Mock.x) Mock.b
-                                        )
-                                    )
-                                )
-                                (makeNotPredicate
-                                    (makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.c)
-                                )
-                        , substitution = mempty
-                        }
-                    )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
-                 ]
-         assertEqualWithExplanation ""
-            expected
-            actual
-     , testCase "Stuck pattern" $ do
-         -- Target: constr11(a)
-         -- Coinductive axiom: constr11(b) => f(b)
-         -- Normal axiom: constr11(c) => f(c)
-         -- Normal axiom: constr10(x) => constr11(x)
-         -- Start pattern: constr10(x)
-         -- Expected:
-         --   Bottom
-         --   or (f(b) and x=b)
-         --   or (f(c) and x=c)
-         --   Stuck (functionalConstr11(x) and x!=a and x!=b and x!=c )
-         [ _actual1, _actual2, _actual3 ] <-
-             runOnePathSteps
-                 (Limit 2)
-                 (makeOnePathRule
-                     (Mock.functionalConstr10 (TermLike.mkElemVar Mock.x))
-                     (Mock.functionalConstr11 Mock.a)
-                 )
-                 [ simpleRewrite (Mock.functionalConstr11 Mock.b) (Mock.f Mock.b)
-                 ]
-                 [ simpleRewrite (Mock.functionalConstr11 Mock.c) (Mock.f Mock.c)
-                 , simpleRewrite
-                     (Mock.functionalConstr10 (TermLike.mkElemVar Mock.y))
-                     (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
-                 ]
-         let equalsXA = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.a
-             equalsXB = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.b
-             equalsXC = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.c
-         assertEqualWithExplanation ""
-             [ Goal $ makeRuleFromPatterns
-                 ( Conditional
-                     { term = Mock.f Mock.b
-                     , predicate = makeTruePredicate
-                     , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.b)]
-                     }
-                 )
-                 (fromTermLike $ Mock.functionalConstr11 Mock.a)
-             , Goal $ makeRuleFromPatterns
-                 ( Conditional
-                     { term = Mock.f Mock.c
-                     , predicate = makeTruePredicate
-                     , substitution = Substitution.unsafeWrap [(ElemVar Mock.x, Mock.c)]
-                     }
-                 )
-                 (fromTermLike $ Mock.functionalConstr11 Mock.a)
-             , GoalRem $ makeRuleFromPatterns
-                 ( Conditional
-                     { term = Mock.functionalConstr11 (TermLike.mkElemVar Mock.x)
-                     , predicate =
-                         makeMultipleAndPredicate
-                             [ makeNotPredicate equalsXA
-                             , makeNotPredicate equalsXB
-                             , makeNotPredicate equalsXC
-                             ]
-                     , substitution = mempty
-                     }
-                 )
-                 (fromTermLike $ Mock.functionalConstr11 Mock.a)
-             ]
-             [ _actual1
-             , _actual2
-             , _actual3
-             ]
+        let equalsXA = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.a
+            equalsXB = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.b
+            equalsXC = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.c
+        assertEqualWithExplanation ""
+            [ Goal $ makeRuleFromPatterns
+                Conditional
+                    { term = Mock.f Mock.b
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        Substitution.unsafeWrap [(ElemVar Mock.x, Mock.b)]
+                    }
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+            , Goal $ makeRuleFromPatterns
+                Conditional
+                    { term = Mock.f Mock.c
+                    , predicate = makeTruePredicate
+                    , substitution =
+                        Substitution.unsafeWrap [(ElemVar Mock.x, Mock.c)]
+                    }
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+            , GoalRemainder $ makeRuleFromPatterns
+                Conditional
+                    { term = Mock.functionalConstr11 (TermLike.mkElemVar Mock.x)
+                    , predicate =
+                        makeMultipleAndPredicate
+                            [ makeNotPredicate equalsXB
+                            , makeNotPredicate equalsXA
+                            , makeNotPredicate equalsXC
+                            ]
+                    , substitution = mempty
+                    }
+                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+            ]
+            [ _actual1
+            , _actual2
+            , _actual3
+            ]
     , testCase "Axiom with requires" $ do
         -- Target: a
         -- Coinductive axiom: n/a
@@ -362,7 +361,7 @@ test_onePathStrategy =
                     $ Mock.f Mock.b
             ]
         assertEqualWithExplanation ""
-            [ GoalRem $ makeRuleFromPatterns
+            [ GoalRemainder $ makeRuleFromPatterns
                 ( Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate =

--- a/kore/test/Test/Kore/OnePath/Step.hs
+++ b/kore/test/Test/Kore/OnePath/Step.hs
@@ -278,7 +278,7 @@ test_onePathStrategy =
         assertEqualWithExplanation ""
             expected
             actual
-    , testCase "zzzStuck pattern" $ do
+    , testCase "Stuck pattern" $ do
         -- Target: constr11(a)
         -- Coinductive axiom: constr11(b) => f(b)
         -- Normal axiom: constr11(c) => f(c)
@@ -328,8 +328,8 @@ test_onePathStrategy =
                     { term = Mock.functionalConstr11 (TermLike.mkElemVar Mock.x)
                     , predicate =
                         makeMultipleAndPredicate
-                            [ makeNotPredicate equalsXB
-                            , makeNotPredicate equalsXA
+                            [ makeNotPredicate equalsXA
+                            , makeNotPredicate equalsXB
                             , makeNotPredicate equalsXC
                             ]
                     , substitution = mempty


### PR DESCRIPTION
Right now we are removing the destination from the remainder and simplifying the result when deriving rules. That's a bit strange from a strategy/goal point of view, so this PR moves that at the strategy level.

To do that, it splits the `Goal` goal into `Goal` and `GoalRewritten`, so that we can easily ignore the latter until the end of a step.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
