### PR TITLE
Function memoization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 
         stage('KEVM Integration') {
           options {
-            timeout(time: 24, unit: 'MINUTES')
+            timeout(time: 16, unit: 'MINUTES')
           }
           steps {
             sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 
         stage('KEVM Integration') {
           options {
-            timeout(time: 48, unit: 'MINUTES')
+            timeout(time: 16, unit: 'MINUTES')
           }
           steps {
             sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 
         stage('KEVM Integration') {
           options {
-            timeout(time: 16, unit: 'MINUTES')
+            timeout(time: 24, unit: 'MINUTES')
           }
           steps {
             sh '''

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -83,6 +83,11 @@ import Kore.Unparser
 
 {-| Evaluates functions on an application pattern.
 -}
+-- TODO (thomas.tuegel): Factor out a "function evaluator" object.
+-- See also: Kore.Step.Function.Memo.Self
+-- Then add a function,
+--   memoize :: Evaluator.Self state -> Memo.Self state -> Evaluator.Self state
+-- to add memoization to a function evaluator.
 evaluateApplication
     :: forall variable simplifier
     .  (SimplifierVariable variable, MonadSimplify simplifier)

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -110,8 +110,13 @@ evaluateApplication
     let
         unevaluatedSimplifier
           | Just hook <- getHook (Attribute.hook symbolAttributes)
-            -- TODO (thomas.tuegel): (not . null) is a nasty hack to avoid
-            -- making the function evaluator a replaceable component.
+          -- TODO (thomas.tuegel): Factor out a second function evaluator and
+          -- remove this check. At startup, the definition's rules are
+          -- simplified using Matching Logic only (no function
+          -- evaluation). During this stage, all the hooks are expected to be
+          -- missing, so that is not an error. If any function evaluators are
+          -- present, we assume that startup is finished, but we should really
+          -- have a separate evaluator for startup.
           , (not . null) axiomIdToEvaluator
           =
             (error . show . Pretty.vsep)

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -79,15 +79,18 @@ evaluateApplication
     -> Application Symbol (TermLike variable)
     -- ^ The pattern to be evaluated
     -> simplifier (OrPattern variable)
-evaluateApplication configurationPredicate childrenPredicate application = do
+evaluateApplication
+    configurationPredicate
+    childrenPredicate
+    (evaluateSortInjection -> application)
+  = do
     substitutionSimplifier <- Simplifier.askSimplifierPredicate
     simplifier <- Simplifier.askSimplifierTermLike
     axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
     let
-        afterInj = evaluateSortInjection application
-        Application { applicationSymbolOrAlias = appHead } = afterInj
-        Symbol { symbolConstructor = symbolId } = appHead
-        termLike = synthesize (ApplySymbolF afterInj)
+        Application { applicationSymbolOrAlias = symbol } = application
+        Symbol { symbolConstructor = symbolId } = symbol
+        termLike = synthesize (ApplySymbolF application)
 
         maybeEvaluatedPattSimplifier =
             maybeEvaluatePattern
@@ -110,7 +113,7 @@ evaluateApplication configurationPredicate childrenPredicate application = do
         unchanged = OrPattern.fromPattern unchangedPatt
 
         getSymbolHook = getHook . Attribute.hook . symbolAttributes
-        getAppHookString = Text.unpack <$> getSymbolHook appHead
+        getAppHookString = Text.unpack <$> getSymbolHook symbol
 
     case maybeEvaluatedPattSimplifier of
         Nothing

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -12,6 +12,10 @@ module Kore.Step.Function.Evaluator
     , evaluatePattern
     ) where
 
+import Control.Error
+    ( ExceptT
+    , exceptT
+    )
 import Control.Exception
     ( assert
     )
@@ -83,7 +87,7 @@ evaluateApplication
     configurationPredicate
     childrenPredicate
     (evaluateSortInjection -> application)
-  = do
+  = finishT $ do
     substitutionSimplifier <- Simplifier.askSimplifierPredicate
     simplifier <- Simplifier.askSimplifierTermLike
     axiomIdToEvaluator <- Simplifier.askSimplifierAxioms
@@ -126,6 +130,9 @@ evaluateApplication
           | otherwise ->
             return unchanged
         Just evaluatedPattSimplifier -> evaluatedPattSimplifier
+  where
+    finishT :: ExceptT r simplifier r -> simplifier r
+    finishT = exceptT return return
 
 {-| Evaluates axioms on patterns.
 -}

--- a/kore/src/Kore/Step/Function/Memo.hs
+++ b/kore/src/Kore/Step/Function/Memo.hs
@@ -1,0 +1,108 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+This module should be imported qualified:
+
+@
+import qualified Kore.Step.Function.Memo as Memo
+@
+
+-}
+
+module Kore.Step.Function.Memo
+    ( Self (..)
+    , Key
+    , Cache
+    , forgetful
+    , simple
+    , liftSelf
+    , new
+    ) where
+
+import Control.Monad.IO.Class
+    ( MonadIO
+    , liftIO
+    )
+import Control.Monad.State.Class
+    ( MonadState
+    )
+import qualified Control.Monad.State.Class as State
+import Control.Monad.State.Strict
+    ( State
+    , runState
+    )
+import Data.HashMap.Strict
+    ( HashMap
+    )
+import qualified Data.HashMap.Strict as HashMap
+import Data.IORef
+import qualified Data.Tuple as Tuple
+
+import Kore.Internal.TermLike
+
+{- | A function application memoizer.
+ -}
+data Self monad =
+    Self
+        { recall
+            :: Application Symbol (TermLike Concrete)
+            -> monad (Maybe (TermLike Concrete))
+        , record
+            :: Application Symbol (TermLike Concrete)
+            -> TermLike Concrete
+            -> monad ()
+        }
+
+{- | The forgetful memoizer.
+
+@forgetful@ recalls nothing and records nothing.
+
+ -}
+forgetful :: Applicative monad => Self monad
+forgetful = Self { recall = \_ -> pure Nothing, record = \_ _ -> pure () }
+
+-- | The concrete function pattern used as a @Key@ into the memoization cache.
+type Key = Application Symbol (TermLike Concrete)
+
+-- | The memoization @Cache@.
+type Cache = HashMap Key (TermLike Concrete)
+
+{- | The simple memoizer.
+
+@simple@ uses a simple 'State' monad for state tracking.
+
+ -}
+simple :: MonadState Cache state => Self state
+simple =
+    Self { recall, record }
+  where
+    recall application = State.gets $ HashMap.lookup application
+    record application result =
+        State.modify' $ HashMap.insert application result
+
+{- | Transform a memoizer using the provided morphism.
+ -}
+liftSelf
+    :: (forall x. m x -> n x)
+    -> (Self m -> Self n)
+liftSelf lifting delegate =
+    Self
+        { recall = \application ->
+            lifting $ recall delegate application
+        , record = \application result ->
+            lifting $ record delegate application result
+        }
+
+{- | Create a new memoizer.
+
+(The memoizer's state is encapsulated in a mutable reference.)
+
+ -}
+new :: forall io. MonadIO io => io (Self io)
+new = do
+    ref <- liftIO $ newIORef HashMap.empty
+    let runStateRef :: State Cache a -> io a
+        runStateRef state =
+            (liftIO . atomicModifyIORef' ref) (Tuple.swap . runState state)
+    return (liftSelf runStateRef simple)

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -85,6 +85,7 @@ import Kore.Profiler.Data
 import Kore.Step.Axiom.Identifier
     ( AxiomIdentifier
     )
+import qualified Kore.Step.Function.Memo as Memo
 import Kore.Syntax.Application
 import ListT
     ( ListT (..)
@@ -167,6 +168,13 @@ class (WithLog LogMessage m, MonadSMT m, MonadProfiler m)
     localSimplifierAxioms locally =
         Monad.Morph.hoist (localSimplifierAxioms locally)
     {-# INLINE localSimplifierAxioms #-}
+
+    askMemo :: m (Memo.Self m)
+    default askMemo
+        :: (MonadTrans t, MonadSimplify n, m ~ t n)
+        => m (Memo.Self m)
+    askMemo = Memo.liftSelf Monad.Trans.lift <$> Monad.Trans.lift askMemo
+    {-# INLINE askMemo #-}
 
 instance (WithLog LogMessage m, MonadSimplify m, Monoid w)
     => MonadSimplify (AccumT w m)

--- a/kore/test/Test/Kore/AllPath.hs
+++ b/kore/test/Test/Kore/AllPath.hs
@@ -358,6 +358,7 @@ instance MonadSimplify AllPathIdentity where
     localSimplifierPredicate = undefined
     askSimplifierAxioms = undefined
     localSimplifierAxioms = undefined
+    askMemo = undefined
 
 -- | 'Goal.transitionRule' instantiated with our unit test rules.
 transitionRule

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -77,6 +77,7 @@ import Kore.Internal.TermLike
 import Kore.Parser
     ( parseKorePattern
     )
+import qualified Kore.Step.Function.Memo as Memo
 import qualified Kore.Step.Result as Result
     ( mergeResults
     )
@@ -183,13 +184,14 @@ testEvaluators = Builtin.koreEvaluators verifiedModule
 testTermLikeSimplifier :: TermLikeSimplifier
 testTermLikeSimplifier = Simplifier.create
 
-testEnv :: Env
+testEnv :: Applicative simplifier => Env simplifier
 testEnv =
     Env
         { metadataTools = testMetadataTools
         , simplifierTermLike = testTermLikeSimplifier
         , simplifierPredicate = testSubstitutionSimplifier
         , simplifierAxioms = testEvaluators
+        , memo = Memo.forgetful
         }
 
 evaluate :: TermLike Variable -> SMT (Pattern Variable)

--- a/kore/test/Test/Kore/Step.hs
+++ b/kore/test/Test/Kore/Step.hs
@@ -559,7 +559,7 @@ mockMetadataTools = MetadataTools
     , smtData = undefined
     }
 
-mockEnv :: Env
+mockEnv :: Env Simplifier
 mockEnv = Mock.env { metadataTools = mockMetadataTools }
 
 sigmaSymbol :: Symbol

--- a/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
@@ -201,12 +201,9 @@ doesn'tApply =
 
 -- * Test environment
 
-testEnv :: Env
-testEnv = Mock.env
-
 evaluateAxioms
     :: [EqualityRule Variable]
     -> TermLike Variable
     -> IO (AttemptedAxiom Variable)
 evaluateAxioms axioms termLike =
-    runSimplifier testEnv $ Kore.evaluateAxioms axioms termLike
+    runSimplifier Mock.env $ Kore.evaluateAxioms axioms termLike

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -276,7 +276,7 @@ testEvaluators =
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule
 
-testEnv :: Env
+testEnv :: Env Simplifier
 testEnv =
     Mock.env
         { metadataTools = testMetadataTools

--- a/kore/test/Test/Kore/Step/Function/Evaluator.hs
+++ b/kore/test/Test/Kore/Step/Function/Evaluator.hs
@@ -96,5 +96,5 @@ simplifierAxioms = Map.fromList [ (fId, fEvaluator) ]
   where
     fId = Axiom.Identifier.Application (TermLike.symbolConstructor fSymbol)
 
-env :: Test.Env
+env :: Test.Env Test.Simplifier
 env = Mock.env { Test.simplifierAxioms = simplifierAxioms }

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -71,6 +71,7 @@ import Kore.Step.Axiom.Identifier
     ( AxiomIdentifier
     )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
+import qualified Kore.Step.Function.Memo as Memo
 import Kore.Step.Rule
     ( EqualityRule (..)
     )
@@ -1196,7 +1197,7 @@ testEvaluators = Builtin.koreEvaluators verifiedModule
 testTermLikeSimplifier :: TermLikeSimplifier
 testTermLikeSimplifier = Simplifier.create
 
-testEnv :: Env
+testEnv :: Env Simplifier
 testEnv =
     Env
         { metadataTools = testMetadataTools
@@ -1209,4 +1210,5 @@ testEnv =
                 , listSimplifiers
                 , mapSimplifiers
                 ]
+        , memo = Memo.forgetful
         }

--- a/kore/test/Test/Kore/Step/Function/Memo.hs
+++ b/kore/test/Test/Kore/Step/Function/Memo.hs
@@ -1,0 +1,42 @@
+module Test.Kore.Step.Function.Memo where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Control.Monad.State.Strict
+    ( evalState
+    )
+
+import Kore.Internal.TermLike
+import Kore.Step.Function.Memo
+
+import Test.Kore.Comparators ()
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Tasty.HUnit.Extensions
+
+test_Self :: [TestTree]
+test_Self =
+    [ testCase "simple - recall recorded result" $ do
+        let Self { recall, record } = simple
+            eval state = evalState state mempty
+            recalled = eval $ do
+                record key result
+                recall key
+        assertEqualWithExplanation "expected recorded result"
+            (Just result)
+            recalled
+    , testCase "new - recall recorded result" $ do
+        Self { recall, record } <- new
+        record key result
+        recalled <- recall key
+        assertEqualWithExplanation "expected recorded result"
+            (Just result)
+            recalled
+    ]
+  where
+    key =
+        Application
+            { applicationSymbolOrAlias = Mock.fSymbol
+            , applicationChildren = [Mock.a]
+            }
+    result = Mock.b

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -60,6 +60,7 @@ import Kore.Internal.TermLike
     )
 import qualified Kore.Internal.TermLike as Internal
 import Kore.Sort
+import qualified Kore.Step.Function.Memo as Memo
 import Kore.Step.Simplification.Data
 import qualified Kore.Step.Simplification.Predicate as Simplifier.Predicate
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
@@ -1533,11 +1534,12 @@ axiomSimplifiers = Map.empty
 predicateSimplifier :: PredicateSimplifier
 predicateSimplifier = Simplifier.Predicate.create
 
-env :: Env
+env :: Applicative simplifier => Env simplifier
 env =
     Env
         { metadataTools = Test.Kore.Step.MockSymbols.metadataTools
         , simplifierTermLike = termLikeSimplifier
         , simplifierPredicate = predicateSimplifier
         , simplifierAxioms = axiomSimplifiers
+        , memo = Memo.forgetful
         }

--- a/kore/test/Test/Kore/Step/Simplification.hs
+++ b/kore/test/Test/Kore/Step/Simplification.hs
@@ -15,8 +15,8 @@ import qualified Kore.Step.Simplification.Data as Kore
 
 import qualified Test.SMT as Test
 
-runSimplifier :: Env -> Simplifier a -> IO a
+runSimplifier :: Env Simplifier -> Simplifier a -> IO a
 runSimplifier env = Test.runSMT . Kore.runSimplifier env
 
-runSimplifierBranch :: Env -> BranchT Simplifier a -> IO [a]
+runSimplifierBranch :: Env Simplifier -> BranchT Simplifier a -> IO [a]
 runSimplifierBranch env = Test.runSMT . Kore.runSimplifierBranch env

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -414,9 +414,7 @@ findSort [] = testSort
 findSort ( Conditional {term} : _ ) = termLikeSort term
 
 evaluate :: And Sort (OrPattern Variable) -> IO (OrPattern Variable)
-evaluate =
-    runSimplifier mockEnv
-    . simplify
+evaluate = runSimplifier Mock.env . simplify
 
 evaluatePatterns
     :: Pattern Variable
@@ -424,8 +422,5 @@ evaluatePatterns
     -> IO (OrPattern Variable)
 evaluatePatterns first second =
     fmap OrPattern.fromPatterns
-    $ runSimplifierBranch mockEnv
+    $ runSimplifierBranch Mock.env
     $ makeEvaluate first second
-
-mockEnv :: Env
-mockEnv = Mock.env

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -312,14 +312,11 @@ testSort = Mock.testSort
 simplify
     :: Exists Sort Variable (OrPattern Variable)
     -> IO (OrPattern Variable)
-simplify = runSimplifier mockEnv . Exists.simplify
+simplify = runSimplifier Mock.env . Exists.simplify
 
 makeEvaluate
     :: ElementVariable Variable
     -> Pattern Variable
     -> IO (OrPattern Variable)
 makeEvaluate variable child =
-    runSimplifier mockEnv $ Exists.makeEvaluate variable child
-
-mockEnv :: Env
-mockEnv = Mock.env
+    runSimplifier Mock.env $ Exists.makeEvaluate variable child

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -130,7 +130,7 @@ dv2 =
         , domainValueChild = mkStringLiteral "dv2"
         }
 
-testEnv :: Env
+testEnv :: Applicative simplifier => Env simplifier
 testEnv = Mock.env
 
 unificationProblem

--- a/scripts/kevm-integration.sh
+++ b/scripts/kevm-integration.sh
@@ -18,6 +18,9 @@ git clone --recurse-submodules 'https://github.com/kframework/evm-semantics' $EV
 
 cd $EVM_SEMANTICS
 
+# Display the HEAD commit on evm-semantics for the log.
+git show HEAD
+
 # Use the K Nightly build from the Kore integration tests.
 rm -rf deps/k/k-distribution/target/release/k
 mkdir -p deps/k/k-distribution/target/release

--- a/scripts/kevm-integration.sh
+++ b/scripts/kevm-integration.sh
@@ -19,7 +19,7 @@ git clone --recurse-submodules 'https://github.com/kframework/evm-semantics' $EV
 cd $EVM_SEMANTICS
 
 # Display the HEAD commit on evm-semantics for the log.
-git show HEAD
+git show -s HEAD
 
 # Use the K Nightly build from the Kore integration tests.
 rm -rf deps/k/k-distribution/target/release/k


### PR DESCRIPTION
Fixes #953.

The function cache is implemented in `Kore.Step.Function.Memo`. An "object-oriented" approach is used to minimize the scope of changes; except for some changes to inject a "forgetful" cache into the tests, the only changes are to initialize the cache in `evalSimplifier` and to check and update the cache in `evaluateApplication`. The tests in `Test.Kore.Step.Function.Memo` illustrate the ease with which we can test such a component in isolation.

The timeout on Jenkins is reduced in anticipation of improved performance.

I am really not attached to the names in `Kore.Step.Function.Memo` if they seem too generic to anyone, but I fully intend that module to be imported qualified always.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
