### PR TITLE
Combining a sequence of rules into one

### DIFF
--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -7,11 +7,21 @@ module Kore.Step.Rule.Combine
     ( mergeRulesPredicate
     ) where
 
-import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Map as Map
 import qualified Data.List as List
+import Data.Set
+    ( Set
+    )
+import qualified Data.Set as Set
 
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables (FreeVariables)
+    )
+import Kore.Internal.TermLike
+    ( mkAnd
+    )
+import Kore.Internal.Variable
+    ( InternalVariable
+    )
 import Kore.Predicate.Predicate
     ( makeCeilPredicate
     , makeMultipleAndPredicate
@@ -20,15 +30,20 @@ import qualified Kore.Predicate.Predicate as Syntax
     ( Predicate
     )
 import Kore.Step.Rule
-    ( RewriteRule (RewriteRule), RulePattern (RulePattern), refreshRulePattern
+    ( RewriteRule (RewriteRule)
+    , RulePattern (RulePattern)
+    , refreshRulePattern
     )
-import qualified Kore.Step.Rule as Rule (freeVariables)
+import qualified Kore.Step.Rule as Rule
+    ( freeVariables
+    )
 import qualified Kore.Step.Rule as Rule.DoNotUse
-import Kore.Internal.TermLike (mkAnd)
-import Kore.Internal.Variable (InternalVariable)
-import Kore.Attribute.Pattern.FreeVariables (FreeVariables(FreeVariables))
-import Kore.Variables.UnifiedVariable (UnifiedVariable)
-import Kore.Substitute (SubstitutionVariable)
+import Kore.Substitute
+    ( SubstitutionVariable
+    )
+import Kore.Variables.UnifiedVariable
+    ( UnifiedVariable
+    )
 
 {-
 Given a list of rules
@@ -94,11 +109,12 @@ renameRuleVariable
   where
     newUsedVariables =
         usedVariables
-        `Set.union` Map.keysSet renaming
-        `Set.union` Set.fromList (Map.elems renaming)
         `Set.union` ruleVariables
+        `Set.union` newRuleVariables
 
     (FreeVariables ruleVariables) = Rule.freeVariables rulePattern
 
-    (renaming, newRulePattern) =
+    (FreeVariables newRuleVariables) = Rule.freeVariables rulePattern
+
+    (_, newRulePattern) =
         refreshRulePattern (FreeVariables usedVariables) rulePattern

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -66,7 +66,7 @@ mergeRulesPredicate
     -> Syntax.Predicate variable
 mergeRulesPredicate rules =
     makeMultipleAndPredicate
-    $ map mergeRulePair
+    $ map mergeRulePairPredicate
     $ makeConsecutivePairs
     $ renameRulesVariables rules
 
@@ -75,11 +75,11 @@ makeConsecutivePairs [] = []
 makeConsecutivePairs [_] = []
 makeConsecutivePairs (a1 : a2 : as) = (a1, a2) : makeConsecutivePairs (a2 : as)
 
-mergeRulePair
+mergeRulePairPredicate
     :: InternalVariable variable
     => (RewriteRule variable, RewriteRule variable)
     -> Syntax.Predicate variable
-mergeRulePair
+mergeRulePairPredicate
     ( RewriteRule RulePattern {right = right1, ensures = ensures1}
     , RewriteRule RulePattern {left = left2, requires = requires2}
     )

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -1,0 +1,104 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+-}
+
+module Kore.Step.Rule.Combine
+    ( mergeRulesPredicate
+    ) where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import qualified Data.List as List
+
+import Kore.Predicate.Predicate
+    ( makeCeilPredicate
+    , makeMultipleAndPredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+    ( Predicate
+    )
+import Kore.Step.Rule
+    ( RewriteRule (RewriteRule), RulePattern (RulePattern), refreshRulePattern
+    )
+import qualified Kore.Step.Rule as Rule (freeVariables)
+import qualified Kore.Step.Rule as Rule.DoNotUse
+import Kore.Internal.TermLike (mkAnd)
+import Kore.Internal.Variable (InternalVariable)
+import Kore.Attribute.Pattern.FreeVariables (FreeVariables(FreeVariables))
+import Kore.Variables.UnifiedVariable (UnifiedVariable)
+import Kore.Substitute (SubstitutionVariable)
+
+{-
+Given a list of rules
+
+@
+L1 -> R1
+L2 -> R2
+...
+Ln -> Rn
+@
+
+returns a predicate P such that applying the above rules in succession
+is the same as applying @(L1 and P) => Rn@.
+
+See docs/2019-09-09-Combining-Rewrite-Axioms.md for details.
+-}
+mergeRulesPredicate
+    :: SubstitutionVariable variable
+    => [RewriteRule variable]
+    -> Syntax.Predicate variable
+mergeRulesPredicate rules =
+    makeMultipleAndPredicate
+    $ map mergeRulePair
+    $ makeConsecutivePairs
+    $ renameRulesVariables rules
+
+makeConsecutivePairs :: [a] -> [(a, a)]
+makeConsecutivePairs [] = []
+makeConsecutivePairs [_] = []
+makeConsecutivePairs (a1 : a2 : as) = (a1, a2) : makeConsecutivePairs (a2 : as)
+
+mergeRulePair
+    :: InternalVariable variable
+    => (RewriteRule variable, RewriteRule variable)
+    -> Syntax.Predicate variable
+mergeRulePair
+    ( RewriteRule RulePattern {right = right1, ensures = ensures1}
+    , RewriteRule RulePattern {left = left2, requires = requires2}
+    )
+  =
+    makeMultipleAndPredicate
+        [ makeCeilPredicate (mkAnd right1 left2)
+        , ensures1
+        , requires2
+        ]
+
+renameRulesVariables
+    :: SubstitutionVariable variable
+    => [RewriteRule variable]
+    -> [RewriteRule variable]
+renameRulesVariables
+    = List.reverse . snd . List.foldl' renameRuleVariable (Set.empty, [])
+
+renameRuleVariable
+    :: SubstitutionVariable variable
+    => (Set (UnifiedVariable variable), [RewriteRule variable])
+    -> RewriteRule variable
+    -> (Set (UnifiedVariable variable), [RewriteRule variable])
+renameRuleVariable
+    (usedVariables, processedRules)
+    (RewriteRule rulePattern)
+  = (newUsedVariables, RewriteRule newRulePattern : processedRules)
+  where
+    newUsedVariables =
+        usedVariables
+        `Set.union` Map.keysSet renaming
+        `Set.union` Set.fromList (Map.elems renaming)
+        `Set.union` ruleVariables
+
+    (FreeVariables ruleVariables) = Rule.freeVariables rulePattern
+
+    (renaming, newRulePattern) =
+        refreshRulePattern (FreeVariables usedVariables) rulePattern

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -519,6 +519,8 @@ anywhereSymbol =
         (typed @Attribute.Symbol . typed @Attribute.Anywhere)
         (Attribute.Anywhere True)
 
+var_x_0 :: ElementVariable Variable
+var_x_0 = ElementVariable $ Variable (testId "x") (Just (Element 0)) testSort
 var_x_1 :: ElementVariable Variable
 var_x_1 = ElementVariable $ Variable (testId "x") (Just (Element 1)) testSort
 var_y_1 :: ElementVariable Variable

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -1,0 +1,120 @@
+module Test.Kore.Step.Rule.Combine where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Default (def)
+
+import Kore.Internal.TermLike (TermLike, mkAnd, mkElemVar)
+import Kore.Step.Rule (RulePattern (RulePattern), RewriteRule (RewriteRule))
+import qualified Kore.Step.Rule as Rule.DoNotUse
+import Kore.Syntax.Variable (Variable)
+import Kore.Step.Rule.Combine
+import qualified Kore.Predicate.Predicate as Syntax(Predicate)
+import Kore.Predicate.Predicate
+    ( makeAndPredicate
+    , makeCeilPredicate
+    , makeMultipleAndPredicate
+    , makeTruePredicate
+    )
+
+import Test.Kore.Comparators ()
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Tasty.HUnit.Extensions
+
+class RewriteRuleBase base where
+    rewritesTo :: base Variable -> base Variable -> RewriteRule Variable
+
+newtype Pair variable = Pair (TermLike variable, Syntax.Predicate variable)
+
+instance RewriteRuleBase Pair where
+    Pair (t1, p1) `rewritesTo` Pair (t2, p2) =
+        RewriteRule RulePattern
+            { left = t1
+            , right = t2
+            , requires = p1
+            , ensures = p2
+            , attributes = def
+            }
+
+instance RewriteRuleBase TermLike where
+    t1 `rewritesTo` t2 =
+        Pair (t1, makeTruePredicate) `rewritesTo` Pair (t2, makeTruePredicate)
+
+test_combineRules :: [TestTree]
+test_combineRules =
+    [ testCase "One rule" $
+        let expected = makeTruePredicate
+            actual = mergeRulesPredicate
+                [ Mock.a `rewritesTo` Mock.cf ]
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Two rules" $
+        let expected = makeCeilPredicate (mkAnd Mock.cf Mock.b)
+            actual = mergeRulesPredicate
+                [ Mock.a `rewritesTo` Mock.cf
+                , Mock.b `rewritesTo` Mock.cg
+                ]
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Three rules case" $
+        let expected =
+                makeAndPredicate
+                    (makeCeilPredicate (mkAnd Mock.cf Mock.b))
+                    (makeCeilPredicate (mkAnd Mock.cg Mock.c))
+
+            actual = mergeRulesPredicate
+                [ Mock.a `rewritesTo` Mock.cf
+                , Mock.b `rewritesTo` Mock.cg
+                , Mock.c `rewritesTo` Mock.ch
+                ]
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Rules with predicates" $
+        let expected =
+                makeMultipleAndPredicate
+                    [ makeMultipleAndPredicate
+                        [ makeCeilPredicate (mkAnd Mock.cf Mock.b)
+                        , makeCeilPredicate (Mock.g Mock.a)
+                        , makeCeilPredicate (Mock.f Mock.b)
+                        ]
+                    , makeMultipleAndPredicate
+                        [ makeCeilPredicate (mkAnd Mock.cg Mock.c)
+                        , makeCeilPredicate (Mock.g Mock.b)
+                        , makeCeilPredicate (Mock.f Mock.c)
+                        ]
+                    ]
+            actual = mergeRulesPredicate
+                [   Pair (Mock.a, makeCeilPredicate (Mock.f Mock.a))
+                    `rewritesTo`
+                    Pair (Mock.cf, makeCeilPredicate (Mock.g Mock.a))
+
+                ,   Pair (Mock.b, makeCeilPredicate (Mock.f Mock.b))
+                    `rewritesTo`
+                    Pair (Mock.cg, makeCeilPredicate (Mock.g Mock.b))
+
+                ,   Pair (Mock.c, makeCeilPredicate (Mock.f Mock.c))
+                    `rewritesTo`
+                    Pair (Mock.ch, makeCeilPredicate (Mock.g Mock.c))
+                ]
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Rules with variables" $
+        let expected =
+                makeMultipleAndPredicate
+                    [ makeCeilPredicate (mkAnd (Mock.g x) (Mock.constr11 x_0))
+                    , makeCeilPredicate (Mock.g x)
+                    , makeCeilPredicate (Mock.h x_0)
+                    ]
+            actual = mergeRulesPredicate
+                [   Pair (Mock.constr10 x, makeCeilPredicate (Mock.f x))
+                    `rewritesTo`
+                    Pair (Mock.g x, makeCeilPredicate (Mock.g x))
+
+                ,   Pair (Mock.constr11 x, makeCeilPredicate (Mock.h x))
+                    `rewritesTo`
+                    Pair (Mock.h x, makeCeilPredicate (Mock.h Mock.a))
+                ]
+        in assertEqualWithExplanation "" expected actual
+    ]
+  where
+    x :: TermLike Variable
+    x = mkElemVar Mock.x
+    x_0 :: TermLike Variable
+    x_0 = mkElemVar Mock.var_x_0

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -3,19 +3,32 @@ module Test.Kore.Step.Rule.Combine where
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.Default (def)
+import Data.Default
+    ( def
+    )
 
-import Kore.Internal.TermLike (TermLike, mkAnd, mkElemVar)
-import Kore.Step.Rule (RulePattern (RulePattern), RewriteRule (RewriteRule))
-import qualified Kore.Step.Rule as Rule.DoNotUse
-import Kore.Syntax.Variable (Variable)
-import Kore.Step.Rule.Combine
-import qualified Kore.Predicate.Predicate as Syntax(Predicate)
+import Kore.Internal.TermLike
+    ( TermLike
+    , mkAnd
+    , mkElemVar
+    )
 import Kore.Predicate.Predicate
     ( makeAndPredicate
     , makeCeilPredicate
     , makeMultipleAndPredicate
     , makeTruePredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+    ( Predicate
+    )
+import Kore.Step.Rule
+    ( RewriteRule (RewriteRule)
+    , RulePattern (RulePattern)
+    )
+import qualified Kore.Step.Rule as Rule.DoNotUse
+import Kore.Step.Rule.Combine
+import Kore.Syntax.Variable
+    ( Variable
     )
 
 import Test.Kore.Comparators ()
@@ -34,6 +47,7 @@ instance RewriteRuleBase Pair where
             , right = t2
             , requires = p1
             , ensures = p2
+            , antiLeft = Nothing
             , attributes = def
             }
 


### PR DESCRIPTION
Given a list of rules
```
L1 -> R1
L2 -> R2
...
Ln -> Rn
```
 computes a predicate P such that applying the above rules in succession is the same as applying `(L1 and P) => Rn`.

Also fixes a free-variables bug for rules.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
