### PR TITLE
Fix ensures

### DIFF
--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -568,15 +568,17 @@ refreshRulePattern (FreeVariables.getFreeVariables -> avoid) rule1 =
         left' = TermLike.substitute subst left
         right' = TermLike.substitute subst right
         requires' = Predicate.substitute subst requires
+        ensures' = Predicate.substitute subst ensures
         rule2 =
             rule1
                 { left = left'
                 , right = right'
                 , requires = requires'
+                , ensures = ensures'
                 }
     in (rename, rule2)
   where
-    RulePattern { left, right, requires } = rule1
+    RulePattern { left, right, requires, ensures } = rule1
     originalFreeVariables =
         FreeVariables.getFreeVariables
         $ Kore.Step.Rule.freeVariables rule1
@@ -587,10 +589,11 @@ freeVariables
     :: Ord variable
     => RulePattern variable
     -> FreeVariables variable
-freeVariables RulePattern { left, right, requires } =
+freeVariables RulePattern { left, right, requires, ensures } =
     TermLike.freeVariables left
     <> TermLike.freeVariables right
     <> Predicate.freeVariables requires
+    <> Predicate.freeVariables ensures
 
 {- | Apply the given function to all variables in a 'RulePattern'.
  -}

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -536,6 +536,8 @@ setY :: SetVariable Variable
 setY = SetVariable $ Variable (testId "@y") mempty testSort
 z :: ElementVariable Variable
 z = ElementVariable $ Variable (testId "z") mempty testSort
+t :: ElementVariable Variable
+t = ElementVariable $ Variable (testId "t") mempty testSort
 m :: ElementVariable Variable
 m = ElementVariable $ Variable (testId "m") mempty mapSort
 xSet :: ElementVariable Variable

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -349,7 +349,9 @@ extractIndexedModule name eModules =
 test_freeVariables :: TestTree
 test_freeVariables =
     testCase "Extract free variables" $ do
-        let expect = FreeVariables . Set.fromList $ ElemVar <$> [Mock.x, Mock.z]
+        let expect =
+                FreeVariables . Set.fromList
+                $ ElemVar <$> [Mock.x, Mock.z, Mock.t]
             actual = Rule.freeVariables testRulePattern
         assertEqual "Expected free variables" expect actual
 
@@ -383,6 +385,6 @@ testRulePattern =
             -- Include a binder to ensure that we respect them.
             mkExists Mock.y (mkElemVar Mock.y)
         , requires = Predicate.makeCeilPredicate (mkElemVar Mock.z)
-        , ensures = Predicate.makeTruePredicate
+        , ensures = Predicate.makeCeilPredicate (mkElemVar Mock.t)
         , attributes = def
         }

--- a/kore/test/Test/Kore/Step/Step.hs
+++ b/kore/test/Test/Kore/Step/Step.hs
@@ -518,8 +518,8 @@ test_applyRewriteRule_ =
 
     -- x => x ensures g(x)=f(x)
     -- vs
-    -- a
-    -- Expected: a and g(a)=f(a)
+    -- y
+    -- Expected: y and g(y)=f(y)
     , testCase "conjoin rule ensures" $ do
         let
             ensures =
@@ -529,19 +529,17 @@ test_applyRewriteRule_ =
             expect :: Either
                 UnificationOrSubstitutionError [OrPattern Variable]
             expect = Right
-                [ OrPattern.fromTermLike
-                    (mkExists
-                        Mock.x
-                        (mkAnd
-                            (mkElemVar Mock.x)
-                            (mkEquals_
-                                (Mock.functional11 (mkElemVar Mock.x))
-                                (Mock.functional10 (mkElemVar Mock.x))
-                            )
-                        )
-                    )
+                [ OrPattern.fromPatterns
+                    [ Conditional
+                        { term = mkElemVar Mock.y
+                        , predicate = makeEqualsPredicate
+                            (Mock.functional11 (mkElemVar Mock.y))
+                            (Mock.functional10 (mkElemVar Mock.y))
+                        , substitution = mempty
+                        }
+                    ]
                 ]
-            initial = Pattern.fromTermLike (mkElemVar Mock.x)
+            initial = Pattern.fromTermLike (mkElemVar Mock.y)
             axiom = RewriteRule ruleId { ensures }
         actual <- applyRewriteRule_ initial axiom
         assertEqualWithExplanation "" expect actual


### PR DESCRIPTION
Note that the refresh change is tested by the `test_refreshRulePattern` at line 358 in Rule.hs, although the test didn't change.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
