### PR TITLE
applyInitialConditions: Do not invoke SMT

### DIFF
--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -82,7 +82,6 @@ import Kore.Step.Rule
     )
 import qualified Kore.Step.Rule as Rule
 import qualified Kore.Step.Rule as RulePattern
-import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
 import qualified Kore.Step.Substitution as Substitution
 import qualified Kore.TopBottom as TopBottom
 import qualified Kore.Unification.Substitution as Substitution
@@ -278,15 +277,10 @@ applyInitialConditions initial unification = do
     -- Combine the initial conditions and the unification conditions.
     -- The axiom requires clause is included in the unification conditions.
     applied <-
-        Monad.liftM MultiOr.make
-        $ Monad.Unify.gather
+        Monad.liftM MultiOr.make . Monad.Unify.gather
         $ Substitution.normalizeExcept (initial <> unification)
-    evaluated <- SMT.Evaluator.filterMultiOr applied
-    -- If 'applied' is \bottom, the rule is considered to not apply and
-    -- no result is returned. If the result is \bottom after this check,
-    -- then the rule is considered to apply with a \bottom result.
-    TopBottom.guardAgainstBottom evaluated
-    return evaluated
+    TopBottom.guardAgainstBottom applied
+    return applied
 
 {- | Produce the final configurations of an applied rule.
 


### PR DESCRIPTION
Invoking SMT at this point causes the `sum-to-n` spec to spin its wheels forever. This was to work around another error that should probably be a warning instead.

The tests are going to fail at first.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
