### PR TITLE
Make check.sh ignore deleted files

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -16,7 +16,7 @@ fi
 
 stack install stylish-haskell
 changed=()
-for file in $(git diff --name-only $UPSTREAM_BRANCH)
+for file in $(git diff --name-only --diff-filter=d $UPSTREAM_BRANCH)
 do
     case $file in
         *.hs|*.hs-boot) ;;


### PR DESCRIPTION
`check.sh` runs stylish on all modified files therefore it fails if any of those files were deleted. This PR should fix this.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
