### PR TITLE
Unfold claim variables

### DIFF
--- a/kore/src/Kore/Attribute/Sort/Constructors.hs
+++ b/kore/src/Kore/Attribute/Sort/Constructors.hs
@@ -32,6 +32,10 @@ data ConstructorLike =
   | ConstructorLikeInjection
     deriving (Show, Eq)
 
+{-| @Nothing@ means that the sort has no constructors that we can recognize.
+@Just value@ means that we recognized the sort's constructors, and @value@
+contains the list of these constructors.
+-}
 newtype Constructors =
     Constructors { getConstructors :: Maybe (NonEmpty ConstructorLike) }
     deriving (Show, Eq)

--- a/kore/src/Kore/Attribute/Sort/Constructors.hs
+++ b/kore/src/Kore/Attribute/Sort/Constructors.hs
@@ -1,0 +1,37 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+
+module Kore.Attribute.Sort.Constructors
+    ( Constructors (..)
+    , ConstructorLike (..)
+    , Constructor (..)
+    ) where
+
+import Data.List.NonEmpty
+    ( NonEmpty
+    )
+
+import Kore.Internal.Symbol
+    ( Symbol
+    )
+import Kore.Sort
+    ( Sort
+    )
+
+data Constructor = Constructor
+    { name :: !Symbol
+    , sorts :: ![Sort]
+    }
+    deriving (Show, Eq)
+
+data ConstructorLike =
+    ConstructorLikeConstructor !Constructor
+  | ConstructorLikeInjection
+    deriving (Show, Eq)
+
+newtype Constructors =
+    Constructors { getConstructors :: Maybe (NonEmpty ConstructorLike) }
+    deriving (Show, Eq)

--- a/kore/src/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/src/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -1,0 +1,210 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+-}
+
+module Kore.Attribute.Sort.ConstructorsBuilder
+    ( indexBySort
+    ) where
+
+import Control.Monad
+    ( when
+    )
+import Data.List.NonEmpty
+    ( NonEmpty ((:|))
+    )
+import qualified Data.Map as Map
+import Data.Maybe
+    ( mapMaybe
+    )
+import qualified Data.Set as Set
+
+import qualified Kore.Attribute.Axiom as Attribute
+    ( Axiom
+    )
+import qualified Kore.Attribute.Axiom as Attribute.Axiom
+    ( constructor
+    )
+import qualified Kore.Attribute.Axiom.Constructor as Axiom.Constructor
+import Kore.Attribute.Sort.Constructors
+    ( Constructor (Constructor)
+    , ConstructorLike (..)
+    , Constructors (Constructors)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Constructors.DoNotUse
+import Kore.IndexedModule.IndexedModule
+    ( VerifiedModule
+    , recursiveIndexedModuleAxioms
+    )
+import Kore.Internal.Symbol
+    ( Symbol (Symbol)
+    )
+import qualified Kore.Internal.Symbol as Symbol.DoNotUse
+import Kore.Internal.TermLike
+    ( pattern App_
+    , pattern Bottom_
+    , pattern ElemVar_
+    , pattern Exists_
+    , pattern Or_
+    , TermLike
+    )
+import Kore.Sort
+    ( Sort (SortActualSort)
+    , SortActual (SortActual)
+    )
+import qualified Kore.Sort as Sort.DoNotUse
+import Kore.Syntax.ElementVariable
+    ( ElementVariable (ElementVariable)
+    )
+import Kore.Syntax.Id
+    ( Id
+    )
+import Kore.Syntax.Sentence
+    ( SentenceAxiom (SentenceAxiom)
+    )
+import qualified Kore.Syntax.Sentence as Sentence.DoNotUse
+import Kore.Syntax.Variable
+    ( Variable (Variable)
+    )
+import qualified Kore.Syntax.Variable as Variable.DoNotUse
+import qualified Kore.Verified as Verified
+    ( SentenceAxiom
+    )
+
+indexBySort
+    :: VerifiedModule symbolAttribute Attribute.Axiom
+    -> Map.Map Id Constructors
+indexBySort indexedModule =
+    Map.fromList
+        (mapMaybe
+            parseNoJunkAxiom
+            (recursiveIndexedModuleAxioms indexedModule)
+        )
+
+parseNoJunkAxiom
+    ::  ( Attribute.Axiom
+        , Verified.SentenceAxiom
+        )
+    -> Maybe (Id, Constructors)
+parseNoJunkAxiom (attributes, SentenceAxiom {sentenceAxiomPattern})
+  | Axiom.Constructor.isConstructor (Attribute.Axiom.constructor attributes)
+  = parseNoJunkPattern sentenceAxiomPattern
+  | otherwise = Nothing
+
+parseNoJunkPattern
+    :: TermLike Variable
+    -> Maybe (Id, Constructors)
+parseNoJunkPattern patt = do  -- Maybe
+    (name, sortBuilder, constructors) <- parseNoJunkPatternHelper patt
+    -- We currently have invalid axioms like
+    -- axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
+    -- We could use them to prove anything we want and skip all the pain of
+    -- doing actual proofs, but it seems that we should pretend that
+    -- all is fine and look the other way when we encounter one of these
+    -- inconsistent things.
+    -- TODO (virgil): Transform this check into an assertion.
+    when (null constructors) Nothing
+    return (name, sortBuilder constructors)
+
+parseNoJunkPatternHelper
+    :: TermLike Variable
+    ->  Maybe
+        ( Id
+        , [ConstructorLike] -> Constructors
+        , [ConstructorLike]
+        )
+parseNoJunkPatternHelper
+    (Bottom_
+        (SortActualSort SortActual
+            { sortActualName, sortActualSorts = [] }
+        )
+    )
+  = Just (sortActualName, fromConstructors, [])
+  where
+    -- TODO: Delete?
+    fromConstructors :: [ConstructorLike] -> Constructors
+    fromConstructors [] = Constructors Nothing
+    fromConstructors (constructor : constructors) =
+        Constructors (Just (constructor :| constructors))
+parseNoJunkPatternHelper (Or_ _ first second) = do  -- Maybe
+    (name, sortBuilder, constructors) <- parseNoJunkPatternHelper second
+    constructor <- parseSMTConstructor first
+    return (name, sortBuilder, constructor : constructors)
+parseNoJunkPatternHelper _ = Nothing
+
+parseSMTConstructor :: TermLike Variable -> Maybe ConstructorLike
+parseSMTConstructor patt =
+    case parsedPatt of
+        App_ symbol children -> do
+            childVariables <-
+                checkOnlyQuantifiedVariablesOnce quantifiedVariables children
+            buildConstructor symbol childVariables
+        _ -> Nothing
+  where
+    (quantifiedVariables, parsedPatt) = parseExists patt
+
+    parseExists
+        :: TermLike Variable
+        -> (Set.Set (ElementVariable Variable), TermLike Variable)
+    parseExists (Exists_ _ variable child) =
+        (Set.insert variable childVars, unquantifiedPatt)
+      where
+        (childVars, unquantifiedPatt) = parseExists child
+    parseExists unquantifiedPatt = (Set.empty, unquantifiedPatt)
+
+    checkOnlyQuantifiedVariablesOnce
+        :: Set.Set (ElementVariable Variable)
+        -> [TermLike Variable]
+        -> Maybe [ElementVariable Variable]
+    checkOnlyQuantifiedVariablesOnce
+        allowedVars
+        []
+      | Set.null allowedVars = Just []
+      | otherwise = Nothing
+    checkOnlyQuantifiedVariablesOnce
+        allowedVars
+        (patt0 : patts)
+      = case patt0 of
+        ElemVar_ var ->
+            if var `Set.member` allowedVars
+                then do
+                    vars <-
+                        checkOnlyQuantifiedVariablesOnce
+                            (Set.delete var allowedVars)
+                            patts
+                    return (var : vars)
+                else Nothing
+        _ -> Nothing
+
+    buildConstructor
+        :: Symbol
+        -> [ElementVariable Variable]
+        -> Maybe ConstructorLike
+    buildConstructor
+        symbol@Symbol { symbolParams = [] }
+        childVariables
+      = do -- Maybe monad
+        sorts <- traverse parseVariableSort childVariables
+        return
+            (ConstructorLikeConstructor Constructor
+                { name = symbol
+                , sorts
+                }
+            )
+
+    -- TODO(virgil): Also handle parameterized constructors and inj.
+    buildConstructor _ _ = Nothing
+
+    parseVariableSort
+        :: ElementVariable Variable
+        -> Maybe Sort
+    parseVariableSort
+        (ElementVariable Variable
+            { variableSort =
+                sort@(SortActualSort SortActual {sortActualSorts = []})
+            }
+        )
+      = Just sort
+    -- TODO(virgil): Also handle parameterized sorts.
+    parseVariableSort _ = Nothing

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -109,6 +109,9 @@ import Kore.Step.Rule as RulePattern
 import qualified Kore.Step.Rule.Combine as Rules
     ( mergeRules
     )
+import Kore.Step.Rule.Expand
+    ( expandOnePathSingleConstructors
+    )
 import Kore.Step.Search
     ( searchGraph
     )
@@ -269,8 +272,14 @@ prove
     -> smt (Either (TermLike Variable) ())
 prove limit definitionModule specModule =
     evalSimplifier definitionModule $ initialize definitionModule $ \initialized -> do
+        tools <- Simplifier.askMetadataTools
         let Initialized { rewriteRules } = initialized
-            specClaims = extractOnePathClaims specModule
+            specClaims =
+                map
+                    (\(attr, rule)
+                        -> (attr, expandOnePathSingleConstructors tools rule)
+                    )
+                    (extractOnePathClaims specModule)
         specAxioms <- Profiler.initialization "simplifyRuleOnSecond"
             $ traverse simplifyRuleOnSecond specClaims
         assertSomeClaims specAxioms

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -33,6 +33,9 @@ import Control.Monad.Trans.Except
     ( runExceptT
     )
 import qualified Data.Bifunctor as Bifunctor
+    ( second
+    )
+import qualified Data.Bifunctor as Bifunctor
 import Data.Coerce
     ( Coercible
     , coerce
@@ -276,9 +279,7 @@ prove limit definitionModule specModule =
         let Initialized { rewriteRules } = initialized
             specClaims =
                 map
-                    (\(attr, rule)
-                        -> (attr, expandOnePathSingleConstructors tools rule)
-                    )
+                    (Bifunctor.second $ expandOnePathSingleConstructors tools)
                     (extractOnePathClaims specModule)
         specAxioms <- Profiler.initialization "simplifyRuleOnSecond"
             $ traverse simplifyRuleOnSecond specClaims

--- a/kore/src/Kore/IndexedModule/MetadataToolsBuilder.hs
+++ b/kore/src/Kore/IndexedModule/MetadataToolsBuilder.hs
@@ -14,6 +14,9 @@ module Kore.IndexedModule.MetadataToolsBuilder
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom
     )
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
 import Kore.Attribute.Symbol
     ( StepperAttributes
     )
@@ -38,4 +41,8 @@ import qualified Kore.Step.SMT.Representation.All as SMT.Representation
 build
     :: VerifiedModule StepperAttributes Attribute.Axiom
     -> SmtMetadataTools StepperAttributes
-build m = extractMetadataTools m SMT.Representation.build
+build m =
+    extractMetadataTools
+        m
+        Attribute.Constructors.indexBySort
+        SMT.Representation.build

--- a/kore/src/Kore/Step/Rule/Expand.hs
+++ b/kore/src/Kore/Step/Rule/Expand.hs
@@ -1,0 +1,268 @@
+{-|
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+-}
+
+module Kore.Step.Rule.Expand
+    ( expandOnePathSingleConstructors
+    ) where
+
+import Data.List
+    ( foldl'
+    , foldr
+    )
+import Data.List.NonEmpty
+    ( NonEmpty ((:|))
+    )
+import qualified Data.Map as Map
+import Data.Maybe
+    ( mapMaybe
+    )
+import qualified Data.Set as Set
+
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables (getFreeVariables)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Attribute.Constructors
+    ( Constructor (Constructor)
+    , ConstructorLike (ConstructorLikeConstructor)
+    , Constructors (Constructors)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Constructors.DoNotUse
+import Kore.IndexedModule.MetadataTools
+    ( SmtMetadataTools
+    , findSortConstructors
+    )
+import Kore.Internal.TermLike
+    ( TermLike
+    , mkApplySymbol
+    , mkElemVar
+    )
+import qualified Kore.Internal.TermLike as TermLike
+    ( freeVariables
+    , substitute
+    )
+import Kore.Predicate.Predicate
+    ( makeAndPredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax.Predicate
+    ( fromSubstitution
+    , substitute
+    )
+import Kore.Sort
+    ( Sort (..)
+    , SortActual (SortActual)
+    )
+import qualified Kore.Sort as Sort.DoNotUse
+import Kore.Step.Rule
+    ( OnePathRule (OnePathRule)
+    , RulePattern (RulePattern)
+    )
+import qualified Kore.Step.Rule as RulePattern
+    ( RulePattern (..)
+    , freeVariables
+    )
+import Kore.Syntax.ElementVariable
+    ( ElementVariable (ElementVariable)
+    )
+import Kore.Syntax.Variable
+    ( Variable (Variable, variableSort)
+    )
+import qualified Kore.Unification.Substitution as Substitution
+    ( wrap
+    )
+import Kore.Variables.Fresh
+    ( refreshVariable
+    )
+import Kore.Variables.UnifiedVariable
+    ( UnifiedVariable (ElemVar)
+    , extractElementVariable
+    )
+
+expandOnePathSingleConstructors
+    :: SmtMetadataTools attributes
+    -> OnePathRule Variable
+    -> OnePathRule Variable
+expandOnePathSingleConstructors metadataTools (OnePathRule rule) =
+    OnePathRule (expandSingleConstructors metadataTools rule)
+
+expandSingleConstructors
+    :: SmtMetadataTools attributes
+    -> RulePattern Variable
+    -> RulePattern Variable
+expandSingleConstructors
+    metadataTools
+    rule@(RulePattern _ _ _ _ _ _)
+  = case rule of
+    RulePattern {left, antiLeft, right, ensures, requires} ->
+        let leftVariables :: [ElementVariable Variable]
+            leftVariables =
+                mapMaybe extractElementVariable
+                $ Set.toList
+                $ getFreeVariables
+                $ TermLike.freeVariables left
+            allUnifiedVariables :: Set.Set (UnifiedVariable Variable)
+            allUnifiedVariables =
+                getFreeVariables (RulePattern.freeVariables rule)
+            allElementVariables :: Set.Set (ElementVariable Variable)
+            allElementVariables = Set.fromList
+                [ v | ElemVar v <- Set.toList allUnifiedVariables]
+            expansion :: Map.Map (UnifiedVariable Variable) (TermLike Variable)
+            expansion =
+                expandVariables metadataTools leftVariables allElementVariables
+            substitutionPredicate =
+                Syntax.Predicate.fromSubstitution
+                    (Substitution.wrap (Map.toList expansion))
+        in rule
+            { RulePattern.left = TermLike.substitute expansion left
+            , RulePattern.antiLeft = TermLike.substitute expansion <$> antiLeft
+            , RulePattern.right = TermLike.substitute expansion right
+            , RulePattern.ensures =
+                Syntax.Predicate.substitute expansion ensures
+            , RulePattern.requires =
+                makeAndPredicate
+                    (Syntax.Predicate.substitute expansion requires)
+                    substitutionPredicate
+            }
+
+expandVariables
+    :: SmtMetadataTools attributes
+    -> [ElementVariable Variable]
+    -> Set.Set (ElementVariable Variable)
+    -> Map.Map (UnifiedVariable Variable) (TermLike Variable)
+expandVariables metadataTools variables toAvoid =
+    fst $ foldl' expandAddVariable (Map.empty, toAvoid) variables
+  where
+    expandAddVariable
+        ::  ( Map.Map (UnifiedVariable Variable) (TermLike Variable)
+            , Set.Set (ElementVariable Variable)
+            )
+        -> ElementVariable Variable
+        ->  ( Map.Map (UnifiedVariable Variable) (TermLike Variable)
+            , Set.Set (ElementVariable Variable)
+            )
+    expandAddVariable (substitution, toAvoid') variable =
+        case expandVariable metadataTools toAvoid' variable of
+            (newVariables, term) ->
+                ( if mkElemVar variable == term
+                    then substitution
+                    else Map.insert (ElemVar variable) term substitution
+                , foldr Set.insert toAvoid' newVariables
+                )
+
+expandVariable
+    :: SmtMetadataTools attributes
+    -> Set.Set (ElementVariable Variable)
+    -> ElementVariable Variable
+    -> (Set.Set (ElementVariable Variable), TermLike Variable)
+expandVariable
+    metadataTools
+    usedVariables
+    variable@(ElementVariable Variable {variableSort})
+  = expandSort metadataTools usedVariables variable UseDirectly variableSort
+
+expandSort
+    :: SmtMetadataTools attributes
+    -> Set.Set (ElementVariable Variable)
+    -> ElementVariable Variable
+    -> VariableUsage
+    -> Sort
+    -> (Set.Set (ElementVariable Variable), TermLike Variable)
+expandSort
+    _metadataTools
+    usedVariables
+    defaultVariable
+    variableUsage
+    sort@(SortVariableSort _)
+  =
+    (updatedUsedVariables, variable)
+  where
+    (updatedUsedVariables, variable) =
+        maybeNewVariable usedVariables defaultVariable sort variableUsage
+expandSort
+    metadataTools
+    usedVariables
+    defaultVariable
+    variableUsage
+    sort@(SortActualSort SortActual { sortActualName })
+  =
+    case findSortConstructors metadataTools sortActualName of
+        Just
+            (Attribute.Constructors.Constructors
+                (Just
+                    ( Attribute.Constructors.ConstructorLikeConstructor
+                        constructor
+                    :| []
+                    )
+                )
+            ) ->
+                expandConstructor
+                    metadataTools
+                    usedVariables
+                    defaultVariable
+                    constructor
+        _ -> maybeNewVariable usedVariables defaultVariable sort variableUsage
+
+expandConstructor
+    :: SmtMetadataTools attributes
+    -> Set.Set (ElementVariable Variable)
+    -> ElementVariable Variable
+    -> Attribute.Constructors.Constructor
+    -> (Set.Set (ElementVariable Variable), TermLike Variable)
+expandConstructor
+    metadataTools
+    usedVariables
+    defaultVariable
+    Attribute.Constructors.Constructor { name = symbol, sorts }
+  = (finalUsedVariables, mkApplySymbol symbol children)
+  where
+    (children, finalUsedVariables) =
+        foldr expandChildSort ([], usedVariables) sorts
+
+    expandChildSort
+        :: Sort
+        -> ([TermLike Variable], Set.Set (ElementVariable Variable))
+        -> ([TermLike Variable], Set.Set (ElementVariable Variable))
+    expandChildSort sort (terms, beforeUsedVariables) =
+        (term : terms, afterUsedVariables)
+      where
+        (afterUsedVariables, term) =
+            expandSort
+                metadataTools
+                beforeUsedVariables
+                defaultVariable
+                UseAsPrototype
+                sort
+
+data VariableUsage = UseDirectly | UseAsPrototype
+
+maybeNewVariable
+    :: Set.Set (ElementVariable Variable)
+    -> ElementVariable Variable
+    -> Sort
+    -> VariableUsage
+    -> (Set.Set (ElementVariable Variable), TermLike Variable)
+maybeNewVariable
+    usedVariables
+    variable@(ElementVariable Variable {variableSort})
+    sort
+    UseDirectly
+  =
+    if sort /= variableSort
+        then error "Unmatching sort for direct use variable."
+        else (usedVariables, mkElemVar variable)
+maybeNewVariable usedVariables variable sort UseAsPrototype =
+    case refreshVariable usedVariables (resort variable) of
+        Just newVariable ->
+            ( Set.insert newVariable usedVariables
+            , mkElemVar newVariable
+            )
+        Nothing ->
+            (error . unlines)
+                [ "Expecting a variable refresh for"
+                , show variable
+                , "but got nothing. Used variables:"
+                , show usedVariables
+                ]
+  where
+    resort (ElementVariable var) = ElementVariable var { variableSort = sort }

--- a/kore/src/Kore/Step/Rule/Expand.hs
+++ b/kore/src/Kore/Step/Rule/Expand.hs
@@ -234,7 +234,27 @@ expandConstructor
                 UseAsPrototype
                 sort
 
-data VariableUsage = UseDirectly | UseAsPrototype
+{-| Context: we have a TermLike that contains a variables, and we
+attempt to expand them into constructor applications whenever that's possible.
+
+We expand a variable by attempting to expand its sort into an unique
+constructor application, and, recursively, the argument sorts of that
+constructor.
+
+This data type tells us how to use the initial variable that we are expanding
+when we can't expand a sort, so we have to return a variable of that sort
+instead.
+-}
+data VariableUsage =
+    UseDirectly
+    -- ^ We don't need to generate a new variable, we are at the top and
+    -- we didn't manage to expand anything, so we can just reuse the
+    -- variable in the original term as the sort's expansion (useful if we
+    -- want to have prettier terms).
+  | UseAsPrototype
+    -- ^ We have expanded the initial sort at least once, so we need a variable
+    -- somewhere in the middle of the expansion. We can't reuse the original
+    -- variable, so we need to generate a new one based on it.
 
 maybeNewVariable
     :: Set.Set (ElementVariable Variable)

--- a/kore/src/Kore/Step/SMT/Representation/All.hs
+++ b/kore/src/Kore/Step/SMT/Representation/All.hs
@@ -10,8 +10,13 @@ module Kore.Step.SMT.Representation.All
     ( build
     ) where
 
+import qualified Data.Map as Map
+
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom
+    )
+import qualified Kore.Attribute.Sort.Constructors as Attribute
+    ( Constructors
     )
 import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
@@ -29,6 +34,9 @@ import qualified Kore.Step.SMT.Representation.Sorts as Sorts
 import qualified Kore.Step.SMT.Representation.Symbols as Symbols
     ( buildRepresentations
     )
+import Kore.Syntax.Id
+    ( Id
+    )
 
 {-| Builds a consistent representation of the sorts and symbols in the given
 module and its submodules.
@@ -38,9 +46,10 @@ sorts).
 -}
 build
     :: VerifiedModule Attribute.Symbol Attribute.Axiom
+    -> Map.Map Id Attribute.Constructors
     -> AST.SmtDeclarations
-build indexedModule =
+build indexedModule sortConstructors =
     resolve (sorts `AST.mergePreferFirst` symbols)
   where
-    sorts = Sorts.buildRepresentations indexedModule
+    sorts = Sorts.buildRepresentations indexedModule sortConstructors
     symbols = Symbols.buildRepresentations indexedModule

--- a/kore/src/Kore/Step/SMT/Representation/Sorts.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Sorts.hs
@@ -158,7 +158,7 @@ buildRepresentations indexedModule sortConstructors =
     sortsWithConstructors blacklist whitelist =
         mapMaybe
             (sortWithConstructor sortConstructors)
-            (filter (not . (`Set.member` blacklist)) whitelist)
+            (filter (`Set.notMember` blacklist) whitelist)
 
     builtinSortDeclarations :: [(Id, AST.UnresolvedSort)]
     builtinSortDeclarations =

--- a/kore/src/Kore/Variables/Fresh.hs
+++ b/kore/src/Kore/Variables/Fresh.hs
@@ -75,8 +75,9 @@ instance FreshVariable variable => FreshVariable (UnifiedVariable variable)
 instance FreshVariable Variable where
     refreshVariable avoiding variable = do
         largest <- Set.lookupLT pivotMax avoiding
-        if largest >= pivotMin
-            then Just (fixSort . nextVariable $ largest)
+        let fixedLargest = fixSort largest
+        if fixedLargest >= pivotMin
+            then Just (nextVariable fixedLargest)
             else Nothing
       where
         pivotMax = variable { variableCounter = Just Sup }

--- a/kore/src/Kore/Variables/Fresh.hs
+++ b/kore/src/Kore/Variables/Fresh.hs
@@ -74,8 +74,7 @@ instance FreshVariable variable => FreshVariable (UnifiedVariable variable)
 
 instance FreshVariable Variable where
     refreshVariable avoiding variable = do
-        largest <- Set.lookupLT pivotMax avoiding
-        let fixedLargest = fixSort largest
+        fixedLargest <- fixSort <$> Set.lookupLT pivotMax avoiding
         if fixedLargest >= pivotMin
             then Just (nextVariable fixedLargest)
             else Nothing

--- a/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -1,0 +1,170 @@
+module Test.Kore.Attribute.Sort.ConstructorsBuilder where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Default
+    ( def
+    )
+import qualified Data.Map as Map
+
+import qualified Kore.Attribute.Axiom as Attribute
+    ( Axiom
+    )
+import qualified Kore.Attribute.Sort.Constructors as Attribute
+    ( Constructor (Constructor)
+    , ConstructorLike (..)
+    , Constructors (Constructors)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Attribute.DoNotUse
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
+import qualified Kore.Attribute.Symbol as Attribute
+    ( Symbol
+    )
+import qualified Kore.Builtin.Int as Int
+import Kore.IndexedModule.IndexedModule
+    ( VerifiedModule
+    )
+import Kore.Internal.ApplicationSorts
+    ( ApplicationSorts (ApplicationSorts)
+    )
+import qualified Kore.Internal.ApplicationSorts as ApplicationSorts.DoNotUse
+import Kore.Internal.Symbol
+    ( Symbol (Symbol)
+    )
+import qualified Kore.Internal.Symbol as Symbol.DoNotUse
+import Kore.Sort
+    ( Sort (..)
+    )
+import Kore.Syntax.Id
+    ( Id (getId)
+    )
+
+import Test.Kore.Comparators ()
+import Test.Kore.Step.SMT.Builders
+    ( emptyModule
+    , indexModule
+    , koreSort
+    , sortDeclaration
+    , symbolDeclaration
+    )
+import qualified Test.Kore.Step.SMT.Builders as Attribute
+    ( constructor
+    , functional
+    , hook
+    )
+import Test.Kore.Step.SMT.Helpers
+    ( constructorAxiom
+    )
+import Test.Kore.With
+    ( with
+    )
+import Test.Tasty.HUnit.Extensions
+
+test_sortParsing :: [TestTree]
+test_sortParsing =
+    [ testForModule "Empty definition"
+        (indexModule $ emptyModule "m")
+        (constructorsAre [])
+    , testForModule "Definition with simple sorts"
+        (indexModule $ emptyModule "m"
+            `with` sortDeclaration "S"
+            `with` sortDeclaration "T"
+        )
+        (constructorsAre [])
+    , testForModule "Definition with constructor-based sorts"
+        (indexModule $ emptyModule "m"
+            `with` sortDeclaration "S"
+            `with` sortDeclaration "T"
+            `with`
+                (symbolDeclaration "C" "S" []
+                    `with` [Attribute.functional, Attribute.constructor]
+                )
+            `with` constructorAxiom "S" [("C", [])]
+        )
+        (constructorsAre
+            [ ("S", noConstructor `with` constructor "C")
+            ]
+        )
+    , testForModule "Definition with complex constructor-based sorts"
+        (indexModule $ emptyModule "m"
+            `with` sortDeclaration "S"
+            `with`
+                (symbolDeclaration "C" "S" []
+                    `with` [Attribute.functional, Attribute.constructor]
+                )
+            `with`
+                (symbolDeclaration "D" "S" ["S"]
+                    `with` [Attribute.functional, Attribute.constructor]
+                )
+            `with` constructorAxiom "S" [("C", []), ("D", ["S"])]
+        )
+        (constructorsAre
+            [   ( "S"
+                , noConstructor
+                    `with` (constructor "D" `withS` koreSort "S")
+                    `with` constructor "C"
+                )
+            ]
+        )
+    , testForModule "Definition with builtin sorts"
+        (indexModule $ emptyModule "m"
+            `with` (sortDeclaration "Integer" `with` Attribute.hook Int.sort)
+        )
+        (constructorsAre [])
+    ]
+
+testForModule
+    :: String
+    -> VerifiedModule Attribute.Symbol Attribute.Axiom
+    -> (String -> Map.Map Id Attribute.Constructors -> TestTree)
+    -> TestTree
+testForModule name m testBuilder =
+    testBuilder name (Attribute.Constructors.indexBySort m)
+
+constructorsAre
+    :: ( HasCallStack )
+    => [(Id, Sort -> Attribute.Constructors)]
+    -> String
+    -> Map.Map Id Attribute.Constructors
+    -> TestTree
+constructorsAre expected name actual =
+    testCase name
+        (assertEqualWithExplanation ""
+            (Map.fromList (map buildConstructors expected))
+            actual
+        )
+  where
+    buildConstructors
+        :: (Id, Sort -> Attribute.Constructors)
+        -> (Id, Attribute.Constructors)
+    buildConstructors (sortId, constructorsBuilder) =
+        ( sortId
+        , constructorsBuilder (koreSort (getId sortId))
+        )
+
+noConstructor :: Sort -> Attribute.Constructors
+noConstructor = const (Attribute.Constructors Nothing)
+
+constructor :: Id -> Sort -> Attribute.ConstructorLike
+constructor constructorId resultSort =
+    Attribute.ConstructorLikeConstructor Attribute.Constructor
+        { name = Symbol
+            { symbolConstructor = constructorId
+            , symbolParams      = []
+            , symbolSorts       = ApplicationSorts
+                { applicationSortsOperands = []
+                , applicationSortsResult   = resultSort
+                }
+            , symbolAttributes  = def
+            }
+        , sorts = []
+        }
+
+withS
+    :: (Sort -> Attribute.ConstructorLike)
+    -> Sort
+    -> (Sort -> Attribute.ConstructorLike)
+withS builder argumentSort = \s -> builder s `with` argumentSort

--- a/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -42,7 +42,6 @@ import Kore.Syntax.Id
     ( Id (getId)
     )
 
-import Test.Kore.Comparators ()
 import Test.Kore.Step.SMT.Builders
     ( emptyModule
     , indexModule
@@ -61,7 +60,6 @@ import Test.Kore.Step.SMT.Helpers
 import Test.Kore.With
     ( with
     )
-import Test.Tasty.HUnit.Extensions
 
 test_sortParsing :: [TestTree]
 test_sortParsing =
@@ -132,7 +130,7 @@ constructorsAre
     -> TestTree
 constructorsAre expected name actual =
     testCase name
-        (assertEqualWithExplanation ""
+        (assertEqual ""
             (Map.fromList (map buildConstructors expected))
             actual
         )

--- a/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -102,8 +102,8 @@ test_sortParsing =
         (constructorsAre
             [   ( "S"
                 , noConstructor
-                    `with` (constructor "D" `withS` koreSort "S")
                     `with` constructor "C"
+                    `with` (constructor "D" `withS` koreSort "S")
                 )
             ]
         )

--- a/kore/test/Test/Kore/IndexedModule/MetadataTools.hs
+++ b/kore/test/Test/Kore/IndexedModule/MetadataTools.hs
@@ -74,11 +74,12 @@ testSubsorts =
             DoNotVerifyAttributes
             Builtin.koreVerifiers
             testSubsortDefinition
-    meta :: MetadataTools () Attribute.Symbol
+    meta :: MetadataTools () () Attribute.Symbol
     meta =
         extractMetadataTools
             (moduleIndex Map.! testObjectModuleName)
-            (const ())
+            (const Map.empty)
+            (const $ const ())
 
 
 testSubsortDefinition :: ParsedDefinition

--- a/kore/test/Test/Kore/IndexedModule/MockMetadataTools.hs
+++ b/kore/test/Test/Kore/IndexedModule/MockMetadataTools.hs
@@ -9,6 +9,7 @@ module Test.Kore.IndexedModule.MockMetadataTools
     , sortInjectionAttributes
     ) where
 
+import qualified Data.Map as Map
 import Data.Maybe
     ( fromMaybe
     )
@@ -22,6 +23,9 @@ import Kore.Attribute.Function
 import Kore.Attribute.Functional
 import Kore.Attribute.Injective
 import qualified Kore.Attribute.Sort as Attribute
+import qualified Kore.Attribute.Sort.Constructors as Attribute
+    ( Constructors
+    )
 import Kore.Attribute.SortInjection
 import Kore.Attribute.Symbol
 import Kore.IndexedModule.MetadataTools
@@ -43,6 +47,9 @@ import qualified Kore.Step.SMT.AST as SMT.AST
 import Kore.Syntax.Application
     ( SymbolOrAlias (..)
     )
+import Kore.Syntax.Id
+    ( Id
+    )
 
 makeMetadataTools
     :: HasCallStack
@@ -51,8 +58,11 @@ makeMetadataTools
     -> [(Sort, Sort)]
     -> [(SymbolOrAlias, ApplicationSorts)]
     -> SMT.AST.SmtDeclarations
+    -> Map.Map Id Attribute.Constructors
     -> SmtMetadataTools StepperAttributes
-makeMetadataTools attr sortTypes isSubsortOf sorts declarations =
+makeMetadataTools
+    attr sortTypes isSubsortOf sorts declarations sortConstructors
+  =
     MetadataTools
         { sortAttributes = caseBasedFunction sortTypes
         -- TODO(Vladimir): fix the inconsistency that both 'subsorts' and
@@ -73,6 +83,7 @@ makeMetadataTools attr sortTypes isSubsortOf sorts declarations =
         , isOverloading = const (const False)
         , isOverloaded = const False
         , smtData = declarations
+        , sortConstructors
         }
 
 caseBasedFunction

--- a/kore/test/Test/Kore/Proof/Value.hs
+++ b/kore/test/Test/Kore/Proof/Value.hs
@@ -3,6 +3,7 @@ module Test.Kore.Proof.Value where
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import qualified Data.Map as Map
 import qualified GHC.Stack as GHC
 
 import qualified Kore.Attribute.Symbol as Attribute
@@ -45,7 +46,7 @@ test_Builtin_InternalInt =
 test_Builtin_InternalBool :: [TestTree]
 test_Builtin_InternalBool =
     [ testValue "true" trueInternal
-    , testValue "fales" falseInternal
+    , testValue "false" falseInternal
     ]
 
 unit_injConstructor :: Assertion
@@ -227,6 +228,7 @@ tools =
         []
         []
         Mock.emptySmtDeclarations
+        Map.empty
 
 assertValue :: GHC.HasCallStack => TermLike Variable -> Assertion
 assertValue termLike =

--- a/kore/test/Test/Kore/Step.hs
+++ b/kore/test/Test/Kore/Step.hs
@@ -524,6 +524,7 @@ mockMetadataTools = MetadataTools
     , isOverloading = undefined
     , isOverloaded = undefined
     , smtData = undefined
+    , sortConstructors = undefined
     }
 
 mockEnv :: Env Simplifier

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -14,7 +14,7 @@ module Test.Kore.Step.MockSymbols where
    * one-element functions are called f, g, h.
    * constructors are called "constr<n><k>" where n is the arity and k is used
      to differentiate between them (both are one-digit).
-   * functional constructors are called "functionallConstr<n><k>"
+   * functional constructors are called "functionalConstr<n><k>"
    * functional symbols are called "functional<n><k>"
    * symbols without any special attribute are called "plain<n><k>"
    * variables are called x, y, z...
@@ -41,6 +41,9 @@ import Kore.Attribute.Hook
     )
 import qualified Kore.Attribute.Sort as Attribute
 import qualified Kore.Attribute.Sort.Concat as Attribute
+import qualified Kore.Attribute.Sort.Constructors as Attribute
+    ( Constructors
+    )
 import qualified Kore.Attribute.Sort.Element as Attribute
 import qualified Kore.Attribute.Sort.Unit as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
@@ -114,8 +117,12 @@ eId :: Id
 eId = testId "e"
 fId :: Id
 fId = testId "f"
+fSort0Id :: Id
+fSort0Id = testId "fSort0"
 gId :: Id
 gId = testId "g"
+gSort0Id :: Id
+gSort0Id = testId "gSort0"
 hId :: Id
 hId = testId "h"
 cfId :: Id
@@ -278,8 +285,14 @@ eSymbol = symbol eId [] testSort & functional & constructor
 fSymbol :: Symbol
 fSymbol = symbol fId [testSort] testSort & function
 
+fSort0Symbol :: Symbol
+fSort0Symbol = symbol fSort0Id [testSort0] testSort0 & function
+
 gSymbol :: Symbol
 gSymbol = symbol gId [testSort] testSort & function
+
+gSort0Symbol :: Symbol
+gSort0Symbol = symbol gSort0Id [testSort0] testSort0 & function
 
 hSymbol :: Symbol
 hSymbol = symbol hId [testSort] testSort & function
@@ -532,7 +545,7 @@ x = ElementVariable $ Variable (testId "x") mempty testSort
 setX :: SetVariable Variable
 setX = SetVariable $ Variable (testId "@x") mempty testSort
 x0 :: ElementVariable Variable
-x0 = ElementVariable $ Variable (testId "x") mempty testSort0
+x0 = ElementVariable $ Variable (testId "x0") mempty testSort0
 y :: ElementVariable Variable
 y = ElementVariable $ Variable (testId "y") mempty testSort
 setY :: SetVariable Variable
@@ -639,6 +652,14 @@ f, g, h
 f arg = Internal.mkApplySymbol fSymbol [arg]
 g arg = Internal.mkApplySymbol gSymbol [arg]
 h arg = Internal.mkApplySymbol hSymbol [arg]
+
+fSort0, gSort0
+    :: InternalVariable variable
+    => GHC.HasCallStack
+    => TermLike variable
+    -> TermLike variable
+fSort0 arg = Internal.mkApplySymbol fSort0Symbol [arg]
+gSort0 arg = Internal.mkApplySymbol gSort0Symbol [arg]
 
 cf :: InternalVariable variable => TermLike variable
 cf = Internal.mkApplySymbol cfSymbol []
@@ -1039,7 +1060,9 @@ symbols =
     , dSymbol
     , eSymbol
     , fSymbol
+    , fSort0Symbol
     , gSymbol
+    , gSort0Symbol
     , hSymbol
     , cfSymbol
     , cfSort0Symbol
@@ -1270,6 +1293,13 @@ smtUnresolvedDeclarations = SMT.Declarations
         ]
     }
 
+sortConstructors :: Map.Map Id Attribute.Constructors
+sortConstructors = Map.fromList
+    [
+    -- TODO(virgil): testSort has constructors, it should have a
+    -- constructor-based definition. The same for others.
+    ]
+
 testSortId :: Id
 testSortId = testId "testSort"
 testSort0Id :: Id
@@ -1483,6 +1513,7 @@ emptyMetadataTools =
         [] -- sortAttributesMapping
         [] -- subsorts
         emptySmtDeclarations
+        Map.empty -- sortConstructors
 
 metadataTools :: GHC.HasCallStack => SmtMetadataTools Attribute.Symbol
 metadataTools =
@@ -1492,6 +1523,7 @@ metadataTools =
         subsorts
         headSortsMapping
         smtDeclarations
+        sortConstructors
 
 termLikeSimplifier :: TermLikeSimplifier
 termLikeSimplifier = Simplifier.create

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -5,10 +5,10 @@ import Test.Tasty
 import Data.Default
     ( def
     )
-
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
+
 import Kore.Internal.TermLike
     ( TermLike
     , mkAnd

--- a/kore/test/Test/Kore/Step/Rule/Expand.hs
+++ b/kore/test/Test/Kore/Step/Rule/Expand.hs
@@ -1,0 +1,241 @@
+module Test.Kore.Step.Rule.Expand where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Default
+    ( def
+    )
+import Data.Function
+    ( (&)
+    )
+import qualified Data.Map as Map
+
+import Data.Sup
+    ( Sup (Element)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Attribute
+    ( Constructor (Constructor)
+    , ConstructorLike (..)
+    , Constructors (Constructors)
+    )
+import qualified Kore.Attribute.Sort.Constructors as Constructors.DoNotUse
+import qualified Kore.Attribute.Symbol as Attribute
+    ( Symbol
+    )
+import Kore.IndexedModule.MetadataTools
+    ( SmtMetadataTools
+    )
+import qualified Kore.IndexedModule.MetadataTools as MetadataTools
+    ( MetadataTools (..)
+    )
+import Kore.Internal.Symbol
+    ( Symbol
+    )
+import qualified Kore.Internal.Symbol as Symbol
+    ( constructor
+    , functional
+    )
+import Kore.Internal.TermLike
+    ( TermLike
+    , mkApplySymbol
+    , mkElemVar
+    )
+import Kore.Predicate.Predicate
+    ( makeEqualsPredicate
+    , makeTruePredicate
+    )
+import qualified Kore.Predicate.Predicate as Syntax
+    ( Predicate
+    )
+import Kore.Step.Rule
+    ( OnePathRule (OnePathRule)
+    , RulePattern (RulePattern)
+    )
+import qualified Kore.Step.Rule as Rule.DoNotUse
+import Kore.Step.Rule.Expand
+import Kore.Syntax.ElementVariable
+    ( ElementVariable (ElementVariable)
+    )
+import Kore.Syntax.Id
+    ( Id
+    )
+import Kore.Syntax.Variable
+    ( Variable (Variable)
+    )
+
+import Test.Kore
+    ( testId
+    )
+import Test.Kore.Comparators ()
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Kore.With
+    ( with
+    )
+import Test.Tasty.HUnit.Extensions
+
+class OnePathRuleBase base where
+    rewritesTo :: base Variable -> base Variable -> OnePathRule Variable
+
+newtype Pair variable = Pair (TermLike variable, Syntax.Predicate variable)
+
+instance OnePathRuleBase Pair where
+    Pair (t1, p1) `rewritesTo` Pair (t2, p2) =
+        OnePathRule RulePattern
+            { left = t1
+            , right = t2
+            , requires = p1
+            , ensures = p2
+            , antiLeft = Nothing
+            , attributes = def
+            }
+
+instance OnePathRuleBase TermLike where
+    t1 `rewritesTo` t2 =
+        Pair (t1, makeTruePredicate) `rewritesTo` Pair (t2, makeTruePredicate)
+
+
+test_expandRule :: [TestTree]
+test_expandRule =
+    [ testCase "Nothing to expand" $
+        let expected = Mock.f x `rewritesTo` Mock.g x
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools [])
+                    (Mock.f x `rewritesTo` Mock.g x)
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Nothing to expand without constructors" $
+        let expected = Mock.f x `rewritesTo` Mock.g x
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools
+                        [ (Mock.testSortId, noConstructor) ]
+                    )
+                    (Mock.f x `rewritesTo` Mock.g x)
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Nothing to expand with multiple constructors" $
+        let expected = Mock.f x `rewritesTo` Mock.g x
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools
+                        [   ( Mock.testSortId
+                            , noConstructor
+                                `with` constructor Mock.aSymbol
+                                `with` constructor Mock.bSymbol
+                            )
+                        ]
+                    )
+                    (Mock.f x `rewritesTo` Mock.g x)
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Expands variable once to constant" $
+        let expected =
+                Pair (Mock.f Mock.a, makeEqualsPredicate x Mock.a)
+                `rewritesTo`
+                Pair (Mock.g Mock.a, makeTruePredicate)
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools
+                        [   ( Mock.testSortId
+                            , noConstructor `with` constructor Mock.aSymbol
+                            )
+                        ]
+                    )
+                    (Mock.f x `rewritesTo` Mock.g x)
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Expands variable once to argument constructor" $
+        let expected =
+                Pair
+                    ( Mock.fSort0 (expandableConstructor1 x00TestSort)
+                    , makeEqualsPredicate
+                        x0
+                        (expandableConstructor1 x00TestSort)
+                    )
+                `rewritesTo`
+                Pair
+                    ( Mock.gSort0 (expandableConstructor1 x00TestSort)
+                    , makeTruePredicate
+                    )
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools
+                        [   ( Mock.testSort0Id
+                            , noConstructor
+                                `with`
+                                    ( constructor expandableConstructor1Symbol
+                                    `with` Mock.testSort
+                                    )
+                            )
+                        ]
+                    )
+                    (Mock.fSort0 x0 `rewritesTo` Mock.gSort0 x0)
+        in assertEqualWithExplanation "" expected actual
+    , testCase "Expands variable twice." $
+        let expected =
+                Pair
+                    ( Mock.fSort0 (expandableConstructor1 Mock.a)
+                    , makeEqualsPredicate
+                        x0
+                        (expandableConstructor1 Mock.a)
+                    )
+                `rewritesTo`
+                Pair
+                    ( Mock.gSort0 (expandableConstructor1 Mock.a)
+                    , makeTruePredicate
+                    )
+            actual =
+                expandOnePathSingleConstructors
+                    (metadataTools
+                        [   ( Mock.testSort0Id
+                            , noConstructor
+                                `with`
+                                    ( constructor expandableConstructor1Symbol
+                                    `with` Mock.testSort
+                                    )
+                            )
+                        ,   ( Mock.testSortId
+                            , noConstructor `with` constructor Mock.aSymbol
+                            )
+                        ]
+                    )
+                    (Mock.fSort0 x0 `rewritesTo` Mock.gSort0 x0)
+        in assertEqualWithExplanation "" expected actual
+    ]
+  where
+    x = mkElemVar Mock.x
+    x0 = mkElemVar Mock.x0
+
+    x00TestSortVar =
+        ElementVariable
+            (Variable (testId "x0") (Just (Element 0)) Mock.testSort)
+    x00TestSort = mkElemVar x00TestSortVar
+
+    metadataTools
+        :: [(Id, Attribute.Constructors)]
+        -> SmtMetadataTools Attribute.Symbol
+    metadataTools sortAndConstructors =
+        Mock.metadataTools
+            { MetadataTools.sortConstructors = Map.fromList sortAndConstructors
+            }
+
+    expandableConstructor1Id :: Id
+    expandableConstructor1Id = testId "expandableConstructor1"
+    expandableConstructor1Symbol :: Symbol
+    expandableConstructor1Symbol =
+        Mock.symbol expandableConstructor1Id [Mock.testSort] Mock.testSort0
+        & Symbol.functional
+        & Symbol.constructor
+    expandableConstructor1
+        :: HasCallStack
+        => TermLike Variable -> TermLike Variable
+    expandableConstructor1 arg =
+        mkApplySymbol expandableConstructor1Symbol [arg]
+
+noConstructor :: Attribute.Constructors
+noConstructor = Attribute.Constructors Nothing
+
+constructor :: Symbol -> Attribute.ConstructorLike
+constructor constructorSymbol =
+    Attribute.ConstructorLikeConstructor Attribute.Constructor
+        { name = constructorSymbol
+        , sorts = []
+        }

--- a/kore/test/Test/Kore/Step/Rule/Expand.hs
+++ b/kore/test/Test/Kore/Step/Rule/Expand.hs
@@ -67,12 +67,10 @@ import Kore.Syntax.Variable
 import Test.Kore
     ( testId
     )
-import Test.Kore.Comparators ()
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.With
     ( with
     )
-import Test.Tasty.HUnit.Extensions
 
 class OnePathRuleBase base where
     rewritesTo :: base Variable -> base Variable -> OnePathRule Variable
@@ -103,7 +101,7 @@ test_expandRule =
                 expandOnePathSingleConstructors
                     (metadataTools [])
                     (Mock.f x `rewritesTo` Mock.g x)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     , testCase "Nothing to expand without constructors" $
         let expected = Mock.f x `rewritesTo` Mock.g x
             actual =
@@ -112,7 +110,7 @@ test_expandRule =
                         [ (Mock.testSortId, noConstructor) ]
                     )
                     (Mock.f x `rewritesTo` Mock.g x)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     , testCase "Nothing to expand with multiple constructors" $
         let expected = Mock.f x `rewritesTo` Mock.g x
             actual =
@@ -126,7 +124,7 @@ test_expandRule =
                         ]
                     )
                     (Mock.f x `rewritesTo` Mock.g x)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     , testCase "Expands variable once to constant" $
         let expected =
                 Pair (Mock.f Mock.a, makeEqualsPredicate x Mock.a)
@@ -141,7 +139,7 @@ test_expandRule =
                         ]
                     )
                     (Mock.f x `rewritesTo` Mock.g x)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     , testCase "Expands variable once to argument constructor" $
         let expected =
                 Pair
@@ -168,7 +166,7 @@ test_expandRule =
                         ]
                     )
                     (Mock.fSort0 x0 `rewritesTo` Mock.gSort0 x0)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     , testCase "Expands variable twice." $
         let expected =
                 Pair
@@ -198,7 +196,7 @@ test_expandRule =
                         ]
                     )
                     (Mock.fSort0 x0 `rewritesTo` Mock.gSort0 x0)
-        in assertEqualWithExplanation "" expected actual
+        in assertEqual "" expected actual
     ]
   where
     x = mkElemVar Mock.x

--- a/kore/test/Test/Kore/Step/SMT/Representation/Sorts.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/Sorts.hs
@@ -5,6 +5,9 @@ import Test.Tasty
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom
     )
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
 import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
     )
@@ -149,4 +152,6 @@ testsForModule
         ]
     -> TestTree
 testsForModule name =
-    Helpers.testsForModule name buildRepresentations
+    Helpers.testsForModule name build
+  where
+    build m = buildRepresentations m (Attribute.Constructors.indexBySort m)

--- a/kore/test/Test/Kore/Step/SMT/Sorts.hs
+++ b/kore/test/Test/Kore/Step/SMT/Sorts.hs
@@ -2,11 +2,29 @@ module Test.Kore.Step.SMT.Sorts where
 
 import Test.Tasty
 
+import Data.Reflection
+    ( Given
+    )
 import Data.Text
     ( Text
     )
 
+import qualified Kore.Attribute.Axiom as Attribute
+    ( Axiom
+    )
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
+import qualified Kore.Attribute.Symbol as Attribute
+    ( Symbol
+    )
 import qualified Kore.Builtin.Int as Int
+import Kore.IndexedModule.IndexedModule
+    ( VerifiedModule
+    )
+import Kore.IndexedModule.MetadataTools
+    ( SmtMetadataTools
+    )
 import Kore.Parser
     ( ParsedPattern
     )
@@ -359,5 +377,14 @@ test_sortDeclaration =
             :: SentenceImport ParsedPattern
             )
 
-    testsForModule name =
-        Helpers.testsForModule name (Declaration.declare . Representation.build)
+    testsForModule name = Helpers.testsForModule name declareSymbolsAndSorts
+
+    declareSymbolsAndSorts
+        ::  ( Given (SmtMetadataTools Attribute.Symbol)
+            , SMT.MonadSMT m
+            )
+        => VerifiedModule Attribute.Symbol Attribute.Axiom
+        -> m ()
+    declareSymbolsAndSorts m =
+        Declaration.declare
+            (Representation.build m (Attribute.Constructors.indexBySort m))

--- a/kore/test/Test/Kore/Step/SMT/Symbols.hs
+++ b/kore/test/Test/Kore/Step/SMT/Symbols.hs
@@ -9,6 +9,9 @@ import Data.Reflection
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom
     )
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
 import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
     )
@@ -119,6 +122,7 @@ test_sortDeclaration =
     ]
   where
     testsForModule name = Helpers.testsForModule name declareSymbolsAndSorts
+
     declareSymbolsAndSorts
         ::  ( Given (SmtMetadataTools Attribute.Symbol)
             , SMT.MonadSMT m
@@ -126,4 +130,5 @@ test_sortDeclaration =
         => VerifiedModule Attribute.Symbol Attribute.Axiom
         -> m ()
     declareSymbolsAndSorts m =
-        Declaration.declare (Representation.build m)
+        Declaration.declare
+            (Representation.build m (Attribute.Constructors.indexBySort m))

--- a/kore/test/Test/Kore/Variables/Fresh.hs
+++ b/kore/test/Test/Kore/Variables/Fresh.hs
@@ -3,6 +3,9 @@ module Test.Kore.Variables.Fresh (test_refreshVariable) where
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Data.Maybe
+    ( isJust
+    )
 import qualified Data.Set as Set
 
 import Kore.Sort
@@ -40,6 +43,14 @@ test_refreshVariable =
     , testCase "refreshVariable - expecting the same sort" $
         assertBool "Expected fresh variable has same sort as original"
             (variableSort original == variableSort fresh2)
+
+    , testCase "refreshVariable - sort order does not matter" $
+        let assertRefreshes a b =
+                assertBool "Expected fresh variable"
+                    (isJust (refreshVariable (Set.singleton a) b))
+        in do
+            assertRefreshes original metaVariableDifferentSort
+            assertRefreshes metaVariableDifferentSort original
     ]
   where
     original = metaVariable

--- a/kore/test/Test/Kore/With.hs
+++ b/kore/test/Test/Kore/With.hs
@@ -13,6 +13,10 @@ import qualified Data.List as List
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
+import qualified Data.List.NonEmpty as NonEmpty
+    ( cons
+    , reverse
+    )
 import qualified Data.Map.Strict as Map
 
 import Kore.Attribute.Attributes
@@ -437,9 +441,11 @@ instance With Attribute.Constructors Attribute.Constructors.ConstructorLike
     with (Attribute.Constructors Nothing) constructorLike =
         Attribute.Constructors (Just (constructorLike :| []))
     with
-        (Attribute.Constructors (Just (c :| cs)))
+        (Attribute.Constructors (Just constructors))
         constructorLike
-      = Attribute.Constructors (Just (constructorLike :| (c : cs)))
+      = Attribute.Constructors
+        $ Just
+        $ nonEmptyAppend constructorLike constructors
 
 instance With Attribute.Constructors.ConstructorLike Kore.Sort
   where
@@ -459,4 +465,7 @@ instance With Attribute.Constructors.Constructor Kore.Sort
     with
         c@(Attribute.Constructors.Constructor {sorts}) sort
       =
-        c{Attribute.Constructors.Constructor.sorts = sorts `with` sort}
+        c{Attribute.Constructors.Constructor.sorts = sorts ++ [sort]}
+
+nonEmptyAppend :: a -> NonEmpty a -> NonEmpty a
+nonEmptyAppend a = NonEmpty.reverse . NonEmpty.cons a . NonEmpty.reverse

--- a/src/main/k/working/imp/merge/2.merge-golden
+++ b/src/main/k/working/imp/merge/2.merge-golden
@@ -52,7 +52,7 @@
                 Lbl'Unds'Map'Unds'{}(
                     /* element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
                         inj{SortId{}, SortKItem{}}(VarX0:SortId{}),
-                        VarI:SortKItem{}
+                        VarI0:SortKItem{}
                     ),
                     /* opaque child: */ VarDotVar30:SortMap{}
                 )

--- a/src/main/k/working/k-equal/specs/iszero-ge-spec.kprove.golden
+++ b/src/main/k/working/k-equal/specs/iszero-ge-spec.kprove.golden
@@ -11,6 +11,14 @@
   </T>
 #And
   {
+    DotVar0
+  #Equals
+    <generatedCounter>
+      DotVar00
+    </generatedCounter>
+  }
+#And
+  {
     I >=Int 0
   #Equals
     true

--- a/src/main/k/working/k-equal/specs/iszero-gt-spec.kprove.golden
+++ b/src/main/k/working/k-equal/specs/iszero-gt-spec.kprove.golden
@@ -11,6 +11,14 @@
   </T>
 #And
   {
+    DotVar0
+  #Equals
+    <generatedCounter>
+      DotVar00
+    </generatedCounter>
+  }
+#And
+  {
     I >Int 0
   #Equals
     true


### PR DESCRIPTION
Whenever we have a claim `left => right` in which the left hand side contains a variable from a sort with only one constructor, the variable will be replaced with an application of that constructor over new variables. If the sorts for some of the new variables are also single-constructor ones, they are expanded, and so on.

Fixes #997 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
