### PR TITLE
Match AxiomIdentifier based on external syntax

### DIFF
--- a/kore/src/Kore/Step/Axiom/Identifier.hs
+++ b/kore/src/Kore/Step/Axiom/Identifier.hs
@@ -27,6 +27,7 @@ module Kore.Step.Axiom.Identifier
 import Control.Applicative
     ( Alternative (..)
     )
+import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
 import Data.Text.Prettyprint.Doc
     ( Pretty (..)
@@ -39,6 +40,7 @@ import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
 import Kore.Debug
+import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.TermLike
     ( CofreeF (..)
     , TermLike
@@ -116,4 +118,13 @@ matchAxiomIdentifier = Recursive.fold matchWorker
                 Exists <$> TermLike.existsChild exists
             TermLike.VariableF _ ->
                 pure Variable
+            TermLike.BuiltinF (Domain.BuiltinMap internalMap) ->
+                pure (Application symbolId)
+              where
+                symbol =
+                    case Foldable.toList internalMap of
+                        [   ] -> Domain.builtinAcUnit internalMap
+                        [ _ ] -> Domain.builtinAcElement internalMap
+                        _ : _ -> Domain.builtinAcConcat internalMap
+                symbolId = TermLike.symbolConstructor symbol
             _ -> empty

--- a/kore/test/Test/Kore/Step/Axiom/Identifier.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Identifier.hs
@@ -43,6 +43,39 @@ test_matchAxiomIdentifier =
         (TermLike.mkExists Mock.x
             $ TermLike.mkEquals_ (TermLike.mkElemVar Mock.x) (Mock.f Mock.a))
         (Exists (Equals Variable (Application Mock.fId)))
+    , testGroup "Map"
+        [ matches "unitMap"
+            (Mock.builtinMap [])
+            (Application Mock.unitMapId)
+        , matches "elementMap"
+            (Mock.builtinMap [(Mock.a, Mock.a)])
+            (Application Mock.elementMapId)
+        , matches "concatMap"
+            (Mock.builtinMap [(Mock.a, Mock.a), (Mock.b, Mock.b)])
+            (Application Mock.concatMapId)
+        ]
+    , testGroup "Set"
+        [ matches "unitSet"
+            (Mock.builtinSet [])
+            (Application Mock.unitSetId)
+        , matches "elementSet"
+            (Mock.builtinSet [Mock.a])
+            (Application Mock.elementSetId)
+        , matches "concatSet"
+            (Mock.builtinSet [Mock.a, Mock.b])
+            (Application Mock.concatSetId)
+        ]
+    , testGroup "List"
+        [ matches "unitList"
+            (Mock.builtinList [])
+            (Application Mock.unitListId)
+        , matches "elementList"
+            (Mock.builtinList [Mock.a])
+            (Application Mock.elementListId)
+        , matches "concatList"
+            (Mock.builtinList [Mock.a, Mock.b])
+            (Application Mock.concatListId)
+        ]
     ]
 
 match

--- a/kore/test/Test/Kore/Step/Axiom/Identifier.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Identifier.hs
@@ -44,39 +44,49 @@ test_matchAxiomIdentifier =
             $ TermLike.mkEquals_ (TermLike.mkElemVar Mock.x) (Mock.f Mock.a))
         (Exists (Equals Variable (Application Mock.fId)))
     , testGroup "Map"
-        [ matches "unitMap"
+        [ test "unitMap"
             (Mock.builtinMap [])
             (Application Mock.unitMapId)
-        , matches "elementMap"
+        , test "elementMap"
             (Mock.builtinMap [(Mock.a, Mock.a)])
             (Application Mock.elementMapId)
-        , matches "concatMap"
+        , test "concatMap"
             (Mock.builtinMap [(Mock.a, Mock.a), (Mock.b, Mock.b)])
             (Application Mock.concatMapId)
         ]
     , testGroup "Set"
-        [ matches "unitSet"
+        [ test "unitSet"
             (Mock.builtinSet [])
             (Application Mock.unitSetId)
-        , matches "elementSet"
+        , test "elementSet"
             (Mock.builtinSet [Mock.a])
             (Application Mock.elementSetId)
-        , matches "concatSet"
+        , test "concatSet"
             (Mock.builtinSet [Mock.a, Mock.b])
             (Application Mock.concatSetId)
         ]
     , testGroup "List"
-        [ matches "unitList"
+        [ test "unitList"
             (Mock.builtinList [])
             (Application Mock.unitListId)
-        , matches "elementList"
+        , test "elementList"
             (Mock.builtinList [Mock.a])
             (Application Mock.elementListId)
-        , matches "concatList"
+        , test "concatList"
             (Mock.builtinList [Mock.a, Mock.b])
             (Application Mock.concatListId)
         ]
     ]
+  where
+    test name termLike axiomIdentifier =
+        testGroup name
+            [ matches name termLike axiomIdentifier
+            , matches ceilName
+                (TermLike.mkCeil_ termLike)
+                (Ceil axiomIdentifier)
+            ]
+      where
+        ceilName = "ceil " <> name
 
 match
     :: GHC.HasCallStack


### PR DESCRIPTION
When `TermLike` patterns are `internalized`, we would not match `AxiomIdentifier`s for internal representations of Map, List, or Set. With this change, we always return an `AxiomIdentifier` based on the external pattern syntax, i.e. ordinary symbols.

Fixes: #1022 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
