### PR TITLE
Consistent substitution normalization

### DIFF
--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -115,6 +115,7 @@ import Kore.Sort
     ( Sort
     )
 import Kore.Step.Simplification.Simplify as Simplifier
+import qualified Kore.Step.Substitution as Substitution
 import Kore.Syntax.ElementVariable
     ( ElementVariable (getElementVariable)
     )
@@ -733,7 +734,8 @@ unifyEqualsNormalized
 
     let unifierTerm :: TermLike variable
         unifierTerm = asInternal tools sort1 renormalized
-    return (unifierTerm `withCondition` unifierPredicate)
+    normalizedPredicate <- Monad.Trans.lift $ Substitution.normalizeExcept unifierPredicate
+    return (unifierTerm `withCondition` normalizedPredicate)
   where
     sort1 = termLikeSort first
 

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -102,6 +102,7 @@ import Kore.Step.Simplification.SimplificationType
     ( SimplificationType
     )
 import Kore.Step.Simplification.Simplify as Simplifier
+import qualified Kore.Step.Substitution as Substitution
 import Kore.Syntax.Sentence
     ( SentenceSort (..)
     )
@@ -444,8 +445,10 @@ unifyEquals
     simplifyChild
     first
     second
-  =
-    unifyEquals0 first second
+  = do
+    (term, unifier) <- Pattern.splitTerm <$> unifyEquals0 first second
+    normalized <- Monad.Trans.lift $ Substitution.normalizeExcept unifier
+    return (Pattern.withCondition term normalized)
   where
     propagatePredicates
         :: Traversable t

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -305,11 +305,11 @@ fromSingleSubstitution
     :: InternalVariable variable
     => (UnifiedVariable variable, TermLike variable)
     -> Conditional variable ()
-fromSingleSubstitution pair =
+fromSingleSubstitution (variable, termLike) =
     Conditional
         { term = ()
         , predicate = Predicate.makeTruePredicate
-        , substitution = Substitution.wrap [pair]
+        , substitution = Substitution.singleton variable termLike
         }
 
 {- | Combine the predicate with the conditions of the first argument.

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -178,7 +178,10 @@ matchIncremental termLike1 termLike2 =
                 $ MultiAnd.toPredicate predicate
             substitution' =
                 Predicate.fromSubstitution
-                $ Substitution.fromMap substitution
+                -- unsafeWrap is safe because the matcher guarantees the
+                -- substitution is normalized.
+                $ Substitution.unsafeWrap
+                $ Map.toList substitution
             solution = predicate' <> substitution'
         return solution
 

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -73,7 +73,6 @@ import Kore.Predicate.Predicate
     ( pattern PredicateTrue
     , makeEqualsPredicate
     , makeNotPredicate
-    , makeTruePredicate
     )
 import Kore.Step.PatternAttributes
     ( isConstructorLikeTop
@@ -94,12 +93,12 @@ import Kore.Step.Substitution
     ( PredicateMerger
     , createLiftedPredicatesAndSubstitutionsMerger
     , createPredicatesAndSubstitutionsMergerExcept
+    , normalizeExcept
     )
 import Kore.TopBottom
 import Kore.Unification.Error
     ( unsupportedPatterns
     )
-import qualified Kore.Unification.Substitution as Substitution
 import Kore.Unification.Unify as Unify
 import Kore.Unparser
 import Kore.Variables.Fresh
@@ -602,14 +601,13 @@ variableFunctionAndEquals
     first@(ElemVar_ v1)
     second@(ElemVar_ v2)
   =
-    return Conditional
-        { term = if v2 > v1 then second else first
-        , predicate = makeTruePredicate
-        , substitution =
-            Substitution.wrap
-                [ if v2 > v1 then (ElemVar v1, second) else (ElemVar v2, first)
-                ]
-        }
+    return
+    $ Pattern.withCondition termLike
+    $ Predicate.fromSingleSubstitution subst
+  where
+    subst@(_, termLike)
+      | v2 > v1   = (ElemVar v1, second)
+      | otherwise = (ElemVar v2, first)
 variableFunctionAndEquals
     configurationPredicate
     simplificationType
@@ -636,7 +634,8 @@ variableFunctionAndEquals
                     resultPredicates -> Unify.scatter resultPredicates
     let result =
             predicate <> Predicate.fromSingleSubstitution (ElemVar v, second)
-    return (Pattern.withCondition second result)
+    normalized <- normalizeExcept result
+    return (Pattern.withCondition second normalized)
 variableFunctionAndEquals _ _ _ _ = empty
 
 {- | Unify a function pattern with a variable.

--- a/kore/src/Kore/Step/Simplification/NoConfusion.hs
+++ b/kore/src/Kore/Step/Simplification/NoConfusion.hs
@@ -33,6 +33,7 @@ import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify as Simplifier
+import qualified Kore.Step.Substitution as Substitution
 import Kore.Unification.Unify as Unify
 import Kore.Unparser
 
@@ -63,7 +64,8 @@ equalInjectiveHeadsAndEquals
         children <- Monad.zipWithM termMerger firstChildren secondChildren
         let merged = Foldable.foldMap Pattern.withoutTerm children
             term = mkApplySymbol firstHead (Pattern.term <$> children)
-        return (Pattern.withCondition term merged)
+        normalized <- Substitution.normalizeExcept merged
+        return (Pattern.withCondition term normalized)
   where
     isFirstInjective = Symbol.isInjective firstHead
     isSecondInjective = Symbol.isInjective secondHead

--- a/kore/src/Kore/Unification/Substitution.hs
+++ b/kore/src/Kore/Unification/Substitution.hs
@@ -101,13 +101,9 @@ data Substitution variable
         !(Map (UnifiedVariable variable) (TermLike variable))
     deriving GHC.Generic
 
--- | 'Eq' does not differentiate normalized and denormalized 'Substitution's.
-instance Ord variable => Eq (Substitution variable) where
-    (==) = Function.on (==) unwrap
+deriving instance Ord variable => Eq (Substitution variable)
 
--- | 'Ord' does not differentiate normalized and denormalized 'Substitution's.
-instance Ord variable => Ord (Substitution variable) where
-    compare = Function.on compare unwrap
+deriving instance Ord variable => Ord (Substitution variable)
 
 instance SOP.Generic (Substitution variable)
 
@@ -118,13 +114,6 @@ instance Debug variable => Debug (Substitution variable)
 instance
     ( Debug variable, Diff variable, Ord variable )
     => Diff (Substitution variable)
-  where
-    diffPrec a b =
-        wrapDiffPrec <$> Function.on diffPrec unwrap a b
-      where
-        wrapDiffPrec diff' = \precOut ->
-            (if precOut >= 10 then Pretty.parens else id)
-            ("Kore.Unification.Substitution.wrap" Pretty.<+> diff' 10)
 
 deriving instance Show variable => Show (Substitution variable)
 

--- a/kore/test/Test/Kore/Step/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Matcher.hs
@@ -401,8 +401,9 @@ test_matcherVariableFunction =
             let evaluated = mkEvaluated Mock.functional00
                 expect =
                     Just . OrPredicate.fromPredicate
-                    $ Predicate.fromSingleSubstitution
-                        (UnifiedVariable.ElemVar Mock.x, evaluated)
+                    $ Predicate.fromSubstitution
+                    $ Substitution.unsafeWrap
+                        [(UnifiedVariable.ElemVar Mock.x, evaluated)]
             actual <- matchDefinition (mkElemVar Mock.x) evaluated
             assertEqual "" expect actual
 
@@ -410,9 +411,9 @@ test_matcherVariableFunction =
             let evaluated = mkEvaluated Mock.cf
                 expect =
                     (Just . OrPredicate.fromPredicate)
-                    (Predicate.fromSingleSubstitution
-                        (UnifiedVariable.ElemVar Mock.x, evaluated))
-                        { predicate = makeCeilPredicate evaluated }
+                    (Predicate.fromSubstitution $ Substitution.unsafeWrap
+                        [(UnifiedVariable.ElemVar Mock.x, evaluated)]
+                    ) { predicate = makeCeilPredicate evaluated }
             actual <- matchDefinition (mkElemVar Mock.x) evaluated
             assertEqual "" expect actual
         ]

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -525,7 +525,7 @@ test_andTermsSimplification =
                         { term =
                             Mock.builtinMap [(Mock.a, fOfA), (Mock.b, fOfB)]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [ (ElemVar Mock.x, fOfA)
                             , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                             ]
@@ -546,7 +546,7 @@ test_andTermsSimplification =
                         { term =
                             Mock.builtinMap [(Mock.a, fOfA), (Mock.b, fOfB)]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [ (ElemVar Mock.x, fOfA)
                             , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                             ]
@@ -567,7 +567,7 @@ test_andTermsSimplification =
                         { term =
                             Mock.builtinMap [(Mock.a, fOfA) , (Mock.b, fOfB)]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [ (ElemVar Mock.x, fOfA)
                             , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                             ]
@@ -588,7 +588,7 @@ test_andTermsSimplification =
                         { term =
                             Mock.builtinMap [(Mock.a, fOfA), (Mock.b, fOfB)]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [ (ElemVar Mock.x, fOfA)
                             , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                             ]
@@ -608,7 +608,7 @@ test_andTermsSimplification =
                     [ Conditional
                         { term = Mock.builtinMap [ (Mock.a, fOfA) ]
                         , predicate = makeTruePredicate
-                        , substitution = Substitution.wrap
+                        , substitution = Substitution.unsafeWrap
                             [ (ElemVar Mock.x, Mock.a)
                             , (ElemVar Mock.y, fOfA)
                             ]
@@ -797,7 +797,7 @@ test_andTermsSimplification =
         , testCase "different lengths" $ do
             let term7 = Mock.builtinList [Mock.a, Mock.a]
                 term8 = Mock.builtinList [Mock.a]
-                expect = Just [Pattern.bottom]
+                expect = Just []
             actual <- unify term7 term8
             assertEqual "" expect actual
 

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -670,7 +670,7 @@ test_equalsSimplification_TermLike =
                         makeAndPredicate
                             (makeCeilPredicate fOfB)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap
+                    , substitution = Substitution.unsafeWrap
                         [ (ElemVar Mock.x, fOfA)
                         , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                         ]
@@ -689,7 +689,7 @@ test_equalsSimplification_TermLike =
                         makeAndPredicate
                             (makeCeilPredicate fOfB)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap
+                    , substitution = Substitution.unsafeWrap
                         [ (ElemVar Mock.x, fOfA)
                         , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                         ]
@@ -708,7 +708,7 @@ test_equalsSimplification_TermLike =
                         makeAndPredicate
                             (makeCeilPredicate fOfB)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap
+                    , substitution = Substitution.unsafeWrap
                         [ (ElemVar Mock.x, fOfA)
                         , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                         ]
@@ -727,7 +727,7 @@ test_equalsSimplification_TermLike =
                         makeAndPredicate
                             (makeCeilPredicate fOfB)
                             (makeCeilPredicate fOfA)
-                    , substitution = Substitution.wrap
+                    , substitution = Substitution.unsafeWrap
                         [ (ElemVar Mock.x, fOfA)
                         , (ElemVar Mock.m, Mock.builtinMap [(Mock.b, fOfB)])
                         ]
@@ -777,8 +777,8 @@ test_equalsSimplification_TermLike =
             in
                 testCase "[a] `concat` x /\\ [a, b] "
                     (assertTermEquals
-                        (Predicate.fromSingleSubstitution
-                            (ElemVar x, Mock.builtinList [Mock.b])
+                        (Predicate.fromSubstitution $ Substitution.unsafeWrap
+                            [(ElemVar x, Mock.builtinList [Mock.b])]
                         )
                         term5
                         term6

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -236,7 +236,8 @@ test_makeEvaluate =
                 [ Conditional
                     { term = fOfA
                     , predicate = makeTruePredicate
-                    , substitution = Substitution.wrap [(ElemVar Mock.y, fOfA)]
+                    , substitution =
+                        Substitution.unsafeWrap [(ElemVar Mock.y, fOfA)]
                     }
                 ]
         actual <-
@@ -261,7 +262,8 @@ test_makeEvaluate =
                                 (makeEqualsPredicate fOfX (Mock.f Mock.a))
                                 (makeEqualsPredicate (mkElemVar Mock.y) fOfX)
                             )
-                    , substitution = Substitution.wrap [(ElemVar Mock.z, fOfA)]
+                    , substitution =
+                        Substitution.unsafeWrap [(ElemVar Mock.z, fOfA)]
                     }
                 ]
         actual <-


### PR DESCRIPTION
The matcher keeps the substitution normalized by construction, but several unification cases were inconsistent about normalizing the substitution. Unification isn't _finished_ until the substitution is normalized, so this doesn't make much sense.

This produced a lot of test failures, so it was a good exercise for tweaking the `Debug.Diff` output (see #1030).

In the future, we may consider changing how substitution normalization works. Presently, it does two different things: it normalizes the substitution itself (de-duplication, back-substitution, and occurs check) and it runs the predicate simplifier over the result. This is awkward: the predicate simplifier also calls substitution normalization. With this mutual recursion, it is hard to change either without introducing a loop. This also causes one of the big cyclic dependencies. We could consider instead keeping the unification `Predicate` always partially normalized (do de-duplication and back-substitution on-the-fly, these are pure operations we can do in the `Semigroup` instance) with a single check at the end of unification which performs the occurs check and re-unifies any predicates generated by de-duplication.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
