### PR TITLE
runSMT: Stop solver gracefully upon error

### DIFF
--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -48,6 +48,7 @@ module SMT
     ) where
 
 import Control.Concurrent.MVar
+import qualified Control.Exception as Exception
 import qualified Control.Lens as Lens hiding
     ( makeLenses
     )
@@ -433,11 +434,11 @@ stopSolver mvar = do
 
 -- | Run an external SMT solver.
 runSMT :: Config -> Logger -> SMT a -> IO a
-runSMT config logger SmtT { runSmtT } = do
-    solver <- newSolver config logger
-    a <- runReaderT runSmtT solver
-    stopSolver solver
-    return a
+runSMT config logger SmtT { runSmtT } =
+    Exception.bracket
+        (newSolver config logger)
+        stopSolver
+        (runReaderT runSmtT)
 
 -- Need to quote every identifier in SMT between pipes
 -- to escape special chars


### PR DESCRIPTION
In normal execution, this does matter because errors kill the parent process,
dispatchng the child solver process. In the unit tests, this leaves unused child
solver processes when a test throws an error. If the number of test errors
exceeds the system's child process limit, the remaining tests will fail: they
will be unable to start new solver processes.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
