### PR TITLE
Identify orphan SMT constructors

### DIFF
--- a/kore/src/Kore/Logger/Output.hs
+++ b/kore/src/Kore/Logger/Output.hs
@@ -168,7 +168,7 @@ parseKoreLogOptions =
         option
             (maybeReader parseTypeString)
             $ long "log"
-            <> help "Log type: None, StdOut, FileText"
+            <> help "Log type: none, stdout, filetext"
     parseTypeString =
         \case
             "none"     -> pure LogNone
@@ -180,7 +180,7 @@ parseKoreLogOptions =
         option
             (maybeReader parseSeverity)
             $ long "log-level"
-            <> help "Log level: Debug, Info, Warning, Error, or Critical"
+            <> help "Log level: debug, info, warning, error, or critical"
     parseSeverity =
         \case
             "debug"    -> pure Debug

--- a/kore/src/Kore/Step/SMT/AST.hs
+++ b/kore/src/Kore/Step/SMT/AST.hs
@@ -176,8 +176,12 @@ by the SMT.
 data KoreSymbolDeclaration sort name
     = SymbolDeclaredDirectly !(AST.FunctionDeclaration sort name)
     -- ^ Normal symbol declaration
-    | SymbolDeclaredIndirectly !(IndirectSymbolDeclaration sort name)
-    -- ^ Symbol declared in a different way (e.g. builtin or constructor).
+    | SymbolBuiltin !(IndirectSymbolDeclaration sort name)
+    -- ^ Builtins should not be declared to the SMT.
+    -- The IndirectSymbolDeclaration value holds dependencies on other sorts
+    -- and debug information.
+    | SymbolConstructor !(IndirectSymbolDeclaration sort name)
+    -- ^ Constructors are declared to the SMT when declaring the sort.
     -- The IndirectSymbolDeclaration value holds dependencies on other sorts
     -- and debug information.
     deriving (Eq, GHC.Generic, Ord, Show)
@@ -197,7 +201,8 @@ instance
 data IndirectSymbolDeclaration sort name =
     IndirectSymbolDeclaration
         { name :: !name
-        , sorts :: ![sort]
+        , resultSort :: !sort
+        , argumentSorts :: ![sort]
         }
     deriving (Eq, GHC.Generic, Ord, Show)
 

--- a/kore/src/Kore/Step/SMT/Declaration/Symbols.hs
+++ b/kore/src/Kore/Step/SMT/Declaration/Symbols.hs
@@ -14,7 +14,7 @@ import qualified Data.Foldable as Foldable
 
 import qualified Kore.Step.SMT.AST as AST
     ( Declarations (Declarations)
-    , KoreSymbolDeclaration (SymbolDeclaredDirectly, SymbolDeclaredIndirectly)
+    , KoreSymbolDeclaration (SymbolBuiltin, SymbolConstructor, SymbolDeclaredDirectly)
     , SmtDeclarations
     , SmtKoreSymbolDeclaration
     , SmtSymbol
@@ -39,5 +39,7 @@ declareKoreSymbolDeclaration
     (AST.SymbolDeclaredDirectly declaration)
   =
     SMT.declareFun_ declaration
-declareKoreSymbolDeclaration (AST.SymbolDeclaredIndirectly _) =
+declareKoreSymbolDeclaration (AST.SymbolBuiltin _) =
+    return ()
+declareKoreSymbolDeclaration (AST.SymbolConstructor _) =
     return ()

--- a/kore/src/Kore/Step/SMT/Representation/Resolve.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Resolve.hs
@@ -317,6 +317,14 @@ resolveKoreSymbolDeclaration
         {resultSort}
     )
   = do
+    -- If the sort does not declare the constructor symbol, and we would try to
+    -- use it, we would get a "not declared error" from the SMT. Also,
+    -- if it's not declared by the sort, then we don't have
+    -- any constraints on it, so there's currently no point in declaring
+    -- it separately.
+    --
+    -- Note that direct smtlib declarations take precedence over constructors,
+    -- so we would not reach this line if this symbol had a smtlib attribute.
     assertMay (sortDeclaresSymbol resultSort symbolId)
 
     SymbolConstructor

--- a/kore/src/Kore/Step/SMT/Representation/Symbols.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Symbols.hs
@@ -124,11 +124,10 @@ builtinDeclaration
         , AST.Symbol
             { smtFromSortArgs = emptySortArgsToSmt (SMT.Atom smtName)
             , declaration =
-                AST.SymbolDeclaredIndirectly AST.IndirectSymbolDeclaration
+                AST.SymbolBuiltin AST.IndirectSymbolDeclaration
                     { name = AST.AlreadyEncoded smtName
-                    , sorts = map
-                        AST.SortReference
-                        (sentenceSymbolResultSort : sentenceSymbolSorts)
+                    , resultSort = AST.SortReference sentenceSymbolResultSort
+                    , argumentSorts = map AST.SortReference sentenceSymbolSorts
                     }
             }
         )
@@ -182,11 +181,10 @@ constructorDeclaration
             { smtFromSortArgs =
                 emptySortArgsToSmt (SMT.Atom $ AST.encode encodedName)
             , declaration =
-                AST.SymbolDeclaredIndirectly AST.IndirectSymbolDeclaration
+                AST.SymbolConstructor AST.IndirectSymbolDeclaration
                     { name = encodedName
-                    , sorts = map
-                        AST.SortReference
-                        (sentenceSymbolResultSort : sentenceSymbolSorts)
+                    , resultSort = AST.SortReference sentenceSymbolResultSort
+                    , argumentSorts = map AST.SortReference sentenceSymbolSorts
                     }
             }
         )

--- a/kore/test/Test/Kore/Step/Condition/Evaluator.hs
+++ b/kore/test/Test/Kore/Step/Condition/Evaluator.hs
@@ -83,7 +83,7 @@ p, q :: TermLike Variable
 p = vBool (testId "p")
 q = vBool (testId "q")
 
-assertRefuted :: Syntax.Predicate Variable -> Assertion
+assertRefuted :: HasCallStack => Syntax.Predicate Variable -> Assertion
 assertRefuted prop = do
     let expect = Just False
     actual <- Test.runSimplifier testEnv $ SMT.Evaluator.decidePredicate prop

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -1232,9 +1232,10 @@ smtConstructor symbolId argumentSorts resultSort =
     SMT.Symbol
         { smtFromSortArgs = const (const (Just (SMT.Atom encodedId)))
         , declaration =
-            SMT.SymbolDeclaredIndirectly SMT.IndirectSymbolDeclaration
+            SMT.SymbolConstructor SMT.IndirectSymbolDeclaration
                 { name = encodableId
-                , sorts = map SMT.SortReference (resultSort : argumentSorts)
+                , resultSort = SMT.SortReference resultSort
+                , argumentSorts = map SMT.SortReference argumentSorts
                 }
         }
   where
@@ -1247,9 +1248,10 @@ smtBuiltinSymbol builtin argumentSorts resultSort =
     SMT.Symbol
         { smtFromSortArgs = const (const (Just (SMT.Atom builtin)))
         , declaration =
-            SMT.SymbolDeclaredIndirectly SMT.IndirectSymbolDeclaration
+            SMT.SymbolBuiltin SMT.IndirectSymbolDeclaration
                 { name = SMT.AlreadyEncoded builtin
-                , sorts = map SMT.SortReference (resultSort : argumentSorts)
+                , resultSort = SMT.SortReference resultSort
+                , argumentSorts = map SMT.SortReference argumentSorts
                 }
         }
 

--- a/kore/test/Test/Kore/Step/SMT/Representation/All.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/All.hs
@@ -1,0 +1,93 @@
+module Test.Kore.Step.SMT.Representation.All where
+
+import Test.Tasty
+
+import qualified Data.Map as Map
+import Data.Text
+    ( Text
+    )
+
+import qualified Kore.Attribute.Axiom as Attribute
+    ( Axiom
+    )
+import qualified Kore.Attribute.Sort.ConstructorsBuilder as Attribute.Constructors
+    ( indexBySort
+    )
+import qualified Kore.Attribute.Symbol as Attribute
+    ( Symbol
+    )
+import Kore.IndexedModule.IndexedModule
+    ( VerifiedModule
+    )
+import qualified Kore.Step.SMT.AST as AST
+    ( Declarations (Declarations)
+    , KoreSortDeclaration (SortDeclarationSort)
+    , Sort (Sort)
+    , encodable
+    , encode
+    )
+import qualified Kore.Step.SMT.AST as AST.DoNotUse
+import qualified Kore.Step.SMT.Representation.All as All
+import qualified SMT
+
+import Test.Kore.Step.SMT.Builders
+    ( constructor
+    , emptyModule
+    , functional
+    , indexModule
+    , sortDeclaration
+    , symbolDeclaration
+    )
+import Test.Kore.Step.SMT.Representation.Helpers
+    ( declarationsAre
+    )
+import qualified Test.Kore.Step.SMT.Representation.Helpers as Helpers
+    ( testsForModule
+    )
+import Test.Kore.With
+    ( with
+    )
+
+test_symbolParsing :: [TestTree]
+test_symbolParsing =
+    [ testsForModule "Definition with orphan constructors"
+        (indexModule $ emptyModule "m"
+            `with` sortDeclaration "S"
+            `with`
+                (symbolDeclaration "C" "S" [] `with` [functional, constructor])
+        )
+        [ declarationsAre
+            AST.Declarations
+                { symbols = Map.empty
+                , sorts = Map.fromList
+                    [ ("#Char", astSortDeclaration "#Char")
+                    , ("S", astSortDeclaration "S")
+                    , ("#String", astSortDeclaration "#String")
+                    ]
+                }
+        ]
+    ]
+  where
+    astSortDeclaration name =
+        AST.Sort
+            { smtFromSortArgs = const $ const $ Just
+                $ SMT.Atom (AST.encode (AST.encodable name))
+            , declaration = AST.SortDeclarationSort
+                SMT.SortDeclaration
+                    { name = AST.encode (AST.encodable name)
+                    , arity = 0
+                    }
+            }
+
+testsForModule
+    :: String
+    -> VerifiedModule Attribute.Symbol Attribute.Axiom
+    ->  [  AST.Declarations SMT.SExpr Text Text
+        -> TestTree
+        ]
+    -> TestTree
+testsForModule name m =
+    Helpers.testsForModule
+        name
+        (\md -> All.build md (Attribute.Constructors.indexBySort m))
+        m

--- a/kore/test/Test/Kore/Step/SMT/Representation/All.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/All.hs
@@ -59,6 +59,11 @@ test_symbolParsing =
         [ declarationsAre
             AST.Declarations
                 { symbols = Map.empty
+                -- "C" not present here because constructors should be declared
+                -- together with their sorts. If the sort does not declare the
+                -- constructor, then the symbol should not be in the
+                -- symbol declarations map.
+
                 , sorts = Map.fromList
                     [ ("#Char", astSortDeclaration "#Char")
                     , ("S", astSortDeclaration "S")

--- a/kore/test/Test/Kore/Step/SMT/Representation/Builders.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/Builders.hs
@@ -123,20 +123,26 @@ unresolvedIndirectSort name =
 
 unresolvedConstructorSymbolMap
     :: Kore.Id
+    -> Kore.Sort
     -> [Kore.Sort]
     -> (Kore.Id, AST.UnresolvedSymbol)
-unresolvedConstructorSymbolMap identifier sorts =
-    (identifier, unresolvedConstructorSymbol identifier sorts)
+unresolvedConstructorSymbolMap identifier resultSort argumentSorts =
+    ( identifier
+    , unresolvedConstructorSymbol identifier resultSort argumentSorts
+    )
 
 unresolvedConstructorSymbol
-    :: Kore.Id -> [Kore.Sort] -> AST.UnresolvedSymbol
-unresolvedConstructorSymbol identifier sorts =
+    :: Kore.Id -> Kore.Sort -> [Kore.Sort] -> AST.UnresolvedSymbol
+unresolvedConstructorSymbol identifier resultSort argumentSorts =
     AST.Symbol
         { smtFromSortArgs = const $ const $ Just
             $ AST.Atom (AST.encode encodable)
-        , declaration = AST.SymbolDeclaredIndirectly
+        , declaration = AST.SymbolConstructor
             AST.IndirectSymbolDeclaration
-                { name = encodable, sorts = map AST.SortReference sorts }
+                { name = encodable
+                , resultSort = AST.SortReference resultSort
+                , argumentSorts = map AST.SortReference argumentSorts
+                }
         }
   where
     encodable = AST.encodable identifier
@@ -170,20 +176,22 @@ unresolvedSmtlibSymbol encodedName inputSorts resultSort =
 unresolvedSmthookSymbolMap
     :: Kore.Id
     -> Text
+    -> Kore.Sort
     -> [Kore.Sort]
     -> (Kore.Id, AST.UnresolvedSymbol)
-unresolvedSmthookSymbolMap identifier encodedName sorts =
-    (identifier, unresolvedSmthookSymbol encodedName sorts)
+unresolvedSmthookSymbolMap identifier encodedName resultSort argumentSorts =
+    (identifier, unresolvedSmthookSymbol encodedName resultSort argumentSorts)
 
 unresolvedSmthookSymbol
-    :: Text -> [Kore.Sort] -> AST.UnresolvedSymbol
-unresolvedSmthookSymbol encodedName sorts =
+    :: Text -> Kore.Sort -> [Kore.Sort] -> AST.UnresolvedSymbol
+unresolvedSmthookSymbol encodedName resultSort argumentSorts =
     AST.Symbol
         { smtFromSortArgs = const $ const $ Just
             $ AST.Atom encodedName
-        , declaration = AST.SymbolDeclaredIndirectly
+        , declaration = AST.SymbolBuiltin
             AST.IndirectSymbolDeclaration
                 { name = AST.AlreadyEncoded encodedName
-                , sorts = map AST.SortReference sorts
+                , resultSort = AST.SortReference resultSort
+                , argumentSorts = map AST.SortReference argumentSorts
                 }
         }

--- a/kore/test/Test/Kore/Step/SMT/Representation/Symbols.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/Symbols.hs
@@ -76,7 +76,7 @@ test_symbolParsing =
             `with` constructorAxiom "S" [("C", [])]
         )
         [ inDeclarations
-            (unresolvedConstructorSymbolMap (testId "C") [koreSort "S"])
+            (unresolvedConstructorSymbolMap (testId "C") (koreSort "S") [])
         , smtForSymbolIs "C" "|HB_C|"
         ]
     , testsForModule "Definition with complex constructor-based sorts"
@@ -92,11 +92,12 @@ test_symbolParsing =
             `with` constructorAxiom "S" [("C", []), ("D", ["T"])]
         )
         [ inDeclarations
-            (unresolvedConstructorSymbolMap (testId "C") [koreSort "S"])
+            (unresolvedConstructorSymbolMap (testId "C") (koreSort "S") [])
         , inDeclarations
             (unresolvedConstructorSymbolMap
                 (testId "D")
-                [koreSort "S", koreSort "T"]
+                (koreSort "S")
+                [koreSort "T"]
             )
         , smtForSymbolIs "C" "|HB_C|"
         , smtForSymbolIs "D" "|HB_D|"
@@ -123,7 +124,7 @@ test_symbolParsing =
         )
         [ inDeclarations
             (unresolvedSmthookSymbolMap
-                (testId "minus") "-" [koreSort "Integer", koreSort "Integer"]
+                (testId "minus") "-" (koreSort "Integer") [ koreSort "Integer"]
             )
         , smtForSymbolIs "minus" "-"
         ]

--- a/kore/test/Test/Kore/With.hs
+++ b/kore/test/Test/Kore/With.hs
@@ -306,16 +306,18 @@ instance With AST.UnresolvedSymbol Kore.Sort where
 instance With AST.UnresolvedKoreSymbolDeclaration Kore.Sort where
     with (AST.SymbolDeclaredDirectly _) _ =
         error "Cannot add sorts to SymbolDeclaredDirectly."
-    with (AST.SymbolDeclaredIndirectly declaration) sort =
-        AST.SymbolDeclaredIndirectly (declaration `with` sort)
+    with (AST.SymbolBuiltin declaration) sort =
+        AST.SymbolBuiltin (declaration `with` sort)
+    with (AST.SymbolConstructor declaration) sort =
+        AST.SymbolConstructor (declaration `with` sort)
 
 instance With AST.UnresolvedIndirectSymbolDeclaration Kore.Sort where
     with
-        s@AST.IndirectSymbolDeclaration {sorts}
+        s@AST.IndirectSymbolDeclaration {argumentSorts}
         sort
       = s
-        { AST.IndirectSymbolDeclaration.sorts =
-            sorts `with` AST.SortReference sort
+        { AST.IndirectSymbolDeclaration.argumentSorts =
+            argumentSorts `with` AST.SortReference sort
         }
 
 newtype ConcreteElement =


### PR DESCRIPTION
Fixes #1049 
Fixes runtimeverification/polkadot-verification#39

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
