### PR TITLE
Disable kbmc integration tests

### DIFF
--- a/scripts/integration-k.sh
+++ b/scripts/integration-k.sh
@@ -7,4 +7,3 @@ export PATH="$(stack path --local-bin)${PATH:+:$PATH}"
 
 MAKE="make --output-sync --jobs --directory $TOP"
 $MAKE test-k
-$MAKE test-bmc


### PR DESCRIPTION
The kbmc integration tests fail randomly.

For example: https://office.runtimeverification.com/jenkins/blue/organizations/jenkins/haskell-backend/detail/PR-1047/9/pipeline

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
