### PR TITLE
Nicer unparsing of Created

### DIFF
--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -478,13 +478,17 @@ instance NFData variable => NFData (TermLike variable) where
 instance SortedVariable variable => Unparse (TermLike variable) where
     unparse term =
         case Recursive.project freshVarTerm of
-            (attrs :< pat) ->
-                Pretty.pretty (getCreated attrs) <> unparse pat
+            (attrs :< termLikeF)
+              | hasKnownCreator created ->
+                Pretty.sep [Pretty.pretty created, unparse termLikeF]
+              | otherwise ->
+                unparse termLikeF
+              where
+                Attribute.Pattern { created } = attrs
       where
         freshVarTerm =
             externalizeFreshVariables
             $ mapVariables toVariable term
-        getCreated = (Lens.^. Lens.Product.field @"created")
 
     unparse2 term =
         case Recursive.project freshVarTerm of


### PR DESCRIPTION
This puts the `Created` information (if present) on the line above the `TermLike`, similar to how `Conditional` marks the `term`.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
