### PR TITLE
Expand aliases when parsing rules

### DIFF
--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -111,7 +111,7 @@ import Kore.Sort
     , SortVariable (SortVariable)
     )
 import Kore.Step.Simplification.ExpandAlias
-    ( substituteWorker
+    ( substituteInAlias
     )
 import Kore.Substitute
     ( SubstitutionVariable
@@ -565,7 +565,7 @@ patternToAxiomPattern
     -> TermLike Variable
     -> Either (Error AxiomPatternError) (QualifiedAxiomPattern Variable)
 patternToAxiomPattern attributes pat
-  | isJust . getPriority . Attribute.priority $ attributes = do
+  | isJust . getPriority . Attribute.priority $ attributes =
     case pat of
         Rewrites_ _
             (And_ _ (Not_ _ antiLeft) (And_ _ requires lhs))
@@ -578,8 +578,8 @@ patternToAxiomPattern attributes pat
                             , ensures = Predicate.wrapPredicate ensures
                             , attributes
                             }
-        _ -> koreFail $ "rule is ill-formed with respect \
-                        \ to the priority attribute."
+        _ -> koreFail "Rule is ill-formed with respect\
+                      \ to the priority attribute."
   | otherwise =
     case pat of
         -- normal rewrite axioms
@@ -595,7 +595,7 @@ patternToAxiomPattern attributes pat
                 , attributes
                 }
         Rewrites_ _ (ApplyAlias_ alias params) rhs ->
-            case substituteWorker alias params of
+            case substituteInAlias alias params of
                And_ _ requires lhs ->
                    patternToAxiomPattern
                        attributes

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -5,6 +5,7 @@ License     : NCSA
 
 module Kore.Step.Simplification.ExpandAlias
     ( expandAlias
+    , substituteWorker
     ) where
 
 import Control.Error

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -5,7 +5,7 @@ License     : NCSA
 
 module Kore.Step.Simplification.ExpandAlias
     ( expandAlias
-    , substituteWorker
+    , substituteInAlias
     ) where
 
 import Control.Error
@@ -67,18 +67,18 @@ expandSingleAlias
     -> Maybe (TermLike variable)
 expandSingleAlias =
     \case
-        ApplyAlias_ alias children -> pure $ substituteWorker alias children
+        ApplyAlias_ alias children -> pure $ substituteInAlias alias children
         _ -> Nothing
 
 -- TODO(Vladimir): Check aliases such that the intersection of alias variables
 -- with the *bounded* variables in the rhs is empty (because we can't currently
 -- handle things like \mu.
-substituteWorker
+substituteInAlias
     :: SubstitutionVariable variable
     => Alias (TermLike Variable)
     -> [TermLike variable]
     -> TermLike variable
-substituteWorker Alias { aliasLeft, aliasRight } children =
+substituteInAlias Alias { aliasLeft, aliasRight } children =
     assert (length aliasLeft == length children)
         $ substitute
             substitutionMap

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -29,6 +29,9 @@ import Kore.Error
 import Kore.IndexedModule.IndexedModule
     ( VerifiedModule
     )
+import Kore.Internal.ApplicationSorts
+    ( ApplicationSorts (..)
+    )
 import Kore.Internal.TermLike hiding
     ( freeVariables
     )
@@ -37,7 +40,9 @@ import Kore.Step.Rule hiding
     ( freeVariables
     )
 import qualified Kore.Step.Rule as Rule
-import Kore.Syntax.Definition
+import Kore.Syntax.Definition hiding
+    ( Alias (..)
+    )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
@@ -71,6 +76,19 @@ axiomPatternsUnitTests =
                     }
                 )
                 (Rule.fromSentence $ mkRewriteAxiom varI1 varI2 Nothing)
+            )
+        , testCase "aliasI1 => I2:AInt"
+            (assertEqual ""
+                (Right $ RewriteAxiomPattern $ RewriteRule RulePattern
+                    { left = varI1
+                    , antiLeft = Nothing
+                    , right = varI2
+                    , requires = Predicate.wrapPredicate (mkTop sortAInt)
+                    , ensures = Predicate.wrapPredicate (mkTop sortAInt)
+                    , attributes = def
+                    }
+                )
+                (Rule.fromSentence $ mkRewriteAxiom applyAliasI1 varI2 Nothing)
             )
         ,   let
                 axiom1, axiom2 :: Verified.Sentence
@@ -310,6 +328,23 @@ varI1 =
         , variableCounter = mempty
         , variableSort = sortAInt
         }
+
+applyAliasI1 =
+    mkApplyAlias aliasI1 []
+  where
+    aliasI1 =
+        Alias
+            { aliasConstructor = testId "AliasI1"
+            , aliasParams = []
+            , aliasSorts =
+                ApplicationSorts
+                    { applicationSortsOperands = []
+                    , applicationSortsResult = sortAInt
+                    }
+            , aliasLeft = []
+            , aliasRight =
+                mkAnd (mkTop sortAInt) varI1
+            }
 
 varI2 =
     mkElemVar $ ElementVariable Variable

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -77,7 +77,7 @@ axiomPatternsUnitTests =
                 )
                 (Rule.fromSentence $ mkRewriteAxiom varI1 varI2 Nothing)
             )
-        , testCase "aliasI1 => I2:AInt"
+        , testCase "alias as rule LHS: ruleLHS => I2:AInt"
             (assertEqual ""
                 (Right $ RewriteAxiomPattern $ RewriteRule RulePattern
                     { left = varI1
@@ -88,7 +88,7 @@ axiomPatternsUnitTests =
                     , attributes = def
                     }
                 )
-                (Rule.fromSentence $ mkRewriteAxiom applyAliasI1 varI2 Nothing)
+                (Rule.fromSentence $ mkRewriteAxiom applyAliasLHS varI2 Nothing)
             )
         ,   let
                 axiom1, axiom2 :: Verified.Sentence
@@ -329,23 +329,6 @@ varI1 =
         , variableSort = sortAInt
         }
 
-applyAliasI1 =
-    mkApplyAlias aliasI1 []
-  where
-    aliasI1 =
-        Alias
-            { aliasConstructor = testId "AliasI1"
-            , aliasParams = []
-            , aliasSorts =
-                ApplicationSorts
-                    { applicationSortsOperands = []
-                    , applicationSortsResult = sortAInt
-                    }
-            , aliasLeft = []
-            , aliasRight =
-                mkAnd (mkTop sortAInt) varI1
-            }
-
 varI2 =
     mkElemVar $ ElementVariable Variable
         { variableName = testId "VarI2"
@@ -366,6 +349,25 @@ varStateCell =
         , variableCounter = mempty
         , variableSort = sortStateCell
         }
+
+applyAliasLHS :: TermLike Variable
+applyAliasLHS =
+    mkApplyAlias ruleLHS []
+  where
+    ruleLHS =
+        Alias
+            { aliasConstructor = testId "RuleLHS"
+            , aliasParams = []
+            , aliasSorts =
+                ApplicationSorts
+                    { applicationSortsOperands = []
+                    , applicationSortsResult = sortAInt
+                    }
+            , aliasLeft = []
+            , aliasRight =
+                mkAnd (mkTop sortAInt) varI1
+            }
+
 
 extractIndexedModule
     :: Text

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -77,9 +77,9 @@ axiomPatternsUnitTests =
                 )
                 (Rule.fromSentence $ mkRewriteAxiom varI1 varI2 Nothing)
             )
-        , testCase "alias as rule LHS: ruleLHS => I2:AInt"
+        , testCase "alias as rule LHS"
             (assertEqual ""
-                (Right $ RewriteAxiomPattern $ RewriteRule RulePattern
+                ( Right $ RewriteAxiomPattern $ RewriteRule RulePattern
                     { left = varI1
                     , antiLeft = Nothing
                     , right = varI2
@@ -88,7 +88,11 @@ axiomPatternsUnitTests =
                     , attributes = def
                     }
                 )
-                (Rule.fromSentence $ mkRewriteAxiom applyAliasLHS varI2 Nothing)
+                (Rule.fromSentence . SentenceAxiomSentence . mkAxiom_ $
+                    mkRewrites
+                        applyAliasLHS
+                        (mkAnd (mkTop sortAInt) varI2)
+                )
             )
         ,   let
                 axiom1, axiom2 :: Verified.Sentence


### PR DESCRIPTION
See https://github.com/kframework/kore/issues/988#issuecomment-539571208
Fixes https://github.com/kframework/kore/issues/988

Note: I didn't move `substituteWorker` to `Kore.Internal.Alias` because that would have resulted in a cyclic import issue between `Kore.internal.Alias` and `Kore.Internal.TermLike`

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
