### PR TITLE
Jenkinsfile: Bring back haskell_documentation and coverage_report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,11 @@ pipeline {
               ./scripts/docs.sh
             '''
           }
+          post {
+            success {
+              archiveArtifacts 'haskell_documentation/**'
+            }
+          }
         }
         stage('Executables') {
           steps {
@@ -58,6 +63,7 @@ pipeline {
       }
       post {
         always {
+          archiveArtifacts 'coverage_report/**'
           junit 'kore/test-results.xml'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
           }
           post {
             success {
-              archiveArtifacts 'haskell_documentation/**'
+              archiveArtifacts 'kore-haddock.tar.gz'
             }
           }
         }
@@ -63,7 +63,7 @@ pipeline {
       }
       post {
         always {
-          archiveArtifacts 'coverage_report/**'
+          archiveArtifacts 'kore-hpc.tar.gz'
           junit 'kore/test-results.xml'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,11 +40,6 @@ pipeline {
               ./scripts/docs.sh
             '''
           }
-          post {
-            success {
-              archiveArtifacts 'kore-haddock.tar.gz'
-            }
-          }
         }
         stage('Executables') {
           steps {

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ haddock:
 		rm haddock.log; \
 	fi
 
-haskell_documentation: haddock
-	cp -r $$($(STACK_HADDOCK) path --local-doc-root) haskell_documentation
+kore-haddock.tar.gz: haddock
+	tar -cf kore-haddock.tar.gz $$($(STACK_HADDOCK) path --local-doc-root)
 
 all: kore k-frontend
 
@@ -47,8 +47,8 @@ test-kore:
 		--test --bench --no-run-benchmarks \
 		--ta --xml=test-results.xml
 
-coverage_report: test-kore
-	cp -r $$($(STACK_TEST) path --local-hpc-root) coverage_report
+kore-hpc.tar.gz: test-kore
+	tar -cf kore-hpc.tar.gz $$($(STACK_TEST) path --local-hpc-root)
 
 test-k:
 	$(MAKE) --directory src/main/k/working test-k

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ haddock:
 	fi
 
 kore-haddock.tar.gz: haddock
-	tar -cf kore-haddock.tar.gz $$($(STACK_HADDOCK) path --local-doc-root)
+	cp -r $$($(STACK_HADDOCK) path --local-doc-root) kore-haddock
+	tar -cf kore-haddock.tar.gz kore-haddock
+	rm -fr kore-haddock
 
 all: kore k-frontend
 
@@ -48,7 +50,9 @@ test-kore:
 		--ta --xml=test-results.xml
 
 kore-hpc.tar.gz: test-kore
-	tar -cf kore-hpc.tar.gz $$($(STACK_TEST) path --local-hpc-root)
+	cp -r $$($(STACK_TEST) path --local-hpc-root) kore-hpc
+	tar -cf kore-hpc.tar.gz kore-hpc
+	rm -fr kore-hpc
 
 test-k:
 	$(MAKE) --directory src/main/k/working test-k

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -6,4 +6,4 @@ export TOP=${TOP:-$(git rev-parse --show-toplevel)}
 export PATH="$(stack path --local-bin)${PATH:+:$PATH}"
 
 MAKE="make -O -j --directory $TOP"
-$MAKE haskell_documentation
+$MAKE kore-haddock.tar.gz

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -6,4 +6,4 @@ export TOP=${TOP:-$(git rev-parse --show-toplevel)}
 export PATH="$(stack path --local-bin)${PATH:+:$PATH}"
 
 MAKE="make -O -j --directory $TOP"
-$MAKE coverage_report "$@"
+$MAKE kore-hpc.tar.gz "$@"


### PR DESCRIPTION
When we switched to Jenkins Pipeline, we stopped archiving test artifacts.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
