### PR TITLE
evaluateApplication/canMemoize: Do not check configuration predicate

### DIFF
--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -159,7 +159,11 @@ evaluateApplication
     canMemoize
       | Symbol.isMemo symbol
       , isTop childrenPredicate
-      , isTop configurationPredicate
+      -- We do not need to check the configuration predicate here: it cannot
+      -- constrain the children because we require that they are all
+      -- concrete. If we ever relax the constraint on the children, then we need
+      -- to re-enable this check.
+      -- , isTop configurationPredicate
       = traverse asConcrete application
       | otherwise
       = Nothing


### PR DESCRIPTION
Fixes #1099.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
