### PR TITLE
TermLike.simplifyInternal: Relax the pattern simplification check

### DIFF
--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -247,7 +247,7 @@ simplifyInternal term predicate = simplifyInternalWorker term
         assertSimplifiedResults getResults = do
             results <- getResults
             let unsimplified =
-                    filter (not . Pattern.isSimplified)
+                    filter (not . TermLike.isSimplified . Pattern.term)
                     $ OrPattern.toPatterns results
             if null unsimplified
                 then return results


### PR DESCRIPTION
We should not require the predicate to be simplified after simplifying the term!
That is the responsibility of the predicate simplifier, not the term
simplifier. Requiring the predicate to be simplified leads to awkward mutual
recursion between the simplifiers.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
