### PR TITLE
Property tests for simplification

### DIFF
--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -32,7 +32,6 @@ import qualified Data.Set as Set
 import Data.Text
     ( Text
     )
-import qualified Data.Text as Text
 
 import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
@@ -73,7 +72,6 @@ import Kore.Internal.TermLike
     , mkBottom
     , mkBuiltin
     , mkCeil
-    , mkDomainValue
     , mkElemVar
     , mkEquals
     , mkEvaluated
@@ -95,10 +93,6 @@ import Kore.Internal.TermLike
 import Kore.Sort
     ( Sort
     )
-import Kore.Syntax.DomainValue
-    ( DomainValue (DomainValue)
-    )
-import qualified Kore.Syntax.DomainValue as DomainValue.DoNotUse
 import Kore.Syntax.ElementVariable
     ( ElementVariable (ElementVariable)
     )
@@ -203,7 +197,11 @@ addQuantifiedElementVariable
 termLikeGen :: Gen (TermLike Variable)
 termLikeGen = do
     topSort <- sortGen
-    Gen.sized (\size -> termLikeGenImpl size topSort)
+    Gen.scale limitTermDepth $ Gen.sized (\size -> termLikeGenImpl size topSort)
+  where
+    limitTermDepth (Range.Size s)
+      | s < 10 = Range.Size s
+      | otherwise = Range.Size 10
 
 termLikeGenImpl :: Range.Size -> Sort -> Gen (TermLike Variable)
 termLikeGenImpl (Range.Size size) requestedSort = do
@@ -250,7 +248,9 @@ _checkTermImplemented term@(Recursive.project -> _ :< termF) =
     checkTermF (BottomF _) = term
     checkTermF (CeilF _) = term
     checkTermF (DomainValueF _) = term
-    checkTermF (BuiltinF _) = term
+    checkTermF (BuiltinF _) = term  -- the ones that are easy to generated are
+                                    -- supposed to be internalized in normal
+                                    -- use.
     checkTermF (EqualsF _) = term
     checkTermF (ExistsF _) = term
     checkTermF (FloorF _) = term
@@ -294,11 +294,6 @@ termGenerators = do
             ]
         literals = catMaybes
             [ maybeStringLiteralGenerator setup ]
-        dv = catMaybes
-            [ maybeIntDVGenerator setup
-            , maybeBoolDVGenerator setup
-            , maybeStringDVGenerator setup
-            ]
     variable <- allVariableGenerators
     symbol <- symbolGenerators
     alias <- aliasGenerators
@@ -306,7 +301,6 @@ termGenerators = do
     return
         (       groupBySort generators
         `merge` groupBySort literals
-        `merge` groupBySort dv
         `merge` wrap variable
         `merge` symbol
         `merge` alias
@@ -643,44 +637,8 @@ maybeSetBuiltinGenerator Setup { maybeSetSorts } =
         Nothing -> Nothing
         Just _ -> error "Not implemented yet."
 
-maybeStringDVGenerator :: Setup -> Maybe TermGenerator
-maybeStringDVGenerator Setup { maybeStringBuiltinSort } =
-    maybeDVGenerator maybeStringBuiltinSort stringGen
-
 stringGen :: Gen Text
 stringGen = Gen.text (Range.linear 0 64) (Reader.lift Gen.unicode)
-
-maybeIntDVGenerator :: Setup -> Maybe TermGenerator
-maybeIntDVGenerator Setup { maybeIntSort } =
-    maybeDVGenerator
-        maybeIntSort
-        (Text.pack . show <$> Gen.int (Range.constant 0 2000))
-
-maybeBoolDVGenerator :: Setup -> Maybe TermGenerator
-maybeBoolDVGenerator Setup { maybeBoolSort } =
-    maybeDVGenerator maybeBoolSort (Text.pack . show <$> Gen.bool)
-
-maybeDVGenerator
-    :: Maybe Sort
-    -> Gen Text
-    -> Maybe TermGenerator
-maybeDVGenerator maybeSort valueGenerator = do
-    dvSort <- maybeSort
-    return TermGenerator
-        { arity = 0
-        , sort = SpecificSort dvSort
-        , generator = dvGenerator dvSort
-        }
-  where
-    dvGenerator domainValueSort _childGenerator resultSort = do
-        Monad.when (domainValueSort /= resultSort) (error "Sort mismatch.")
-        value <- valueGenerator
-        return
-            (mkDomainValue DomainValue
-                { domainValueSort
-                , domainValueChild = mkStringLiteral value
-                }
-            )
 
 symbolGenerators :: Gen (Map.Map SortRequirements [TermGenerator])
 symbolGenerators = do

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -50,6 +50,9 @@ import qualified Kore.Attribute.Sort.Unit as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Int as Builtin.Int
+import qualified Kore.Builtin.List as List
+import qualified Kore.Builtin.Map as Map
+import qualified Kore.Builtin.Set as Set
 import qualified Kore.Builtin.String as Builtin.String
 import qualified Kore.Domain.Builtin as Domain
 import Kore.IndexedModule.MetadataTools
@@ -65,6 +68,12 @@ import Kore.Internal.TermLike
     )
 import qualified Kore.Internal.TermLike as Internal
 import Kore.Sort
+import Kore.Step.Axiom.EvaluationStrategy
+    ( builtinEvaluation
+    )
+import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
+    ( AxiomIdentifier (..)
+    )
 import qualified Kore.Step.Function.Memo as Memo
 import qualified Kore.Step.Simplification.Condition as Simplifier.Condition
 import Kore.Step.Simplification.Data
@@ -1612,3 +1621,47 @@ generatorSetup =
         }
   where
     doesNotHaveArguments Symbol {symbolParams} = null symbolParams
+
+builtinSimplifiers :: BuiltinAndAxiomSimplifierMap
+builtinSimplifiers =
+    Map.fromList
+        [   ( AxiomIdentifier.Application unitMapId
+            , builtinEvaluation Map.evalUnit
+            )
+        ,   ( AxiomIdentifier.Application elementMapId
+            , builtinEvaluation Map.evalElement
+            )
+        ,   ( AxiomIdentifier.Application concatMapId
+            , builtinEvaluation Map.evalConcat
+            )
+        ,   ( AxiomIdentifier.Application unitSetId
+            , builtinEvaluation Set.evalUnit
+            )
+        ,   ( AxiomIdentifier.Application elementSetId
+            , builtinEvaluation Set.evalElement
+            )
+        ,   ( AxiomIdentifier.Application concatSetId
+            , builtinEvaluation Set.evalConcat
+            )
+        ,   ( AxiomIdentifier.Application unitListId
+            , builtinEvaluation List.evalUnit
+            )
+        ,   ( AxiomIdentifier.Application elementListId
+            , builtinEvaluation List.evalElement
+            )
+        ,   ( AxiomIdentifier.Application concatListId
+            , builtinEvaluation List.evalConcat
+            )
+        ,   ( AxiomIdentifier.Application tdivIntId
+            , builtinEvaluation
+                (Builtin.Int.builtinFunctions Map.! Builtin.Int.tdivKey)
+            )
+        ,   ( AxiomIdentifier.Application lessIntId
+            , builtinEvaluation
+                (Builtin.Int.builtinFunctions Map.! Builtin.Int.ltKey)
+            )
+        ,   ( AxiomIdentifier.Application greaterEqIntId
+            , builtinEvaluation
+                (Builtin.Int.builtinFunctions Map.! Builtin.Int.geKey)
+            )
+        ]

--- a/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
+++ b/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
@@ -1,0 +1,100 @@
+module Test.Kore.Step.Simplification.IntegrationProperty
+    ( test_simplifiesToSimplified
+    ) where
+
+import Hedgehog
+    ( PropertyT
+    , annotate
+    , discard
+    , forAll
+    , (===)
+    )
+import Test.Tasty
+
+import Control.Exception
+    ( ErrorCall (..)
+    )
+import Control.Monad.Catch
+    ( MonadThrow
+    , catch
+    , throwM
+    )
+import qualified Control.Monad.Trans as Trans
+import Data.List
+    ( isInfixOf
+    )
+import qualified Data.Map.Strict as Map
+import Debug.Trace
+
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+import Kore.Internal.Pattern
+    ( Pattern
+    )
+import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import Kore.Step.Axiom.EvaluationStrategy
+    ( simplifierWithFallback
+    )
+import qualified Kore.Step.Simplification.Data as Simplification
+import qualified Kore.Step.Simplification.Pattern as Pattern
+    ( simplify
+    )
+import Kore.Step.Simplification.Simplify
+import qualified SMT
+
+import Kore.Unparser
+import Test.ConsistentKore
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Kore.Step.Simplification
+import Test.SMT
+    ( testPropertyWithSolver
+    )
+
+test_simplifiesToSimplified :: TestTree
+test_simplifiesToSimplified =
+    testPropertyWithSolver "simplify returns simplified pattern" $ do
+        term <- forAll (runTermGen Mock.generatorSetup termLikeGen)
+        (annotate . unlines)
+            [" ***** unparsed input =", unparseToString term, " ***** "]
+        simplified <- catch
+            (evaluateT (Pattern.fromTermLike term))
+            (exceptionHandler term)
+        (===) True (OrPattern.isSimplified simplified)
+  where
+    -- Discard exceptions that are normal for randomly generated patterns.
+    exceptionHandler
+        :: (Monad m, MonadThrow m)
+        => TermLike Variable
+        -> ErrorCall
+        -> PropertyT m a
+    exceptionHandler term err@(ErrorCallWithLocation message _location)
+      | "Unification case that should be handled somewhere else"
+        `isInfixOf` message
+      = discard
+      | otherwise = do
+        traceM ("Error for input: " ++ unparseToString term)
+        throwM err
+
+evaluateT
+    :: Trans.MonadTrans t => Pattern Variable -> t SMT.SMT (OrPattern Variable)
+evaluateT = Trans.lift . evaluate
+
+evaluate :: Pattern Variable -> SMT.SMT (OrPattern Variable)
+evaluate = evaluateWithAxioms Map.empty
+
+evaluateWithAxioms
+    :: BuiltinAndAxiomSimplifierMap
+    -> Pattern Variable
+    -> SMT.SMT (OrPattern Variable)
+evaluateWithAxioms axioms = Simplification.runSimplifier env . Pattern.simplify
+  where
+    env = Mock.env { simplifierAxioms }
+    simplifierAxioms :: BuiltinAndAxiomSimplifierMap
+    simplifierAxioms =
+        Map.unionWith
+            simplifierWithFallback
+            Mock.builtinSimplifiers
+            axioms


### PR DESCRIPTION
The first property test for simplification.

We should also test that marking a simplified term as not simplified and resimplifying yields the same term. However, given how hard it was to make this test work, I would leave it for another PR.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
