### PR TITLE
Only re-order variable-renaming substitutions

### DIFF
--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -4,6 +4,7 @@ module Test.Kore.Step.Function.Integration
     , test_List
     , test_lookupMap
     , test_updateMap
+    , test_Ceil
     ) where
 
 import Test.Tasty
@@ -1066,6 +1067,65 @@ uInt = elemVarS (testId "uInt") intSort
 vInt = elemVarS (testId "vInt") intSort
 xInt = elemVarS (testId "xInt") intSort
 yInt = elemVarS (testId "yInt") intSort
+
+xsInt :: SetVariable Variable
+xsInt = setVarS (testId "xsInt") intSort
+
+test_Ceil :: [TestTree]
+test_Ceil =
+    [ simplifies "\\ceil(dummy(X)) => ... ~ \\ceil(dummy(Y))"
+        ceilDummyRule
+        (mkCeil_ $ Builtin.dummyInt $ mkElemVar yInt)
+    , notSimplifies "\\ceil(dummy(X)) => \\not(\\equals(X, 0)) !~ dummy(Y)"
+        ceilDummyRule
+        (Builtin.dummyInt $ mkElemVar yInt)
+    , simplifies "\\ceil(dummy(@X)) => ... ~ \\ceil(dummy(Y))"
+        ceilDummySetRule
+        (mkCeil_ $ Builtin.dummyInt $ mkElemVar yInt)
+    ]
+
+ceilDummyRule :: EqualityRule Variable
+ceilDummyRule =
+    axiom_
+        (mkCeil_ $ Builtin.dummyInt $ mkElemVar xInt)
+        (mkEquals_ (Builtin.eqInt (mkElemVar xInt) (mkInt 0)) (mkBool False))
+
+ceilDummySetRule :: EqualityRule Variable
+ceilDummySetRule =
+    axiom_
+        (mkCeil_ $ Builtin.dummyInt $ mkSetVar xsInt)
+        (mkEquals_ (Builtin.eqInt (mkSetVar xsInt) (mkInt 0)) (mkBool False))
+
+-- Simplification tests: check that one or more rules applies or not
+withSimplified
+    :: (CommonAttemptedAxiom -> Assertion)
+    -> TestName
+    -> EqualityRule Variable
+    -> TermLike Variable
+    -> TestTree
+withSimplified check comment rule term =
+    testCase comment $ do
+        actual <- evaluateWith (simplificationEvaluation rule) term
+        check actual
+
+simplifies, notSimplifies
+    :: TestName
+    -> EqualityRule Variable
+    -> TermLike Variable
+    -> TestTree
+simplifies =
+    withSimplified $ \attempted -> do
+        results <- expectApplied attempted
+        expectNoRemainders results
+  where
+    expectApplied NotApplicable     = assertFailure "Expected Applied"
+    expectApplied (Applied results) = return results
+    expectNoRemainders =
+        assertBool "Expected no remainders"
+        . isBottom
+        . Lens.view (field @"remainders")
+notSimplifies =
+    withSimplified (assertBool "Expected NotApplicable" . isNotApplicable)
 
 axiomEvaluator
     :: TermLike Variable


### PR DESCRIPTION
This bug fix is a prerequisite for reverting #1144. I am submitting the revert separately to keep this pull request clean.

When we introduced set variables, we forgot to update the function that sorts variable-renaming substitutions; it would accidentally re-order substitutions of the form `x:S{} = @Y:S{}` which is *not* a renaming.

I also renamed the function, because every time I look at it, I forget what it does. But if anyone else feels strongly about this, I will put it back.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
