### PR TITLE
Merge rules in batches

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -468,8 +468,12 @@ koreMerge execOptions mergeOptions = do
     mainModule <- loadModule mainModuleName definition
     let KoreMergeOptions {rulesFileName} = mergeOptions
     ruleIds <- lift $ loadRuleIds rulesFileName
+    let KoreMergeOptions {maybeBatchSize} = mergeOptions
     eitherMergedRule <- execute execOptions mainModule $
-        mergeRules mainModule ruleIds
+        case maybeBatchSize of
+            Just batchSize ->
+                mergeRulesConsecutiveBatches batchSize mainModule ruleIds
+            Nothing -> mergeAllRules mainModule ruleIds
     case eitherMergedRule of
         (Left err) -> do
             lift $ Text.putStrLn err

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -5,6 +5,7 @@ License     : NCSA
 
 module Kore.Step.Rule.Combine
     ( mergeRules
+    , mergeRulesConsecutiveBatches
     , mergeRulesPredicate
     ) where
 
@@ -42,13 +43,11 @@ import Kore.Internal.Variable
     ( InternalVariable
     )
 import Kore.Predicate.Predicate
-    ( makeAndPredicate
+    ( Predicate
+    , makeAndPredicate
     , makeCeilPredicate
     , makeMultipleAndPredicate
     , makeTruePredicate
-    )
-import Kore.Predicate.Predicate
-    ( Predicate
     )
 import Kore.Step.Rule
     ( RewriteRule (RewriteRule)
@@ -201,3 +200,30 @@ mergeRules (renameRulesVariables . Foldable.toList -> rules) =
         firstRule
     RewriteRule RulePattern {right = lastRight, ensures = lastEnsures} =
         last rules
+
+{-| Merge rules in consecutive batches.
+
+As an example, when trying to merge rules 1..9 in batches of 4, it
+first merges rules 1, 2, 3 and 4 into rule 4', then rules 4', 5, 6, 7
+into rule 7', then returns the result of merging 7', 8 and 9.
+-}
+mergeRulesConsecutiveBatches
+    :: (MonadSimplify simplifier, SimplifierVariable variable)
+    => Int
+    -- ^ Batch size
+    -> NonEmpty (RewriteRule variable)
+    -- Rules to merge
+    -> simplifier [RewriteRule variable]
+mergeRulesConsecutiveBatches
+    batchSize
+    (rule :| rules)
+  | batchSize <= 1 = error ("Invalid group size: " ++ show batchSize)
+  | null rules = return [rule]
+  | otherwise = do
+    let (rulesBatch, remainder) = splitAt (batchSize - 1) rules
+    mergedRulesList <- mergeRules (rule :| rulesBatch)
+    BranchT.gather $ do
+        mergedRule <- BranchT.scatter mergedRulesList
+        allMerged <-
+            mergeRulesConsecutiveBatches batchSize (mergedRule :| remainder)
+        BranchT.scatter allMerged

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -18,14 +18,12 @@ import Kore.Logger.Output
     ( emptyLogger
     )
 import Kore.Predicate.Predicate
-    ( makeAndPredicate
+    ( Predicate
+    , makeAndPredicate
     , makeCeilPredicate
     , makeEqualsPredicate
     , makeMultipleAndPredicate
     , makeTruePredicate
-    )
-import Kore.Predicate.Predicate
-    ( Predicate
     )
 import Kore.Step.Rule
     ( RewriteRule (RewriteRule)
@@ -248,6 +246,43 @@ test_combineRules =
     x0 = mkElemVar Mock.var_x_0
     y = mkElemVar Mock.y
 
+test_combineRulesGrouped :: [TestTree]
+test_combineRulesGrouped =
+    [ testCase "One rule" $ do
+        let expected = [Mock.a `rewritesTo` Mock.cf]
+
+        actual <- runMergeRulesGrouped [ Mock.a `rewritesTo` Mock.cf ]
+
+        assertEqual "" expected actual
+    , testCase "Two rules" $ do
+        let expected = [Mock.a `rewritesTo` Mock.cf]
+
+        actual <- runMergeRules
+            [ Mock.a `rewritesTo` Mock.b
+            , Mock.b `rewritesTo` Mock.cf
+            ]
+
+        assertEqual "" expected actual
+    , testCase "Two rules" $ do
+        let expected =
+                [   Mock.functionalConstr10
+                        (Mock.functionalConstr11 (Mock.functionalConstr12 z))
+                    `rewritesTo` z
+                ]
+
+        actual <- runMergeRules
+            [ Mock.functionalConstr10 x `rewritesTo` x
+            , Mock.functionalConstr11 y `rewritesTo` y
+            , Mock.functionalConstr12 z `rewritesTo` z
+            ]
+
+        assertEqual "" expected actual
+    ]
+  where
+    x = mkElemVar Mock.x
+    y = mkElemVar Mock.y
+    z = mkElemVar Mock.z
+
 runMergeRules
     :: [RewriteRule Variable]
     -> IO [RewriteRule Variable]
@@ -256,3 +291,12 @@ runMergeRules (rule : rules) =
     $ runSimplifier Mock.env
     $ mergeRules (rule :| rules)
 runMergeRules [] = error "Unexpected empty list of rules."
+
+runMergeRulesGrouped
+    :: [RewriteRule Variable]
+    -> IO [RewriteRule Variable]
+runMergeRulesGrouped (rule : rules) =
+    SMT.runSMT SMT.defaultConfig emptyLogger
+    $ runSimplifier Mock.env
+    $ mergeRulesConsecutiveBatches 2 (rule :| rules)
+runMergeRulesGrouped [] = error "Unexpected empty list of rules."


### PR DESCRIPTION
To merge in batch mode:
```
kore-exec definition.kore --merge-rules rule-list --module WASM-WITH-K-TERM --merge-batch-size 2
```

To merge without batches, just omit the flag:
```
kore-exec definition.kore --merge-rules rule-list --module WASM-WITH-K-TERM
```
---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
