### PR TITLE
Repl: print to stdout when output file is missing

### DIFF
--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -112,7 +112,7 @@ runRepl
     -- ^ optional output file
     -> m ()
 runRepl _ [] _ _ _ outputFile =
-    let printTerm = maybe putStr writeFile (unOutputFile outputFile)
+    let printTerm = maybe putStrLn writeFile (unOutputFile outputFile)
     in liftIO . printTerm . unparseToString $ topTerm
   where
     topTerm :: TermLike Variable

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -111,12 +111,9 @@ runRepl
     -> OutputFile
     -- ^ optional output file
     -> m ()
-runRepl _ [] _ _ _ outputFile = do
-    let fileName =
-            fromMaybe
-                (error "Output file not specified")
-                (unOutputFile outputFile)
-    liftIO $ writeFile fileName (unparseToString topTerm)
+runRepl _ [] _ _ _ outputFile =
+    let printTerm = maybe putStr writeFile (unOutputFile outputFile)
+    in liftIO . printTerm . unparseToString $ topTerm
   where
     topTerm :: TermLike Variable
     topTerm = mkTop $ mkSortVariable "R"

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -322,7 +322,7 @@ exit = do
     onePathClaims <- generateInProgressOPClaims
     sort <- currentClaimSort
     let conj = conjOfOnePathClaims onePathClaims sort
-        printTerm = maybe putStr writeFile (unOutputFile ofile)
+        printTerm = maybe putStrLn writeFile (unOutputFile ofile)
     liftIO . printTerm . unparseToString $ conj
     if isCompleted (Map.elems proofs)
        then return SuccessStop

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -319,14 +319,11 @@ exit
 exit = do
     proofs <- allProofs
     ofile <- Lens.view (field @"outputFile")
-    let fileName =
-            fromMaybe (error "Output file not specified") (unOutputFile ofile)
     onePathClaims <- generateInProgressOPClaims
     sort <- currentClaimSort
     let conj = conjOfOnePathClaims onePathClaims sort
-    liftIO $ writeFile
-            fileName
-            ( unparseToString conj )
+        printTerm = maybe putStr writeFile (unOutputFile ofile)
+    liftIO . printTerm . unparseToString $ conj
     if isCompleted (Map.elems proofs)
        then return SuccessStop
        else return FailStop


### PR DESCRIPTION
Fixes https://github.com/kframework/kore/issues/1178

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
