### PR TITLE
Jenkinsfile: Extend 'Integration: KEVM' time limit to 48 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
     }
     stage('Integration: KEVM') {
       options {
-        timeout(time: 32, unit: 'MINUTES')
+        timeout(time: 48, unit: 'MINUTES')
       }
       steps {
         sh '''


### PR DESCRIPTION
---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
