### PR TITLE
Start cleaning up logging options

### DIFF
--- a/kore/src/Kore/Logger.hs
+++ b/kore/src/Kore/Logger.hs
@@ -126,7 +126,7 @@ instance Pretty.Pretty Scope where
 -- | This type should not be used directly, but rather should be created and
 -- dispatched through the `log` functions.
 data LogMessage = LogMessage
-    { message   :: !Text
+    { message   :: Text
     -- ^ message being logged
     , severity  :: !Severity
     -- ^ log level / severity of message
@@ -313,4 +313,3 @@ instance Monad m => MonadLog (LoggerT m) where
 instance MonadTrans LoggerT where
     lift = LoggerT . Monad.Trans.lift
     {-# INLINE lift #-}
-

--- a/kore/src/Kore/Logger/Output.hs
+++ b/kore/src/Kore/Logger/Output.hs
@@ -172,7 +172,8 @@ parseKoreLogOptions =
             "warning"  -> pure Warning
             "error"    -> pure Error
             "critical" -> pure Critical
-            _          -> pure Warning
+            ""         -> pure Warning
+            _          -> Nothing
     parseScope =
         option
             parseCommaSeparatedScopes

--- a/kore/src/Kore/Logger/Output.hs
+++ b/kore/src/Kore/Logger/Output.hs
@@ -94,10 +94,8 @@ import Kore.Logger
 -- | 'KoreLogType' is passed via command line arguments and decides if and how
 -- the logger will operate.
 data KoreLogType
-    = LogNone
-    -- ^ do not log when no '--log' is passed
-    | LogStdErr
-    -- ^ log to StdOut when '--log StdOut' is passed
+    = LogStdErr
+    -- ^ log to StdErr when '--log StdErr' is passed
     | LogFileText
     -- ^ log to "./kore-(date).log" when '--log FileText' is passed
     deriving (Read)
@@ -125,8 +123,6 @@ withLogger
     -> IO a
 withLogger KoreLogOptions { logType, logLevel, logScopes } cont =
     case logType of
-        LogNone     ->
-            cont mempty
         LogStdErr   ->
             cont (stderrLogger logLevel logScopes)
         LogFileText -> do
@@ -150,7 +146,7 @@ runLoggerT options = withLogger options . runReaderT . getLoggerT
 parseKoreLogOptions :: Parser KoreLogOptions
 parseKoreLogOptions =
     KoreLogOptions
-    <$> (parseType <|> pure LogNone)
+    <$> (parseType <|> pure LogStdErr)
     <*> (parseLevel <|> pure Warning)
     <*> (parseScope <|> pure mempty)
   where
@@ -158,11 +154,10 @@ parseKoreLogOptions =
         option
             (maybeReader parseTypeString)
             $ long "log"
-            <> help "Log type: none, stdout, filetext"
+            <> help "Log type: stderr, filetext"
     parseTypeString =
         \case
-            "none"     -> pure LogNone
-            "stdout"   -> pure LogStdErr
+            "stderr"   -> pure LogStdErr
             "filetext" -> pure LogFileText
             _          -> Nothing
     parseLevel =
@@ -177,7 +172,7 @@ parseKoreLogOptions =
             "warning"  -> pure Warning
             "error"    -> pure Error
             "critical" -> pure Critical
-            _          -> Nothing
+            _          -> pure Warning
     parseScope =
         option
             parseCommaSeparatedScopes

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -351,8 +351,8 @@ helpText =
     \                                      these scopes are used for filtering\
                                            \ the logged information, for example,\
                                            \ '[]' will log all scopes\n\
-    \                                      <type> can be 'none', 'stdout',\
-                                           \ or 'file filename'\n\
+    \                                      <type> can be 'stdout' or\n\
+                                           \'file filename'\n\
     \exit                                  exits the repl\
     \\n\n\
     \Available modifiers:\n\

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -175,7 +175,7 @@ data ReplAlias = ReplAlias
 
 data LogType
     = NoLogging
-    | LogToStdOut
+    | LogToStdErr
     | LogToFile !FilePath
     deriving (Eq, Show)
 

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -351,7 +351,7 @@ helpText =
     \                                      these scopes are used for filtering\
                                            \ the logged information, for example,\
                                            \ '[]' will log all scopes\n\
-    \                                      <type> can be 'stdout' or\n\
+    \                                      <type> can be 'stderr' or\n\
                                            \'file filename'\n\
     \exit                                  exits the repl\
     \\n\n\

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -277,7 +277,7 @@ logScope =
 logType :: Parser LogType
 logType = logStdOut <|> logFile
   where
-    logStdOut = LogToStdOut <$  literal "stderr"
+    logStdOut = LogToStdErr <$  literal "stderr"
     logFile   = LogToFile   <$$> literal "file" *> quotedOrWordWithout ""
 
 redirect :: ReplCommand -> Parser ReplCommand

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -275,9 +275,8 @@ logScope =
             <* optional (literal ",")
 
 logType :: Parser LogType
-logType = noLogging <|> logStdOut <|> logFile
+logType = logStdOut <|> logFile
   where
-    noLogging = NoLogging   <$  literal "none"
     logStdOut = LogToStdOut <$  literal "stdout"
     logFile   = LogToFile   <$$> literal "file" *> quotedOrWordWithout ""
 

--- a/kore/src/Kore/Repl/Parser.hs
+++ b/kore/src/Kore/Repl/Parser.hs
@@ -277,7 +277,7 @@ logScope =
 logType :: Parser LogType
 logType = logStdOut <|> logFile
   where
-    logStdOut = LogToStdOut <$  literal "stdout"
+    logStdOut = LogToStdOut <$  literal "stderr"
     logFile   = LogToFile   <$$> literal "file" *> quotedOrWordWithout ""
 
 redirect :: ReplCommand -> Parser ReplCommand

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -435,7 +435,7 @@ liftSimplifierWithLogger mLogger simplifier = do
     logTypeToLogger =
         \case
             NoLogging   -> pure (mempty, Nothing)
-            LogToStdOut -> pure (Logger.logTextStderr, Nothing)
+            LogToStdErr -> pure (Logger.logTextStderr, Nothing)
             LogToFile file -> do
                 handle <- Monad.Trans.lift . liftIO $ openFile file AppendMode
                 pure (Logger.logTextHandle handle, Just handle)

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -599,7 +599,7 @@ runWithState command axioms claims claim stateTransformer
         output' <- readIORef output
         return $ Result output' c s
   where
-    logOptions = Logger.KoreLogOptions Logger.LogNone Logger.Debug mempty
+    logOptions = Logger.KoreLogOptions Logger.LogStdErr Logger.Debug mempty
     liftSimplifier logger =
         SMT.runSMT SMT.defaultConfig logger . Kore.runSimplifier testEnv
 

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -497,7 +497,7 @@ logUpdatesState =
         axioms  = []
         claim   = emptyClaim
         command =
-            Log Logger.Info (makeLogScope ["scope1", "scope2"]) LogToStdOut
+            Log Logger.Info (makeLogScope ["scope1", "scope2"]) LogToStdErr
     in do
         Result { output, continue, state } <-
             run command axioms [claim] claim
@@ -505,7 +505,7 @@ logUpdatesState =
         continue `equals`     Continue
         state
             `hasLogging`
-            (Logger.Info, (makeLogScope ["scope1", "scope2"]), LogToStdOut)
+            (Logger.Info, (makeLogScope ["scope1", "scope2"]), LogToStdErr)
 
 proveSecondClaim :: IO ()
 proveSecondClaim =

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -419,9 +419,9 @@ initScriptTests =
 logTests :: [ParserTest ReplCommand]
 logTests =
     [ "log debug [] stderr"
-        `parsesTo_` Log Logger.Debug mempty LogToStdOut
+        `parsesTo_` Log Logger.Debug mempty LogToStdErr
     , "log critical [scope1] stderr"
-        `parsesTo_` Log Logger.Critical (makeLogScope ["scope1"]) LogToStdOut
+        `parsesTo_` Log Logger.Critical (makeLogScope ["scope1"]) LogToStdErr
     , "log info [ scope1,  scope2 ] file \"f s\""
         `parsesTo_` Log Logger.Info (makeLogScope ["scope1", "scope2"]) (LogToFile "f s")
     , "log info [ scope1  scope2 ] file \"f s\""

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -418,9 +418,9 @@ initScriptTests =
 
 logTests :: [ParserTest ReplCommand]
 logTests =
-    [ "log debug [] stdout"
+    [ "log debug [] stderr"
         `parsesTo_` Log Logger.Debug mempty LogToStdOut
-    , "log critical [scope1] stdout"
+    , "log critical [scope1] stderr"
         `parsesTo_` Log Logger.Critical (makeLogScope ["scope1"]) LogToStdOut
     , "log info [ scope1,  scope2 ] file \"f s\""
         `parsesTo_` Log Logger.Info (makeLogScope ["scope1", "scope2"]) (LogToFile "f s")

--- a/kore/test/Test/Kore/Repl/Parser.hs
+++ b/kore/test/Test/Kore/Repl/Parser.hs
@@ -418,8 +418,8 @@ initScriptTests =
 
 logTests :: [ParserTest ReplCommand]
 logTests =
-    [ "log debug [] none"
-        `parsesTo_` Log Logger.Debug mempty NoLogging
+    [ "log debug [] stdout"
+        `parsesTo_` Log Logger.Debug mempty LogToStdOut
     , "log critical [scope1] stdout"
         `parsesTo_` Log Logger.Critical (makeLogScope ["scope1"]) LogToStdOut
     , "log info [ scope1,  scope2 ] file \"f s\""


### PR DESCRIPTION
---
Referencing #1187 

- remove `--log none`
- set default `--log-level` to `warning`
- change `--log stdout` in `--log stderr`

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
