### PR TITLE
ReachabilityRule as Claim

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -120,6 +120,7 @@ import Kore.Profiler.Data
 import Kore.Step
 import Kore.Step.Rule
     ( OnePathRule (..)
+    , ReachabilityRule (..)
     , RewriteRule (..)
     )
 import Kore.Step.Search
@@ -449,7 +450,7 @@ koreProve execOptions proveOptions = do
                     Bounded.Failed final -> return (failure final)
             else
                 either failure (const success)
-                <$> prove stepLimit mainModule specModule (Proxy @(OnePathRule Variable))
+                <$> prove stepLimit mainModule specModule (Proxy @(ReachabilityRule Variable))
     lift $ renderResult execOptions (unparse final)
     return exitCode
   where

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -22,9 +22,6 @@ import qualified Data.Foldable as Foldable
 import Data.List
     ( intercalate
     )
-import Data.Proxy
-    ( Proxy (..)
-    )
 import Data.Reflection
 import Data.Semigroup
     ( (<>)
@@ -118,9 +115,6 @@ import Kore.Profiler.Data
     ( MonadProfiler
     )
 import Kore.Step
-import Kore.Step.Rule
-    ( ReachabilityRule (..)
-    )
 import Kore.Step.Search
     ( SearchType (..)
     )

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -119,18 +119,13 @@ import Kore.Profiler.Data
     )
 import Kore.Step
 import Kore.Step.Rule
-    ( OnePathRule (..)
-    , ReachabilityRule (..)
-    , RewriteRule (..)
+    ( ReachabilityRule (..)
     )
 import Kore.Step.Search
     ( SearchType (..)
     )
 import qualified Kore.Step.Search as Search
 import Kore.Step.SMT.Lemma
-import Kore.Strategies.Goal
-    ( Rule (OnePathRewriteRule)
-    )
 import Kore.Syntax.Definition
     ( ModuleName (..)
     )

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -445,7 +445,7 @@ koreProve execOptions proveOptions = do
                     Bounded.Failed final -> return (failure final)
             else
                 either failure (const success)
-                <$> prove stepLimit mainModule specModule (Proxy @(ReachabilityRule Variable))
+                <$> prove stepLimit mainModule specModule
     lift $ renderResult execOptions (unparse final)
     return exitCode
   where

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -58,14 +58,9 @@ import Kore.Logger.Output
     )
 import Kore.Repl.Data
 import Kore.Step.Rule
-    ( OnePathRule (..)
-    , ReachabilityRule (..)
-    , RewriteRule (..)
+    ( ReachabilityRule (..)
     )
 import Kore.Step.SMT.Lemma
-import Kore.Strategies.Goal
-    ( Rule (OnePathRewriteRule)
-    )
 import Kore.Syntax.Module
     ( ModuleName (..)
     )

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -56,15 +56,9 @@ import Kore.Logger.Output
     , swappableLogger
     )
 import Kore.Repl.Data
-import Kore.Step.Rule
-    ( ReachabilityRule (..)
-    )
 import Kore.Step.SMT.Lemma
 import Kore.Syntax.Module
     ( ModuleName (..)
-    )
-import Kore.Syntax.Variable
-    ( Variable
     )
 import qualified SMT
 

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -59,6 +59,7 @@ import Kore.Logger.Output
 import Kore.Repl.Data
 import Kore.Step.Rule
     ( OnePathRule (..)
+    , ReachabilityRule (..)
     , RewriteRule (..)
     )
 import Kore.Step.SMT.Lemma
@@ -235,7 +236,7 @@ mainWithOptions
                         proveWithRepl
                             indexedModule
                             specDefIndexedModule
-                            (Proxy @(OnePathRule Variable))
+                            (Proxy @(ReachabilityRule Variable))
                             mLogger
                             replScript
                             replMode

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -44,7 +44,6 @@ import System.Exit
 import Data.Limit
     ( Limit (..)
     )
-import Data.Proxy
 import Kore.Exec
     ( proveWithRepl
     )

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -231,7 +231,6 @@ mainWithOptions
                         proveWithRepl
                             indexedModule
                             specDefIndexedModule
-                            (Proxy @(ReachabilityRule Variable))
                             mLogger
                             replScript
                             replMode

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -63,6 +63,7 @@ dependencies:
   - recursion-schemes
   - reflection
   - semialign
+  - streams
   - template-haskell
   - text
   - these

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -40,9 +40,6 @@ import qualified Data.Bifunctor as Bifunctor
     ( first
     , second
     )
-import Data.Coerce
-    ( coerce
-    )
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -543,8 +543,8 @@ simplifyRuleOnSecond
     => (Attribute.Axiom, claim)
     -> simplifier (Attribute.Axiom, claim)
 simplifyRuleOnSecond (atts, rule) = do
-    rule' <- Rule.simplifyRewriteRule (RewriteRule . coerce $ rule)
-    return (atts, coerce . getRewriteRule $ rule')
+    rule' <- Rule.simplifyRewriteRule (RewriteRule . Goal.toRulePattern $ rule)
+    return (atts, Goal.fromRulePattern rule . getRewriteRule $ rule')
 
 -- | Construct an execution graph for the given input pattern.
 execute

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -653,9 +653,10 @@ initializeProver definitionModule specModule within =
             mapM (mapMSecond simplifyToList) specClaims
         specAxioms <- Profiler.initialization "simplifyRuleOnSecond"
             $ traverse simplifyRuleOnSecond (concat simplifiedSpecClaims)
-        let
-            axioms = Goal.fromRulePattern undefined . getRewriteRule <$> rewriteRules
-            claims = fmap makeClaim specAxioms
+        let claims = fmap makeClaim specAxioms
+            -- TODO: unsafe creation of axioms from first claim
+            firstClaim = head claims
+            axioms = Goal.fromRulePattern (Goal.goalToRule firstClaim) . getRewriteRule <$> rewriteRules
             initializedProver = InitializedProver { axioms, claims}
         within initializedProver
   where

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -40,6 +40,9 @@ import qualified Data.Bifunctor as Bifunctor
     ( first
     , second
     )
+import Data.Coerce
+    ( coerce
+    )
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
@@ -109,6 +112,7 @@ import qualified Kore.Repl.Data as Repl.Data
 import Kore.Step
 import Kore.Step.Rule
     ( EqualityRule
+    , ReachabilityRule (..)
     , RewriteRule (RewriteRule)
     , RulePattern (RulePattern)
     , extractImplicationClaims
@@ -284,29 +288,21 @@ search verifiedModule strategy termLike searchPattern searchConfig =
 
 -- | Proving a spec given as a module containing rules to be proven
 prove
-    ::  forall claim smt
+    ::  forall smt
       . ( Log.WithLog Log.LogMessage smt
         , MonadCatch smt
         , MonadProfiler smt
         , MonadUnliftIO smt
         , MonadSMT smt
-        , Claim claim
-        , Eq claim
-        , Show claim
-        , Show (Goal.Rule claim)
-        , TopBottom claim
-        , Goal.ProofState claim (Pattern Variable) ~ CommonProofState
         )
     => Limit Natural
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The main module
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The spec module
-    -> Proxy claim
-    -- ^ Proxy for the claim type
     -> smt (Either (TermLike Variable) ())
-prove limit definitionModule specModule claimProxy =
-    evalProver definitionModule specModule claimProxy
+prove limit definitionModule specModule =
+    evalProver definitionModule specModule
     $ \initialized -> do
         let InitializedProver { axioms, claims } = initialized
         result <-
@@ -317,23 +313,19 @@ prove limit definitionModule specModule claimProxy =
                 (map (\x -> (x,limit)) (extractUntrustedClaims' claims))
         return $ Bifunctor.first Pattern.toTermLike result
   where
-    extractUntrustedClaims' :: [claim] -> [claim]
+    extractUntrustedClaims'
+        :: [ReachabilityRule Variable]
+        -> [ReachabilityRule Variable]
     extractUntrustedClaims' =
         filter (not . Goal.isTrusted)
 
 -- | Initialize and run the repl with the main and spec modules. This will loop
 -- the repl until the user exits.
 proveWithRepl
-    :: forall claim
-     . Claim claim
-    => Eq claim
-    => TopBottom claim
-    => VerifiedModule StepperAttributes Attribute.Axiom
+    :: VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The main module
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The spec module
-    -> Proxy claim
-    -- ^ Proxy for the claim type
     -> MVar (Log.LogAction IO Log.SomeEntry)
     -> Repl.Data.ReplScript
     -- ^ Optional script
@@ -345,13 +337,12 @@ proveWithRepl
 proveWithRepl
     definitionModule
     specModule
-    claimProxy
     mvar
     replScript
     replMode
     outputFile
   =
-    evalProver definitionModule specModule claimProxy
+    evalProver definitionModule specModule
     $ \initialized -> do
         let InitializedProver { axioms, claims } = initialized
         Repl.runRepl axioms claims mvar replScript replMode outputFile
@@ -377,8 +368,7 @@ boundedModelCheck limit definitionModule specModule searchOrder =
             specClaims = extractImplicationClaims specModule
         assertSomeClaims specClaims
         assertSingleClaim specClaims
-        let
-            axioms = fmap Bounded.Axiom rewriteRules
+        let axioms = fmap Bounded.Axiom rewriteRules
             claims = fmap makeClaim specClaims
 
         Bounded.checkClaim
@@ -587,10 +577,10 @@ initialize verifiedModule within = do
     let initialized = Initialized { rewriteRules }
     within initialized
 
-data InitializedProver claim =
+data InitializedProver =
     InitializedProver
-        { axioms :: ![Goal.Rule claim]
-        , claims :: ![claim]
+        { axioms :: ![Goal.Rule (ReachabilityRule Variable)]
+        , claims :: ![ReachabilityRule Variable]
         }
 
 data MaybeChanged a = Changed !a | Unchanged !a
@@ -601,14 +591,11 @@ fromMaybeChanged (Unchanged a) = a
 
 -- | Collect various rules and simplifiers in preparation to execute.
 initializeProver
-    :: forall simplifier claim a
+    :: forall simplifier a
     .  MonadSimplify simplifier
-    => Claim claim
-    => Eq claim
-    => TopBottom claim
     => VerifiedModule StepperAttributes Attribute.Axiom
     -> VerifiedModule StepperAttributes Attribute.Axiom
-    -> (InitializedProver claim -> simplifier a)
+    -> (InitializedProver -> simplifier a)
     -> simplifier a
 initializeProver definitionModule specModule within =
     initialize definitionModule
@@ -616,7 +603,7 @@ initializeProver definitionModule specModule within =
         tools <- Simplifier.askMetadataTools
         let Initialized { rewriteRules } = initialized
             changedSpecClaims
-                :: [(Attribute.Axiom, MaybeChanged claim)]
+                :: [(Attribute.Axiom, MaybeChanged (ReachabilityRule Variable))]
             changedSpecClaims =
                 map
                     (Bifunctor.second $ expandClaim tools)
@@ -629,7 +616,8 @@ initializeProver definitionModule specModule within =
                 simplified <- f rule
                 return (map ((,) attribute) simplified)
             simplifyToList
-                :: claim -> simplifier [claim]
+                :: ReachabilityRule Variable
+                -> simplifier [ReachabilityRule Variable]
             simplifyToList rules = do
                 simplified <- simplifyRuleLhs rules
                 return (MultiAnd.extractPatterns simplified)
@@ -637,30 +625,26 @@ initializeProver definitionModule specModule within =
         Log.withLogScope (Log.Scope "ExpandedClaim")
             $ mapM_ (logChangedClaim . snd) changedSpecClaims
 
-        let specClaims :: [(Attribute.Axiom, claim)]
+        let specClaims :: [(Attribute.Axiom, ReachabilityRule Variable)]
             specClaims =
                 map (Bifunctor.second fromMaybeChanged) changedSpecClaims
 
         -- This assertion should come before simplifiying the claims,
         -- since simplification should remove all trivial claims.
         assertSomeClaims specClaims
-        let firstClaim = snd . head $ specClaims
         simplifiedSpecClaims <-
             mapM (mapMSecond simplifyToList) specClaims
         specAxioms <- Profiler.initialization "simplifyRuleOnSecond"
             $ traverse simplifyRuleOnSecond (concat simplifiedSpecClaims)
         let claims = fmap makeClaim specAxioms
-            axioms =
-                Goal.fromRulePattern (Goal.goalToRule firstClaim)
-                . getRewriteRule
-                <$> rewriteRules
+            axioms = coerce rewriteRules
             initializedProver = InitializedProver { axioms, claims}
         within initializedProver
   where
     expandClaim
         :: SmtMetadataTools attributes
-        -> claim
-        -> MaybeChanged claim
+        -> ReachabilityRule Variable
+        -> MaybeChanged (ReachabilityRule Variable)
     expandClaim tools claim =
         if claim /= expanded
             then Changed expanded
@@ -670,31 +654,26 @@ initializeProver definitionModule specModule within =
 
     logChangedClaim
         :: HasCallStack
-        => MaybeChanged claim
+        => MaybeChanged (ReachabilityRule Variable)
         -> simplifier ()
     logChangedClaim (Changed claim) =
         Log.logInfo ("Claim variables were expanded:\n" <> unparseToText claim)
     logChangedClaim (Unchanged _) = return ()
 
 evalProver
-    ::  forall claim smt a
+    ::  forall smt a
       . ( Log.WithLog Log.LogMessage smt
         , MonadProfiler smt
         , MonadUnliftIO smt
         , MonadSMT smt
-        , Claim claim
-        , Eq claim
-        , TopBottom claim
         )
     => VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The main module
     -> VerifiedModule StepperAttributes Attribute.Axiom
     -- ^ The spec module
-    -> Proxy claim
-    -- ^ Proxy for the claim type
-    -> (InitializedProver claim -> Simplifier.SimplifierT smt a)
+    -> (InitializedProver -> Simplifier.SimplifierT smt a)
     -- The prover
     -> smt a
-evalProver definitionModule specModule _ prover =
+evalProver definitionModule specModule prover =
     evalSimplifier definitionModule
     $ initializeProver definitionModule specModule prover

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -526,16 +526,17 @@ assertSomeClaims claims =
         ++  "on the representation of claims."
 
 makeClaim
-    :: Coercible (RulePattern Variable) claim
+    :: Goal.FromRulePattern claim
+    => Goal.ToRulePattern claim
     => (Attribute.Axiom, claim) -> claim
 makeClaim (attributes, rule) =
-    coerce RulePattern
+    Goal.fromRulePattern rule RulePattern
         { attributes = attributes
-        , left = left . coerce $ rule
-        , antiLeft = antiLeft . coerce $ rule
-        , right = right . coerce $ rule
-        , requires = requires . coerce $ rule
-        , ensures = ensures . coerce $ rule
+        , left = left . Goal.toRulePattern $ rule
+        , antiLeft = antiLeft . Goal.toRulePattern $ rule
+        , right = right . Goal.toRulePattern $ rule
+        , requires = requires . Goal.toRulePattern $ rule
+        , ensures = ensures . Goal.toRulePattern $ rule
         }
 
 simplifyRuleOnSecond

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -507,14 +507,14 @@ makeClaim
     :: Goal.FromRulePattern claim
     => Goal.ToRulePattern claim
     => (Attribute.Axiom, claim) -> claim
-makeClaim (attributes, rule) =
-    Goal.fromRulePattern rule RulePattern
+makeClaim (attributes, ruleType@(Goal.toRulePattern -> rule)) =
+    Goal.fromRulePattern ruleType RulePattern
         { attributes = attributes
-        , left = left . Goal.toRulePattern $ rule
-        , antiLeft = antiLeft . Goal.toRulePattern $ rule
-        , right = right . Goal.toRulePattern $ rule
-        , requires = requires . Goal.toRulePattern $ rule
-        , ensures = ensures . Goal.toRulePattern $ rule
+        , left = left rule
+        , antiLeft = antiLeft rule
+        , right = right rule
+        , requires = requires rule
+        , ensures = ensures rule
         }
 
 simplifyRuleOnSecond

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -654,7 +654,7 @@ initializeProver definitionModule specModule within =
         specAxioms <- Profiler.initialization "simplifyRuleOnSecond"
             $ traverse simplifyRuleOnSecond (concat simplifiedSpecClaims)
         let
-            axioms = coerce <$> rewriteRules
+            axioms = Goal.fromRulePattern undefined . getRewriteRule <$> rewriteRules
             claims = fmap makeClaim specAxioms
             initializedProver = InitializedProver { axioms, claims}
         within initializedProver

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -40,10 +40,6 @@ import qualified Data.Bifunctor as Bifunctor
     ( first
     , second
     )
-import Data.Coerce
-    ( Coercible
-    , coerce
-    )
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
@@ -113,7 +109,6 @@ import qualified Kore.Repl.Data as Repl.Data
 import Kore.Step
 import Kore.Step.Rule
     ( EqualityRule
-    , ImplicationRule (..)
     , RewriteRule (RewriteRule)
     , RulePattern (RulePattern)
     , extractImplicationClaims

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -50,9 +50,6 @@ import qualified Data.Map as Map
 import Data.Maybe
     ( mapMaybe
     )
-import Data.Proxy
-    ( Proxy
-    )
 import Data.Text
     ( Text
     )
@@ -151,11 +148,7 @@ import qualified Kore.Step.Strategy as Strategy
 import qualified Kore.Strategies.Goal as Goal
 import Kore.Strategies.Verification
     ( Claim
-    , CommonProofState
     , verify
-    )
-import Kore.TopBottom
-    ( TopBottom (..)
     )
 import Kore.Unparser
     ( unparseToText

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -193,8 +193,8 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
     addIndexesToClaims len cls =
     -- TODO: ruleToGoal is unsafe
         fmap
-            (ruleToGoal . addIndex)
-            (zip (fmap goalToRule cls) [len..])
+            (\(c, i) -> ruleToGoal c (addIndex (goalToRule c, i)))
+            (zip cls [len..])
 
     addIndex
         :: (axiom, Int)

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -195,8 +195,8 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         -> [claim]
     addIndexesToClaims len cls =
         fmap
-            (coerce . addIndex)
-            (zip (fmap coerce cls) [len..])
+            (ruleToGoal . addIndex)
+            (zip (fmap goalToRule cls) [len..])
 
     addIndex
         :: (axiom, Int)
@@ -210,10 +210,11 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         -> axiom
     modifyAttribute att rule =
         let rp = axiomToRulePatt rule in
-            coerce $ rp { Rule.attributes = att }
+            fromRulePattern rule
+                $ rp { Rule.attributes = att }
 
     axiomToRulePatt :: axiom -> Rule.RulePattern Variable
-    axiomToRulePatt = coerce
+    axiomToRulePatt = toRulePattern
 
     getAttribute :: axiom -> Attribute.Axiom
     getAttribute = Rule.attributes . axiomToRulePatt

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -43,9 +43,6 @@ import Control.Monad.State.Strict
     , StateT
     , evalStateT
     )
-import Data.Coerce
-    ( coerce
-    )
 import Data.Generics.Product
 import qualified Data.Graph.Inductive.Graph as Graph
 import Data.List

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -190,11 +190,12 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         :: Int
         -> [claim]
         -> [claim]
-    addIndexesToClaims len cls =
-    -- TODO: ruleToGoal is unsafe
-        fmap
-            (\(c, i) -> ruleToGoal c (addIndex (goalToRule c, i)))
-            (zip cls [len..])
+    addIndexesToClaims len claims' =
+        let toAxiomAndBack (claim', index) =
+                ruleToGoal
+                    claim'
+                    $ addIndex (goalToRule claim', index)
+        in fmap toAxiomAndBack (zip claims' [len..])
 
     addIndex
         :: (axiom, Int)

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -190,12 +190,12 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         :: Int
         -> [claim]
         -> [claim]
-    addIndexesToClaims len claims' =
+    addIndexesToClaims len claims'' =
         let toAxiomAndBack (claim', index) =
                 ruleToGoal
                     claim'
                     $ addIndex (goalToRule claim', index)
-        in fmap toAxiomAndBack (zip claims' [len..])
+        in fmap toAxiomAndBack (zip claims'' [len..])
 
     addIndex
         :: (axiom, Int)

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -191,11 +191,11 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         -> [claim]
         -> [claim]
     addIndexesToClaims len claims'' =
-        let toAxiomAndBack (claim', index) =
+        let toAxiomAndBack claim' index =
                 ruleToGoal
                     claim'
                     $ addIndex (goalToRule claim', index)
-        in fmap toAxiomAndBack (zip claims'' [len..])
+        in zipWith toAxiomAndBack claims'' [len..]
 
     addIndex
         :: (axiom, Int)

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -194,6 +194,7 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
         -> [claim]
         -> [claim]
     addIndexesToClaims len cls =
+    -- TODO: ruleToGoal is unsafe
         fmap
             (ruleToGoal . addIndex)
             (zip (fmap goalToRule cls) [len..])

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -73,10 +73,6 @@ import qualified Control.Monad.Trans.Class as Monad.Trans
 import Control.Monad.Trans.Except
     ( runExceptT
     )
-import Data.Coerce
-    ( Coercible
-    , coerce
-    )
 import qualified Data.Foldable as Foldable
 import Data.Functor
     ( ($>)
@@ -357,8 +353,7 @@ showClaim =
 showAxiom
     :: MonadState (ReplState claim) m
     => axiom ~ Rule claim
-    => Coercible axiom (RulePattern Variable)
-    => Coercible (RulePattern Variable) axiom
+    => ToRulePattern axiom
     => Unparse axiom
     => MonadWriter ReplOutput m
     => Either AxiomIndex RuleName
@@ -627,7 +622,7 @@ showRule configNode = do
         Just rule -> do
             axioms <- Lens.use (field @"axioms")
             tell . showRewriteRule $ rule
-            let ruleIndex = getRuleIndex . coerce $ rule
+            let ruleIndex = getRuleIndex . toRulePattern $ rule
             putStrLn'
                 $ fromMaybe "Error: identifier attribute wasn't initialized."
                 $ showAxiomOrClaim (length axioms) ruleIndex
@@ -872,7 +867,7 @@ tryAxiomClaimWorker mode ref = do
         first' = TermLike.refreshVariables (TermLike.freeVariables second) first
 
     extractLeftPattern :: Either axiom claim -> TermLike Variable
-    extractLeftPattern = left . either coerce coerce
+    extractLeftPattern = left . either toRulePattern toRulePattern
 
 -- | Removes specified node and all its child nodes.
 clear
@@ -1101,7 +1096,7 @@ recursiveForcedStep n node
 
 -- | Display a rule as a String.
 showRewriteRule
-    :: Coercible (RulePattern Variable) rule
+    :: ToRulePattern rule
     => Unparse rule
     => rule
     -> ReplOutput
@@ -1110,7 +1105,7 @@ showRewriteRule rule =
     <> makeAuxReplOutput
         (show . Pretty.pretty . extractSourceAndLocation $ rule')
   where
-    rule' = coerce rule
+    rule' = toRulePattern rule
 
     extractSourceAndLocation
         :: RulePattern Variable
@@ -1172,14 +1167,14 @@ printNotFound = putStrLn' "Variable or index not found"
 -- parameter is needed in order to distinguish between axioms and claims and
 -- represents the number of available axioms.
 showDotGraph
-    :: Coercible axiom (RulePattern Variable)
+    :: ToRulePattern axiom
     => Int -> InnerGraph axiom -> IO ()
 showDotGraph len =
     flip Graph.runGraphvizCanvas' Graph.Xlib
         . Graph.graphToDot (graphParams len)
 
 saveDotGraph
-    :: Coercible axiom (RulePattern Variable)
+    :: ToRulePattern axiom
     => Int
     -> InnerGraph axiom
     -> FilePath
@@ -1196,7 +1191,7 @@ saveDotGraph len gr file =
         $ path <> ".jpeg"
 
 graphParams
-    :: Coercible axiom (RulePattern Variable)
+    :: ToRulePattern axiom
     => Int
     -> Graph.GraphvizParams
          Graph.Node

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -13,6 +13,8 @@ module Kore.Step.Rule
     , ReachabilityRule (..)
     , ImplicationRule (..)
     , RulePattern (..)
+    , ToRulePattern (..)
+    , FromRulePattern (..)
     , allPathGlobally
     , rulePattern
     , isHeatingRule
@@ -42,6 +44,10 @@ import Control.DeepSeq
     )
 import Control.Exception
     ( assert
+    )
+import Data.Coerce
+    ( Coercible
+    , coerce
     )
 import qualified Data.Default as Default
 import Data.Map.Strict
@@ -916,3 +922,45 @@ applySubstitution substitution rule =
     subst = Substitution.toMap substitution
     finalRule = substitute subst rule
     substitutedVariables = Substitution.variables substitution
+
+-- | The typeclasses 'ToRulePattern' and 'FromRulePattern' are intended to
+-- be implemented by types which contain more (or the same amount of)
+-- information as 'RulePattern Variable'.
+class ToRulePattern rule where
+    toRulePattern :: rule -> RulePattern Variable
+    default toRulePattern
+        :: Coercible rule (RulePattern Variable)
+        => rule -> RulePattern Variable
+    toRulePattern = coerce
+
+instance ToRulePattern (OnePathRule Variable)
+
+instance ToRulePattern (AllPathRule Variable)
+
+instance ToRulePattern (ImplicationRule Variable)
+
+instance ToRulePattern (ReachabilityRule Variable) where
+    toRulePattern (OnePath rule) = toRulePattern rule
+    toRulePattern (AllPath rule) = toRulePattern rule
+
+-- | We need to know the context when transforming a 'RulePattern Variable'
+-- into a 'rule', hence the first 'rule' argument. In general it can be ignored
+-- when the 'rule' and the 'RulePattern Variable' are representationally equal.
+class FromRulePattern rule where
+    fromRulePattern :: rule -> RulePattern Variable -> rule
+    default fromRulePattern
+        :: Coercible (RulePattern Variable) rule
+        => rule -> RulePattern Variable -> rule
+    fromRulePattern _ = coerce
+
+instance FromRulePattern (OnePathRule Variable)
+
+instance FromRulePattern (AllPathRule Variable)
+
+instance FromRulePattern (ImplicationRule Variable)
+
+instance FromRulePattern (ReachabilityRule Variable) where
+    fromRulePattern (OnePath _) rulePat =
+        OnePath $ coerce rulePat
+    fromRulePattern (AllPath _) rulePat =
+        AllPath $ coerce rulePat

--- a/kore/src/Kore/Step/Rule/Expand.hs
+++ b/kore/src/Kore/Step/Rule/Expand.hs
@@ -57,6 +57,7 @@ import qualified Kore.Sort as Sort.DoNotUse
 import Kore.Step.Rule
     ( AllPathRule (..)
     , OnePathRule (..)
+    , ReachabilityRule (..)
     , RulePattern (RulePattern)
     )
 import qualified Kore.Step.Rule as RulePattern
@@ -136,6 +137,20 @@ instance ExpandSingleConstructors (OnePathRule Variable) where
 instance ExpandSingleConstructors (AllPathRule Variable) where
     expandSingleConstructors tools =
         AllPathRule . expandSingleConstructors tools . getAllPathRule
+
+instance ExpandSingleConstructors (ReachabilityRule Variable) where
+    expandSingleConstructors tools (OnePath rule) =
+        OnePath
+        . OnePathRule
+        . expandSingleConstructors tools
+        . getOnePathRule
+        $ rule
+    expandSingleConstructors tools (AllPath rule) =
+        AllPath
+        . AllPathRule
+        . expandSingleConstructors tools
+        . getAllPathRule
+        $ rule
 
 expandVariables
     :: SmtMetadataTools attributes

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -38,6 +38,7 @@ import Kore.Internal.Predicate
 import Kore.Step.Rule
     ( AllPathRule (..)
     , OnePathRule (..)
+    , ReachabilityRule (..)
     , RulePattern (RulePattern)
     )
 import qualified Kore.Step.Rule as RulePattern
@@ -105,3 +106,9 @@ instance SimplifyRuleLHS (OnePathRule Variable) where
 
 instance SimplifyRuleLHS (AllPathRule Variable) where
     simplifyRuleLhs = fmap (fmap AllPathRule) . simplifyRuleLhs . getAllPathRule
+
+instance SimplifyRuleLHS (ReachabilityRule Variable) where
+    simplifyRuleLhs (OnePath rule) =
+        (fmap . fmap) OnePath $ simplifyRuleLhs rule
+    simplifyRuleLhs (AllPath rule) =
+        (fmap . fmap) AllPath $ simplifyRuleLhs rule

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -37,6 +37,9 @@ import Data.Coerce
     )
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
 import qualified Data.Set as Set
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import Data.Witherable
@@ -180,7 +183,7 @@ class Goal goal where
         :: goal
         -> [goal]
         -> [Rule goal]
-        -> [Strategy (Prim goal)]
+        -> NonEmpty (Strategy (Prim goal))
 
 class ClaimExtractor claim where
     extractClaim
@@ -270,7 +273,7 @@ instance Goal (OnePathRule Variable) where
 
     strategy _ goals rules =
         onePathFirstStep rewrites
-        : repeat
+        :| repeat
             ( onePathFollowupStep
                 coinductiveRewrites
                 rewrites
@@ -326,7 +329,7 @@ instance Goal (AllPathRule Variable) where
 
     strategy _ goals rules =
         allPathFirstStep rewrites
-        : repeat
+        :| repeat
             ( allPathFollowupStep
                 coinductiveRewrites
                 rewrites
@@ -420,7 +423,7 @@ instance Goal (ReachabilityRule Variable) where
         :: ReachabilityRule Variable
         -> [ReachabilityRule Variable]
         -> [Rule (ReachabilityRule Variable)]
-        -> [Strategy (Prim (ReachabilityRule Variable))]
+        -> NonEmpty (Strategy (Prim (ReachabilityRule Variable)))
     strategy goal claims axioms =
         case goal of
             OnePath rule ->
@@ -458,14 +461,16 @@ maybeAllPath (AllPath rule) = Just rule
 maybeAllPath _ = Nothing
 
 reachabilityOnePathStrategy
-    :: [Strategy (Prim (OnePathRule Variable))]
-    -> [Strategy (Prim (ReachabilityRule Variable))]
+    :: Functor t
+    => t (Strategy (Prim (OnePathRule Variable)))
+    -> t (Strategy (Prim (ReachabilityRule Variable)))
 reachabilityOnePathStrategy strategy' =
     (fmap . fmap . fmap) OPRule strategy'
 
 reachabilityAllPathStrategy
-    :: [Strategy (Prim (AllPathRule Variable))]
-    -> [Strategy (Prim (ReachabilityRule Variable))]
+    :: Functor t
+    => t (Strategy (Prim (AllPathRule Variable)))
+    -> t (Strategy (Prim (ReachabilityRule Variable)))
 reachabilityAllPathStrategy strategy' =
     (fmap . fmap . fmap) APRule strategy'
 

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -361,8 +361,9 @@ instance ClaimExtractor (AllPathRule Variable) where
 
 instance Goal (ReachabilityRule Variable) where
 
-    data Rule (ReachabilityRule Variable) = APRule (Rule (AllPathRule Variable))
-                                          | OPRule (Rule (OnePathRule Variable))
+    newtype Rule (ReachabilityRule Variable) =
+        ReachabilityRewriteRule
+            { unReachabilityRewriteRule :: RewriteRule Variable }
         deriving (GHC.Generic, Show)
 
     type Prim (ReachabilityRule Variable) =
@@ -373,10 +374,6 @@ instance Goal (ReachabilityRule Variable) where
 
     goalToRule (OnePath rule) = OPRule . goalToRule $ rule
     goalToRule (AllPath rule) = APRule . goalToRule $ rule
-
-    -- TODO: this is unsafe
-    ruleToGoal (OPRule rule) = OnePath . ruleToGoal $ rule
-    ruleToGoal (APRule rule) = AllPath . ruleToGoal $ rule
 
     transitionRule
         :: (MonadCatch m, MonadSimplify m)

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -4,6 +4,7 @@ License     : NCSA
 -}
 module Kore.Strategies.Goal
     ( Goal (..)
+    , ToRulePattern (..)
     , ClaimExtractor (..)
     , Rule (..)
     , TransitionRuleTemplate (..)
@@ -924,8 +925,31 @@ getConfiguration (coerce -> RulePattern { left, requires }) =
 getDestination
     :: forall rule variable
     .  Ord variable
-    => Coercible rule (RulePattern variable)
+    => ToRulePattern rule
     => rule
     -> Pattern variable
-getDestination (coerce -> RulePattern { right, ensures }) =
+getDestination (toRulePattern -> RulePattern { right, ensures }) =
     Pattern.withCondition right (Conditional.fromPredicate ensures)
+
+class ToRulePattern rule where
+    toRulePattern :: rule -> RulePattern Variable
+
+instance ToRulePattern (OnePathRule Variable) where
+    toRulePattern = coerce
+
+instance ToRulePattern (Rule (OnePathRule Variable)) where
+    toRulePattern = coerce
+
+instance ToRulePattern (AllPathRule Variable) where
+    toRulePattern = coerce
+
+instance ToRulePattern (Rule (AllPathRule Variable)) where
+    toRulePattern = coerce
+
+instance ToRulePattern (ReachabilityRule Variable) where
+    toRulePattern (OnePath rule) = coerce rule
+    toRulePattern (AllPath rule) = coerce rule
+
+instance ToRulePattern (Rule (ReachabilityRule Variable)) where
+    toRulePattern (OPRule rule) = coerce rule
+    toRulePattern (APRule rule) = coerce rule

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -907,18 +907,18 @@ removalPredicate destination config =
 
 class ToRulePattern rule where
     toRulePattern :: rule -> RulePattern Variable
-
-instance ToRulePattern (OnePathRule Variable) where
+    default toRulePattern
+        :: Coercible rule (RulePattern Variable)
+        => rule -> RulePattern Variable
     toRulePattern = coerce
 
-instance ToRulePattern (Rule (OnePathRule Variable)) where
-    toRulePattern = coerce
+instance ToRulePattern (OnePathRule Variable)
 
-instance ToRulePattern (AllPathRule Variable) where
-    toRulePattern = coerce
+instance ToRulePattern (Rule (OnePathRule Variable))
 
-instance ToRulePattern (Rule (AllPathRule Variable)) where
-    toRulePattern = coerce
+instance ToRulePattern (AllPathRule Variable)
+
+instance ToRulePattern (Rule (AllPathRule Variable))
 
 instance ToRulePattern (ReachabilityRule Variable) where
     toRulePattern (OnePath rule) = toRulePattern rule
@@ -930,18 +930,18 @@ instance ToRulePattern (Rule (ReachabilityRule Variable)) where
 
 class FromRulePattern rule where
     fromRulePattern :: rule -> RulePattern Variable -> rule
-
-instance FromRulePattern (OnePathRule Variable) where
+    default fromRulePattern
+        :: Coercible (RulePattern Variable) rule
+        => rule -> RulePattern Variable -> rule
     fromRulePattern _ = coerce
 
-instance FromRulePattern (Rule (OnePathRule Variable)) where
-    fromRulePattern _ = coerce
+instance FromRulePattern (OnePathRule Variable)
 
-instance FromRulePattern (AllPathRule Variable) where
-    fromRulePattern _ = coerce
+instance FromRulePattern (Rule (OnePathRule Variable))
 
-instance FromRulePattern (Rule (AllPathRule Variable)) where
-    fromRulePattern _ = coerce
+instance FromRulePattern (AllPathRule Variable)
+
+instance FromRulePattern (Rule (AllPathRule Variable))
 
 instance FromRulePattern (ReachabilityRule Variable) where
     fromRulePattern (OnePath _) rulePat =

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -833,7 +833,7 @@ derivePar rules goal = errorBracket $ do
 
 -- | Apply 'Rule's to the goal in sequence.
 deriveSeq
-    :: forall m goal variable
+    :: forall m goal
     .  (MonadCatch m, MonadSimplify m)
     => Goal goal
     => ProofState.ProofState goal ~ ProofState goal goal

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -37,10 +37,11 @@ import Data.Coerce
     )
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
-import Data.List.NonEmpty
-    ( NonEmpty (..)
-    )
 import qualified Data.Set as Set
+import Data.Stream.Infinite
+    ( Stream (..)
+    )
+import qualified Data.Stream.Infinite as Stream
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import Data.Witherable
     ( mapMaybe
@@ -183,7 +184,7 @@ class Goal goal where
         :: goal
         -> [goal]
         -> [Rule goal]
-        -> NonEmpty (Strategy (Prim goal))
+        -> Stream (Strategy (Prim goal))
 
 class ClaimExtractor claim where
     extractClaim
@@ -273,7 +274,8 @@ instance Goal (OnePathRule Variable) where
 
     strategy _ goals rules =
         onePathFirstStep rewrites
-        :| repeat
+        :> Stream.iterate
+            id
             ( onePathFollowupStep
                 coinductiveRewrites
                 rewrites
@@ -329,7 +331,8 @@ instance Goal (AllPathRule Variable) where
 
     strategy _ goals rules =
         allPathFirstStep rewrites
-        :| repeat
+        :> Stream.iterate
+            id
             ( allPathFollowupStep
                 coinductiveRewrites
                 rewrites
@@ -423,7 +426,7 @@ instance Goal (ReachabilityRule Variable) where
         :: ReachabilityRule Variable
         -> [ReachabilityRule Variable]
         -> [Rule (ReachabilityRule Variable)]
-        -> NonEmpty (Strategy (Prim (ReachabilityRule Variable)))
+        -> Stream (Strategy (Prim (ReachabilityRule Variable)))
     strategy goal claims axioms =
         case goal of
             OnePath rule ->

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -81,7 +81,6 @@ import qualified Kore.Step.Result as Result
 import Kore.Step.Rule
     ( AllPathRule (..)
     , FromRulePattern (..)
-    , ImplicationRule (..)
     , OnePathRule (..)
     , QualifiedAxiomPattern (..)
     , ReachabilityRule (..)
@@ -124,7 +123,6 @@ import qualified Kore.Unification.UnifierT as Monad.Unify
 import Kore.Unparser
     ( Unparse
     , unparse
-    , unparse2
     , unparseToText
     )
 import Kore.Variables.UnifiedVariable

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -76,6 +76,7 @@ import qualified Kore.Profiler.Profile as Profile
 import qualified Kore.Step.Result as Result
 import Kore.Step.Rule
     ( AllPathRule (..)
+    , ImplicationRule (..)
     , OnePathRule (..)
     , QualifiedAxiomPattern (..)
     , ReachabilityRule (..)
@@ -366,6 +367,7 @@ instance Goal (ReachabilityRule Variable) where
     goalToRule (OnePath rule) = OPRule . goalToRule $ rule
     goalToRule (AllPath rule) = APRule . goalToRule $ rule
 
+    -- TODO: this is unsafe
     ruleToGoal (OPRule rule) = OnePath . ruleToGoal $ rule
     ruleToGoal (APRule rule) = AllPath . ruleToGoal $ rule
 
@@ -985,3 +987,6 @@ makeRuleFromPatterns ruleType configuration destination =
         , ensures
         , attributes = Default.def
         }
+
+instance FromRulePattern (ImplicationRule Variable)
+instance ToRulePattern (ImplicationRule Variable)

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -118,6 +118,7 @@ import qualified Kore.Unification.UnifierT as Monad.Unify
 import Kore.Unparser
     ( Unparse
     , unparse
+    , unparse2
     , unparseToText
     )
 import Kore.Variables.UnifiedVariable
@@ -342,9 +343,9 @@ instance SOP.Generic (Rule (AllPathRule Variable))
 
 instance SOP.HasDatatypeInfo (Rule (AllPathRule Variable))
 
-instance  Debug (Rule (AllPathRule Variable))
+instance Debug (Rule (AllPathRule Variable))
 
-instance  Diff (Rule (AllPathRule Variable))
+instance Diff (Rule (AllPathRule Variable))
 
 instance ClaimExtractor (AllPathRule Variable) where
     extractClaim sentence =
@@ -434,6 +435,19 @@ instance Goal (ReachabilityRule Variable) where
                     rule
                     (mapMaybe maybeAllPath claims)
                     (mapMaybe maybeAllPathRule axioms)
+
+instance Unparse (Rule (ReachabilityRule Variable)) where
+    unparse (OPRule rule) = unparse rule
+    unparse (APRule rule) = unparse rule
+    unparse2 (OPRule rule) = unparse2 rule
+    unparse2 (APRule rule) = unparse2 rule
+
+instance ClaimExtractor (ReachabilityRule Variable) where
+    extractClaim sentence =
+        case fromSentenceAxiom (Syntax.getSentenceClaim sentence) of
+            Right (OnePathClaimPattern claim) -> Just . OnePath $ claim
+            Right (AllPathClaimPattern claim) -> Just . AllPath $ claim
+            _ -> Nothing
 
 maybeOnePath :: ReachabilityRule Variable -> Maybe (OnePathRule Variable)
 maybeOnePath (OnePath rule) = Just rule

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -973,6 +973,12 @@ instance FromRulePattern (ReachabilityRule Variable) where
     fromRulePattern (AllPath _) rulePat =
         AllPath $ coerce rulePat
 
+instance FromRulePattern (Rule (ReachabilityRule Variable)) where
+    fromRulePattern (OPRule _) rulePat =
+        OPRule $ coerce rulePat
+    fromRulePattern (APRule _) rulePat =
+        APRule $ coerce rulePat
+
 getConfiguration
     :: forall goal
     .  ToRulePattern goal

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -33,6 +33,7 @@ import Data.Limit
     ( Limit
     )
 import qualified Data.Limit as Limit
+import qualified Data.List.NonEmpty as NonEmpty
 
 import Kore.Debug
 import qualified Kore.Internal.Condition as Condition
@@ -147,7 +148,7 @@ verifyClaim
         limitedStrategy =
             Limit.takeWithin
                 stepLimit
-                (strategy goal claims axioms)
+                (NonEmpty.toList $ strategy goal claims axioms)
     executionGraph <-
         runStrategy
             (modifiedTransitionRule destination) limitedStrategy startPattern

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -65,34 +65,10 @@ import Numeric.Natural
 
 type CommonProofState  = ProofState.ProofState (Pattern Variable)
 
-class ToRulePattern rule where
-    toRulePattern :: rule -> RulePattern Variable
-
-instance ToRulePattern (OnePathRule Variable) where
-    toRulePattern = coerce
-
-instance ToRulePattern (Rule (OnePathRule Variable)) where
-    toRulePattern = coerce
-
-instance ToRulePattern (AllPathRule Variable) where
-    toRulePattern = coerce
-
-instance ToRulePattern (Rule (AllPathRule Variable)) where
-    toRulePattern = coerce
-
-instance ToRulePattern (ReachabilityRule Variable) where
-    toRulePattern (OnePath rule) = coerce rule
-    toRulePattern (AllPath rule) = coerce rule
-
-instance ToRulePattern (Rule (ReachabilityRule Variable)) where
-    toRulePattern (OPRule rule) = coerce rule
-    toRulePattern (APRule rule) = coerce rule
-
 {- | Class type for claim-like rules
 -}
 type Claim claim =
     ( Coercible (Rule claim) (RulePattern Variable)
-    , Coercible claim (RulePattern Variable)
     , ToRulePattern claim
     , Unparse claim
     , Unparse (Rule claim)

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -64,9 +64,7 @@ type CommonProofState  = ProofState.ProofState (Pattern Variable)
 {- | Class type for claim-like rules
 -}
 type Claim claim =
-    ( Coercible (RulePattern Variable) claim
-    , Coercible (Rule claim) (RulePattern Variable)
-    , Coercible (RulePattern Variable) (Rule claim)
+    ( Coercible (Rule claim) (RulePattern Variable)
     , Coercible claim (RulePattern Variable)
     , Unparse claim
     , Unparse (Rule claim)

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -22,9 +22,6 @@ import Control.Monad.Except
     )
 import qualified Control.Monad.Except as Monad.Except
 import qualified Control.Monad.Trans as Monad.Trans
-import Data.Coerce
-    ( coerce
-    )
 import qualified Data.Foldable as Foldable
 import qualified Data.Graph.Inductive.Graph as Graph
 import Data.Limit

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -169,8 +169,6 @@ verifyClaim
 -- | Attempts to perform a single proof step, starting at the configuration
 -- in the execution graph designated by the provided node. Re-constructs the
 -- execution graph by inserting this step.
--- The implementation assumes that either all strategy steps are equal
--- or that the first step is different from the rest.
 verifyClaimStep
     :: forall claim m
     .  (MonadCatch m, MonadSimplify m)

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -33,7 +33,7 @@ import Data.Limit
     ( Limit
     )
 import qualified Data.Limit as Limit
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Stream.Infinite as Stream
 
 import Kore.Debug
 import qualified Kore.Internal.Condition as Condition
@@ -148,7 +148,7 @@ verifyClaim
         limitedStrategy =
             Limit.takeWithin
                 stepLimit
-                (NonEmpty.toList $ strategy goal claims axioms)
+                (Foldable.toList $ strategy goal claims axioms)
     executionGraph <-
         runStrategy
             (modifiedTransitionRule destination) limitedStrategy startPattern
@@ -203,17 +203,13 @@ verifyClaimStep
     strategy' :: Strategy (Prim claim)
     strategy'
         | isRoot = firstStep
-        | otherwise =
-            case followupSteps of
-                [] -> firstStep
-                secondStep : strategyTail ->
-                    secondStep
+        | otherwise = followupStep
 
     firstStep :: Strategy (Prim claim)
-    firstStep = NonEmpty.head $ strategy target claims axioms
+    firstStep = strategy target claims axioms Stream.!! 0
 
-    followupSteps :: [Strategy (Prim claim)]
-    followupSteps = NonEmpty.tail $ strategy target claims axioms
+    followupStep :: Strategy (Prim claim)
+    followupStep = strategy target claims axioms Stream.!! 1
 
     isRoot :: Bool
     isRoot = node == root

--- a/kore/src/Kore/Strategies/Verification.hs
+++ b/kore/src/Kore/Strategies/Verification.hs
@@ -23,10 +23,8 @@ import Control.Monad.Except
 import qualified Control.Monad.Except as Monad.Except
 import qualified Control.Monad.Trans as Monad.Trans
 import Data.Coerce
-    ( Coercible
-    , coerce
+    ( coerce
     )
-import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
 import qualified Data.Graph.Inductive.Graph as Graph
 import Data.Limit
@@ -36,18 +34,8 @@ import qualified Data.Limit as Limit
 import qualified Data.Stream.Infinite as Stream
 
 import Kore.Debug
-import qualified Kore.Internal.Condition as Condition
-import qualified Kore.Internal.Conditional as Conditional
 import Kore.Internal.Pattern
     ( Pattern
-    )
-import qualified Kore.Internal.Pattern as Pattern
-import Kore.Step.Rule as RulePattern
-    ( AllPathRule (..)
-    , OnePathRule (..)
-    , ReachabilityRule (..)
-    , RewriteRule (..)
-    , RulePattern (..)
     )
 import Kore.Step.Rule.Expand
 import Kore.Step.Rule.Simplify
@@ -68,12 +56,6 @@ import Numeric.Natural
     )
 
 type CommonProofState  = ProofState.ProofState (Pattern Variable)
-
-instance FromRulePattern (Rule (ReachabilityRule Variable)) where
-    fromRulePattern (OPRule _) rulePat =
-        OPRule $ coerce rulePat
-    fromRulePattern (APRule _) rulePat =
-        APRule $ coerce rulePat
 
 {- | Class type for claim-like rules
 -}

--- a/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
+++ b/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
@@ -13,15 +13,15 @@ import Data.Function
     )
 import Data.Functor.Identity
 import qualified Data.Graph.Inductive as Gr
-import Data.List.NonEmpty
-    ( NonEmpty (..)
-    )
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
 import Data.Sequence
     ( Seq
     )
 import qualified Data.Sequence as Seq
+import Data.Stream.Infinite
+    ( Stream (..)
+    )
+import qualified Data.Stream.Infinite as Stream
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 import GHC.Stack
@@ -223,7 +223,7 @@ test_runStrategy =
         . unAllPathIdentity
         $ Strategy.runStrategy
             Goal.transitionRule
-            (NonEmpty.toList $ Goal.strategy (unRule goal) [unRule goal] axioms)
+            (Foldable.toList $ Goal.strategy (unRule goal) [unRule goal] axioms)
             (ProofState.Goal . unRule $ goal)
     disproves
         :: HasCallStack
@@ -312,7 +312,7 @@ instance Goal.Goal Goal where
     type ProofState Goal a = ProofState.ProofState a
 
     strategy _ goals rules =
-        firstStep :| repeat nextStep
+        firstStep :> Stream.iterate id nextStep
       where
         firstStep =
             (Strategy.sequence . map Strategy.apply)

--- a/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
+++ b/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
@@ -13,6 +13,10 @@ import Data.Function
     )
 import Data.Functor.Identity
 import qualified Data.Graph.Inductive as Gr
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
 import Data.Sequence
     ( Seq
@@ -219,7 +223,7 @@ test_runStrategy =
         . unAllPathIdentity
         $ Strategy.runStrategy
             Goal.transitionRule
-            (Goal.strategy (unRule goal) [unRule goal] axioms)
+            (NonEmpty.toList $ Goal.strategy (unRule goal) [unRule goal] axioms)
             (ProofState.Goal . unRule $ goal)
     disproves
         :: HasCallStack
@@ -308,7 +312,7 @@ instance Goal.Goal Goal where
     type ProofState Goal a = ProofState.ProofState a
 
     strategy _ goals rules =
-        firstStep : repeat nextStep
+        firstStep :| repeat nextStep
       where
         firstStep =
             (Strategy.sequence . map Strategy.apply)

--- a/kore/test/Test/Kore/Strategies/OnePath/Step.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Step.hs
@@ -11,6 +11,7 @@ import Data.List
     ( nub
     , sort
     )
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe
     ( fromMaybe
     )
@@ -850,6 +851,6 @@ runOnePathSteps
         goal
         (Limit.takeWithin
             stepLimit
-            (strategy goal coinductiveRewrites rewrites)
+            (NonEmpty.toList $ strategy goal coinductiveRewrites rewrites)
         )
     return (sort $ nub result)

--- a/kore/test/Test/Kore/Strategies/OnePath/Step.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Step.hs
@@ -38,7 +38,6 @@ import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
     ( Conditional (Conditional)
     )
-import qualified Kore.Internal.Conditional as Conditional.DoNotUse
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
     ( Predicate

--- a/kore/test/Test/Kore/Strategies/OnePath/Step.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Step.hs
@@ -7,11 +7,11 @@ import Test.Tasty
 import Data.Default
     ( def
     )
+import qualified Data.Foldable as Foldable
 import Data.List
     ( nub
     , sort
     )
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe
     ( fromMaybe
     )
@@ -851,6 +851,6 @@ runOnePathSteps
         goal
         (Limit.takeWithin
             stepLimit
-            (NonEmpty.toList $ strategy goal coinductiveRewrites rewrites)
+            (Foldable.toList $ strategy goal coinductiveRewrites rewrites)
         )
     return (sort $ nub result)

--- a/kore/test/Test/Kore/Strategies/OnePath/Step.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Step.hs
@@ -51,6 +51,7 @@ import Kore.Step.Rule
     , ReachabilityRule (..)
     , RewriteRule (RewriteRule)
     , RulePattern (RulePattern)
+    , rulePattern
     )
 import Kore.Step.Rule as RulePattern
     ( RulePattern (..)
@@ -87,10 +88,7 @@ makeOnePathRule
     -> TermLike Variable
     -> OnePathRule Variable
 makeOnePathRule term dest =
-    OnePathRule
-    $ makeRuleFromPatterns
-        (fromTermLike term)
-        (fromTermLike dest)
+    OnePathRule $ rulePattern term dest
 
 makeReachabilityOnePathRule
     :: TermLike Variable
@@ -329,8 +327,8 @@ test_onePathStrategy =
                     (Mock.functionalConstr11 (TermLike.mkElemVar Mock.y))
                 ]
         let expected =
-                [ ProofState.Goal $ makeRuleFromPatterns
-                    ( Conditional
+                [ ProofState.Goal $ makeOnePathRule
+                    ( toTermLike $ Conditional
                         { term = Mock.f Mock.b
                         , predicate = makeTruePredicate
                         , substitution =
@@ -338,9 +336,9 @@ test_onePathStrategy =
                                 [(ElemVar Mock.x, Mock.b)]
                         }
                     )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
-                , ProofState.Goal $ makeRuleFromPatterns
-                    ( Conditional
+                    (Mock.functionalConstr11 Mock.a)
+                , ProofState.Goal $ makeOnePathRule
+                    ( toTermLike $ Conditional
                         { term = Mock.f Mock.c
                         , predicate = makeTruePredicate
                         , substitution =
@@ -348,9 +346,9 @@ test_onePathStrategy =
                                 [(ElemVar Mock.x, Mock.c)]
                         }
                     )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
-                , ProofState.Goal $ makeRuleFromPatterns
-                    ( Conditional
+                    (Mock.functionalConstr11 Mock.a)
+                , ProofState.Goal $ makeOnePathRule
+                    ( toTermLike $ Conditional
                         { term = Mock.h (TermLike.mkElemVar Mock.x)
                         , predicate =  -- TODO(virgil): Better and simplification.
                             makeAndPredicate
@@ -375,7 +373,7 @@ test_onePathStrategy =
                         , substitution = mempty
                         }
                     )
-                    (fromTermLike $ Mock.functionalConstr11 Mock.a)
+                    (Mock.functionalConstr11 Mock.a)
                 ]
         assertEqual ""
             expected
@@ -429,24 +427,26 @@ test_onePathStrategy =
             equalsXB = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.b
             equalsXC = makeEqualsPredicate (TermLike.mkElemVar Mock.x) Mock.c
         assertEqual ""
-            [ ProofState.Goal $ makeRuleFromPatterns
-                Conditional
+            [ ProofState.Goal $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.f Mock.b
                     , predicate = makeTruePredicate
                     , substitution =
                         Substitution.unsafeWrap [(ElemVar Mock.x, Mock.b)]
                     }
-                (fromTermLike $ Mock.functionalConstr11 Mock.a)
-            , ProofState.Goal $ makeRuleFromPatterns
-                Conditional
+                )
+                (Mock.functionalConstr11 Mock.a)
+            , ProofState.Goal $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.f Mock.c
                     , predicate = makeTruePredicate
                     , substitution =
                         Substitution.unsafeWrap [(ElemVar Mock.x, Mock.c)]
                     }
-                (fromTermLike $ Mock.functionalConstr11 Mock.a)
-            , ProofState.GoalRemainder $ makeRuleFromPatterns
-                Conditional
+                )
+                (Mock.functionalConstr11 Mock.a)
+            , ProofState.GoalRemainder $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.functionalConstr11 (TermLike.mkElemVar Mock.x)
                     , predicate =
                         makeMultipleAndPredicate
@@ -456,7 +456,8 @@ test_onePathStrategy =
                             ]
                     , substitution = mempty
                     }
-                (fromTermLike $ Mock.functionalConstr11 Mock.a)
+                )
+                (Mock.functionalConstr11 Mock.a)
             ]
             [ _actual1
             , _actual2
@@ -499,8 +500,8 @@ test_onePathStrategy =
                     $ Mock.f Mock.b
             ]
         assertEqual ""
-            [ ProofState.GoalRemainder $ makeRuleFromPatterns
-                ( Conditional
+            [ ProofState.GoalRemainder $ makeOnePathRule
+                ( toTermLike Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate =
                         makeNotPredicate
@@ -510,7 +511,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (fromTermLike Mock.a)
+                Mock.a
             , ProofState.Proven
             ]
             [ _actual1
@@ -573,8 +574,8 @@ test_onePathStrategy =
         -- Expected: a | f(b) < 0
         [ _actual ] <- runOnePathSteps
             (Limit 1)
-            (makeRuleFromPatterns
-                (Conditional
+            (makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate = makeEqualsPredicate
                         (Mock.lessInt
@@ -585,7 +586,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (fromTermLike Mock.a)
+                Mock.a
             )
             []
             [ rewriteWithPredicate
@@ -611,8 +612,8 @@ test_onePathStrategy =
             ]
         [ _actualReach ] <- runOnePathSteps
             (Limit 1)
-            (OnePath $ makeRuleFromPatterns
-                (Conditional
+            (OnePath $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate = makeEqualsPredicate
                         (Mock.lessInt
@@ -623,7 +624,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (fromTermLike Mock.a)
+                Mock.a
             )
             []
             [ rewriteReachabilityWithPredicate
@@ -648,8 +649,8 @@ test_onePathStrategy =
                 )
             ]
         assertEqual ""
-            [ ProofState.Goal $ makeRuleFromPatterns
-                ( Conditional
+            [ ProofState.Goal $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.a
                     , predicate =
                         makeEqualsPredicate
@@ -661,7 +662,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (fromTermLike Mock.a)
+                Mock.a
             ]
             [ _actual
             ]
@@ -675,8 +676,8 @@ test_onePathStrategy =
         -- Expected: a | f(b) < 0
         [ _actual ] <- runOnePathSteps
             (Limit 1)
-            (makeRuleFromPatterns
-                (Conditional
+            (makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate = makeEqualsPredicate
                         (Mock.lessInt
@@ -687,7 +688,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (Pattern.fromTermLike Mock.a)
+                Mock.a
             )
             []
             [ rewriteWithPredicate
@@ -703,8 +704,8 @@ test_onePathStrategy =
             ]
         [ _actualReach ] <- runOnePathSteps
             (Limit 1)
-            (OnePath $ makeRuleFromPatterns
-                (Conditional
+            (OnePath $ makeOnePathRule
+                (toTermLike Conditional
                     { term = Mock.functionalConstr10 Mock.b
                     , predicate = makeEqualsPredicate
                         (Mock.lessInt
@@ -715,7 +716,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (Pattern.fromTermLike Mock.a)
+                Mock.a
             )
             []
             [ rewriteReachabilityWithPredicate
@@ -730,8 +731,8 @@ test_onePathStrategy =
                 )
             ]
         assertEqual ""
-            [ ProofState.Goal $ makeRuleFromPatterns
-                ( Conditional
+            [ ProofState.Goal $ makeOnePathRule
+                ( toTermLike Conditional
                     { term = Mock.a
                     , predicate =
                         makeEqualsPredicate
@@ -743,7 +744,7 @@ test_onePathStrategy =
                     , substitution = mempty
                     }
                 )
-                (Pattern.fromTermLike Mock.a)
+                Mock.a
             ]
             [ _actual ]
         assertEqual "onepath == reachability onepath"

--- a/kore/test/Test/Kore/Strategies/OnePath/Step.hs
+++ b/kore/test/Test/Kore/Strategies/OnePath/Step.hs
@@ -799,7 +799,7 @@ simpleReachabilityRewrite
     -> TermLike Variable
     -> Rule (ReachabilityRule Variable)
 simpleReachabilityRewrite left right =
-    OPRule (simpleRewrite left right)
+    coerce (simpleRewrite left right)
 
 rewriteWithPredicate
     :: TermLike Variable
@@ -823,7 +823,7 @@ rewriteReachabilityWithPredicate
     -> Predicate Variable
     -> Rule (ReachabilityRule Variable)
 rewriteReachabilityWithPredicate left right predicate =
-    OPRule (rewriteWithPredicate left right predicate)
+    coerce (rewriteWithPredicate left right predicate)
 
 runSteps
     :: Goal goal

--- a/kore/test/Test/Kore/Strategies/Reachability/Verification.hs
+++ b/kore/test/Test/Kore/Strategies/Reachability/Verification.hs
@@ -1,0 +1,1041 @@
+module Test.Kore.Strategies.Reachability.Verification
+    ( test_reachabilityVerification
+    ) where
+
+import Test.Tasty
+
+import Data.Default
+    ( def
+    )
+import Data.Limit
+    ( Limit (..)
+    )
+
+import qualified Kore.Attribute.Axiom as Attribute
+import Kore.Internal.Pattern
+    ( Conditional (Conditional)
+    )
+import Kore.Internal.Pattern as Conditional
+    ( Conditional (..)
+    )
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate
+    ( makeEqualsPredicate
+    , makeNotPredicate
+    , makeTruePredicate
+    )
+import Kore.Internal.TermLike
+import Kore.Step.Rule
+    ( AllPathRule (..)
+    , OnePathRule (..)
+    , ReachabilityRule (..)
+    , RewriteRule (..)
+    , RulePattern (..)
+    )
+import Kore.Strategies.Goal
+
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Kore.Strategies.Common
+import Test.Tasty.HUnit.Ext
+
+test_reachabilityVerification :: [TestTree]
+test_reachabilityVerification =
+    [ testCase "OnePath: Runs zero steps" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 0)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleOnePathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "AllPath: Runs zero steps" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 0)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleAllPathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "Mixed: Runs zero steps" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 0)
+            [simpleAxiom Mock.a Mock.b]
+            [ simpleOnePathClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "OnePath: Runs one step" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error b
+        -- Note that the check that we have reached the destination happens
+        -- at the beginning of each step. At the beginning of the first step
+        -- the pattern is 'a', so we didn't reach our destination yet, even if
+        -- the rewrite transforms 'a' into 'b'. We detect the success at the
+        -- beginning of the second step, which does not run here.
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleOnePathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "AllPath: Runs one step" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error b
+        -- Note that the check that we have reached the destination happens
+        -- at the beginning of each step. At the beginning of the first step
+        -- the pattern is 'a', so we didn't reach our destination yet, even if
+        -- the rewrite transforms 'a' into 'b'. We detect the success at the
+        -- beginning of the second step, which does not run here.
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleAllPathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "Mixed: Runs one step" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: error b
+        -- Note that the check that we have reached the destination happens
+        -- at the beginning of each step. At the beginning of the first step
+        -- the pattern is 'a', so we didn't reach our destination yet, even if
+        -- the rewrite transforms 'a' into 'b'. We detect the success at the
+        -- beginning of the second step, which does not run here.
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a Mock.b]
+            [ simpleOnePathClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "OnePath: Returns first failing claim" $ do
+        -- Axiom: a => b or c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
+            [simpleOnePathClaim Mock.a Mock.d]
+        assertEqual ""
+            (Left . Pattern.fromTermLike $ Mock.b)
+            actual
+    , testCase "AllPath: Returns first failing claim" $ do
+        -- Axiom: a => b or c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
+            [simpleAllPathClaim Mock.a Mock.d]
+        assertEqual ""
+            (Left . Pattern.fromTermLike $ Mock.b)
+            actual
+    , testCase "Mixed: Returns first failing claim" $ do
+        -- Axiom: a => b or c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 1)
+            [simpleAxiom Mock.a (mkOr Mock.b Mock.c)]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.a Mock.d
+            ]
+        assertEqual ""
+            (Left . Pattern.fromTermLike $ Mock.b)
+            actual
+    , testCase "OnePath: Verifies one claim" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 2)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleOnePathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: Verifies one claim" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 2)
+            [simpleAxiom Mock.a Mock.b]
+            [simpleAllPathClaim Mock.a Mock.b]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: Verifies one claim" $ do
+        -- Axiom: a => b
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 2)
+            [simpleAxiom Mock.a Mock.b]
+            [ simpleOnePathClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "OnePath: Trusted claim cannot prove itself" $ do
+        -- Trusted Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 4)
+            []
+            [ simpleOnePathTrustedClaim Mock.a Mock.b
+            , simpleOnePathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "AllPath: Trusted claim cannot prove itself" $ do
+        -- Trusted Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 4)
+            []
+            [ simpleAllPathTrustedClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "Mixed: Trusted claim cannot prove itself" $ do
+        -- Trusted Claim: a => b
+        -- Expected: error a
+        actual <- runVerification
+            (Limit 4)
+            []
+            [ simpleOnePathTrustedClaim Mock.a Mock.b
+            , simpleOnePathClaim Mock.a Mock.b
+            , simpleAllPathTrustedClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.a)
+            actual
+    , testCase "OnePath: Verifies one claim multiple steps" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [simpleOnePathClaim Mock.a Mock.c]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: Verifies one claim multiple steps" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [simpleAllPathClaim Mock.a Mock.c]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: Verifies one claim multiple steps" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [ simpleOnePathClaim Mock.a Mock.c
+            , simpleAllPathClaim Mock.a Mock.c
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "OnePath: Verifies one claim stops early" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [simpleOnePathClaim Mock.a Mock.c]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: Verifies one claim stops early" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [simpleAllPathClaim Mock.a Mock.c]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: Verifies one claim stops early" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            ]
+            [ simpleOnePathClaim Mock.a Mock.c
+            , simpleAllPathClaim Mock.a Mock.c
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "OnePath: Verifies one claim with branching" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr11(x) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom (Mock.functionalConstr11 (mkElemVar Mock.x)) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleOnePathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual "" (Right ()) actual
+    , testCase "AllPath: Verifies one claim with branching" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr11(x) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom (Mock.functionalConstr11 (mkElemVar Mock.x)) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleAllPathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual "" (Right ()) actual
+    , testCase "Mixed: Verifies one claim with branching" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr11(x) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom (Mock.functionalConstr11 (mkElemVar Mock.x)) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleOnePathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            , simpleAllPathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual "" (Right ()) actual
+    , testCase "OnePath: Partial verification failure" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: error constr11(x) and x != a
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleOnePathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual ""
+            (Left Conditional
+                { term = Mock.functionalConstr11 (mkElemVar Mock.x)
+                , predicate =
+                    makeNotPredicate $ makeEqualsPredicate (mkElemVar Mock.x) Mock.a
+                , substitution = mempty
+                }
+            )
+            actual
+    , testCase "AllPath: Partial verification failure" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: error constr11(x) and x != a
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleAllPathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual ""
+            (Left Conditional
+                { term = Mock.functionalConstr11 (mkElemVar Mock.x)
+                , predicate =
+                    makeNotPredicate $ makeEqualsPredicate (mkElemVar Mock.x) Mock.a
+                , substitution = mempty
+                }
+            )
+            actual
+    , testCase "Mixed: Partial verification failure" $ do
+        -- Axiom: constr11(a) => b
+        -- Axiom: constr10(x) => constr11(x)
+        -- Claim: constr10(x) => b
+        -- Expected: error constr11(x) and x != a
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom (Mock.functionalConstr11 Mock.a) Mock.b
+            , simpleAxiom
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                (Mock.functionalConstr11 (mkElemVar Mock.x))
+            ]
+            [ simpleOnePathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            , simpleAllPathClaim
+                (Mock.functionalConstr10 (mkElemVar Mock.x))
+                Mock.b
+            ]
+        assertEqual ""
+            (Left Conditional
+                { term = Mock.functionalConstr11 (mkElemVar Mock.x)
+                , predicate =
+                    makeNotPredicate $ makeEqualsPredicate (mkElemVar Mock.x) Mock.a
+                , substitution = mempty
+                }
+            )
+            actual
+    , testCase "OnePath: Verifies two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => e
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleOnePathClaim Mock.a Mock.c
+            , simpleOnePathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: Verifies two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => e
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleAllPathClaim Mock.a Mock.c
+            , simpleAllPathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: Verifies two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => e
+        -- Expected: success
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleAllPathClaim Mock.a Mock.c
+            , simpleOnePathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "OnePath: fails first of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => e
+        -- Claim: d => e
+        -- Expected: error c
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleOnePathClaim Mock.a Mock.e
+            , simpleOnePathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.c)
+            actual
+    , testCase "AllPath: fails first of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => e
+        -- Claim: d => e
+        -- Expected: error c
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleAllPathClaim Mock.a Mock.e
+            , simpleAllPathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.c)
+            actual
+    , testCase "Mixed: fails first of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => e
+        -- Claim: d => e
+        -- Expected: error c
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleOnePathClaim Mock.a Mock.e
+            , simpleAllPathClaim Mock.d Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.c)
+            actual
+    , testCase "OnePath: fails second of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => c
+        -- Expected: error e
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleOnePathClaim Mock.a Mock.c
+            , simpleOnePathClaim Mock.d Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "AllPath: fails second of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => c
+        -- Expected: error e
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleAllPathClaim Mock.a Mock.c
+            , simpleAllPathClaim Mock.d Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "Mixed: fails second of two claims" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: d => e
+        -- Claim: a => c
+        -- Claim: d => c
+        -- Expected: error e
+        actual <- runVerification
+            (Limit 3)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.d Mock.e
+            ]
+            [ simpleOnePathClaim Mock.a Mock.c
+            , simpleAllPathClaim Mock.d Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "OnePath: second proves first but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => c
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "AllPath: second proves first but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => c
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "Mixed: second proves first but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => c
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathClaim Mock.b Mock.c
+            , simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "Mixed: different claim types so\
+               \ second can't prove first" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => c
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "OnePath: first proves second but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: b => c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.b Mock.c
+            , simpleOnePathClaim Mock.a Mock.d
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "AllPath: first proves second but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: b => c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleAllPathClaim Mock.b Mock.c
+            , simpleAllPathClaim Mock.a Mock.d
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "Mixed: first proves second but fails" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: b => c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.b Mock.c
+            , simpleOnePathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.c
+            , simpleAllPathClaim Mock.a Mock.d
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "Mixed: first doesn't prove second\
+               \ because they are different claim types" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: b => c
+        -- Claim: a => d
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.b Mock.c
+            , simpleAllPathClaim Mock.a Mock.d
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "OnePath: trusted second proves first" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Trusted Claim: b => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathTrustedClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: trusted second proves first" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Trusted Claim: b => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathTrustedClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: trusted second proves first" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Trusted Claim: b => c
+        -- Expected: success
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathTrustedClaim Mock.b Mock.c
+            , simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathTrustedClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "Mixed: trusted second doesn't prove first\
+               \ because of different claim types" $ do
+        -- Axiom: a => b
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Trusted Claim: b => c
+        -- Expected: error b
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleAllPathTrustedClaim Mock.b Mock.c
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.b)
+            actual
+    , testCase "OnePath: Prefers using claims for rewriting" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => e
+        -- Expected: error e
+        --    first verification: a=>b=>e,
+        --        without second claim would be: a=>b=>c=>d
+        --    second verification: b=>c=>d, not visible here
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathClaim Mock.b Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "AllPath: Prefers using claims for rewriting" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => e
+        -- Expected: error e
+        --    first verification: a=>b=>e,
+        --        without second claim would be: a=>b=>c=>d
+        --    second verification: b=>c=>d, not visible here
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "Mixed: Prefers using claims for rewriting" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => e
+        -- Expected: error e
+        --    first verification: a=>b=>e,
+        --        without second claim would be: a=>b=>c=>d
+        --    second verification: b=>c=>d, not visible here
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleOnePathClaim Mock.b Mock.e
+            , simpleAllPathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.e)
+            actual
+    , testCase "Mixed: Doesn't apply claim because of\
+               \ different claim type" $ do
+        -- Axiom: a => b
+        -- Axiom: b => c
+        -- Axiom: c => d
+        -- Claim: a => d
+        -- Claim: b => e
+        -- Expected: error d
+        --    first verification: a=>b=>c=>d
+        --    second verification: b=>c=>d is now visible here
+        actual <- runVerification
+            (Limit 4)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.b Mock.c
+            , simpleAxiom Mock.c Mock.d
+            ]
+            [ simpleOnePathClaim Mock.a Mock.d
+            , simpleAllPathClaim Mock.b Mock.e
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.d)
+            actual
+    , testCase "OnePath: Provable using one-path; not provable\
+               \ using all-path" $ do
+        -- Axioms:
+        --     a => b
+        --     a => c
+        -- Claim: a => b
+        -- Expected: success
+        actual <- runVerification
+            (Limit 5)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.a Mock.c
+            ]
+            [ simpleOnePathClaim Mock.a Mock.b ]
+        assertEqual ""
+            (Right ())
+            actual
+    , testCase "AllPath: Provable using one-path; not provable\
+               \ using all-path" $ do
+        -- Axioms:
+        --     a => b
+        --     a => c
+        -- Claim: a => b
+        -- Expected: error c
+        actual <- runVerification
+            (Limit 5)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.a Mock.c
+            ]
+            [ simpleAllPathClaim Mock.a Mock.b ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.c)
+            actual
+    , testCase "Mixed: Provable using one-path; not provable\
+               \ using all-path" $ do
+        -- Axioms:
+        --     a => b
+        --     a => c
+        -- Claim: a => b
+        -- Expected: error c
+        actual <- runVerification
+            (Limit 5)
+            [ simpleAxiom Mock.a Mock.b
+            , simpleAxiom Mock.a Mock.c
+            ]
+            [ simpleOnePathClaim Mock.a Mock.b
+            , simpleAllPathClaim Mock.a Mock.b
+            ]
+        assertEqual ""
+            (Left $ Pattern.fromTermLike Mock.c)
+            actual
+    ]
+
+simpleAxiom
+    :: TermLike Variable
+    -> TermLike Variable
+    -> Rule (ReachabilityRule Variable)
+simpleAxiom left right =
+    ReachabilityRewriteRule $ simpleRewrite left right
+
+simpleOnePathClaim
+    :: TermLike Variable
+    -> TermLike Variable
+    -> ReachabilityRule Variable
+simpleOnePathClaim left right =
+    OnePath . OnePathRule . getRewriteRule $ simpleRewrite left right
+
+simpleAllPathClaim
+    :: TermLike Variable
+    -> TermLike Variable
+    -> ReachabilityRule Variable
+simpleAllPathClaim left right =
+    AllPath . AllPathRule . getRewriteRule $ simpleRewrite left right
+
+simpleOnePathTrustedClaim
+    :: TermLike Variable
+    -> TermLike Variable
+    -> ReachabilityRule Variable
+simpleOnePathTrustedClaim left right =
+    OnePath
+    . OnePathRule
+    $ RulePattern
+            { left = left
+            , antiLeft = Nothing
+            , right = right
+            , requires = makeTruePredicate
+            , ensures = makeTruePredicate
+            , attributes = def
+                { Attribute.trusted = Attribute.Trusted True }
+            }
+
+simpleAllPathTrustedClaim
+    :: TermLike Variable
+    -> TermLike Variable
+    -> ReachabilityRule Variable
+simpleAllPathTrustedClaim left right =
+    AllPath
+    . AllPathRule
+    $ RulePattern
+            { left = left
+            , antiLeft = Nothing
+            , right = right
+            , requires = makeTruePredicate
+            , ensures = makeTruePredicate
+            , attributes = def
+                { Attribute.trusted = Attribute.Trusted True }
+            }


### PR DESCRIPTION
Checkpoint in https://github.com/kframework/kore/issues/906

- `kore-exec` and `kore-repl` now use `ReachabilityRule Variable`
- Replaces the `Coercible` constaints in `Claim` with `ToRulePattern` and `FromRulePattern` on `goal` and `Rule goal`
- Adds `goalToRule` and `ruleToGoal` as methods in `Goal`.
- `Rule (ReachabilityRule Variable)` is now a newtype over `RewriteRule Variable`.
- `Goal.strategy` now returns a `Stream` to make a general version of `verifyClaimStep` typesafe when extracting the first and followup steps from the `Strategy` list/stream. This needed a new package dependency, will revert if you think it's a bit overkill.
- Added `Test.Kore.Strategies.Reachability.Verification`.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
