### PR TITLE
Allow building with Cabal out-of-the-box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tags
 /haskell_documentation
 test-results.xml
 .directory
+/dist-newstyle/
+/dist/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  kore
+
+allow-newer:
+  ghc-trace-events:base
+
+package *
+  ghc-options: -fhide-source-paths

--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,6 @@ allow-newer:
 
 package *
   ghc-options: -fhide-source-paths
+
+package kore
+  ghc-options: -Wall -Werror

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -24,56 +24,56 @@ extra-source-files:
 description: Please see the [README](README.md) file.
 
 dependencies:
-  - base >= 4.7
-  - array
-  - bytestring >= 0.10
-  - comonad
-  - containers >= 0.5.8
-  - clock
-  - co-log
-  - cryptonite
-  - data-default
-  - deepseq
-  - directory
-  - errors
-  - exceptions
-  - extra
-  - fgl
-  - free
-  - filepath
-  - generic-lens
-  - generics-sop
-  - ghc-trace-events
-  - gitrev
-  - graphviz
-  - groom
-  - hashable
-  - haskeline
-  - integer-gmp
-  - lens
+  - base >=4.7
+  - array >=0.5
+  - bytestring >=0.10
+  - comonad >=5.0
+  - containers >=0.5.8
+  - clock >=0.8
+  - co-log >=0.3
+  - cryptonite >=0.25
+  - data-default >=0.7
+  - deepseq >=1.4
+  - directory >=1.3
+  - errors >=2.3
+  - exceptions >=0.10
+  - extra >=1.6
+  - fgl >=5.7
+  - free >=5.1
+  - filepath >=1.4
+  - generic-lens >=1.1
+  - generics-sop >=0.4 && <0.5
+  - ghc-trace-events >= 0.0
+  - gitrev >=1.3
+  - graphviz >=2999.20
+  - groom >=0.1
+  - hashable >=1.2
+  - haskeline >=0.7
+  - integer-gmp >=1.0
+  - lens >=4.17
   - megaparsec >= 7.0.4
-  - memory
-  - mmorph
-  - mtl
-  - optparse-applicative
-  - parser-combinators
-  - prettyprinter
-  - process
-  - profunctors
-  - recursion-schemes
-  - reflection
-  - semialign
-  - template-haskell
-  - text
-  - these
-  - time
-  - transformers
-  - unliftio-core
-  - unordered-containers
-  - witherable
+  - memory >=0.14
+  - mmorph >=1.1
+  - mtl >=2.2
+  - optparse-applicative >=0.14
+  - parser-combinators >=1.1
+  - prettyprinter >=1.2
+  - process >=1.6
+  - profunctors >=5.3
+  - recursion-schemes >=5.1
+  - reflection >=2.1
+  - semialign >=1
+  - template-haskell >=2.14
+  - text >=1.2
+  - these >=1.0
+  - time >=1.8
+  - transformers >=0.4
+  - unliftio-core >=0.1
+  - unordered-containers >=0.2
+  - witherable >=0.3
 
 build-tools:
-  - tasty-discover
+  - tasty-discover:tasty-discover >=4.2
 
 default-extensions:
   - BangPatterns
@@ -169,19 +169,17 @@ tests:
     ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
-      - call-stack
-      - directory >= 1.2.2
-      - filepath
-      - hedgehog
-      - QuickCheck
-      - quickcheck-instances
-      - tasty
-      - tasty-ant-xml
-      - tasty-hedgehog
-      - tasty-hunit
-      - tasty-golden
-      - tasty-quickcheck
-      - template-haskell
+      - QuickCheck >=2.13
+      - call-stack >=0.1
+      - hedgehog >=1.0
+      - quickcheck-instances >=0.3
+      - tasty >=1.2
+      - tasty-ant-xml >=1.1
+      - tasty-hedgehog >=1.0
+      - tasty-golden >=2.3
+      - tasty-hunit >=0.10
+      - tasty-quickcheck >=0.10
+      - template-haskell >=2.14
 
 benchmarks:
   kore-parser-benchmark:
@@ -194,10 +192,8 @@ benchmarks:
     ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
-      - criterion
-      - directory >= 1.2.2
-      - filepath
-      - template-haskell
+      - criterion >=1.5
+      - template-haskell >=2.14
 
   kore-exec-benchmark:
     main: Main.hs
@@ -209,9 +205,6 @@ benchmarks:
     ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
-      - criterion
-      - directory >= 1.2.2
-      - filepath
-      - process
-      - template-haskell
-      - temporary
+      - criterion >=1.5
+      - template-haskell >=2.14
+      - temporary >=1.3


### PR DESCRIPTION
- .gitignore: Add Cabal temporary paths
- package.yaml: Specify some version bounds

The lower version bounds are not strictly necessary, but it's a good idea
anyway. One upper version bound was added which will help avoid trouble with
future updates to LTS Haskell.

I wanted to use Cabal for some of the profiling I'm doing (it has more profiling options and better defaults). There's really no reason not to support building with either Cabal or Stack; even if we all continue to use Stack the ongoing cost is basically zero.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
