### PR TITLE
Collect RTS statistics

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,10 @@ pipeline {
         sh '''
           ./scripts/integration-kevm.sh
         '''
+        archiveArtifacts 'kevm-add0-stats.json'
+        archiveArtifacts 'kevm-pop1-stats.json'
+        archiveArtifacts 'kevm-sum-to-10-stats.json'
+        archiveArtifacts 'kevm-sum-to-n-spec-stats.json'
       }
     }
     stage('Integration: KWASM') {
@@ -90,6 +94,10 @@ pipeline {
         sh '''
           ./scripts/integration-kwasm.sh
         '''
+        archiveArtifacts 'kwasm-simple-arithmetic-spec-stats.json'
+        archiveArtifacts 'kwasm-loops-spec-stats.json'
+        archiveArtifacts 'kwasm-memory-symbolic-type-spec-stats.json'
+        archiveArtifacts 'kwasm-locals-spec-stats.json'
       }
     }
     stage('Update K Submodules') {
@@ -108,9 +116,6 @@ pipeline {
                     , message: "Build failure: ${env.BUILD_URL}"
         }
       }
-    }
-    success {
-      archiveArtifacts 'profile.json'
     }
   }
 }

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -381,25 +381,29 @@ main = do
     Foldable.forM_ (localOptions options) mainWithOptions
 
 mainWithOptions :: KoreExecOptions -> IO ()
-mainWithOptions execOptions@KoreExecOptions { koreLogOptions } = do
-    exitCode <- runLoggerT koreLogOptions
-        $ case () of
-            ()
-              | Just proveOptions <- koreProveOptions execOptions ->
-                koreProve execOptions proveOptions
-
-              | Just searchOptions <- koreSearchOptions execOptions ->
-                koreSearch execOptions searchOptions
-
-              | Just mergeOptions <- koreMergeOptions execOptions ->
-                koreMerge execOptions mergeOptions
-
-              | otherwise ->
-                koreRun execOptions
+mainWithOptions execOptions = do
+    let KoreExecOptions { koreLogOptions } = execOptions
+    exitCode <- runLoggerT koreLogOptions go
     let KoreExecOptions { rtsStatistics } = execOptions
     Foldable.forM_ rtsStatistics $ \filePath ->
         writeStats filePath =<< getStats
     exitWith exitCode
+  where
+    KoreExecOptions { koreProveOptions } = execOptions
+    KoreExecOptions { koreSearchOptions } = execOptions
+    KoreExecOptions { koreMergeOptions } = execOptions
+    go
+      | Just proveOptions <- koreProveOptions =
+        koreProve execOptions proveOptions
+
+      | Just searchOptions <- koreSearchOptions =
+        koreSearch execOptions searchOptions
+
+      | Just mergeOptions <- koreMergeOptions =
+        koreMerge execOptions mergeOptions
+
+      | otherwise =
+        koreRun execOptions
 
 koreSearch :: KoreExecOptions -> KoreSearchOptions -> Main ExitCode
 koreSearch execOptions searchOptions = do

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -140,6 +140,7 @@ import SMT
     ( MonadSMT
     )
 import qualified SMT
+import Stats
 
 import GlobalMain
 
@@ -264,6 +265,7 @@ data KoreExecOptions = KoreExecOptions
     , koreSearchOptions   :: !(Maybe KoreSearchOptions)
     , koreProveOptions    :: !(Maybe KoreProveOptions)
     , koreMergeOptions    :: !(Maybe KoreMergeOptions)
+    , rtsStatistics       :: !(Maybe FilePath)
     }
 
 -- | Command Line Argument Parser
@@ -315,6 +317,7 @@ parseKoreExecOptions =
         <*> pure Nothing
         <*> optional parseKoreProveOptions
         <*> optional parseKoreMergeOptions
+        <*> optional parseRtsStatistics
     SMT.Config { timeOut = defaultTimeOut } = SMT.defaultConfig
     readSMTTimeOut = do
         i <- auto
@@ -353,6 +356,14 @@ parseKoreExecOptions =
                 , long "module"
                 , help "The name of the main module in the Kore definition."
                 ]
+    parseRtsStatistics =
+        strOption (mconcat infos)
+      where
+        infos =
+            [ metavar "FILENAME"
+            , long "rts-statistics"
+            , help "Write runtime statistics to FILENAME in JSON format."
+            ]
 
 -- | modifiers for the Command line parser description
 parserInfoModifiers :: InfoMod options
@@ -370,20 +381,25 @@ main = do
     Foldable.forM_ (localOptions options) mainWithOptions
 
 mainWithOptions :: KoreExecOptions -> IO ()
-mainWithOptions execOptions@KoreExecOptions { koreLogOptions } =
-    (=<<) exitWith $ runLoggerT koreLogOptions $ case () of
-    ()
-      | Just proveOptions <- koreProveOptions execOptions ->
-        koreProve execOptions proveOptions
+mainWithOptions execOptions@KoreExecOptions { koreLogOptions } = do
+    exitCode <- runLoggerT koreLogOptions
+        $ case () of
+            ()
+              | Just proveOptions <- koreProveOptions execOptions ->
+                koreProve execOptions proveOptions
 
-      | Just searchOptions <- koreSearchOptions execOptions ->
-        koreSearch execOptions searchOptions
+              | Just searchOptions <- koreSearchOptions execOptions ->
+                koreSearch execOptions searchOptions
 
-      | Just mergeOptions <- koreMergeOptions execOptions ->
-        koreMerge execOptions mergeOptions
+              | Just mergeOptions <- koreMergeOptions execOptions ->
+                koreMerge execOptions mergeOptions
 
-      | otherwise ->
-        koreRun execOptions
+              | otherwise ->
+                koreRun execOptions
+    let KoreExecOptions { rtsStatistics } = execOptions
+    Foldable.forM_ rtsStatistics $ \filePath ->
+        writeStats filePath =<< getStats
+    exitWith exitCode
 
 koreSearch :: KoreExecOptions -> KoreSearchOptions -> Main ExitCode
 koreSearch execOptions searchOptions = do

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -25,6 +25,7 @@ description: Please see the [README](README.md) file.
 
 dependencies:
   - base >= 4.7
+  - aeson
   - array
   - bytestring >= 0.10
   - comonad

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -131,7 +131,7 @@ executables:
     source-dirs:
       - app/exec
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8 -T"
     dependencies:
       - kore
 
@@ -167,7 +167,7 @@ tests:
     main: Test.hs
     source-dirs:
       - test
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8 -T"
     dependencies:
       - kore
       - call-stack
@@ -183,6 +183,7 @@ tests:
       - tasty-golden
       - tasty-quickcheck
       - template-haskell
+      - temporary
 
 benchmarks:
   kore-parser-benchmark:

--- a/kore/src/Debug.hs
+++ b/kore/src/Debug.hs
@@ -32,6 +32,7 @@ import Data.Functor.Const
 import Data.Functor.Identity
     ( Identity
     )
+import Data.Int
 import Data.Map
     ( Map
     )
@@ -66,6 +67,7 @@ import Data.Typeable
 import Data.Void
     ( Void
     )
+import Data.Word
 import Debug.Trace
     ( traceM
     )
@@ -278,6 +280,15 @@ instance Debug Integer where
 
 instance Debug Int where
     debugPrec x = \_ -> parens (x < 0) (Pretty.pretty x)
+
+instance Debug Int64 where
+    debugPrec x = \_ -> parens (x < 0) (Pretty.pretty x)
+
+instance Debug Word32 where
+    debugPrec x = \_ -> Pretty.pretty x
+
+instance Debug Word64 where
+    debugPrec x = \_ -> Pretty.pretty x
 
 instance Debug Char where
     debugPrec x = \_ -> Pretty.squotes (Pretty.pretty x)
@@ -536,6 +547,15 @@ instance Diff Integer where
     diffPrec = diffPrecEq
 
 instance Diff Int where
+    diffPrec = diffPrecEq
+
+instance Diff Int64 where
+    diffPrec = diffPrecEq
+
+instance Diff Word32 where
+    diffPrec = diffPrecEq
+
+instance Diff Word64 where
     diffPrec = diffPrecEq
 
 instance Diff Char where

--- a/kore/src/Stats.hs
+++ b/kore/src/Stats.hs
@@ -1,0 +1,82 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+ -}
+
+module Stats
+    ( Stats (..)
+    , getStats
+    , writeStats
+    , readStats
+    ) where
+
+import Data.Aeson
+    ( FromJSON
+    , ToJSON
+    )
+import qualified Data.Aeson as Aeson
+import Data.Word
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+import qualified GHC.Stats as GHC
+import qualified System.Mem as System
+
+import Debug
+
+data Stats =
+    Stats
+        { gcs, major_gcs :: !Word32
+        , allocated_bytes, max_live_bytes :: !Word64
+        , mutator_cpu_ns, mutator_elapsed_ns :: !GHC.RtsTime
+        , gc_cpu_ns, gc_elapsed_ns :: !GHC.RtsTime
+        , cpu_ns, elapsed_ns :: !GHC.RtsTime
+        }
+    deriving (Eq, Read, Show)
+    deriving (GHC.Generic)
+
+instance FromJSON Stats
+
+instance ToJSON Stats
+
+instance SOP.Generic Stats
+
+instance SOP.HasDatatypeInfo Stats
+
+instance Debug Stats
+
+instance Diff Stats
+
+fromGHC :: GHC.RTSStats -> Stats
+fromGHC rtsStats =
+    Stats
+        { gcs, major_gcs
+        , allocated_bytes, max_live_bytes
+        , mutator_cpu_ns, mutator_elapsed_ns
+        , gc_cpu_ns, gc_elapsed_ns
+        , cpu_ns, elapsed_ns
+        }
+  where
+    GHC.RTSStats
+        { gcs, major_gcs
+        , allocated_bytes, max_live_bytes
+        , mutator_cpu_ns, mutator_elapsed_ns
+        , gc_cpu_ns, gc_elapsed_ns
+        , cpu_ns, elapsed_ns
+        }
+      = rtsStats
+
+getStats :: IO Stats
+getStats = do
+    -- Some counters are only updated after a major GC.
+    System.performMajorGC
+    fromGHC <$> GHC.getRTSStats
+
+writeStats :: FilePath -> Stats -> IO ()
+writeStats = Aeson.encodeFile
+
+readStats :: FilePath -> IO Stats
+readStats filePath =
+    either errorWith return =<< Aeson.eitherDecodeFileStrict filePath
+  where
+    errorWith message = error ("readStats: " ++ message)

--- a/kore/test/Test/Stats.hs
+++ b/kore/test/Test/Stats.hs
@@ -1,0 +1,24 @@
+module Test.Stats ( test_Stats ) where
+
+import Test.Tasty
+
+import System.IO
+    ( hClose
+    )
+import System.IO.Temp
+
+import Stats
+
+import Test.Tasty.HUnit.Ext
+
+test_Stats :: [TestTree]
+test_Stats =
+    [ testCase "read back what we wrote" $ do
+        original <- getStats
+        let roundtrip filePath hndl = do
+                hClose hndl
+                writeStats filePath original
+                readStats filePath
+        reread <- withSystemTempFile "kore-test-Test-Stats-.json" roundtrip
+        assertEqual "expected same stats" original reread
+    ]

--- a/scripts/integration-kevm.sh
+++ b/scripts/integration-kevm.sh
@@ -35,20 +35,14 @@ make build-haskell -B
 
 make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell test-interactive-search
 
-for each in \
-    tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json \
-    tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json \
-    tests/interactive/sumTo10.evm
-do
-    command time -o "$TOP/profile.json" -a \
-        -f "{ \"evm-semantics/$each\": { \"user_sec\": %U, \"resident_kbytes\": %M } }" \
-        make TEST_CONCRETE_BACKEND=haskell "$each".run-interactive
-done
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-add0-stats.json" \
+    make TEST_CONCRETE_BACKEND=haskell tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive
 
-for each in \
-    tests/specs/examples/sum-to-n-spec.k
-do
-    command time -o "$TOP/profile.json" -a \
-        -f "{ \"evm-semantics/$each\": { \"user_sec\": %U, \"resident_kbytes\": %M } }" \
-        make TEST_SYMBOLIC_BACKEND=haskell "$each".prove
-done
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-pop1-stats.json" \
+    make TEST_CONCRETE_BACKEND=haskell tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive
+
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-sum-to-10-stats.json" \
+    make TEST_CONCRETE_BACKEND=haskell tests/interactive/sumTo10.evm.run-interactive
+
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-sum-to-n-spec-stats.json" \
+    make TEST_SYMBOLIC_BACKEND=haskell tests/specs/examples/sum-to-n-spec.k.prove

--- a/scripts/integration-kwasm.sh
+++ b/scripts/integration-kwasm.sh
@@ -28,13 +28,14 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-for each in \
-    tests/proofs/simple-arithmetic-spec.k.prove \
-    tests/proofs/loops-spec.k.prove \
-    tests/proofs/memory-symbolic-type-spec.k.prove \
-    tests/proofs/locals-spec.k.prove
-do
-    command time -o "$TOP/profile.json" -a \
-        -f "{ \"wasm-semantics/$each\": { \"user_sec\": %U, \"resident_kbytes\": %M } }" \
-        make TEST_SYMBOLIC_BACKEND=haskell $each
-done
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-simple-arithmetic-spec-stats.json" \
+    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/simple-arithmetic-spec.k.prove
+
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-loops-spec-stats.json" \
+    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/loops-spec.k.prove
+
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-memory-symbolic-type-spec-stats.json" \
+    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/memory-symbolic-type-spec.k.prove
+
+env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-locals-spec-stats.json" \
+    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/locals-spec.k.prove


### PR DESCRIPTION
- Enable the `-T` GHC RTS flag by default for `kore-exec` and `kore-test` so that RTS statistics are always available. This does not seem to have significant overhead.
- Add a flag `--rts-statistics ⟨filename⟩` to `kore-exec` which collects the RTS statistics at the end of execution and writes them to the named file (JSON format).
- Use `--rts-statistics` and `KORE_EXEC_OPTS` to collect statistics on Jenkins, instead of using the `time` command. This gives better performance indicators because it does not include frontend time or memory usage (the latter is especially significant).

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
