### PR TITLE
Handle IOException when we can't find 'z3'

### DIFF
--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -444,15 +444,16 @@ stopSolver mvar = do
 runSMT :: Config -> Logger -> SMT a -> IO a
 runSMT config logger SmtT { runSmtT } =
     Exception.bracket
-        (newSolver config logger `Exception.catch` formatError)
+        (newSolver config logger `Exception.catch` showZ3NotFound)
         stopSolver
         (runReaderT runSmtT)
   where
-    formatError :: Exception.IOException -> IO a
-    formatError _ =
+    showZ3NotFound :: Exception.IOException -> IO a
+    showZ3NotFound e =
         error
-            $ "SMT errror: could not find the 'z3' executable. "
-            <> "Please make sure it's available in your path."
+            $ Exception.displayException e <> "\n"
+            <> "We couldn't start Z3 due to the exception above. "
+            <> "Is Z3 installed?"
 
 -- Need to quote every identifier in SMT between pipes
 -- to escape special chars

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -10,7 +10,7 @@ Maintainer  : thomas.tuegel@runtimeverification.com
 module SMT
     ( SMT, SmtT, runSmtT
     , Solver
-    , newSolver, stopSolver
+    , stopSolver
     , runSMT
     , MonadSMT (..)
     , Config (..)
@@ -444,9 +444,15 @@ stopSolver mvar = do
 runSMT :: Config -> Logger -> SMT a -> IO a
 runSMT config logger SmtT { runSmtT } =
     Exception.bracket
-        (newSolver config logger)
+        (newSolver config logger `Exception.catch` formatError)
         stopSolver
         (runReaderT runSmtT)
+  where
+    formatError :: Exception.IOException -> IO a
+    formatError _ =
+        error
+            $ "SMT errror: could not find the 'z3' executable. "
+            <> "Please make sure it's available in your path."
 
 -- Need to quote every identifier in SMT between pipes
 -- to escape special chars


### PR DESCRIPTION
Fixes #1131 

Does it make sense to check the `IOException` and make sure it's this specific error? I'm not sure it can fail in any other way. Maybe if the user doesn't have permission to run `z3`...? But I'm not sure how that would happen.

I also removed `newSolver` as an alternate way to run SMT queries since it was not used anywhere, thus making `runSMT` the only point of failure -- unless we use `SimpleSMT` directly.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
