### PR TITLE
functionAnd: Restrict to function symbols

### DIFF
--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -190,8 +190,9 @@ andSimplifySuccess
     -> Assertion
 andSimplifySuccess term1 term2 results = do
     let expect = map unificationResult results
-    Right subst' <-
-        runSMT
+    subst' <-
+        fmap (either (error . show) id)
+        $ runSMT
         $ runSimplifier testEnv
         $ Monad.Unify.runUnifierT
         $ simplifyAnds (unificationProblem term1 term2 :| [])


### PR DESCRIPTION
Because we do not evaluate functions during unification, we sometimes have to
emit an Equals predicate between two patterns that we will evaluate later. This
suppresses many errors surrounding missing unification cases. We will restrict
this fallback to the case of And between a function symbol and a
non-simplifiable pattern. This allows us to handle cases like `f(x) ∧ 1` without
suppressing errors for cases like `f(x) ∧ f(y)`.

Fixes: #1256

This turns the `wrc20-spec.k` error into:

```
kore-exec: Not implemented error:
    Unsupported patterns: Unknown unification case.
    first = 
        Lbl'Unds'ModuleInstCellMap'Unds'{}(
            LblModuleInstCellMapItem{}(
                Lbl'-LT-'modIdx'-GT-'{}(VarCUR0:SortInt{}),
                Lbl'-LT-'moduleInst'-GT-'{}(
                    Lbl'-LT-'modIdx'-GT-'{}(VarCUR0:SortInt{}),
                    Var'Unds'101:SortExportsCell{},
                    Lbl'-LT-'typeIds'-GT-'{}(VarTYPEIDS:SortMap{}),
                    Lbl'-LT-'types'-GT-'{}(VarTYPES0:SortMap{}),
                    Var'Unds'111:SortNextTypeIdxCell{},
                    Lbl'-LT-'funcIds'-GT-'{}(VarIDS:SortMap{}),
                    Lbl'-LT-'funcAddrs'-GT-'{}(VarADDRS:SortMap{}),
                    Lbl'-LT-'nextFuncIdx'-GT-'{}(VarNEXTIDX:SortInt{}),
                    Var'Unds'121:SortTabIdsCell{},
                    Var'Unds'131:SortTabAddrsCell{},
                    Var'Unds'141:SortMemIdsCell{},
                    Var'Unds'151:SortMemAddrsCell{},
                    Var'Unds'161:SortGlobIdsCell{},
                    Var'Unds'171:SortGlobalAddrsCell{},
                    Var'Unds'181:SortNextGlobIdxCell{}
                )
            ),
            VarDotVar6:SortModuleInstCellMap{}
        )
    second = 
        /* builtin: */
        Lbl'Unds'ModuleInstCellMap'Unds'{}(
            /* element: */ LblModuleInstCellMapItem{}(
                Lbl'-LT-'modIdx'-GT-'{}(VarCUR:SortInt{}),
                Lbl'-LT-'moduleInst'-GT-'{}(
                    Lbl'-LT-'modIdx'-GT-'{}(VarCUR:SortInt{}),
                    Lbl'-LT-'exports'-GT-'{}(Var'Unds'160:SortMap{}),
                    Lbl'-LT-'typeIds'-GT-'{}(Var'Unds'170:SortMap{}),
                    Lbl'-LT-'types'-GT-'{}(VarTYPES:SortMap{}),
                    Lbl'-LT-'nextTypeIdx'-GT-'{}(VarNEXTTYPEIDX:SortInt{}),
                    Lbl'-LT-'funcIds'-GT-'{}(Var'Unds'1:SortMap{}),
                    Lbl'-LT-'funcAddrs'-GT-'{}(Var'Unds'3:SortMap{}),
                    Lbl'-LT-'nextFuncIdx'-GT-'{}(VarNEXTFUNCIDX:SortInt{}),
                    Lbl'-LT-'tabIds'-GT-'{}(Var'Unds'180:SortMap{}),
                    Lbl'-LT-'tabAddrs'-GT-'{}(Var'Unds'190:SortMap{}),
                    Lbl'-LT-'memIds'-GT-'{}(Var'Unds'200:SortMap{}),
                    Lbl'-LT-'memAddrs'-GT-'{}(
                        /* builtin: */
                        /* concrete element: */ Lbl'UndsPipe'-'-GT-Unds'{}(
                            inj{SortInt{}, SortKItem{}}(
                                /* builtin: */ \dv{SortInt{}}("0")
                            ),
                            inj{SortInt{}, SortKItem{}}(VarMEMADDR:SortInt{})
                        )
                    ),
                    Lbl'-LT-'globIds'-GT-'{}(Var'Unds'210:SortMap{}),
                    Lbl'-LT-'globalAddrs'-GT-'{}(Var'Unds'220:SortMap{}),
                    Lbl'-LT-'nextGlobIdx'-GT-'{}(Var'Unds'230:SortInt{})
                )
            ),
            /* opaque child: */ VarDotVar7:SortModuleInstCellMap{}
        )
while applying a \rewrite axiom to the pattern:
...
```

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
