### PR TITLE
Better profiling experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test-results.xml
 .directory
 /dist-newstyle/
 /dist/
+cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,8 @@ allow-newer:
 
 package *
   ghc-options: -fhide-source-paths
+  ghc-options: -fno-prof-auto
 
 package kore
   ghc-options: -Wall -Werror
+  ghc-options: -fprof-auto-top

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -23,6 +23,12 @@ extra-source-files:
 # common to point users to the README.md file.
 description: Please see the [README](README.md) file.
 
+flags:
+  threaded:
+    description: Use the threaded runtime. Recommended to disable for profiling.
+    manual: true
+    default: true
+
 dependencies:
   - base >=4.7
   - aeson >=1.4
@@ -127,58 +133,65 @@ ghc-options:
 library:
   source-dirs: src
 
+_common-exe: &common-exe
+  when:
+    - condition: flag(threaded)
+      then:
+        ghc-options: -threaded -rtsopts "-with-rtsopts=-N -T -A32M -qn8"
+      else:
+        ghc-options: -rtsopts "-with-rtsopts=-A32M"
+
 executables:
   kore-parser:
     main: Main.hs
     source-dirs:
       - app/parser
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
+    <<: *common-exe
 
   kore-exec:
     main: Main.hs
     source-dirs:
       - app/exec
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8 -T"
     dependencies:
       - kore
+    <<: *common-exe
 
   kore-format:
     main: Main.hs
     source-dirs:
       - app/format
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
+    <<: *common-exe
 
   kore-repl:
     main: Main.hs
     source-dirs:
       - app/repl
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
+    <<: *common-exe
 
   kore-profiler:
     main: Main.hs
     source-dirs:
       - app/profiler
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
+    <<: *common-exe
 
 tests:
   kore-test:
     main: Test.hs
     source-dirs:
       - test
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8 -T"
     dependencies:
       - kore
       - QuickCheck >=2.13
@@ -193,6 +206,7 @@ tests:
       - tasty-quickcheck >=0.10
       - template-haskell >=2.14
       - temporary >=1.3
+    <<: *common-exe
 
 benchmarks:
   kore-parser-benchmark:
@@ -202,11 +216,11 @@ benchmarks:
     source-dirs:
       - bench/parser
       - test
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
       - criterion >=1.5
       - template-haskell >=2.14
+    <<: *common-exe
 
   kore-exec-benchmark:
     main: Main.hs
@@ -215,9 +229,9 @@ benchmarks:
     source-dirs:
       - bench/exec
       - test
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8"
     dependencies:
       - kore
       - criterion >=1.5
       - template-haskell >=2.14
       - temporary >=1.3
+    <<: *common-exe


### PR DESCRIPTION
This pull request improves the profiling experience.

You must use `cabal` to build the package, and you must have version 3.0 or later (run `cabal --version` to check). Stack does not seem to allow the user to override the profiling options passed to GHC, but this is essential for acceptable performance. You can install `cabal` and GHC with [`ghcup`](https://www.haskell.org/ghcup/).

To build:

```
# This writes the cabal.project.local file.
# The setting persists until you --disable-profiling or delete the file.
cabal configure --enable-profiling
cabal build kore
# At the end of the build, cabal will print the path of
# the kore-exec binary it built, you need to copy it into place:
cp [...]/kore-exec ./.build/kore/bin
```

With these changes, profiling overhead is about 500%, which is better than the 3000% we were seeing with Stack.

I am adding appropriate `INLINE` pragmas to get reasonable profiling reports. (Anything marked `INLINE` will not be reported automatically.)

Fixes: #1346 
See also: #1335 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
