### PR TITLE
kore-exec: Use compacting garbage collector on oldest branch

### DIFF
--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -142,7 +142,7 @@ executables:
     source-dirs:
       - app/exec
       - app/share
-    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -A32M -qn8 -T"
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-c -N -A32M -qn8 -T"
     dependencies:
       - kore
 


### PR DESCRIPTION
This is a work-around for #1335. It doesn't solve the underlying problem, but it
should reduce memory use in the meantime.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
