### PR TITLE
Reduce inappropriate laziness

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -29,6 +29,9 @@
 # - functions:
 #   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
 
+- modules:
+  - {name: [Data.Map], within: []}
+
 
 # Add custom hints for this project
 #

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,10 +80,6 @@ pipeline {
         sh '''
           ./scripts/integration-kevm.sh
         '''
-        archiveArtifacts 'kevm-add0-stats.json'
-        archiveArtifacts 'kevm-pop1-stats.json'
-        archiveArtifacts 'kevm-sum-to-10-stats.json'
-        archiveArtifacts 'kevm-sum-to-n-spec-stats.json'
       }
     }
     stage('Integration: KWASM') {
@@ -94,10 +90,6 @@ pipeline {
         sh '''
           ./scripts/integration-kwasm.sh
         '''
-        archiveArtifacts 'kwasm-simple-arithmetic-spec-stats.json'
-        archiveArtifacts 'kwasm-loops-spec-stats.json'
-        archiveArtifacts 'kwasm-memory-symbolic-type-spec-stats.json'
-        archiveArtifacts 'kwasm-locals-spec-stats.json'
       }
     }
     stage('Update K Submodules') {

--- a/kore/app/parser/Main.hs
+++ b/kore/app/parser/Main.hs
@@ -9,7 +9,7 @@ import Control.Monad.Trans
 import Control.Monad.Trans.Reader
     ( runReaderT
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Semigroup
     ( (<>)
     )

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -40,10 +40,10 @@ import Data.Function
 import Data.List
     ( intercalate
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Semigroup
     ( (<>)
     )

--- a/kore/bench/exec/Main.hs
+++ b/kore/bench/exec/Main.hs
@@ -9,7 +9,7 @@ import Data.Limit
     ( Limit
     )
 import qualified Data.Limit as Limit
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -137,7 +137,7 @@ _common-exe: &common-exe
   when:
     - condition: flag(threaded)
       then:
-        ghc-options: -threaded -rtsopts "-with-rtsopts=-N -T -A32M -qn8"
+        ghc-options: -threaded -rtsopts "-with-rtsopts=-N -T -A32M -qn4"
       else:
         ghc-options: -rtsopts "-with-rtsopts=-A32M"
 

--- a/kore/src/Data/Graph/TopologicalSort.hs
+++ b/kore/src/Data/Graph/TopologicalSort.hs
@@ -16,7 +16,7 @@ import Data.Graph
     ( SCC (..)
     , stronglyConnComp
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 

--- a/kore/src/Debug.hs
+++ b/kore/src/Debug.hs
@@ -33,10 +33,10 @@ import Data.Functor.Identity
     ( Identity
     )
 import Data.Int
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     , isJust

--- a/kore/src/Kore/ASTHelpers.hs
+++ b/kore/src/Kore/ASTHelpers.hs
@@ -21,7 +21,7 @@ import Control.Comonad.Trans.Cofree
 import Data.Foldable
     ( foldl'
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text
     ( Text

--- a/kore/src/Kore/ASTVerifier/AliasVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/AliasVerifier.hs
@@ -18,10 +18,10 @@ import qualified Data.Foldable as Foldable
 import Data.Function
 import qualified Data.Functor.Foldable as Recursive
 import Data.Generics.Product
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Set
     ( Set

--- a/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -17,7 +17,7 @@ import Control.Monad
     ( foldM
     )
 import qualified Data.Foldable as Foldable
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
 import qualified Data.Map.Strict as Map

--- a/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/ModuleVerifier.hs
@@ -23,7 +23,7 @@ import qualified Data.Foldable as Foldable
 import Data.Function
 import Data.Generics.Product
 import qualified Data.List as List
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Text
     ( Text

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -23,7 +23,7 @@ import Data.Function
     ( (&)
     )
 import qualified Data.Functor.Foldable as Recursive
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text
     ( Text

--- a/kore/src/Kore/ASTVerifier/PatternVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier/PatternVerifier.hs
@@ -41,7 +41,7 @@ import qualified Control.Monad.Trans.Class as Trans
 import Control.Monad.Trans.Maybe
 import qualified Data.Foldable as Foldable
 import qualified Data.Function as Function
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Set
     ( Set
     )

--- a/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/SentenceVerifier.hs
@@ -38,7 +38,7 @@ import qualified Control.Monad.State.Strict as State
 import qualified Data.Foldable as Foldable
 import Data.Function
 import Data.Generics.Product.Fields
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( isJust
     , mapMaybe

--- a/kore/src/Kore/ASTVerifier/Verifier.hs
+++ b/kore/src/Kore/ASTVerifier/Verifier.hs
@@ -27,10 +27,10 @@ import Control.Monad.RWS.Strict
     )
 import qualified Control.Monad.State.Strict as State
 import Data.Generics.Product
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified GHC.Generics as GHC
 
 import Kore.AST.Error

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -12,7 +12,7 @@ import Control.DeepSeq
 import qualified Data.Foldable as Foldable
 import Data.Functor.Const
 import Data.Hashable
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Monoid
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -12,7 +12,7 @@ import Control.DeepSeq
 import qualified Data.Foldable as Foldable
 import Data.Functor.Const
 import Data.Hashable
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Monoid
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC

--- a/kore/src/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/src/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -14,7 +14,7 @@ import Control.Monad
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( mapMaybe
     )

--- a/kore/src/Kore/Builtin.hs
+++ b/kore/src/Kore/Builtin.hs
@@ -38,10 +38,10 @@ import qualified Control.Lens as Lens
 import Data.Function
 import qualified Data.Functor.Foldable as Recursive
 import Data.Generics.Product
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Semigroup
     ( (<>)
     )

--- a/kore/src/Kore/Builtin/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool.hs
@@ -40,10 +40,10 @@ import Data.Functor
     ( ($>)
     )
 import qualified Data.HashMap.Strict as HashMap
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/src/Kore/Builtin/Int.hs
+++ b/kore/src/Kore/Builtin/Int.hs
@@ -73,10 +73,10 @@ import Data.Bits
     , (.|.)
     )
 import qualified Data.HashMap.Strict as HashMap
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -25,10 +25,10 @@ module Kore.Builtin.KEqual
 
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.HashMap.Strict as HashMap
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.String
     ( IsString
     )

--- a/kore/src/Kore/Builtin/Krypto.hs
+++ b/kore/src/Kore/Builtin/Krypto.hs
@@ -47,10 +47,10 @@ import Data.ByteString
 import qualified Data.ByteString as ByteString
 import Data.Char as Char
 import qualified Data.HashMap.Strict as HashMap
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.String
     ( IsString
     , fromString

--- a/kore/src/Kore/Builtin/Map/Map.hs
+++ b/kore/src/Kore/Builtin/Map/Map.hs
@@ -37,7 +37,7 @@ module Kore.Builtin.Map.Map
     , valuesKey
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.String
     ( IsString
     )

--- a/kore/src/Kore/Builtin/Set/Set.hs
+++ b/kore/src/Kore/Builtin/Set/Set.hs
@@ -26,7 +26,7 @@ module Kore.Builtin.Set.Set
     , list2setKey
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.String
     ( IsString
     )

--- a/kore/src/Kore/Builtin/String.hs
+++ b/kore/src/Kore/Builtin/String.hs
@@ -54,10 +54,10 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.List
     ( findIndex
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/src/Kore/Debug.hs
+++ b/kore/src/Kore/Debug.hs
@@ -65,10 +65,10 @@ import Control.Monad.Trans.Maybe
 import Data.List
     ( intercalate
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Debug.Trace
 
 import Debug

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -42,10 +42,10 @@ import Control.Lens.Iso
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Foldable as Foldable
 import Data.Hashable
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Sequence
     ( Seq
     )

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -46,7 +46,7 @@ import Data.Coerce
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     , mapMaybe

--- a/kore/src/Kore/Internal/ApplicationSorts.hs
+++ b/kore/src/Kore/Internal/ApplicationSorts.hs
@@ -17,10 +17,10 @@ import Data.Function
 import Data.Hashable
     ( Hashable
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -7,7 +7,7 @@ module Kore.ModelChecker.Simplification
     ( checkImplicationIsTop
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Prettyprint.Doc as Pretty
 

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -68,10 +68,10 @@ import Data.List.Extra
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )
-import qualified Data.Map as Map
 import Data.Map.Strict
     ( Map
     )
+import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Sequence
     ( Seq

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -42,7 +42,7 @@ import Data.Generics.Product
 import Data.List
     ( foldl'
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
 import qualified Data.Map.Strict as Map

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -17,7 +17,7 @@ import qualified Data.Foldable as Foldable
 import Data.List
     ( partition
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
 import qualified Data.Map.Strict as Map

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -20,7 +20,7 @@ import Data.List
 import Data.Map
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     , mapMaybe

--- a/kore/src/Kore/Step/Rule/Expand.hs
+++ b/kore/src/Kore/Step/Rule/Expand.hs
@@ -14,7 +14,7 @@ import Data.List
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( mapMaybe
     )

--- a/kore/src/Kore/Step/SMT/Representation/All.hs
+++ b/kore/src/Kore/Step/SMT/Representation/All.hs
@@ -10,7 +10,7 @@ module Kore.Step.SMT.Representation.All
     ( build
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom

--- a/kore/src/Kore/Step/SMT/Representation/Resolve.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Resolve.hs
@@ -13,7 +13,7 @@ module Kore.Step.SMT.Representation.Resolve
 import Control.Error.Safe
     ( assertMay
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/src/Kore/Step/SMT/Representation/Symbols.hs
+++ b/kore/src/Kore/Step/SMT/Representation/Symbols.hs
@@ -10,7 +10,7 @@ module Kore.Step.SMT.Representation.Symbols
     ( buildRepresentations
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( mapMaybe
     )

--- a/kore/src/Kore/Step/SMT/Resolvers.hs
+++ b/kore/src/Kore/Step/SMT/Resolvers.hs
@@ -13,7 +13,7 @@ module Kore.Step.SMT.Resolvers
     , translateSymbol
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Reflection
     ( Given
     , given

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -17,7 +17,7 @@ module Kore.Step.Simplification.Ceil
 
 import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -182,10 +182,10 @@ evalSimplifier
     -> SimplifierT smt a
     -> smt a
 evalSimplifier verifiedModule simplifier = do
-    env <- runSimplifier earlyEnv initialize
+    !env <- runSimplifier earlyEnv initialize
     runReaderT (runSimplifierT simplifier) env
   where
-    earlyEnv =
+    !earlyEnv =
         Env
             { metadataTools = earlyMetadataTools
             , simplifierTermLike

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -17,7 +17,7 @@ import Control.Error.Util
 import Control.Exception
     ( assert
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -9,7 +9,7 @@ module Kore.Step.Simplification.Rule
     , simplifyFunctionAxioms
     ) where
 
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
 

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -54,7 +54,7 @@ import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
 import qualified Data.Functor.Foldable as Recursive
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -19,7 +19,7 @@ import Control.Monad
     )
 import Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -770,17 +770,17 @@ removeDestinationWorker
     -> goal
     -> Strategy.TransitionT (Rule goal) m (ProofState goal goal)
 removeDestinationWorker stateConstructor goal = withConfiguration goal $ do
-        removal <- removalPredicate destination configuration
-        if isTop removal
-            then return . stateConstructor $ goal
-            else do
-                simplifiedRemoval <-
-                    SMT.Evaluator.filterMultiOr
-                    =<< simplifyAndRemoveTopExists
-                        (Conditional.andPredicate configuration removal)
-                if not (isBottom simplifiedRemoval)
-                    then return . GoalStuck $ goal
-                    else return Proven
+    removal <- removalPredicate destination configuration
+    if isTop removal
+        then return . stateConstructor $ goal
+        else do
+            simplifiedRemoval <-
+                SMT.Evaluator.filterMultiOr
+                =<< simplifyAndRemoveTopExists
+                    (Conditional.andPredicate configuration removal)
+            if not (isBottom simplifiedRemoval)
+                then return . GoalStuck $ goal
+                else return Proven
   where
     configuration = getConfiguration goal
     configFreeVars = Pattern.freeVariables configuration

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -960,6 +960,7 @@ removalPredicate
   | isFunctionPattern configTerm
   , isFunctionPattern destTerm
   = do
+    -- TODO (thomas.tuegel): Use unification here, not simplification.
     unifiedConfigs <- simplifyTerm (mkAnd configTerm destTerm)
     case OrPattern.toPatterns unifiedConfigs of
         _ | OrPattern.isFalse unifiedConfigs ->

--- a/kore/src/Kore/Strategies/ProofState.hs
+++ b/kore/src/Kore/Strategies/ProofState.hs
@@ -51,14 +51,14 @@ instance Filterable Prim where
 
 {- | The state of the reachability proof strategy for @goal@.
  -}
-data ProofState a
-    = Goal a
+data ProofState goal
+    = Goal !goal
     -- ^ The indicated goal is being proven.
-    | GoalRemainder a
+    | GoalRemainder !goal
     -- ^ The indicated goal remains after rewriting.
-    | GoalRewritten a
+    | GoalRewritten !goal
     -- ^ We already rewrote the goal this step.
-    | GoalStuck a
+    | GoalStuck !goal
     -- ^ If the terms unify and the condition does not imply
     -- the goal, the proof is stuck. This state should be reachable
     -- only by applying RemoveDestination.

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -25,7 +25,7 @@ import qualified Data.Functor.Foldable as Recursive
 import qualified Data.List as List
     ( foldl'
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( catMaybes
     , fromMaybe

--- a/kore/test/Test/Data/Graph/TopologicalSort.hs
+++ b/kore/test/Test/Data/Graph/TopologicalSort.hs
@@ -3,7 +3,7 @@ module Test.Data.Graph.TopologicalSort
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import Data.Graph.TopologicalSort
 

--- a/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
+++ b/kore/test/Test/Kore/Attribute/Sort/ConstructorsBuilder.hs
@@ -8,7 +8,7 @@ import Test.Tasty.HUnit
 import Data.Default
     ( def
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -36,10 +36,10 @@ import qualified Control.Monad.Trans as Trans
 import Data.Function
     ( (&)
     )
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -62,10 +62,10 @@ import Data.Function
     ( (&)
     )
 import qualified Data.List as List
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Reflection as Reflection
 import qualified Data.Set as Set

--- a/kore/test/Test/Kore/Builtin/Set.hs
+++ b/kore/test/Test/Kore/Builtin/Set.hs
@@ -70,7 +70,7 @@ import qualified Control.Monad.Trans as Trans
 import qualified Data.Default as Default
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Reflection as Reflection
 import qualified Data.Sequence as Seq

--- a/kore/test/Test/Kore/Contains.hs
+++ b/kore/test/Test/Kore/Contains.hs
@@ -4,10 +4,10 @@ module Test.Kore.Contains
 
 import Test.Tasty
 
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import qualified Kore.Step.SMT.AST as AST
     ( Declarations (Declarations)

--- a/kore/test/Test/Kore/Exec.hs
+++ b/kore/test/Test/Kore/Exec.hs
@@ -16,7 +16,7 @@ import Data.Limit
     ( Limit (..)
     )
 import qualified Data.Limit as Limit
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/IndexedModule/MockMetadataTools.hs
+++ b/kore/test/Test/Kore/IndexedModule/MockMetadataTools.hs
@@ -9,7 +9,7 @@ module Test.Kore.IndexedModule.MockMetadataTools
     , sortInjectionAttributes
     ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/IndexedModule/Resolvers.hs
+++ b/kore/test/Test/Kore/IndexedModule/Resolvers.hs
@@ -8,10 +8,10 @@ import Test.Tasty.HUnit
 
 import Data.Default
 import qualified Data.List as List
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/IndexedModule/SortGraph.hs
+++ b/kore/test/Test/Kore/IndexedModule/SortGraph.hs
@@ -6,7 +6,7 @@ module Test.Kore.IndexedModule.SortGraph
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -35,7 +35,7 @@ import Data.IORef
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import Data.Text
     ( pack

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -13,7 +13,7 @@ import qualified Data.Default as Default
 import Data.Function
     ( (&)
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -15,10 +15,10 @@ import Test.Tasty
 import qualified Control.Lens as Lens
 import Data.Function
 import Data.Generics.Product
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import Prelude hiding

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -20,7 +20,7 @@ import Data.Function
     ( (&)
     )
 import Data.Generics.Product
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/Step/Rule/Expand.hs
+++ b/kore/test/Test/Kore/Step/Rule/Expand.hs
@@ -10,7 +10,7 @@ import Data.Default
 import Data.Function
     ( (&)
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import Data.Sup
     ( Sup (Element)

--- a/kore/test/Test/Kore/Step/RulePattern.hs
+++ b/kore/test/Test/Kore/Step/RulePattern.hs
@@ -7,7 +7,7 @@ import Test.Tasty.HUnit.Ext
 
 import Data.Default
 import qualified Data.Foldable as Foldable
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 import Kore.Attribute.Pattern.FreeVariables as FreeVariables

--- a/kore/test/Test/Kore/Step/SMT/Representation/All.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/All.hs
@@ -4,7 +4,7 @@ module Test.Kore.Step.SMT.Representation.All
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/test/Test/Kore/Step/SMT/Representation/Builders.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/Builders.hs
@@ -13,7 +13,7 @@ module Test.Kore.Step.SMT.Representation.Builders
 
 import Test.Kore.Step.SMT.Builders ()
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/kore/test/Test/Kore/Step/SMT/Representation/Helpers.hs
+++ b/kore/test/Test/Kore/Step/SMT/Representation/Helpers.hs
@@ -7,7 +7,7 @@ module Test.Kore.Step.SMT.Representation.Helpers
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import qualified Kore.Attribute.Axiom as Attribute
     ( Axiom

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -15,7 +15,7 @@ import qualified Control.Error as Error
 import Data.Default
     ( Default (..)
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text
     ( Text

--- a/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -5,7 +5,7 @@ module Test.Kore.Step.Simplification.Application
 import Test.Tasty
 
 import qualified Data.List as List
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import Data.Sup
 import Kore.Internal.Condition as Condition

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -4,7 +4,7 @@ module Test.Kore.Step.Simplification.Ceil
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe
     ( fromMaybe
     )

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -4,7 +4,7 @@ module Test.Kore.Step.Simplification.Condition
 
 import Test.Tasty
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 
 import Kore.Internal.Condition
     ( Condition

--- a/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
+++ b/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
@@ -140,8 +140,8 @@ test_transitionRule_CheckProven =
 test_transitionRule_CheckGoalRem :: [TestTree]
 test_transitionRule_CheckGoalRem =
     [ unmodified ProofState.Proven
-    , unmodified (ProofState.Goal    (A, B))
-    , done       (ProofState.GoalRemainder undefined)
+    , unmodified (ProofState.Goal          (A, B))
+    , done       (ProofState.GoalRemainder (A, B))
     ]
   where
     run = runTransitionRule ProofState.CheckGoalRemainder

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -16,7 +16,7 @@ import qualified Data.Foldable as Foldable
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )

--- a/scripts/integration-kevm.sh
+++ b/scripts/integration-kevm.sh
@@ -33,15 +33,9 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-# Small tests
-env GHCRTS='-M512M' \
-  make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
-    test-interactive-search \
-    tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive
-
-# Medium tests
-env GHCRTS='-M1G' \
-  make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
-    tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive \
-    tests/interactive/sumTo10.evm.run-interactive \
-    tests/specs/examples/sum-to-n-spec.k.prove
+make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
+  test-interactive-search \
+  tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive \
+  tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive \
+  tests/interactive/sumTo10.evm.run-interactive \
+  tests/specs/examples/sum-to-n-spec.k.prove

--- a/scripts/integration-kevm.sh
+++ b/scripts/integration-kevm.sh
@@ -34,14 +34,14 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 make build-haskell -B
 
 # Small tests
-env GHCRTS='-M256M' \
+env GHCRTS='-M512M' \
   make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
     test-interactive-search \
-    tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive \
-    tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive \
+    tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive
 
 # Medium tests
-env GHCRTS='-M384M' \
+env GHCRTS='-M1G' \
   make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
+    tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive \
     tests/interactive/sumTo10.evm.run-interactive \
     tests/specs/examples/sum-to-n-spec.k.prove

--- a/scripts/integration-kevm.sh
+++ b/scripts/integration-kevm.sh
@@ -33,16 +33,15 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell test-interactive-search
+# Small tests
+env GHCRTS='-M256M' \
+  make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
+    test-interactive-search \
+    tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive \
+    tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive \
 
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-add0-stats.json" \
-    make TEST_CONCRETE_BACKEND=haskell tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json.run-interactive
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-pop1-stats.json" \
-    make TEST_CONCRETE_BACKEND=haskell tests/ethereum-tests/VMTests/vmIOandFlowOperations/pop1.json.run-interactive
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-sum-to-10-stats.json" \
-    make TEST_CONCRETE_BACKEND=haskell tests/interactive/sumTo10.evm.run-interactive
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kevm-sum-to-n-spec-stats.json" \
-    make TEST_SYMBOLIC_BACKEND=haskell tests/specs/examples/sum-to-n-spec.k.prove
+# Medium tests
+env GHCRTS='-M384M' \
+  make -j8 TEST_CONCRETE_BACKEND=haskell TEST_SYMBOLIC_BACKEND=haskell \
+    tests/interactive/sumTo10.evm.run-interactive \
+    tests/specs/examples/sum-to-n-spec.k.prove

--- a/scripts/integration-kwasm.sh
+++ b/scripts/integration-kwasm.sh
@@ -28,9 +28,8 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-env GHCRTS='-M512M' \
-  make -j8 TEST_SYMBOLIC_BACKEND=haskell \
-    tests/proofs/simple-arithmetic-spec.k.prove \
-    tests/proofs/loops-spec.k.prove \
-    tests/proofs/memory-symbolic-type-spec.k.prove \
-    tests/proofs/locals-spec.k.prove
+make -j8 TEST_SYMBOLIC_BACKEND=haskell \
+  tests/proofs/simple-arithmetic-spec.k.prove \
+  tests/proofs/loops-spec.k.prove \
+  tests/proofs/memory-symbolic-type-spec.k.prove \
+  tests/proofs/locals-spec.k.prove

--- a/scripts/integration-kwasm.sh
+++ b/scripts/integration-kwasm.sh
@@ -28,8 +28,8 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-env GHCRTS='-M128M' \
-  make TEST_SYMBOLIC_BACKEND=haskell \
+env GHCRTS='-M512M' \
+  make -j8 TEST_SYMBOLIC_BACKEND=haskell \
     tests/proofs/simple-arithmetic-spec.k.prove \
     tests/proofs/loops-spec.k.prove \
     tests/proofs/memory-symbolic-type-spec.k.prove \

--- a/scripts/integration-kwasm.sh
+++ b/scripts/integration-kwasm.sh
@@ -28,14 +28,9 @@ ln -s $TOP/.build/k deps/k/k-distribution/target/release
 
 make build-haskell -B
 
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-simple-arithmetic-spec-stats.json" \
-    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/simple-arithmetic-spec.k.prove
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-loops-spec-stats.json" \
-    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/loops-spec.k.prove
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-memory-symbolic-type-spec-stats.json" \
-    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/memory-symbolic-type-spec.k.prove
-
-env KORE_EXEC_OPTS="--rts-statistics $TOP/kwasm-locals-spec-stats.json" \
-    make TEST_SYMBOLIC_BACKEND=haskell tests/proofs/locals-spec.k.prove
+env GHCRTS='-M128M' \
+  make TEST_SYMBOLIC_BACKEND=haskell \
+    tests/proofs/simple-arithmetic-spec.k.prove \
+    tests/proofs/loops-spec.k.prove \
+    tests/proofs/memory-symbolic-type-spec.k.prove \
+    tests/proofs/locals-spec.k.prove


### PR DESCRIPTION
Careful reading of the profiling report yielded up to an 80% reduction in max residency. In particular, I noticed places where the call graph looked like this:

```
  parent
    child
      ...
        ...
          parent
```

That is, somewhere deep inside `child`, the program is re-entering `parent`. This is a red-flag for a laziness problem unless one of these conditions holds:

1. `parent` is passed as an argument to `child`
2. `parent` and `child` are mutually-recursive
3. `parent` passes to `child` a gradually-unfolded lazy data structure

Basically, unless you really intend laziness, this pattern indicates a problem. This pattern was unknown to me, so I'm calling it a "re-entrant call graph".

None of these conditions held here, so I applied strictness. In particular, I noticed that:

1. `removeDestinationWorker` calls `askSimplifierTermLike` (:+1:) which eventually descends back into `removeDestinationWorker` (:thinking:)
1. `runSimplifier` wraps the simplifier which eventually calls `evaluateApplication` (:+1:) which descends back into `runSimplifier` (:thinking:)

To fix `removeDestinationWorker` I lifted the body of that function so that it would run in `simplifier` instead of `TransitionT _ simplifier`. `TransitionT` is `ListT`-based, so it can be prone to these problems. My comments earlier today about removing `BranchT` were not far off: if we removed the `ListT`-based things, this could not happen. However, I am very pleased to solve the issue more tactically.

While I was working on `removeDestinationWorker`, I noticed that the `ProofGoal` data type was lazy; I made it strict to keep with our code guidelines and prevent future problems, but it is not related to this problem.

To fix `runSimplifier`, I applied bang-patterns to the `Env` (environment) so that it is fully evaluated before execution begins. After that, the call stack was still re-entrant. I observed that the re-entrant call to `runSimplifier` always appeared above `axiomPatternsToEvaluators`. Upon examining that function, I noticed that it uses `Data.Map` instead of `Data.Map.Strict`; correcting the module's imports finally resolved the re-entrant call stack.

Resolving these two bugs reduces max residency by up to 80% (measured on the `tests/specs/erc20/ds/balanceOf-spec.k` spec in `evm-semantics` with `--depth 2`). I also observed that max residency only increases by 1 MB between `--depth 2` and `--depth 4` on that proof, which satisfies me that the memory use is now appropriate.

To prevent this problem from occurring again, I have added heap limits to the `evm-semantics` and `wasm-semantics` integration tests in our repository. Changes that cause the heap limits to be exceeded will fail in CI. (@ehildenb We could also upstream the heap limits, if you prefer.)

To prevent problems like accidental use of lazy `Data.Map`, I recommend we add `hlint` to our CI checks. We can use `hlint` to forbid importing certain modules. (It allows to make individual exceptions, of course.)

Fixes #1335 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
