### PR TITLE
Wrap side conditions in their own type

### DIFF
--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -93,6 +93,9 @@ import Kore.Internal.Pattern
     ( Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
 import Kore.Internal.Symbol
     ( Symbol
     )
@@ -970,7 +973,8 @@ unifyEqualsNormalizedAc
         return (terms, predicate)
 
     simplify :: TermLike variable -> unifier (Pattern variable)
-    simplify term = alternate $ simplifyConditionalTerm Condition.top term
+    simplify term =
+        alternate $ simplifyConditionalTerm SideCondition.topTODO term
 
     simplifyPair
         :: (TermLike variable, Domain.Value normalized (TermLike variable))
@@ -1009,7 +1013,7 @@ unifyEqualsNormalizedAc
       where
         simplifyTermLike :: TermLike variable -> unifier (Pattern variable)
         simplifyTermLike term =
-            alternate $ simplifyConditionalTerm Condition.top term
+            alternate $ simplifyConditionalTerm SideCondition.topTODO term
 
 buildResultFromUnifiers
     :: forall normalized unifier variable

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -85,9 +85,6 @@ import Kore.IndexedModule.MetadataTools
 import qualified Kore.IndexedModule.MetadataTools as MetadataTools
 import qualified Kore.IndexedModule.Resolvers as IndexedModule
 import Kore.Internal.ApplicationSorts
-import Kore.Internal.Condition as Condition
-    ( topTODO
-    )
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern
     ( Conditional (..)
@@ -102,6 +99,9 @@ import Kore.Internal.Predicate
     ( makeEqualsPredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
 import Kore.Internal.TermLike as TermLike
 import Kore.Sort
     ( predicateSort
@@ -520,7 +520,7 @@ unifyEqualsUnsolved
     -> unifier (Pattern variable)
 unifyEqualsUnsolved SimplificationType.And a b = do
     let unified = TermLike.markSimplified $ mkAnd a b
-    orCondition <- Ceil.makeEvaluateTerm Condition.topTODO unified
+    orCondition <- Ceil.makeEvaluateTerm SideCondition.topTODO unified
     predicate <- Monad.Unify.scatter orCondition
     return (unified `Pattern.withCondition` predicate)
 unifyEqualsUnsolved SimplificationType.Equals a b =

--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -43,9 +43,11 @@ import Kore.Builtin.Builtin
     )
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Error
-import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.And as And
 import qualified Kore.Step.Simplification.Ceil as Ceil
@@ -140,15 +142,15 @@ evalKEq true (valid :< app) =
         let pattern1 = Pattern.fromTermLike termLike1
             pattern2 = Pattern.fromTermLike termLike2
 
-        defined1 <- Ceil.makeEvaluate Condition.topTODO pattern1
-        defined2 <- Ceil.makeEvaluate Condition.topTODO pattern2
+        defined1 <- Ceil.makeEvaluate SideCondition.topTODO pattern1
+        defined2 <- Ceil.makeEvaluate SideCondition.topTODO pattern2
         defined <- And.simplifyEvaluated defined1 defined2
 
         equalTerms <-
             Equals.makeEvaluateTermsToPredicate
                 termLike1
                 termLike2
-                Condition.topTODO
+                SideCondition.topTODO
         let trueTerm = Bool.asInternal sort true
             truePatterns = Pattern.withCondition trueTerm <$> equalTerms
 

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -93,6 +93,10 @@ import Kore.Internal.Predicate
     ( makeMultipleOrPredicate
     , unwrapPredicate
     )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    , topTODO
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Logger as Log
 import qualified Kore.ModelChecker.Bounded as Bounded
@@ -274,7 +278,8 @@ search
     -> Search.Config
     -- ^ The bound on the number of search matches and the search type
     -> smt (TermLike Variable)
-search breadthLimit verifiedModule strategy termLike searchPattern searchConfig =
+search breadthLimit verifiedModule strategy termLike searchPattern searchConfig
+  =
     evalSimplifier verifiedModule $ do
         execution <- execute breadthLimit verifiedModule strategy termLike
         let
@@ -283,7 +288,7 @@ search breadthLimit verifiedModule strategy termLike searchPattern searchConfig 
         solutionsLists <-
             searchGraph
                 searchConfig
-                (match Condition.topTODO searchPattern)
+                (match SideCondition.topTODO searchPattern)
                 executionGraph
         let
             solutions = concatMap MultiOr.extractPatterns solutionsLists
@@ -601,7 +606,9 @@ execute breadthLimit verifiedModule strategy inputPattern =
         simplifier <- Simplifier.askSimplifierTermLike
         axiomIdToSimplifier <- Simplifier.askSimplifierAxioms
         simplifiedPatterns <-
-            Pattern.simplify Condition.top (Pattern.fromTermLike inputPattern)
+            Pattern.simplify
+                SideCondition.top
+                (Pattern.fromTermLike inputPattern)
         let
             initialPattern =
                 case MultiOr.extractPatterns simplifiedPatterns of

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -9,7 +9,6 @@ module Kore.Internal.Condition
     , markSimplified
     , eraseConditionalTerm
     , top
-    , topTODO
     , bottom
     , topCondition
     , bottomCondition
@@ -84,10 +83,6 @@ top =
         , predicate = Predicate.makeTruePredicate_
         , substitution = mempty
         }
-
--- | A 'top' 'Condition' for refactoring which should eventually be removed.
-topTODO :: InternalVariable variable => Condition variable
-topTODO = top
 
 bottom :: InternalVariable variable => Condition variable
 bottom =

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -5,7 +5,7 @@ License     : NCSA
 
 module Kore.Internal.SideCondition
     ( SideCondition  -- Constructor not exported on purpose
-    , addAssumedTrue
+    , andCondition
     , assumeTrueCondition
     , assumeTruePredicate
     , mapVariables
@@ -40,6 +40,13 @@ import Kore.Unparser
     ( Unparse (..)
     )
 
+{-| Side condition used in the evaluation context.
+
+It is not added to the result.
+
+It is usually used to remove infeasible branches, but it may also be used for
+other purposes, say, to remove redundant parts of the result predicate.
+-}
 newtype SideCondition variable =
     SideCondition
         { assumedTrue :: Condition variable }
@@ -83,19 +90,18 @@ top = SideCondition
 topTODO :: InternalVariable variable => SideCondition variable
 topTODO = top
 
-addAssumedTrue
+andCondition
     :: InternalVariable variable
     => SideCondition variable
     -> Condition variable
     -> SideCondition variable
-addAssumedTrue sideCondition@SideCondition {assumedTrue} newCondition =
+andCondition sideCondition@SideCondition {assumedTrue} newCondition =
     sideCondition
         { assumedTrue = assumedTrue `Condition.andCondition` newCondition }
 
-assumeTrueCondition
-    :: InternalVariable variable => Condition variable -> SideCondition variable
+assumeTrueCondition :: Condition variable -> SideCondition variable
 assumeTrueCondition condition =
-    addAssumedTrue top condition
+    SideCondition { assumedTrue = condition }
 
 assumeTruePredicate
     :: InternalVariable variable => Predicate variable -> SideCondition variable

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -1,0 +1,123 @@
+{-|
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+-}
+
+module Kore.Internal.SideCondition
+    ( SideCondition  -- Constructor not exported on purpose
+    , addAssumedTrue
+    , assumeTrueCondition
+    , assumeTruePredicate
+    , mapVariables
+    , top
+    , topTODO
+    , toPredicate
+    ) where
+
+import Kore.Attribute.Pattern.FreeVariables
+    ( HasFreeVariables (..)
+    )
+import Kore.Internal.Condition
+    ( Condition
+    )
+import qualified Kore.Internal.Condition as Condition
+    ( andCondition
+    , fromPredicate
+    , mapVariables
+    , toPredicate
+    , top
+    )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
+import Kore.Internal.Variable
+    ( InternalVariable
+    )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
+import Kore.Unparser
+    ( Unparse (..)
+    )
+
+newtype SideCondition variable =
+    SideCondition
+        { assumedTrue :: Condition variable }
+    deriving (Eq, Show)
+
+instance TopBottom (SideCondition variable) where
+    isTop sideCondition@(SideCondition _) =
+        isTop assumedTrue
+      where
+        SideCondition {assumedTrue} = sideCondition
+    isBottom sideCondition@(SideCondition _) =
+        isBottom assumedTrue
+      where
+        SideCondition {assumedTrue} = sideCondition
+
+instance InternalVariable variable
+    => HasFreeVariables (SideCondition variable) variable
+  where
+    freeVariables sideCondition@(SideCondition _) =
+        freeVariables assumedTrue
+      where
+        SideCondition {assumedTrue} = sideCondition
+
+instance InternalVariable variable => Unparse (SideCondition variable) where
+    unparse sideCondition@(SideCondition _) =
+        unparse assumedTrue
+      where
+        SideCondition {assumedTrue} = sideCondition
+
+    unparse2 sideCondition@(SideCondition _) =
+        unparse2 assumedTrue
+      where
+        SideCondition {assumedTrue} = sideCondition
+
+top :: InternalVariable variable => SideCondition variable
+top = SideCondition
+    { assumedTrue = Condition.top
+    }
+
+-- | A 'top' 'Condition' for refactoring which should eventually be removed.
+topTODO :: InternalVariable variable => SideCondition variable
+topTODO = top
+
+addAssumedTrue
+    :: InternalVariable variable
+    => SideCondition variable
+    -> Condition variable
+    -> SideCondition variable
+addAssumedTrue sideCondition@SideCondition {assumedTrue} newCondition =
+    sideCondition
+        { assumedTrue = assumedTrue `Condition.andCondition` newCondition }
+
+assumeTrueCondition
+    :: InternalVariable variable => Condition variable -> SideCondition variable
+assumeTrueCondition condition =
+    addAssumedTrue top condition
+
+assumeTruePredicate
+    :: InternalVariable variable => Predicate variable -> SideCondition variable
+assumeTruePredicate predicate =
+    assumeTrueCondition (Condition.fromPredicate predicate)
+
+toPredicate
+    :: InternalVariable variable
+    => SideCondition variable
+    -> Predicate variable
+toPredicate condition@(SideCondition _) =
+    Condition.toPredicate assumedTrue
+  where
+    SideCondition { assumedTrue } = condition
+
+mapVariables
+    :: (Ord variable1, Ord variable2)
+    => (variable1 -> variable2)
+    -> SideCondition variable1
+    -> SideCondition variable2
+mapVariables mapper condition@(SideCondition _) =
+    SideCondition
+        { assumedTrue = Condition.mapVariables mapper assumedTrue }
+  where
+    SideCondition { assumedTrue } = condition

--- a/kore/src/Kore/Logger/WarnSimplificationWithRemainder.hs
+++ b/kore/src/Kore/Logger/WarnSimplificationWithRemainder.hs
@@ -17,15 +17,17 @@ import Data.Typeable
     ( Typeable
     )
 
-import Kore.Internal.Condition
-    ( Condition
-    )
-import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.OrPattern
     ( OrPattern
     )
 import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( mapVariables
+    )
 import Kore.Internal.TermLike
     ( TermLike
     )
@@ -43,7 +45,7 @@ will skip the rule in that case.
 data WarnSimplificationWithRemainder =
     WarnSimplificationWithRemainder
         { inputPattern :: TermLike Variable
-        , inputCondition :: Condition Variable
+        , sideCondition :: SideCondition Variable
         , results :: OrPattern Variable
         , remainders :: OrPattern Variable
         }
@@ -56,19 +58,19 @@ warnSimplificationWithRemainder
     :: MonadLog logger
     => InternalVariable variable
     => TermLike variable  -- ^ input pattern
-    -> Condition variable  -- ^ input condition
+    -> SideCondition variable  -- ^ input condition
     -> OrPattern variable  -- ^ results
     -> OrPattern variable  -- ^ remainders
     -> logger ()
 warnSimplificationWithRemainder
     (TermLike.mapVariables toVariable -> inputPattern)
-    (Condition.mapVariables toVariable -> inputCondition)
+    (SideCondition.mapVariables toVariable -> sideCondition)
     (fmap (Pattern.mapVariables toVariable) -> results)
     (fmap (Pattern.mapVariables toVariable) -> remainders)
   =
     logM WarnSimplificationWithRemainder
         { inputPattern
-        , inputCondition
+        , sideCondition
         , results
         , remainders
         }
@@ -84,7 +86,7 @@ instance Pretty WarnSimplificationWithRemainder where
                 [ "input pattern:"
                 , Pretty.indent 2 (unparse inputPattern)
                 , "input condition:"
-                , Pretty.indent 2 (unparse inputCondition)
+                , Pretty.indent 2 (unparse sideCondition)
                 , "results:"
                 , Pretty.indent 2 (unparseOrPattern results)
                 , "remainders:"
@@ -93,6 +95,6 @@ instance Pretty WarnSimplificationWithRemainder where
             , "Rule will be skipped."
             ]
       where
-        WarnSimplificationWithRemainder { inputPattern, inputCondition } = entry
+        WarnSimplificationWithRemainder { inputPattern, sideCondition } = entry
         WarnSimplificationWithRemainder { results, remainders } = entry
         unparseOrPattern = Pretty.vsep . map unparse . OrPattern.toPatterns

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -79,6 +79,9 @@ import Numeric.Natural
 import Kore.Internal.Condition
     ( Condition
     )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
     ( TermLike
     )
@@ -449,7 +452,7 @@ data Config claim m = Config
         -> m (ExecutionGraph (Rule claim))
     -- ^ Stepper function, it is a partially applied 'verifyClaimStep'
     , unifier
-        :: Condition Variable
+        :: SideCondition Variable
         -> TermLike Variable
         -> TermLike Variable
         -> UnifierWithExplanation m (Condition Variable)

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -137,6 +137,12 @@ import Kore.Internal.Pattern
     ( Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( assumeTrueCondition
+    )
 import Kore.Internal.TermLike
     ( TermLike
     )
@@ -876,7 +882,10 @@ tryAxiomClaimWorker mode ref = do
                 patternUnifier
                     (Pattern.splitTerm -> (secondTerm, secondCondition))
                   =
-                    runUnifier' secondCondition first secondTerm
+                    runUnifier' sideCondition first secondTerm
+                  where
+                    sideCondition =
+                        SideCondition.assumeTrueCondition secondCondition
 
     tryForceAxiomOrClaim
         :: Either axiom claim
@@ -898,12 +907,12 @@ tryAxiomClaimWorker mode ref = do
                 updateExecutionGraph graph
 
     runUnifier'
-        :: Condition Variable
+        :: SideCondition Variable
         -> TermLike Variable
         -> TermLike Variable
         -> ReplM claim m ()
-    runUnifier' topCondition first second =
-        runUnifier topCondition first' second
+    runUnifier' sideCondition first second =
+        runUnifier sideCondition first' second
         >>= tell . formatUnificationMessage
       where
         first' = TermLike.refreshVariables (freeVariables second) first

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -110,6 +110,9 @@ import Kore.Internal.Pattern
     ( toTermLike
     )
 import Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
     ( Sort
     , TermLike
@@ -486,16 +489,16 @@ runUnifier
     => Monad.Trans.MonadTrans t
     => MonadSimplify m
     => MonadIO m
-    => Condition Variable
+    => SideCondition Variable
     -> TermLike Variable
     -> TermLike Variable
     -> t m (Either ReplOutput (NonEmpty (Condition Variable)))
-runUnifier topCondition first second = do
+runUnifier sideCondition first second = do
     unifier <- asks unifier
     mvar <- asks logger
     liftSimplifierWithLogger mvar
         . runUnifierWithExplanation
-        $ unifier topCondition first second
+        $ unifier sideCondition first second
 
 getNodeState :: InnerGraph axiom -> Graph.Node -> Maybe (NodeState, Graph.Node)
 getNodeState graph node =

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -44,6 +44,9 @@ import Kore.Internal.OrPattern
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Log
 import Kore.Logger.DebugAppliedRule
@@ -165,14 +168,14 @@ finalizeAppliedRule
     :: forall unifier variable
     .  SimplifierVariable variable
     => MonadUnify unifier
-    => Condition variable
+    => SideCondition variable
     -- ^ Top level condition
     -> EqualityPattern variable
     -- ^ Applied rule
     -> OrCondition variable
     -- ^ Conditions of applied rule
     -> unifier (OrPattern variable)
-finalizeAppliedRule topCondition renamedRule appliedConditions =
+finalizeAppliedRule sideCondition renamedRule appliedConditions =
     Monad.liftM OrPattern.fromPatterns . Monad.Unify.gather
     $ finalizeAppliedRuleWorker =<< Monad.Unify.scatter appliedConditions
   where
@@ -185,7 +188,7 @@ finalizeAppliedRule topCondition renamedRule appliedConditions =
             ensures = EqualityPattern.ensures renamedRule
             ensuresCondition = Condition.fromPredicate ensures
         finalCondition <- simplifyPredicate
-            topCondition
+            sideCondition
             (Just appliedCondition)
             ensuresCondition
         -- Apply the normalized substitution to the right-hand side of the
@@ -201,7 +204,7 @@ finalizeRule
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
-    => Condition (Target variable)
+    => SideCondition (Target variable)
     -- Top-level condition
     -> Pattern (Target variable)
     -- ^ Initial conditions
@@ -210,19 +213,19 @@ finalizeRule
     -> unifier [Result EqualityPattern variable]
     -- TODO (virgil): This is broken, it should take advantage of the unifier's
     -- branching and not return a list.
-finalizeRule topCondition initial unifiedRule =
+finalizeRule sideCondition initial unifiedRule =
     Monad.Unify.gather $ do
         let initialCondition = Conditional.withoutTerm initial
         let unificationCondition = Conditional.withoutTerm unifiedRule
         applied <- applyInitialConditions
-            topCondition
+            sideCondition
             (Just initialCondition)
             unificationCondition
         -- Log unifiedRule here since ^ guards against bottom
         debugAppliedRule unifiedRule
         checkSubstitutionCoverage initial unifiedRule
         let renamedRule = Conditional.term unifiedRule
-        final <- finalizeAppliedRule topCondition renamedRule applied
+        final <- finalizeAppliedRule sideCondition renamedRule applied
         let result = unwrapAndQuantifyConfiguration <$> final
         return Step.Result { appliedRule = unifiedRule, result }
 
@@ -304,18 +307,18 @@ finalizeRulesSequence
     :: forall unifier variable
     .  SimplifierVariable variable
     => MonadUnify unifier
-    => Condition (Target variable)
+    => SideCondition (Target variable)
     -> Pattern (Target variable)
     -> [UnifiedRule (Target variable) (EqualityPattern (Target variable))]
     -> unifier (Results EqualityPattern variable)
-finalizeRulesSequence topCondition initial unifiedRules
+finalizeRulesSequence sideCondition initial unifiedRules
   = do
     (results, remainder) <-
         State.runStateT
             (traverse finalizeRuleSequence' unifiedRules)
             (Conditional.withoutTerm initial)
     remainders' <- Monad.Unify.gather $
-        applyRemainder topCondition initial remainder
+        applyRemainder sideCondition initial remainder
     return Step.Results
         { results = Seq.fromList $ Foldable.fold results
         , remainders =
@@ -334,7 +337,7 @@ finalizeRulesSequence topCondition initial unifiedRules
         remainder <- State.get
         let remainderPattern = Conditional.withCondition initialTerm remainder
         results <- Monad.Trans.lift $
-            finalizeRule topCondition remainderPattern unifiedRule
+            finalizeRule sideCondition remainderPattern unifiedRule
         let unification = Conditional.withoutTerm unifiedRule
             remainder' =
                 Condition.fromPredicate
@@ -355,7 +358,7 @@ applyRulesSequence
         , MonadUnify unifier
         )
     => UnificationProcedure
-    -> Condition (Target variable)
+    -> SideCondition (Target variable)
     -> Pattern (Target variable)
     -- ^ Configuration being rewritten
     -> [EqualityPattern variable]
@@ -363,10 +366,10 @@ applyRulesSequence
     -> unifier (Results EqualityPattern variable)
 applyRulesSequence
     unificationProcedure
-    topCondition
+    sideCondition
     initial
     -- Wrap the rules so that unification prefers to substitute
     -- axiom variables.
     (map EqualityPattern.toAxiomVariables -> rules)
-  = unifyRules unificationProcedure topCondition initial rules
-    >>= finalizeRulesSequence topCondition initial
+  = unifyRules unificationProcedure sideCondition initial rules
+    >>= finalizeRulesSequence sideCondition initial

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -50,7 +50,7 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import qualified Kore.Internal.SideCondition as SideCondition
-    ( addAssumedTrue
+    ( andCondition
     )
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike as TermLike
@@ -226,7 +226,7 @@ maybeEvaluatePattern
         merged <- bracketAxiomEvaluationLog $ do
             let sideConditions =
                     sideCondition
-                    `SideCondition.addAssumedTrue` childrenCondition
+                    `SideCondition.andCondition` childrenCondition
             result <-
                 Profile.axiomEvaluation identifier
                 $ evaluator termLike sideConditions

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -34,6 +34,9 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.AndPredicates as AndPredicates
 import qualified Kore.Step.Simplification.Ceil as Ceil
@@ -149,14 +152,14 @@ substitutionConditions subst =
 ceilChildOfApplicationOrTop
     :: forall variable m
     .  (SimplifierVariable variable, MonadSimplify m)
-    => Condition variable
+    => SideCondition variable
     -> TermLike variable
     -> m (Condition variable)
-ceilChildOfApplicationOrTop predicate patt =
+ceilChildOfApplicationOrTop sideCondition patt =
     case patt of
         App_ _ children -> do
             ceil <-
-                traverse (Ceil.makeEvaluateTerm predicate) children
+                traverse (Ceil.makeEvaluateTerm sideCondition) children
                 >>= ( AndPredicates.simplifyEvaluatedMultiPredicate
                     . MultiAnd.make
                     )

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -35,6 +35,9 @@ import Kore.Internal.OrPattern
     )
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
 import Kore.Internal.TermLike as TermLike
 import qualified Kore.Logger as Log
 import qualified Kore.Step.Remainder as Remainder
@@ -134,7 +137,7 @@ finalizeAppliedRule renamedRule appliedConditions =
             ensuresCondition = Condition.fromPredicate ensures
         finalCondition <-
             simplifyPredicate
-                Condition.top (Just appliedCondition) ensuresCondition
+                SideCondition.topTODO (Just appliedCondition) ensuresCondition
         -- Apply the normalized substitution to the right-hand side of the
         -- axiom.
         let
@@ -161,7 +164,7 @@ finalizeRule initial unifiedRule =
         let initialCondition = Conditional.withoutTerm initial
         let unificationCondition = Conditional.withoutTerm unifiedRule
         applied <- applyInitialConditions
-            Condition.top
+            SideCondition.topTODO
             (Just initialCondition)
             unificationCondition
         checkSubstitutionCoverage initial unifiedRule
@@ -182,7 +185,7 @@ finalizeRulesParallel initial unifiedRules = do
     let unifications = MultiOr.make (Conditional.withoutTerm <$> unifiedRules)
         remainder = Condition.fromPredicate (Remainder.remainder' unifications)
     remainders' <- Monad.Unify.gather $
-        applyRemainder Condition.top initial remainder
+        applyRemainder SideCondition.topTODO initial remainder
     return Step.Results
         { results = Seq.fromList results
         , remainders =
@@ -204,7 +207,7 @@ finalizeRulesSequence initial unifiedRules
             (traverse finalizeRuleSequence' unifiedRules)
             (Conditional.withoutTerm initial)
     remainders' <- Monad.Unify.gather $
-        applyRemainder Condition.top initial remainder
+        applyRemainder SideCondition.topTODO initial remainder
     return Step.Results
         { results = Seq.fromList $ Foldable.fold results
         , remainders =
@@ -253,7 +256,7 @@ applyRulesParallel
     -- axiom variables.
     (map toAxiomVariables -> rules)
     initial
-  = unifyRules unificationProcedure Condition.top initial rules
+  = unifyRules unificationProcedure SideCondition.topTODO initial rules
     >>= finalizeRulesParallel initial
 
 {- | Apply the given rewrite rules to the initial configuration in parallel.
@@ -304,7 +307,7 @@ applyRulesSequence
     -- Wrap the rules so that unification prefers to substitute
     -- axiom variables.
     (map toAxiomVariables -> rules)
-  = unifyRules unificationProcedure Condition.top initial rules
+  = unifyRules unificationProcedure SideCondition.topTODO initial rules
     >>= finalizeRulesSequence initial
 
 {- | Apply the given rewrite rules to the initial configuration in sequence.

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -32,7 +32,6 @@ import Kore.Attribute.Pattern.FreeVariables
     )
 import qualified Kore.Internal.Condition as Condition
     ( fromPredicate
-    , topTODO
     )
 import Kore.Internal.Conditional
     ( Conditional (Conditional)
@@ -44,6 +43,9 @@ import Kore.Internal.Predicate
     , makeCeilPredicate_
     , makeMultipleAndPredicate
     , makeTruePredicate_
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
     )
 import Kore.Internal.TermLike
     ( mkAnd
@@ -174,7 +176,7 @@ mergeRules (a :| []) = return [a]
 mergeRules (renameRulesVariables . Foldable.toList -> rules) =
     BranchT.gather $ do
         Conditional {term = (), predicate, substitution} <-
-            simplifyCondition Condition.topTODO . Condition.fromPredicate
+            simplifyCondition SideCondition.topTODO . Condition.fromPredicate
             $ makeAndPredicate firstRequires mergedPredicate
         evaluation <- SMT.evaluate predicate
         evaluatedPredicate <- case evaluation of

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -36,6 +36,9 @@ import qualified Kore.Internal.Predicate as Predicate
     ( coerceSort
     , unwrapPredicate
     )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
     ( mkAnd
     , mkCeil_
@@ -82,7 +85,7 @@ instance SimplifierVariable variable => SimplifyRuleLHS (RulePattern variable)
             Pattern.simplifyTopConfiguration lhsWithPredicate
         fullySimplified <-
             simplifyConditionsWithSmt
-                makeTruePredicate_
+                SideCondition.top
                 simplifiedTerms
         let rules =
                 map (setRuleLeft rule) (MultiOr.extractPatterns fullySimplified)

--- a/kore/src/Kore/Step/Search.hs
+++ b/kore/src/Kore/Step/Search.hs
@@ -54,6 +54,9 @@ import Kore.Internal.Pattern
     , Pattern
     )
 import qualified Kore.Internal.Pattern as Conditional
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Step.Simplification.Simplify
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
     ( evaluate
@@ -131,14 +134,14 @@ searchGraph Config { searchType, bound } match executionGraph = do
 matchWith
     :: forall variable m
     .  (SimplifierVariable variable, MonadSimplify m)
-    => Condition variable
+    => SideCondition variable
     -> Pattern variable
     -> Pattern variable
     -> MaybeT m (OrCondition variable)
-matchWith topCondition e1 e2 = do
+matchWith sideCondition e1 e2 = do
     eitherUnifiers <-
         Monad.Trans.lift $ Unifier.runUnifierT
-        $ unificationProcedure topCondition t1 t2
+        $ unificationProcedure sideCondition t1 t2
     let
         maybeUnifiers :: Maybe [Condition variable]
         maybeUnifiers = hush eitherUnifiers
@@ -154,7 +157,7 @@ matchWith topCondition e1 e2 = do
         mergeAndEvaluateBranches predSubst = do
             merged <-
                 mergePredicatesAndSubstitutions
-                    topCondition
+                    sideCondition
                     [ Conditional.predicate predSubst
                     , Conditional.predicate e1
                     , Conditional.predicate e2
@@ -166,7 +169,7 @@ matchWith topCondition e1 e2 = do
             case smtEvaluation of
                     Nothing ->
                         mergePredicatesAndSubstitutions
-                            topCondition
+                            sideCondition
                             [ Conditional.predicate simplified ]
                             [ Conditional.substitution merged
                             , Conditional.substitution simplified

--- a/kore/src/Kore/Step/Simplification/Application.hs
+++ b/kore/src/Kore/Step/Simplification/Application.hs
@@ -16,9 +16,6 @@ import Branch
     ( BranchT
     )
 import qualified Branch as Branch
-import Kore.Internal.Condition
-    ( Condition
-    )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
     ( fullCrossProduct
@@ -33,6 +30,9 @@ import Kore.Internal.Pattern
     , Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Profiler.Profile as Profile
     ( simplificationBranching
@@ -60,13 +60,13 @@ then merging everything into an Pattern.
 -}
 simplify
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Application Symbol (OrPattern variable)
     -> simplifier (OrPattern variable)
-simplify predicate application = do
+simplify sideCondition application = do
     evaluated <-
         traverse
-            (makeAndEvaluateApplications predicate symbol)
+            (makeAndEvaluateApplications sideCondition symbol)
             childrenCrossProduct
     let result = OrPattern.flatten evaluated
     Profile.simplificationBranching
@@ -88,7 +88,7 @@ simplify predicate application = do
 
 makeAndEvaluateApplications
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Symbol
     -> [Pattern variable]
     -> simplifier (OrPattern variable)
@@ -97,44 +97,44 @@ makeAndEvaluateApplications =
 
 makeAndEvaluateSymbolApplications
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Symbol
     -> [Pattern variable]
     -> simplifier (OrPattern variable)
-makeAndEvaluateSymbolApplications predicate symbol children = do
+makeAndEvaluateSymbolApplications sideCondition symbol children = do
     expandedApplications <-
-        Branch.gather $ makeExpandedApplication predicate symbol children
+        Branch.gather $ makeExpandedApplication sideCondition symbol children
     orResults <- traverse
-        (evaluateApplicationFunction predicate)
+        (evaluateApplicationFunction sideCondition)
         expandedApplications
     return (MultiOr.mergeAll orResults)
 
 evaluateApplicationFunction
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -- ^ The predicate from the configuration
     -> ExpandedApplication variable
     -- ^ The pattern to be evaluated
     -> simplifier (OrPattern variable)
 evaluateApplicationFunction
-    configurationCondition
+    sideCondition
     Conditional { term, predicate, substitution }
   =
     evaluateApplication
-        configurationCondition
+        sideCondition
         Conditional { term = (), predicate, substitution }
         term
 
 makeExpandedApplication
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Symbol
     -> [Pattern variable]
     -> BranchT simplifier (ExpandedApplication variable)
-makeExpandedApplication topCondition symbol children = do
+makeExpandedApplication sideCondition symbol children = do
     merged <-
         mergePredicatesAndSubstitutions
-            topCondition
+            sideCondition
             (map Pattern.predicate children)
             (map Pattern.substitution children)
     let term = symbolApplication symbol (Pattern.term <$> children)

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -26,9 +26,6 @@ import qualified Kore.Attribute.Symbol as Attribute.Symbol
     ( isTotal
     )
 import qualified Kore.Domain.Builtin as Domain
-import Kore.Internal.Condition
-    ( Condition
-    )
 import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
     ( Conditional (..)
@@ -54,6 +51,9 @@ import Kore.Internal.Predicate
     , makeTruePredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
 import qualified Kore.Step.Function.Evaluator as Axiom
@@ -76,14 +76,14 @@ A ceil(or) is equal to or(ceil). We also take into account that
 -}
 simplify
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Ceil Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify
-    condition
+    sideCondition
     Ceil { ceilChild = child }
   =
-    simplifyEvaluated condition child
+    simplifyEvaluated sideCondition child
 
 {-| 'simplifyEvaluated' evaluates a ceil given its child, see 'simplify'
 for details.
@@ -104,11 +104,11 @@ carry around.
 simplifyEvaluated
     :: SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
-simplifyEvaluated predicate child =
-    MultiOr.flatten <$> traverse (makeEvaluate predicate) child
+simplifyEvaluated sideCondition child =
+    MultiOr.flatten <$> traverse (makeEvaluate sideCondition) child
 
 {-| Evaluates a ceil given its child as an Pattern, see 'simplify'
 for details.
@@ -116,26 +116,26 @@ for details.
 makeEvaluate
     :: SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> Pattern variable
     -> simplifier (OrPattern variable)
-makeEvaluate predicate child
+makeEvaluate sideCondition child
   | Pattern.isTop    child = return OrPattern.top
   | Pattern.isBottom child = return OrPattern.bottom
-  | otherwise              = makeEvaluateNonBoolCeil predicate child
+  | otherwise              = makeEvaluateNonBoolCeil sideCondition child
 
 makeEvaluateNonBoolCeil
     :: SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> Pattern variable
     -> simplifier (OrPattern variable)
-makeEvaluateNonBoolCeil predicate patt@Conditional {term}
+makeEvaluateNonBoolCeil sideCondition patt@Conditional {term}
   | isTop term =
     return $ OrPattern.fromPattern
         patt {term = mkTop_} -- erase the term's sort.
   | otherwise = do
-    termCeil <- makeEvaluateTerm predicate term
+    termCeil <- makeEvaluateTerm sideCondition term
     result <-
         And.simplifyEvaluatedMultiPredicate
             (MultiAnd.make
@@ -155,11 +155,11 @@ makeEvaluateTerm
     :: forall variable simplifier
     .  SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> TermLike variable
     -> simplifier (OrCondition variable)
 makeEvaluateTerm
-    configurationCondition
+    sideCondition
     term@(Recursive.project -> _ :< projected)
   =
     makeEvaluateTermWorker
@@ -174,18 +174,16 @@ makeEvaluateTerm
       , let headAttributes = symbolAttributes patternHead
       , Attribute.Symbol.isTotal headAttributes = do
             let Application { applicationChildren = children } = app
-            simplifiedChildren <- mapM
-                                    (makeEvaluateTerm configurationCondition)
-                                    children
+            simplifiedChildren <- mapM (makeEvaluateTerm sideCondition) children
             let ceils = simplifiedChildren
             And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
 
       | BuiltinF child <- projected =
-        makeEvaluateBuiltin configurationCondition child
+        makeEvaluateBuiltin sideCondition child
 
       | InjF inj <- projected = do
         InjSimplifier { evaluateCeilInj } <- askInjSimplifier
-        (makeEvaluateTerm configurationCondition . ceilChild . evaluateCeilInj)
+        (makeEvaluateTerm sideCondition . ceilChild . evaluateCeilInj)
             Ceil
                 { ceilResultSort = termLikeSort term -- sort is irrelevant
                 , ceilOperandSort = termLikeSort term
@@ -194,7 +192,7 @@ makeEvaluateTerm
 
       | otherwise = do
         evaluation <- Axiom.evaluatePattern
-            configurationCondition
+            sideCondition
             Conditional
                 { term = ()
                 , predicate = makeTruePredicate_
@@ -228,37 +226,43 @@ makeEvaluateBuiltin
     :: forall variable simplifier
     .  SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> Builtin (TermLike variable)
     -> simplifier (OrCondition variable)
 makeEvaluateBuiltin
-    predicate
+    sideCondition
     patt@(Domain.BuiltinMap Domain.InternalAc
         {builtinAcChild}
     )
   =
     fromMaybe
         (return unsimplified)
-        (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
+        (makeEvaluateNormalizedAc
+            sideCondition
+            (Domain.unwrapAc builtinAcChild)
+        )
   where
     unsimplified =
         OrCondition.fromCondition . Condition.fromPredicate
         $ Predicate.markSimplified . makeCeilPredicate_ $ mkBuiltin patt
-makeEvaluateBuiltin predicate (Domain.BuiltinList l) = do
-    children <- mapM (makeEvaluateTerm predicate) (Foldable.toList l)
+makeEvaluateBuiltin sideCondition (Domain.BuiltinList l) = do
+    children <- mapM (makeEvaluateTerm sideCondition) (Foldable.toList l)
     let
         ceils :: [OrCondition variable]
         ceils = children
     And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
 makeEvaluateBuiltin
-    predicate
+    sideCondition
     patt@(Domain.BuiltinSet Domain.InternalAc
         {builtinAcChild}
     )
   =
     fromMaybe
         (return unsimplified)
-        (makeEvaluateNormalizedAc predicate (Domain.unwrapAc builtinAcChild))
+        (makeEvaluateNormalizedAc
+            sideCondition
+            (Domain.unwrapAc builtinAcChild)
+        )
   where
     unsimplified =
         OrCondition.fromCondition
@@ -278,23 +282,21 @@ makeEvaluateNormalizedAc
         , Traversable (Domain.Value normalized)
         , Domain.AcWrapper normalized
         )
-    =>  Condition variable
+    =>  SideCondition variable
     ->  Domain.NormalizedAc
             normalized
             (TermLike Concrete)
             (TermLike variable)
     -> Maybe (simplifier (OrCondition variable))
 makeEvaluateNormalizedAc
-    configurationCondition
+    sideCondition
     Domain.NormalizedAc
         { elementsWithVariables
         , concreteElements
         , opaque = []
         }
   = TermLike.assertConstructorLikeKeys concreteKeys . Just $ do
-    variableKeyConditions <- mapM
-                                (makeEvaluateTerm configurationCondition)
-                                variableKeys
+    variableKeyConditions <- mapM (makeEvaluateTerm sideCondition) variableKeys
     variableValueConditions <- evaluateValues variableValues
     concreteValueConditions <- evaluateValues concreteValues
 
@@ -332,7 +334,7 @@ makeEvaluateNormalizedAc
             mapM
                 (flip
                     (Equals.makeEvaluateTermsToPredicate variableTerm)
-                    configurationCondition
+                    sideCondition
                 )
                 -- TODO(virgil): consider eliminating these repeated
                 -- concatenations.
@@ -354,7 +356,7 @@ makeEvaluateNormalizedAc
         evaluateWrapper
             :: Domain.Value normalized (TermLike variable)
             -> simplifier (Domain.Value normalized (OrCondition variable))
-        evaluateWrapper = traverse (makeEvaluateTerm configurationCondition)
+        evaluateWrapper = traverse (makeEvaluateTerm sideCondition)
 
         evaluateWrappers
             :: [Domain.Value normalized (TermLike variable)]
@@ -362,13 +364,11 @@ makeEvaluateNormalizedAc
         evaluateWrappers = traverse evaluateWrapper
 
 makeEvaluateNormalizedAc
-    configurationCondition
+    sideCondition
     Domain.NormalizedAc
         { elementsWithVariables = []
         , concreteElements
         , opaque = [opaqueAc]
         }
-  | Map.null concreteElements = Just $ makeEvaluateTerm
-                                        configurationCondition
-                                        opaqueAc
+  | Map.null concreteElements = Just $ makeEvaluateTerm sideCondition opaqueAc
 makeEvaluateNormalizedAc _  _ = Nothing

--- a/kore/src/Kore/Step/Simplification/Ceil.hs-boot
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs-boot
@@ -3,9 +3,6 @@ module Kore.Step.Simplification.Ceil
     , makeEvaluateTerm
     ) where
 
-import Kore.Internal.Condition
-    ( Condition
-    )
 import Kore.Internal.OrCondition
     ( OrCondition
     )
@@ -14,6 +11,9 @@ import Kore.Internal.OrPattern
     )
 import Kore.Internal.Pattern
     ( Pattern
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
     )
 import Kore.Internal.TermLike
     ( TermLike
@@ -26,7 +26,7 @@ import Kore.Step.Simplification.Simplify
 makeEvaluate
     :: SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> Pattern variable
     -> simplifier (OrPattern variable)
 
@@ -34,6 +34,6 @@ makeEvaluateTerm
     :: forall variable simplifier
     .  SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> TermLike variable
     -> simplifier (OrCondition variable)

--- a/kore/src/Kore/Step/Simplification/Condition.hs
+++ b/kore/src/Kore/Step/Simplification/Condition.hs
@@ -27,6 +27,9 @@ import Kore.Internal.Predicate
     , unwrapPredicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Step.Simplification.Simplify
 import Kore.Step.Simplification.SubstitutionSimplifier
     ( SubstitutionSimplifier (..)
@@ -59,7 +62,7 @@ simplify
         , MonadSimplify simplifier
         )
     =>  SubstitutionSimplifier simplifier
-    ->  Condition variable
+    ->  SideCondition variable
     ->  Conditional variable any
     ->  BranchT simplifier (Conditional variable any)
 simplify SubstitutionSimplifier { simplifySubstitution } sideCondition initial =
@@ -107,7 +110,7 @@ simplifyPredicate
         , SimplifierVariable variable
         , MonadSimplify simplifier
         )
-    =>  Condition variable
+    =>  SideCondition variable
     ->  Predicate variable
     ->  BranchT simplifier (Condition variable)
 simplifyPredicate sideCondition predicate = do

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -49,6 +49,9 @@ import Kore.Internal.Predicate
     , makeEqualsPredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.And as And
     ( simplifyEvaluated
@@ -163,11 +166,11 @@ Equals(a and b, b and a) will not be evaluated to Top.
 -}
 simplify
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
-simplify predicate Equals { equalsFirst = first, equalsSecond = second } =
-    simplifyEvaluated predicate first second
+simplify sideCondition Equals { equalsFirst = first, equalsSecond = second } =
+    simplifyEvaluated sideCondition first second
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 
@@ -184,24 +187,24 @@ carry around.
 -}
 simplifyEvaluated
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
-simplifyEvaluated predicate first second
+simplifyEvaluated sideCondition first second
   | first == second = return OrPattern.top
   -- TODO: Maybe simplify equalities with top and bottom to ceil and floor
   | otherwise = do
     let isFunctionConditional Conditional {term} = isFunctionPattern term
     case (firstPatterns, secondPatterns) of
         ([firstP], [secondP]) ->
-            makeEvaluate firstP secondP predicate
+            makeEvaluate firstP secondP sideCondition
         ([firstP], _)
             | isFunctionConditional firstP ->
-                makeEvaluateFunctionalOr predicate firstP secondPatterns
+                makeEvaluateFunctionalOr sideCondition firstP secondPatterns
         (_, [secondP])
             | isFunctionConditional secondP ->
-                makeEvaluateFunctionalOr predicate secondP firstPatterns
+                makeEvaluateFunctionalOr sideCondition secondP firstPatterns
         _
             | OrPattern.isPredicate first && OrPattern.isPredicate second ->
                 Iff.simplifyEvaluated first second
@@ -209,7 +212,7 @@ simplifyEvaluated predicate first second
                 makeEvaluate
                     (OrPattern.toPattern first)
                     (OrPattern.toPattern second)
-                    predicate
+                    sideCondition
   where
     firstPatterns = MultiOr.extractPatterns first
     secondPatterns = MultiOr.extractPatterns second
@@ -217,13 +220,13 @@ simplifyEvaluated predicate first second
 makeEvaluateFunctionalOr
     :: forall variable simplifier
     .  (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
+    => SideCondition variable
     -> Pattern variable
     -> [Pattern variable]
     -> simplifier (OrPattern variable)
-makeEvaluateFunctionalOr predicate first seconds = do
-    firstCeil <- Ceil.makeEvaluate predicate first
-    secondCeilsWithProofs <- mapM (Ceil.makeEvaluate predicate) seconds
+makeEvaluateFunctionalOr sideCondition first seconds = do
+    firstCeil <- Ceil.makeEvaluate sideCondition first
+    secondCeilsWithProofs <- mapM (Ceil.makeEvaluate sideCondition) seconds
     firstNotCeil <- Not.simplifyEvaluated firstCeil
     let secondCeils = secondCeilsWithProofs
     secondNotCeils <- traverse Not.simplifyEvaluated secondCeils
@@ -259,7 +262,7 @@ makeEvaluate
     :: (SimplifierVariable variable, MonadSimplify simplifier)
     => Pattern variable
     -> Pattern variable
-    -> Condition variable
+    -> SideCondition variable
     -> simplifier (OrPattern variable)
 makeEvaluate
     first@Conditional { term = Top_ _ }
@@ -282,20 +285,20 @@ makeEvaluate
         , predicate = PredicateTrue
         , substitution = (Substitution.unwrap -> [])
         }
-    predicate
+    sideCondition
   = do
-    result <- makeEvaluateTermsToPredicate firstTerm secondTerm predicate
+    result <- makeEvaluateTermsToPredicate firstTerm secondTerm sideCondition
     return (Pattern.fromCondition <$> result)
 
 makeEvaluate
     first@Conditional { term = firstTerm }
     second@Conditional { term = secondTerm }
-    predicate
+    sideCondition
   = do
     let first' = first { term = if termsAreEqual then mkTop_ else firstTerm }
-    firstCeil <- Ceil.makeEvaluate predicate first'
+    firstCeil <- Ceil.makeEvaluate sideCondition first'
     let second' = second { term = if termsAreEqual then mkTop_ else secondTerm }
-    secondCeil <- Ceil.makeEvaluate predicate second'
+    secondCeil <- Ceil.makeEvaluate sideCondition second'
     firstCeilNegation <- Not.simplifyEvaluated firstCeil
     secondCeilNegation <- Not.simplifyEvaluated secondCeil
     termEquality <- makeEvaluateTermsAssumesNoBottom firstTerm secondTerm
@@ -355,9 +358,9 @@ makeEvaluateTermsToPredicate
     :: (SimplifierVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
-    -> Condition variable
+    -> SideCondition variable
     -> simplifier (OrCondition variable)
-makeEvaluateTermsToPredicate first second configurationCondition
+makeEvaluateTermsToPredicate first second sideCondition
   | first == second = return OrCondition.top
   | otherwise = do
     result <- runMaybeT $ termEquals first second
@@ -368,8 +371,8 @@ makeEvaluateTermsToPredicate first second configurationCondition
                 $ Predicate.markSimplified
                 $ makeEqualsPredicate_ first second
         Just predicatedOr -> do
-            firstCeilOr <- Ceil.makeEvaluateTerm configurationCondition first
-            secondCeilOr <- Ceil.makeEvaluateTerm configurationCondition second
+            firstCeilOr <- Ceil.makeEvaluateTerm sideCondition first
+            secondCeilOr <- Ceil.makeEvaluateTerm sideCondition second
             firstCeilNegation <- Not.simplifyEvaluatedPredicate firstCeilOr
             secondCeilNegation <- Not.simplifyEvaluatedPredicate secondCeilOr
             ceilNegationAnd <- And.simplifyEvaluatedMultiPredicate

--- a/kore/src/Kore/Step/Simplification/Inj.hs
+++ b/kore/src/Kore/Step/Simplification/Inj.hs
@@ -30,10 +30,9 @@ import Kore.Step.Simplification.Simplify as Simplifier
 -}
 simplify
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => Condition variable
-    -> Inj (OrPattern variable)
+    => Inj (OrPattern variable)
     -> simplifier (OrPattern variable)
-simplify _ injOrPattern = do
+simplify injOrPattern = do
     let composed = Compose . fmap liftConditional $ distributeOr injOrPattern
     InjSimplifier { evaluateInj } <- askInjSimplifier
     let evaluated = evaluateInj <$> composed

--- a/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -22,7 +22,7 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import qualified Kore.Internal.SideCondition as SideCondition
-    ( addAssumedTrue
+    ( andCondition
     , topTODO
     )
 import Kore.Internal.TermLike
@@ -70,4 +70,4 @@ simplify sideCondition pattern' = do
             (Conditional.andCondition simplifiedTerm condition)
   where
     (term, condition) = Conditional.splitTerm pattern'
-    termSideCondition = sideCondition `SideCondition.addAssumedTrue` condition
+    termSideCondition = sideCondition `SideCondition.andCondition` condition

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -13,9 +13,6 @@ import Data.Map.Strict
     ( Map
     )
 
-import qualified Kore.Internal.Condition as Condition
-    ( top
-    )
 import Kore.Internal.Conditional
     ( Conditional (..)
     )
@@ -26,6 +23,9 @@ import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
     ( pattern PredicateTrue
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
     )
 import Kore.Internal.TermLike
     ( TermLike
@@ -170,4 +170,4 @@ simplifyPattern
 simplifyPattern termLike =
     Simplifier.localSimplifierTermLike (const Simplifier.create)
     $ Simplifier.localSimplifierAxioms (const mempty)
-    $ Pattern.simplify Condition.top (Pattern.fromTermLike termLike)
+    $ Pattern.simplify SideCondition.topTODO (Pattern.fromTermLike termLike)

--- a/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -82,7 +82,7 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import qualified Kore.Internal.SideCondition as SideCondition
-    ( addAssumedTrue
+    ( andCondition
     , topTODO
     )
 import Kore.Internal.TermLike
@@ -202,7 +202,7 @@ simplifyAnds MakeAnd { makeAnd } (NonEmpty.sort -> patterns) =
             _ -> do
                 let sideCondition =
                         SideCondition.topTODO
-                        `SideCondition.addAssumedTrue` intermediateCondition
+                        `SideCondition.andCondition` intermediateCondition
                 simplified <-
                     makeAnd
                         intermediateTerm

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -68,7 +68,7 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import qualified Kore.Internal.SideCondition as SideCondition
-    ( addAssumedTrue
+    ( andCondition
     , mapVariables
     )
 import Kore.Internal.TermLike
@@ -208,7 +208,7 @@ unifyRule
   = do
     let (initialTerm, initialCondition) = Pattern.splitTerm initial
         mergedSideCondition =
-            sideCondition `SideCondition.addAssumedTrue` initialCondition
+            sideCondition `SideCondition.andCondition` initialCondition
     -- Rename free axiom variables to avoid free variables from the initial
     -- configuration.
     let
@@ -446,7 +446,7 @@ simplifyPredicate
 simplifyPredicate sideCondition (Just initialCondition) conditional = do
     partialResult <- Branch.alternate
         (Simplifier.simplifyCondition
-            (sideCondition `SideCondition.addAssumedTrue` initialCondition)
+            (sideCondition `SideCondition.andCondition` initialCondition)
             conditional
         )
     -- TODO (virgil): Consider using different simplifyPredicate implementations

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -25,6 +25,9 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Step.Simplification.Simplify as Simplifier
 import Kore.Step.Simplification.SubstitutionSimplifier
     ( SubstitutionSimplifier (..)
@@ -63,7 +66,7 @@ mergePredicatesAndSubstitutions
     :: forall variable simplifier
     .  SimplifierVariable variable
     => MonadSimplify simplifier
-    => Condition variable
+    => SideCondition variable
     -> [Predicate variable]
     -> [Substitution variable]
     -> BranchT simplifier (Condition variable)

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -84,6 +84,9 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( assumeTrueCondition
+    )
 import Kore.Internal.TermLike
     ( isFunctionPattern
     , mkAnd
@@ -983,7 +986,7 @@ removalPredicate
                     $ (const <$> destination <*> substPattern)
             evaluatedRemainder <-
                 Exists.makeEvaluate
-                    configPredicate extraElemVariables remainderPattern
+                    sideCondition extraElemVariables remainderPattern
             return
                 . Predicate.makeNotPredicate
                 . Condition.toPredicate
@@ -1013,6 +1016,7 @@ removalPredicate
   where
     Conditional { term = destTerm } = destination
     (configTerm, configPredicate) = Pattern.splitTerm configuration
+    sideCondition = SideCondition.assumeTrueCondition configPredicate
     -- The variables of the destination that are missing from the
     -- configuration. These are the variables which should be existentially
     -- quantified in the removal predicate.

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -26,7 +26,7 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import qualified Kore.Internal.SideCondition as SideCondition
-    ( addAssumedTrue
+    ( andCondition
     )
 import Kore.Internal.TermLike
 import qualified Kore.Logger as Logger
@@ -80,7 +80,7 @@ unificationProcedure sideCondition p1 p2
     TopBottom.guardAgainstBottom pat
     let (term, conditions) = Conditional.splitTerm pat
         mergedSideCondition =
-            sideCondition `SideCondition.addAssumedTrue` conditions
+            sideCondition `SideCondition.andCondition` conditions
     orCeil <- Ceil.makeEvaluateTerm mergedSideCondition term
     ceil' <- Monad.Unify.scatter orCeil
     BranchT.alternate . simplifyCondition sideCondition

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -22,6 +22,12 @@ import Kore.Internal.Condition
     ( Condition
     )
 import qualified Kore.Internal.Pattern as Conditional
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( addAssumedTrue
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Logger as Logger
 import Kore.Step.Simplification.AndTerms
@@ -49,11 +55,11 @@ unificationProcedure
     ::  ( SimplifierVariable variable
         , MonadUnify unifier
         )
-    => Condition variable
+    => SideCondition variable
     -> TermLike variable
     -> TermLike variable
     -> unifier (Condition variable)
-unificationProcedure topCondition p1 p2
+unificationProcedure sideCondition p1 p2
   | p1Sort /= p2Sort = do
     Monad.Unify.explainBottom
         "Cannot unify different sorts."
@@ -73,9 +79,11 @@ unificationProcedure topCondition p1 p2
     pat <- termUnification p1 p2
     TopBottom.guardAgainstBottom pat
     let (term, conditions) = Conditional.splitTerm pat
-    orCeil <- Ceil.makeEvaluateTerm conditions term
+        mergedSideCondition =
+            sideCondition `SideCondition.addAssumedTrue` conditions
+    orCeil <- Ceil.makeEvaluateTerm mergedSideCondition term
     ceil' <- Monad.Unify.scatter orCeil
-    BranchT.alternate . simplifyCondition topCondition
+    BranchT.alternate . simplifyCondition sideCondition
         $ Conditional.andCondition ceil' conditions
   where
       p1Sort = termLikeSort p1

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -30,7 +30,6 @@ import Kore.Internal.OrCondition
     ( OrCondition
     )
 import qualified Kore.Internal.OrCondition as OrCondition
-import qualified Kore.Internal.Pattern as Pattern
 import Kore.Step.Simplification.AndTerms
     ( termUnification
     )
@@ -99,8 +98,7 @@ unificationMakeAnd :: MonadUnify unifier => MakeAnd unifier
 unificationMakeAnd =
     MakeAnd { makeAnd }
   where
-    makeAnd termLike1 termLike2 condition = do
+    makeAnd termLike1 termLike2 sideCondition = do
         unified <- termUnification termLike1 termLike2
-        Pattern.andCondition unified condition
-            & Simplifier.simplifyCondition Condition.topTODO
+        Simplifier.simplifyCondition sideCondition unified
             & BranchT.alternate

--- a/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/kore/src/Kore/Unification/UnifierImpl.hs
@@ -25,9 +25,6 @@ import Data.Map.Strict
 import qualified Data.Map.Strict as Map
 
 import qualified Branch
-import qualified Kore.Internal.Condition as Condition
-    ( topTODO
-    )
 import Kore.Internal.Conditional
     ( Conditional (..)
     )
@@ -37,6 +34,9 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.AndTerms
     ( termUnification
@@ -178,5 +178,5 @@ normalizeExcept conditional = do
     normalized <- normalizeOnce conditional
     let (term, predicate') = Conditional.splitTerm normalized
     simplified <- Branch.alternate
-        $ Simplifier.simplifyCondition Condition.topTODO predicate'
+        $ Simplifier.simplifyCondition SideCondition.topTODO predicate'
     return simplified { term }

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -32,10 +32,6 @@ import Branch
     ( BranchT
     )
 import qualified Branch as BranchT
-import qualified Kore.Internal.Condition as Condition
-    ( topTODO
-    )
-import qualified Kore.Internal.Pattern as Pattern
 import Kore.Logger
     ( MonadLog (..)
     )
@@ -158,8 +154,7 @@ unificationMakeAnd :: MonadUnify unifier => MakeAnd unifier
 unificationMakeAnd =
     MakeAnd { makeAnd }
   where
-    makeAnd termLike1 termLike2 condition = do
+    makeAnd termLike1 termLike2 sideCondition = do
         unified <- termUnification termLike1 termLike2
         BranchT.alternate
-            $ Simplifier.simplifyCondition Condition.topTODO
-            $ Pattern.andCondition unified condition
+            $ Simplifier.simplifyCondition sideCondition unified

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -81,9 +81,6 @@ import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
     ( build
     )
 import qualified Kore.IndexedModule.SortGraph as SortGraph
-import Kore.Internal.Condition as Condition
-    ( top
-    )
 import qualified Kore.Internal.MultiOr as MultiOr
     ( extractPatterns
     )
@@ -92,6 +89,9 @@ import Kore.Internal.OrPattern
     )
 import Kore.Internal.Pattern
     ( Pattern
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
     )
 import qualified Kore.Internal.Symbol as Internal
     ( Symbol
@@ -260,13 +260,13 @@ simplify =
     . runNoSMT
     . runSimplifier testEnv
     . Branch.gather
-    . simplifyConditionalTerm Condition.top
+    . simplifyConditionalTerm SideCondition.top
 
 evaluate
     :: (MonadSMT smt, MonadUnliftIO smt, MonadProfiler smt, MonadLog smt)
     => TermLike Variable
     -> smt (Pattern Variable)
-evaluate = runSimplifier testEnv . (`TermLike.simplify` Condition.top)
+evaluate = runSimplifier testEnv . (`TermLike.simplify` SideCondition.top)
 
 evaluateT
     :: Trans.MonadTrans t
@@ -279,7 +279,7 @@ evaluateToList :: TermLike Variable -> SMT [Pattern Variable]
 evaluateToList =
     fmap MultiOr.extractPatterns
     . runSimplifier testEnv
-    . TermLike.simplifyToOr Condition.top
+    . TermLike.simplifyToOr SideCondition.top
 
 runStep
     :: Pattern Variable

--- a/kore/test/Test/Kore/Builtin/Krypto.hs
+++ b/kore/test/Test/Kore/Builtin/Krypto.hs
@@ -28,10 +28,12 @@ import qualified GHC.TypeLits as TypeLits
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Krypto as Krypto
 import qualified Kore.Builtin.String as String
-import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern
     ( Pattern
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
     )
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Data
@@ -171,7 +173,7 @@ evaluate builtin termLike = do
         Map.lookup builtin Krypto.builtinFunctions
         & expectConstructor @"Just"
     attempt <-
-        runBuiltinAndAxiomSimplifier evaluator termLike Condition.top
+        runBuiltinAndAxiomSimplifier evaluator termLike SideCondition.top
         & runSimplifier testEnv
         & SMT.runNoSMT mempty
     attemptResults <- expectConstructor @"Applied" attempt

--- a/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
@@ -33,6 +33,9 @@ import Kore.Internal.Predicate
     , makeOrPredicate
     , makeTruePredicate_
     )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( assumeTruePredicate
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Axiom.Evaluate as Kore
 import Kore.Step.EqualityPattern
@@ -233,4 +236,7 @@ evaluateAxioms
     -> IO (AttemptedAxiom Variable)
 evaluateAxioms axioms (termLike, predicate) =
     runSimplifier Mock.env . fmap Results.toAttemptedAxiom
-    $ Kore.evaluateAxioms axioms (Condition.fromPredicate predicate) termLike
+    $ Kore.evaluateAxioms
+        axioms
+        (SideCondition.assumeTruePredicate predicate)
+        termLike

--- a/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/test/Test/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -15,7 +15,6 @@ import qualified Kore.Attribute.Axiom as Attribute.Axiom
 import qualified Kore.Attribute.Axiom.Concrete as Attribute
     ( Concrete (Concrete)
     )
-import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern as Pattern
     ( Conditional (Conditional)
@@ -30,6 +29,9 @@ import Kore.Internal.Predicate
     , makeNotPredicate
     , makeTruePredicate
     , makeTruePredicate_
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( assumeTruePredicate
     )
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
@@ -618,4 +620,4 @@ evaluateWithPredicate
     -> IO CommonAttemptedAxiom
 evaluateWithPredicate (BuiltinAndAxiomSimplifier simplifier) term predicate =
     runSimplifier Mock.env
-    $ simplifier term (Condition.fromPredicate predicate)
+    $ simplifier term (SideCondition.assumeTruePredicate predicate)

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -40,9 +40,11 @@ import Kore.IndexedModule.MetadataTools
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
     ( build
     )
-import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
@@ -324,7 +326,7 @@ test_functionRegistry =
         let expect = mkApplySymbol sHead []
         simplified <-
             runSimplifier testEnv
-            $ Pattern.simplify Condition.top
+            $ Pattern.simplify SideCondition.top
             $ makePattern $ mkApplySymbol gHead []
         let actual =
                 Pattern.term $ head

--- a/kore/test/Test/Kore/Step/EquationalStep.hs
+++ b/kore/test/Test/Kore/Step/EquationalStep.hs
@@ -31,6 +31,9 @@ import Kore.Internal.Predicate as Predicate
     , makeTruePredicate
     , makeTruePredicate_
     )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import Kore.Step.EqualityPattern as EqualityPattern
     ( EqualityPattern (..)
@@ -629,7 +632,7 @@ applyEquationalRulesSequence_
   = do
     results <- Step.applyRulesSequence
         unificationProcedure
-        Condition.top
+        SideCondition.top
         initialConfig
         rules
     Step.assertFunctionLikeResults (term initialConfig) results

--- a/kore/test/Test/Kore/Step/Function/Evaluator.hs
+++ b/kore/test/Test/Kore/Step/Function/Evaluator.hs
@@ -18,6 +18,9 @@ import Kore.Internal.OrPattern
     ( OrPattern
     )
 import qualified Kore.Internal.OrPattern as OrPattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
     ( Application
     , Symbol
@@ -104,7 +107,8 @@ evaluateApplication
     -> Application Symbol (TermLike Variable)
     -> IO (OrPattern Variable)
 evaluateApplication predicate =
-    Test.runSimplifier env . Kore.evaluateApplication Condition.top predicate
+    Test.runSimplifier env
+    . Kore.evaluateApplication SideCondition.top predicate
 
 simplifierAxioms :: Kore.BuiltinAndAxiomSimplifierMap
 simplifierAxioms = Map.fromList [ (fId, fEvaluator) ]

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -63,6 +63,12 @@ import Kore.Internal.Predicate
     , makeTruePredicate
     , makeTruePredicate_
     )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
@@ -604,7 +610,7 @@ test_functionIntegration =
         -> IO (Pattern Variable)
     evaluate functionIdToEvaluator patt =
         runSimplifier Mock.env { simplifierAxioms = functionIdToEvaluator }
-        $ TermLike.simplify patt Condition.top
+        $ TermLike.simplify patt SideCondition.top
 
 test_Nat :: [TestTree]
 test_Nat =
@@ -667,7 +673,7 @@ equals comment term results =
 simplify :: TermLike Variable -> IO (OrPattern Variable)
 simplify =
     runSimplifier testEnv
-    . (TermLike.simplifyToOr Condition.top)
+    . (TermLike.simplifyToOr SideCondition.top)
 
 evaluateWith
     :: BuiltinAndAxiomSimplifier
@@ -675,7 +681,7 @@ evaluateWith
     -> IO CommonAttemptedAxiom
 evaluateWith simplifier patt =
     runSimplifier testEnv
-    $ runBuiltinAndAxiomSimplifier simplifier patt Condition.top
+    $ runBuiltinAndAxiomSimplifier simplifier patt SideCondition.top
 
 -- Applied tests: check that one or more rules applies or not
 withApplied
@@ -1270,7 +1276,7 @@ mockEvaluator
     :: Monad simplifier
     => AttemptedAxiom variable
     -> TermLike variable
-    -> Condition variable
+    -> SideCondition variable
     -> simplifier (AttemptedAxiom variable)
 mockEvaluator evaluation _ _ = return evaluation
 

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -78,6 +78,9 @@ import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
 
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty.HUnit.Ext
@@ -94,7 +97,7 @@ applyInitialConditions
 applyInitialConditions initial unification =
     (fmap . fmap) Foldable.toList
     $ evalUnifier
-    $ Step.applyInitialConditions Condition.top (Just initial) unification
+    $ Step.applyInitialConditions SideCondition.top (Just initial) unification
 
 test_applyInitialConditions :: [TestTree]
 test_applyInitialConditions =
@@ -155,7 +158,8 @@ unifyRule
             [Conditional Variable (RulePattern Variable)]
         )
 unifyRule initial rule =
-    evalUnifier $ Step.unifyRule unificationProcedure Condition.top initial rule
+    evalUnifier
+    $ Step.unifyRule unificationProcedure SideCondition.top initial rule
   where
     unificationProcedure = UnificationProcedure Unification.unificationProcedure
 

--- a/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -8,9 +8,6 @@ import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 
 import Data.Sup
-import Kore.Internal.Condition as Condition
-    ( top
-    )
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -22,6 +19,9 @@ import Kore.Internal.Predicate
     , makeEqualsPredicate_
     , makeTruePredicate
     , makeTruePredicate_
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
     )
 import Kore.Internal.TermLike as TermLike
 import Kore.Step.Axiom.EvaluationStrategy
@@ -320,6 +320,6 @@ evaluate
     -- ^ Map from axiom IDs to axiom evaluators
     -> Application Symbol (OrPattern Variable)
     -> IO (OrPattern Variable)
-evaluate simplifierAxioms = runSimplifier mockEnv . simplify Condition.top
+evaluate simplifierAxioms = runSimplifier mockEnv . simplify SideCondition.top
   where
     mockEnv = Mock.env { simplifierAxioms }

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -24,6 +24,12 @@ import Kore.Internal.Predicate
     , makeEqualsPredicate_
     , makeTruePredicate_
     )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike as TermLike
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
     ( AxiomIdentifier (..)
@@ -572,7 +578,7 @@ mockEvaluator
     :: MonadSimplify simplifier
     => AttemptedAxiom variable
     -> TermLike variable
-    -> Condition variable
+    -> SideCondition variable
     -> simplifier (AttemptedAxiom variable)
 mockEvaluator evaluation _ _ = return evaluation
 
@@ -600,7 +606,7 @@ evaluate
     -> IO (OrPattern Variable)
 evaluate ceil =
     runSimplifier mockEnv
-    $ Ceil.simplify Condition.top ceil
+    $ Ceil.simplify SideCondition.top ceil
   where
     mockEnv = Mock.env
 
@@ -616,6 +622,6 @@ makeEvaluateWithAxioms
     -> IO (OrPattern Variable)
 makeEvaluateWithAxioms axiomIdToSimplifier child =
     runSimplifier mockEnv
-    $ Ceil.makeEvaluate Condition.top child
+    $ Ceil.makeEvaluate SideCondition.top child
   where
     mockEnv = Mock.env { simplifierAxioms = axiomIdToSimplifier }

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -11,7 +11,6 @@ import Kore.Internal.Condition
     , Conditional (..)
     )
 import qualified Kore.Internal.Condition as Conditional
-import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrCondition
     ( OrCondition
@@ -21,6 +20,12 @@ import Kore.Internal.Predicate
     ( makeAndPredicate
     , makeEqualsPredicate_
     , makeTruePredicate_
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
     )
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
@@ -273,7 +278,7 @@ runSimplifier
 runSimplifier patternSimplifierMap predicate =
     fmap MultiOr.make
     $ Test.runSimplifierBranch env
-    $ simplifier Condition.top predicate
+    $ simplifier SideCondition.top predicate
   where
     env = Mock.env { Test.simplifierAxioms = patternSimplifierMap }
     ConditionSimplifier simplifier =
@@ -295,14 +300,14 @@ simpleEvaluator
     :: (SimplifierVariable variable, MonadSimplify simplifier)
     => [(TermLike variable, TermLike variable)]
     -> TermLike variable
-    -> Condition variable
+    -> SideCondition variable
     -> simplifier (AttemptedAxiom variable)
 simpleEvaluator [] _  _ = return NotApplicable
-simpleEvaluator ((from, to) : ps) patt predicate
+simpleEvaluator ((from, to) : ps) patt sideCondition
   | from == patt =
     return $ Applied AttemptedAxiomResults
         { results = OrPattern.fromTermLike to
         , remainders = OrPattern.bottom
         }
   | otherwise =
-    simpleEvaluator ps patt predicate
+    simpleEvaluator ps patt sideCondition

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -39,6 +39,9 @@ import Kore.Internal.Predicate
     , makeTruePredicate
     , makeTruePredicate_
     )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Equals
     ( makeEvaluate
@@ -953,7 +956,7 @@ evaluateOr
     :: Equals Sort (OrPattern Variable)
     -> IO (OrPattern Variable)
 evaluateOr =
-    runSimplifier mockEnv . simplify Condition.top
+    runSimplifier mockEnv . simplify SideCondition.top
   where
     mockEnv = Mock.env
 
@@ -963,7 +966,7 @@ evaluate
     -> IO (OrPattern Variable)
 evaluate first second =
     runSimplifier mockEnv
-    $ makeEvaluate first second Condition.top
+    $ makeEvaluate first second SideCondition.top
   where
     mockEnv = Mock.env
 
@@ -973,6 +976,6 @@ evaluateTermsGeneric
     -> IO (OrCondition Variable)
 evaluateTermsGeneric first second =
     runSimplifier mockEnv
-    $ makeEvaluateTermsToPredicate first second Condition.top
+    $ makeEvaluateTermsToPredicate first second SideCondition.top
   where
     mockEnv = Mock.env

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -31,6 +31,9 @@ import Kore.Internal.Predicate
     , makeTruePredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.Exists as Exists
 import qualified Kore.Unification.Substitution as Substitution
@@ -355,11 +358,12 @@ testSort = Mock.testSort
 simplify
     :: Exists Sort Variable (OrPattern Variable)
     -> IO (OrPattern Variable)
-simplify = runSimplifier Mock.env . Exists.simplify Condition.top
+simplify = runSimplifier Mock.env . Exists.simplify SideCondition.top
 
 makeEvaluate
     :: ElementVariable Variable
     -> Pattern Variable
     -> IO (OrPattern Variable)
 makeEvaluate variable child =
-    runSimplifier Mock.env $ Exists.makeEvaluate Condition.top [variable] child
+    runSimplifier Mock.env
+    $ Exists.makeEvaluate SideCondition.top [variable] child

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -22,7 +22,6 @@ import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.Map as Map
 import qualified Kore.Builtin.Set as Set
 import qualified Kore.Domain.Builtin as Domain
-import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -49,6 +48,9 @@ import Kore.Internal.Predicate
     , makeTruePredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
     ( builtinEvaluation
@@ -1112,7 +1114,8 @@ evaluateWithAxioms
     :: BuiltinAndAxiomSimplifierMap
     -> Pattern Variable
     -> IO (OrPattern Variable)
-evaluateWithAxioms axioms = runSimplifier env . Pattern.simplify Condition.top
+evaluateWithAxioms axioms =
+    runSimplifier env . Pattern.simplify SideCondition.top
   where
     env = Mock.env { simplifierAxioms }
     simplifierAxioms :: BuiltinAndAxiomSimplifierMap

--- a/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
+++ b/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
@@ -26,7 +26,6 @@ import Data.List
 import qualified Data.Map.Strict as Map
 import Debug.Trace
 
-import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -35,6 +34,9 @@ import Kore.Internal.Pattern
     ( Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
     ( simplifierWithFallback
@@ -91,7 +93,7 @@ evaluateWithAxioms
     -> Pattern Variable
     -> SMT.SMT (OrPattern Variable)
 evaluateWithAxioms axioms =
-    Simplification.runSimplifier env . Pattern.simplify Condition.top
+    Simplification.runSimplifier env . Pattern.simplify SideCondition.top
   where
     env = Mock.env { simplifierAxioms }
     simplifierAxioms :: BuiltinAndAxiomSimplifierMap

--- a/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
@@ -12,19 +12,18 @@ import Kore.Internal.OrPattern
     ( OrPattern
     )
 import qualified Kore.Internal.OrPattern as OrPattern
-    ( fromPatterns
-    )
-import qualified Kore.Internal.OrPattern as OrPattern
     ( bottom
+    , fromPatterns
     , top
     )
 import Kore.Internal.Predicate
-    ( makeAndPredicate
+    ( Predicate
+    , makeAndPredicate
     , makeEqualsPredicate_
     , makeTruePredicate_
     )
-import Kore.Internal.Predicate
-    ( Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( assumeTruePredicate
     )
 import Kore.Internal.TermLike
     ( TermLike
@@ -124,4 +123,6 @@ runSimplifyPredicates
     -> IO (OrPattern Variable)
 runSimplifyPredicates predicate orPattern =
     Test.runSimplifier Mock.env
-    $ simplifyConditionsWithSmt predicate orPattern
+    $ simplifyConditionsWithSmt
+        (SideCondition.assumeTruePredicate predicate)
+        orPattern

--- a/kore/test/Test/Kore/Step/Simplification/Pattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Pattern.hs
@@ -5,7 +5,6 @@ module Test.Kore.Step.Simplification.Pattern
 
 import Test.Tasty
 
-import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -15,6 +14,9 @@ import Kore.Internal.Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.Pattern as Pattern
 
@@ -85,7 +87,7 @@ bottomLike =
     (termLike Mock.a) { Pattern.predicate = Predicate.makeFalsePredicate_ }
 
 simplify :: Pattern Variable -> IO (OrPattern Variable)
-simplify = runSimplifier Mock.env . Pattern.simplify Condition.top
+simplify = runSimplifier Mock.env . Pattern.simplify SideCondition.top
 
 simplifyAndRemoveTopExists :: Pattern Variable -> IO (OrPattern Variable)
 simplifyAndRemoveTopExists =

--- a/kore/test/Test/Kore/Step/Simplification/TermLike.hs
+++ b/kore/test/Test/Kore/Step/Simplification/TermLike.hs
@@ -9,9 +9,6 @@ import Control.Monad
     ( void
     )
 
-import Kore.Internal.Condition as Condition
-    ( top
-    )
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -19,6 +16,9 @@ import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
 import qualified Kore.Step.Simplification.TermLike as TermLike
 
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 
@@ -30,7 +30,7 @@ test_simplifyInternal =
 
 simplifyInternalEvaluated :: TermLike Variable -> IO (OrPattern Variable)
 simplifyInternalEvaluated original =
-    runSimplifier env $ TermLike.simplifyInternal original Condition.top
+    runSimplifier env $ TermLike.simplifyInternal original SideCondition.top
   where
     env = Mock.env
         { simplifierTermLike =

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -32,6 +32,10 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    , topTODO
+    )
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Data
     ( Env (..)
@@ -269,7 +273,7 @@ unificationProcedureSuccessWithSimplifiers
             runSMT
             $ runSimplifier mockEnv
             $ Monad.Unify.runUnifierT
-            $ unificationProcedure Condition.topTODO term1 term2
+            $ unificationProcedure SideCondition.topTODO term1 term2
         let
             normalize
                 ::  Condition Variable
@@ -844,7 +848,8 @@ simplifyPattern (UnificationTerm term) = do
     return $ UnificationTerm term'
   where
     simplifier = do
-        simplifiedPatterns <- Pattern.simplify Condition.top expandedPattern
+        simplifiedPatterns <-
+            Pattern.simplify SideCondition.top expandedPattern
         case MultiOr.extractPatterns simplifiedPatterns of
             [] -> return Pattern.bottom
             (config : _) -> return config

--- a/kore/test/Test/Kore/Unification/UnifierT.hs
+++ b/kore/test/Test/Kore/Unification/UnifierT.hs
@@ -22,6 +22,9 @@ import Kore.Internal.MultiOr
 import qualified Kore.Internal.MultiOr as MultiOr
 import qualified Kore.Internal.OrCondition as OrCondition
 import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( top
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Axiom.EvaluationStrategy as EvaluationStrategy
 import qualified Kore.Step.Axiom.Identifier as Axiom.Identifier
@@ -381,7 +384,7 @@ merge s1 s2 =
   where
     mergeSubstitutionsExcept =
         Branch.alternate
-        . Simplifier.simplifyCondition Condition.top
+        . Simplifier.simplifyCondition SideCondition.top
         . Condition.fromSubstitution
         . mconcat
     mockEnv = Mock.env
@@ -389,7 +392,7 @@ merge s1 s2 =
 normalize :: Conditional Variable term -> IO [Conditional Variable term]
 normalize =
     Test.runSimplifierBranch mockEnv
-    . Condition.simplifyCondition Condition.top
+    . Condition.simplifyCondition SideCondition.top
   where
     mockEnv = Mock.env
 
@@ -405,7 +408,7 @@ normalizeExcept predicated =
     $ Test.runSimplifier mockEnv
     $ Monad.Unify.runUnifierT
     $ Branch.alternate
-    $ Simplifier.simplifyCondition Condition.top predicated
+    $ Simplifier.simplifyCondition SideCondition.top predicated
   where
     mockEnv = Mock.env { simplifierAxioms }
     simplifierAxioms =


### PR DESCRIPTION
This PR is mostly a refactoring which attempts to make the code more readable and safer. The current code uses many distinct names for the side condition, and places it randomly in function argument lists.

While this PR does not solve the random placement, it uses the same name everywhere (hopefully a more descriptive one) and wraps the condition is a newtype, which makes it obvious, say, which argument is the side condition and which is the condition being simplified.

This made it possible to discover some issues in the various `makeAnd` implementations we use for unification.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
