### PR TITLE
Fixed no-helpers found bug

### DIFF
--- a/test/include.mk
+++ b/test/include.mk
@@ -125,7 +125,7 @@ PATTERN_OPTS = --pattern "$$(cat $*.k)"
 
 ### SCRIPTS
 
-test-%.sh.out: $(KORE_EXEC) $(TEST_DIR)/test-%.sh $(TEST_DIR)/test-%-*
+test-%.sh.out: $(KORE_EXEC) $(TEST_DIR)/test-%.sh
 	@echo ">>>" $(CURDIR) $(@:.out=)
 	rm -f $@
 	$(TEST_DIR)/$(@:.out=) > $@ || true

--- a/test/regression-evm-semantics-39dd1e5/Makefile
+++ b/test/regression-evm-semantics-39dd1e5/Makefile
@@ -1,1 +1,3 @@
 include $(CURDIR)/../include.mk
+
+test-%.sh.out: $(TEST_DIR)/test-%-*

--- a/test/regression-wasm-semantics-840390f/Makefile
+++ b/test/regression-wasm-semantics-840390f/Makefile
@@ -1,1 +1,3 @@
 include $(CURDIR)/../include.mk
+
+test-%.sh.out: $(TEST_DIR)/test-%-*


### PR DESCRIPTION
@andreiburdusa  and I looked earlier over an issue where a `test-...-.sh.out` rule was not firing.

Andrei had to leave but I managed to find the issue in the fact that the dependency rule `$(TEST_DIR)/test-%-*` was requiring that at least one file matching that pattern exists.

Assuming we don't always want to provide such a file, I've modified the rule to usa a `wildcard` (and had to enable [Make Secondary Expansion](https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html).

@andreiburdusa : I hope that works.

What also confused us was the default rule of `make a.out` to copy `a` to `a.out` which was being used since matching our rule didn't work...

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
