### PR TITLE
Simplifiers should set the simplified bit only on patterns created in…

### DIFF
--- a/kore/src/Kore/Step/Simplification/Not.hs
+++ b/kore/src/Kore/Step/Simplification/Not.hs
@@ -103,7 +103,8 @@ simplifyEvaluatedPredicate
 simplifyEvaluatedPredicate notChild =
     fmap OrCondition.fromConditions $ gather $ do
         let not' = Not { notChild = notChild, notSort = () }
-        andPredicate <- scatterAnd (makeEvaluateNotPredicate <$> distributeNot not')
+        andPredicate <-
+            scatterAnd (makeEvaluateNotPredicate <$> distributeNot not')
         mkMultiAndPredicate andPredicate
 
 {-|'makeEvaluate' simplifies a 'Not' pattern given its 'Pattern'
@@ -123,7 +124,7 @@ makeEvaluateNot
     -> OrPattern variable
 makeEvaluateNot Not { notChild } =
     MultiOr.merge
-        (Pattern.fromTermLike . TermLike.markSimplified <$> makeTermNot term)
+        (Pattern.fromTermLike <$> makeTermNot term)
         (MultiOr.singleton $ Pattern.fromConditionSorted
             (termLikeSort term)
             (makeEvaluatePredicate predicate)
@@ -181,7 +182,7 @@ makeTermNot (And_ _ term1 term2) =
 makeTermNot term
   | isBottom term = MultiOr.singleton mkTop_
   | isTop term    = MultiOr.singleton mkBottom_
-  | otherwise     = MultiOr.singleton $ mkNot term
+  | otherwise     = MultiOr.singleton $ TermLike.markSimplified $ mkNot term
 
 {- | Distribute 'Not' over 'MultiOr' using de Morgan's identity.
  -}


### PR DESCRIPTION
…side.

This may seem pedantic and useless right now, but it actually makes a difference in the PR which disables branching for functions.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
