### PR TITLE
Stop using side conditions for substitutions

### DIFF
--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -145,7 +145,7 @@ evalKEq true (valid :< app) =
 
         defined1 <- Ceil.makeEvaluate sideCondition pattern1
         defined2 <- Ceil.makeEvaluate sideCondition pattern2
-        defined <- And.simplifyEvaluated sideCondition defined1 defined2
+        defined <- And.simplifyEvaluated defined1 defined2
 
         equalTerms <-
             Equals.makeEvaluateTermsToPredicate
@@ -160,7 +160,7 @@ evalKEq true (valid :< app) =
             falsePatterns = Pattern.withCondition falseTerm <$> notEqualTerms
 
         let undefinedResults = Or.simplifyEvaluated truePatterns falsePatterns
-        results <- And.simplifyEvaluated sideCondition defined undefinedResults
+        results <- And.simplifyEvaluated defined undefinedResults
         pure $ Applied AttemptedAxiomResults
             { results
             , remainders = OrPattern.bottom

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -161,7 +161,6 @@ ceilChildOfApplicationOrTop sideCondition patt =
             ceil <-
                 traverse (Ceil.makeEvaluateTerm sideCondition) children
                 >>= ( AndPredicates.simplifyEvaluatedMultiPredicate
-                        sideCondition
                     . MultiAnd.make
                     )
             pure Conditional

--- a/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -37,9 +37,6 @@ import Kore.Internal.OrCondition
 import Kore.Internal.Pattern
     ( Condition
     )
-import Kore.Internal.SideCondition
-    ( SideCondition
-    )
 import Kore.Step.Simplification.Simplify
     ( MonadSimplify
     , SimplifierVariable
@@ -49,10 +46,9 @@ import qualified Kore.Step.Substitution as Substitution
 simplifyEvaluatedMultiPredicate
     :: forall variable simplifier
     .  (SimplifierVariable variable, MonadSimplify simplifier)
-    => SideCondition variable
-    -> MultiAnd (OrCondition variable)
+    => MultiAnd (OrCondition variable)
     -> simplifier (OrCondition variable)
-simplifyEvaluatedMultiPredicate sideCondition predicates = do
+simplifyEvaluatedMultiPredicate predicates = do
     let
         crossProduct :: MultiOr [Condition variable]
         crossProduct =
@@ -65,8 +61,7 @@ simplifyEvaluatedMultiPredicate sideCondition predicates = do
         :: [Condition variable]
         -> BranchT simplifier (Condition variable)
     andConditions predicates' =
-        fmap markSimplified
-        $ Substitution.normalize sideCondition (Foldable.fold predicates')
+        fmap markSimplified $ Substitution.normalize (Foldable.fold predicates')
       where
         markSimplified =
             Condition.setPredicateSimplified

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -139,7 +139,6 @@ makeEvaluateNonBoolCeil sideCondition patt@Conditional {term}
     termCeil <- makeEvaluateTerm sideCondition term
     result <-
         And.simplifyEvaluatedMultiPredicate
-            sideCondition
             (MultiAnd.make
                 [ MultiOr.make [Condition.eraseConditionalTerm patt]
                 , termCeil
@@ -178,9 +177,7 @@ makeEvaluateTerm
             let Application { applicationChildren = children } = app
             simplifiedChildren <- mapM (makeEvaluateTerm sideCondition) children
             let ceils = simplifiedChildren
-            And.simplifyEvaluatedMultiPredicate
-                sideCondition
-                (MultiAnd.make ceils)
+            And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
 
       | BuiltinF child <- projected =
         fromMaybe
@@ -253,7 +250,7 @@ makeEvaluateBuiltin sideCondition (Domain.BuiltinList l) = Just $ do
     let
         ceils :: [OrCondition variable]
         ceils = children
-    And.simplifyEvaluatedMultiPredicate sideCondition (MultiAnd.make ceils)
+    And.simplifyEvaluatedMultiPredicate (MultiAnd.make ceils)
 makeEvaluateBuiltin
     sideCondition
     (Domain.BuiltinSet Domain.InternalAc
@@ -302,7 +299,6 @@ makeEvaluateNormalizedAc
             ++ variableKeyConditions
             ++ elementsWithVariablesDistinct
     And.simplifyEvaluatedMultiPredicate
-        sideCondition
         (MultiAnd.make allConditions)
   where
     concreteElementsList

--- a/kore/src/Kore/Step/Simplification/Condition.hs
+++ b/kore/src/Kore/Step/Simplification/Condition.hs
@@ -93,8 +93,7 @@ simplify SubstitutionSimplifier { simplifySubstitution } sideCondition initial =
         ->  BranchT simplifier (Conditional variable any')
     normalize conditional@Conditional { substitution } = do
         let conditional' = conditional { substitution = mempty }
-        predicates' <- Monad.Trans.lift $
-            simplifySubstitution sideCondition substitution
+        predicates' <- Monad.Trans.lift $ simplifySubstitution substitution
         predicate' <- Branch.scatter predicates'
         return $ Conditional.andCondition conditional' predicate'
 

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -219,7 +219,6 @@ makeEvaluate sideCondition variables original = do
                         , Conditional.substitution = freeSubstitution
                         }
                     else makeEvaluateBoundRight
-                        sideCondition
                         variable
                         freeSubstitution
                         normalized
@@ -340,14 +339,12 @@ See also: 'quantifyPattern'
 makeEvaluateBoundRight
     :: forall variable simplifier
     . (SimplifierVariable variable, MonadSimplify simplifier)
-    => SideCondition variable
-    -> ElementVariable variable  -- ^ variable to be quantified
+    => ElementVariable variable  -- ^ variable to be quantified
     -> Substitution variable  -- ^ free substitution
     -> Pattern variable  -- ^ pattern to quantify
     -> BranchT simplifier (Pattern variable)
-makeEvaluateBoundRight sideCondition variable freeSubstitution normalized = do
+makeEvaluateBoundRight variable freeSubstitution normalized = do
     orCondition <- Monad.Trans.lift $ And.simplifyEvaluatedMultiPredicate
-        sideCondition
         (MultiAnd.make
             [   OrCondition.fromCondition quantifyCondition
             ,   OrCondition.fromCondition

--- a/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/kore/src/Kore/Step/Simplification/Iff.hs
@@ -20,9 +20,6 @@ import Kore.Internal.OrPattern
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition
-    ( SideCondition
-    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
@@ -42,11 +39,10 @@ and for children with top terms.
 -}
 simplify
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => SideCondition variable
-    -> Iff Sort (OrPattern variable)
+    => Iff Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
-simplify sideCondition Iff { iffFirst = first, iffSecond = second } =
-    simplifyEvaluated sideCondition first second
+simplify Iff { iffFirst = first, iffSecond = second } =
+    simplifyEvaluated first second
 
 {-| evaluates an 'Iff' given its two 'OrPattern' children.
 
@@ -67,18 +63,16 @@ carry around.
 -}
 simplifyEvaluated
     :: (SimplifierVariable variable, MonadSimplify simplifier)
-    => SideCondition variable
-    -> OrPattern variable
+    => OrPattern variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
 simplifyEvaluated
-    sideCondition
     first
     second
   | OrPattern.isTrue first   = return second
-  | OrPattern.isFalse first  = Not.simplifyEvaluated sideCondition second
+  | OrPattern.isFalse first  = Not.simplifyEvaluated second
   | OrPattern.isTrue second  = return first
-  | OrPattern.isFalse second = Not.simplifyEvaluated sideCondition first
+  | OrPattern.isFalse second = Not.simplifyEvaluated first
   | otherwise =
     return $ case ( firstPatterns, secondPatterns ) of
         ([firstP], [secondP]) -> makeEvaluate firstP secondP

--- a/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -121,8 +121,7 @@ newtype SubstitutionSimplifier simplifier =
         { simplifySubstitution
             :: forall variable
             .  SubstitutionVariable variable
-            => SideCondition variable
-            -> Substitution variable
+            => Substitution variable
             -> simplifier (OrCondition variable)
         }
 
@@ -143,10 +142,9 @@ substitutionSimplifier =
     wrapper
         :: forall variable
         .  SubstitutionVariable variable
-        => SideCondition variable
-        -> Substitution variable
+        => Substitution variable
         -> simplifier (OrCondition variable)
-    wrapper sideCondition substitution =
+    wrapper substitution =
         fmap OrCondition.fromConditions . Branch.gather $ do
             (predicate, result) <- worker substitution & maybeT empty return
             let condition = Condition.fromNormalizationSimplified result
@@ -154,7 +152,8 @@ substitutionSimplifier =
             TopBottom.guardAgainstBottom condition'
             return condition'
       where
-        worker = simplifySubstitutionWorker sideCondition simplifierMakeAnd
+        worker =
+            simplifySubstitutionWorker SideCondition.topTODO simplifierMakeAnd
 
 -- * Implementation
 

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -382,7 +382,7 @@ simplifyInternal term sideCondition = do
             SignednessF _ -> doNotSimplify
             --
             AndF andF ->
-                And.simplify sideCondition =<< simplifyChildren andF
+                And.simplify =<< simplifyChildren andF
             ApplySymbolF applySymbolF ->
                 Application.simplify sideCondition
                     =<< simplifyChildren applySymbolF
@@ -400,13 +400,13 @@ simplifyInternal term sideCondition = do
                             exists
                 in  Exists.simplify sideCondition =<< simplifyChildren fresh
             IffF iffF ->
-                Iff.simplify sideCondition =<< simplifyChildren iffF
+                Iff.simplify =<< simplifyChildren iffF
             ImpliesF impliesF ->
-                Implies.simplify sideCondition =<< simplifyChildren impliesF
+                Implies.simplify =<< simplifyChildren impliesF
             InF inF ->
                 In.simplify sideCondition =<< simplifyChildren inF
             NotF notF ->
-                Not.simplify sideCondition =<< simplifyChildren notF
+                Not.simplify =<< simplifyChildren notF
             --
             BottomF bottomF ->
                 Bottom.simplify <$> simplifyChildren bottomF

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -44,12 +44,11 @@ import Kore.Unification.Unify
 normalize
     :: forall variable term simplifier
     .  (SimplifierVariable variable, MonadSimplify simplifier)
-    => SideCondition variable
-    -> Conditional variable term
+    => Conditional variable term
     -> BranchT simplifier (Conditional variable term)
-normalize sideCondition conditional@Conditional { substitution } = do
+normalize conditional@Conditional { substitution } = do
     results <- Monad.Trans.lift $
-        simplifySubstitution sideCondition substitution
+        simplifySubstitution substitution
     scatter (applyTermPredicate <$> results)
   where
     applyTermPredicate =

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -30,8 +30,8 @@ import Kore.Internal.OrCondition
     ( OrCondition
     )
 import qualified Kore.Internal.OrCondition as OrCondition
-import Kore.Internal.SideCondition
-    ( SideCondition
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
     )
 import Kore.Internal.Substitution
     ( Normalization (..)
@@ -70,10 +70,9 @@ substitutionSimplifier =
     wrapper
         :: forall variable
         .  SubstitutionVariable variable
-        => SideCondition variable
-        -> Substitution variable
+        => Substitution variable
         -> unifier (OrCondition variable)
-    wrapper sideCondition substitution = do
+    wrapper substitution = do
         (predicate, result) <- worker substitution & maybeT empty return
         condition <- fromNormalization result
         let condition' = Condition.fromPredicate predicate <> condition
@@ -81,7 +80,8 @@ substitutionSimplifier =
         TopBottom.guardAgainstBottom conditions
         return conditions
       where
-        worker = simplifySubstitutionWorker sideCondition unificationMakeAnd
+        worker =
+            simplifySubstitutionWorker SideCondition.topTODO unificationMakeAnd
 
     fromNormalization
         :: SimplifierVariable variable

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -22,9 +22,6 @@ import Kore.Internal.Predicate
     , makeTruePredicate
     , makeTruePredicate_
     )
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.And
@@ -455,7 +452,7 @@ findSort [] = testSort
 findSort ( Conditional {term} : _ ) = termLikeSort term
 
 evaluate :: And Sort (OrPattern Variable) -> IO (OrPattern Variable)
-evaluate = runSimplifier Mock.env . simplify SideCondition.top
+evaluate = runSimplifier Mock.env . simplify
 
 evaluatePatterns
     :: Pattern Variable
@@ -464,4 +461,4 @@ evaluatePatterns
 evaluatePatterns first second =
     fmap OrPattern.fromPatterns
     $ runSimplifierBranch Mock.env
-    $ makeEvaluate SideCondition.top first second
+    $ makeEvaluate first second

--- a/kore/test/Test/Kore/Step/Simplification/Iff.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Iff.hs
@@ -19,9 +19,6 @@ import Kore.Internal.Predicate
     , makeIffPredicate
     , makeTruePredicate
     )
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.Iff as Iff
@@ -204,7 +201,7 @@ simplify
     -> IO (OrPattern Variable)
 simplify =
     runSimplifier mockEnv
-    . Iff.simplify SideCondition.top
+    . Iff.simplify
     . fmap simplifiedOrPattern
   where
     mockEnv = Mock.env

--- a/kore/test/Test/Kore/Step/Simplification/Implies.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Implies.hs
@@ -29,9 +29,6 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.Implies as Implies
 
@@ -146,6 +143,6 @@ simplifyEvaluated
     -> IO (OrPattern Variable)
 simplifyEvaluated first second =
     runSimplifier mockEnv
-    $ Implies.simplifyEvaluated SideCondition.top first second
+    $ Implies.simplifyEvaluated first second
   where
     mockEnv = Mock.env

--- a/kore/test/Test/Kore/Step/Simplification/Not.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Not.hs
@@ -26,9 +26,6 @@ import Kore.Internal.Predicate
     ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.Not as Not
@@ -178,6 +175,6 @@ simplifyEvaluated
     :: OrPattern Variable
     -> IO (OrPattern Variable)
 simplifyEvaluated =
-    runSimplifier mockEnv . Not.simplifyEvaluated SideCondition.top
+    runSimplifier mockEnv . Not.simplifyEvaluated
   where
     mockEnv = Mock.env

--- a/kore/test/Test/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/test/Test/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -10,9 +10,6 @@ import qualified GHC.Stack as GHC
 
 import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.OrCondition as OrCondition
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.SubstitutionSimplifier
@@ -192,7 +189,7 @@ test_SubstitutionSimplifier =
                 let SubstitutionSimplifier { simplifySubstitution } =
                         Simplification.substitutionSimplifier
                 actual <- runSimplifier Mock.env
-                    $ simplifySubstitution SideCondition.top input
+                    $ simplifySubstitution input
                 let expect = Condition.fromNormalizationSimplified <$> results
                     actualConditions = OrCondition.toConditions actual
                     actualSubstitutions =
@@ -207,7 +204,7 @@ test_SubstitutionSimplifier =
                         Unification.substitutionSimplifier
                 actual <-
                     runSimplifier Mock.env . runUnifierT
-                    $ simplifySubstitution SideCondition.top input
+                    $ simplifySubstitution input
                 let expect1 normalization@Normalization { denormalized }
                       | null denormalized =
                         Right $


### PR DESCRIPTION
Probably it's not worth the trouble, but this seems to somewhat improve the run time for `test/regression-evm-semantics-39dd1e5/test-sum-to-n.sh` by ~5%

Without this PR:
455.71user 30.96system 4:50.48elapsed 167%CPU (0avgtext+0avgdata 1243420maxresident)k
0inputs+0outputs (0major+340944minor)pagefaults 0swaps

With this PR:
434.27user 30.46system 4:36.44elapsed 168%CPU (0avgtext+0avgdata 1250492maxresident)k
0inputs+0outputs (0major+342744minor)pagefaults 0swaps


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
