### PR TITLE
Absolutely no branching during equality evaluation

### DIFF
--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -22,6 +22,7 @@ module Kore.Internal.Conditional
     , markPredicateSimplified
     , markPredicateSimplifiedConditional
     , setPredicateSimplified
+    , assertNormalized
     ) where
 
 import Prelude.Kore
@@ -32,6 +33,7 @@ import Control.Comonad
 import Control.DeepSeq
     ( NFData
     )
+import qualified Control.Exception as Exception
 import Data.Hashable
 import Data.Monoid
     ( (<>)
@@ -486,3 +488,16 @@ setPredicateSimplified
     -> Conditional variable term
 setPredicateSimplified simplified conditional@Conditional { predicate } =
     conditional { predicate = Predicate.setSimplified simplified predicate }
+
+assertNormalized
+    :: HasCallStack
+    => Ord variable
+    => Conditional variable term
+    -> a -> a
+assertNormalized Conditional { predicate, substitution } a =
+    Exception.assert normalizedSubstitution
+    $ Exception.assert irrelevantSubstitution a
+  where
+    normalizedSubstitution = Substitution.isNormalized substitution
+    irrelevantSubstitution =
+        Predicate.isFreeOf predicate (Substitution.variables substitution)

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -8,6 +8,7 @@ module Kore.Internal.OrPattern
     , coerceSort
     , isSimplified
     , fromPatterns
+    , gatherPatterns
     , toPatterns
     , fromPattern
     , fromTermLike
@@ -30,6 +31,7 @@ import qualified Data.Foldable as Foldable
 import Branch
     ( BranchT
     )
+import qualified Branch
 import Kore.Internal.Condition
     ( Condition
     )
@@ -76,6 +78,15 @@ fromPatterns
     => f (Pattern variable)
     -> OrPattern variable
 fromPatterns = from . Foldable.toList
+
+{- | 'Branch.gather' many branches into a single disjunction.
+ -}
+gatherPatterns
+    :: Monad monad
+    => Ord variable
+    => BranchT monad (Pattern variable)
+    -> monad (OrPattern variable)
+gatherPatterns = fmap fromPatterns . Branch.gather
 
 {- | Examine a disjunction of 'Pattern.Pattern's.
  -}

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -8,6 +8,7 @@ License     : NCSA
 
 module Kore.Internal.SideCondition
     ( SideCondition  -- Constructor not exported on purpose
+    , assumedTrue
     , andCondition
     , assumeTrueCondition
     , assumeTruePredicate

--- a/kore/src/Kore/Log/DebugAppliedRule.hs
+++ b/kore/src/Kore/Log/DebugAppliedRule.hs
@@ -42,7 +42,7 @@ import Kore.Step.Axiom.Identifier
     )
 import qualified Kore.Step.Axiom.Identifier as Axiom.Identifier
 import Kore.Step.EqualityPattern
-    ( EqualityPattern
+    ( EqualityRule
     )
 import qualified Kore.Step.EqualityPattern as Equality
 import qualified Kore.Step.Step as Equality
@@ -67,7 +67,7 @@ We will log the applied rule and its unification or matching condition.
 
  -}
 newtype DebugAppliedRule =
-    DebugAppliedRule { appliedRule :: Unified (EqualityPattern Variable) }
+    DebugAppliedRule { appliedRule :: Unified (EqualityRule Variable) }
     deriving (Eq)
     deriving (GHC.Generic)
 
@@ -98,7 +98,7 @@ instance SQL.Table DebugAppliedRule
 debugAppliedRule
     :: MonadLog log
     => InternalVariable variable
-    => Conditional variable (EqualityPattern variable)
+    => Conditional variable (EqualityRule variable)
     -> log ()
 debugAppliedRule =
     logEntry
@@ -151,7 +151,7 @@ filterDebugAppliedRule debugAppliedRuleOptions entry
 
 isSelectedRule
     :: DebugAppliedRuleOptions
-    -> Unified (EqualityPattern Variable)
+    -> Unified (EqualityRule Variable)
     -> Bool
 isSelectedRule debugAppliedRuleOptions =
     maybe False (`Set.member` debugAppliedRules) . appliedRuleId

--- a/kore/src/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/src/Kore/Step/Axiom/Evaluate.hs
@@ -44,12 +44,9 @@ import Kore.Step.Axiom.Identifier
     ( matchAxiomIdentifier
     )
 import Kore.Step.EqualityPattern
-    ( EqualityPattern (EqualityPattern)
-    , EqualityRule (..)
+    ( EqualityRule (..)
     )
-import qualified Kore.Step.EqualityPattern as EqualityPattern
-    ( EqualityPattern (..)
-    )
+import qualified Kore.Step.EqualityPattern as EqualityRule
 import qualified Kore.Step.EquationalStep as Step
 import Kore.Step.Remainder
     ( ceilChildOfApplicationOrTop
@@ -77,7 +74,7 @@ evaluateAxioms
     => [EqualityRule Variable]
     -> SideCondition variable
     -> TermLike variable
-    -> simplifier (Step.Results EqualityPattern variable)
+    -> simplifier (Step.Results EqualityRule variable)
 evaluateAxioms equalityRules sideCondition termLike
   | any ruleIsConcrete equalityRules
   -- All of the current pattern's children (most likely an ApplicationF)
@@ -130,7 +127,7 @@ evaluateAxioms equalityRules sideCondition termLike
 
     logAppliedRule :: MonadLog log => EqualityRule Variable -> log ()
     logAppliedRule
-        (EqualityRule EqualityPattern
+        (EqualityRule
             {left, attributes = Attribute.Axiom {sourceLocation}}
         )
       =
@@ -142,8 +139,7 @@ evaluateAxioms equalityRules sideCondition termLike
     ruleIsConcrete =
         Attribute.Axiom.Concrete.isConcrete
         . Attribute.Axiom.concrete
-        . EqualityPattern.attributes
-        . getEqualityRule
+        . EqualityRule.attributes
 
     notApplicable =
         Result.Results
@@ -153,11 +149,10 @@ evaluateAxioms equalityRules sideCondition termLike
 
     maybeNotApplicable = maybeT (return notApplicable) return
 
-    unwrapEqualityRule (EqualityRule rule) =
+    unwrapEqualityRule =
         EqualityPattern.mapRuleVariables
             (fmap fromVariable)
             (fmap fromVariable)
-            rule
 
     rejectNarrowing (Result.results -> results) =
         (Monad.guard . not) (any Step.isNarrowingResult results)

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -179,7 +179,8 @@ matchIncremental termLike1 termLike2 =
                 $ MultiAnd.toPredicate predicate
             substitution' =
                 Condition.fromSubstitution
-                $ Substitution.fromMap substitution
+                $ Substitution.unsafeWrap
+                $ Map.toList substitution
             solution = predicate' <> substitution'
         return solution
 

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -51,8 +51,7 @@ import Kore.Step.Axiom.Identifier
     )
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import Kore.Step.EqualityPattern
-    ( EqualityPattern (..)
-    , EqualityRule (EqualityRule)
+    ( EqualityRule (..)
     , getPriorityOfRule
     , isSimplificationRule
     )
@@ -117,7 +116,7 @@ axiomToIdAxiomPatternPair axiom =
         Left _ -> Nothing
         Right
             (FunctionAxiomPattern
-                axiomPat@(EqualityRule EqualityPattern { left })
+                axiomPat@(EqualityRule { left })
             )
           -> do
             identifier <- AxiomIdentifier.matchAxiomIdentifier left
@@ -193,7 +192,7 @@ axiom.
 
  -}
 ignoreEqualityRule :: EqualityRule Variable -> Bool
-ignoreEqualityRule (EqualityRule EqualityPattern { attributes })
+ignoreEqualityRule (EqualityRule { attributes })
   | isAssoc = True
   | isComm = True
   -- TODO (thomas.tuegel): Add unification cases for builtin units and enable
@@ -212,7 +211,7 @@ ignoreEqualityRule (EqualityRule EqualityPattern { attributes })
 {- | Should we ignore the 'EqualityRule' for evaluating function definitions?
  -}
 ignoreDefinition :: EqualityRule Variable -> Bool
-ignoreDefinition (EqualityRule EqualityPattern { left }) =
+ignoreDefinition (EqualityRule { left }) =
     assert isLeftFunctionLike False
   where
     isLeftFunctionLike =

--- a/kore/src/Kore/Step/EqualityPattern.hs
+++ b/kore/src/Kore/Step/EqualityPattern.hs
@@ -5,8 +5,7 @@ License     : NCSA
 
 -}
 module Kore.Step.EqualityPattern
-    ( EqualityPattern (..)
-    , EqualityRule (..)
+    ( EqualityRule (..)
     , equalityPattern
     , equalityRuleToTerm
     , isSimplificationRule
@@ -43,6 +42,9 @@ import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.Symbol
     ( Symbol (..)
     )
+import Kore.Internal.TermLike
+    ( TermLike
+    )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Internal.Variable
     ( InternalVariable
@@ -54,9 +56,7 @@ import Kore.TopBottom
     ( TopBottom (..)
     )
 import Kore.Unparser
-    ( Unparse
-    , unparse
-    , unparse2
+    ( Unparse (..)
     )
 import qualified Kore.Variables.Fresh as Fresh
 import qualified SQL
@@ -64,7 +64,7 @@ import qualified SQL
 {- | Function axioms
 
  -}
-data EqualityPattern variable = EqualityPattern
+data EqualityRule variable = EqualityRule
     { requires :: !(Predicate variable)
     , left  :: !(TermLike.TermLike variable)
     , right :: !(TermLike.TermLike variable)
@@ -73,72 +73,6 @@ data EqualityPattern variable = EqualityPattern
     }
     deriving (Eq, Ord, Show)
     deriving (GHC.Generic)
-
-instance NFData variable => NFData (EqualityPattern variable)
-
-instance SOP.Generic (EqualityPattern variable)
-
-instance SOP.HasDatatypeInfo (EqualityPattern variable)
-
-instance Debug variable => Debug (EqualityPattern variable)
-
-instance (Debug variable, Diff variable) => Diff (EqualityPattern variable)
-
-instance InternalVariable variable => Pretty (EqualityPattern variable) where
-    pretty rulePattern'@(EqualityPattern _ _ _ _ _) =
-        Pretty.vsep
-            [ "requires:"
-            , Pretty.indent 4 (unparse requires)
-            , "left:"
-            , Pretty.indent 4 (unparse left)
-            , "right:"
-            , Pretty.indent 4 (unparse right)
-            , "ensures:"
-            , Pretty.indent 4 (unparse ensures)
-            ]
-      where
-        EqualityPattern
-            { requires
-            , left
-            , right
-            , ensures
-            } = rulePattern'
-
-instance TopBottom (EqualityPattern variable) where
-    isTop _ = False
-    isBottom _ = False
-
-instance
-    (InternalVariable variable, Typeable variable)
-    => SQL.Table (EqualityPattern variable)
-
-instance
-    (InternalVariable variable, Typeable variable)
-    => SQL.Column (EqualityPattern variable)
-  where
-    defineColumn = SQL.defineForeignKeyColumn
-    toColumn = SQL.toForeignKeyColumn
-
--- | Creates a basic, unconstrained, Equality pattern
-equalityPattern
-    :: InternalVariable variable
-    => TermLike.TermLike variable
-    -> TermLike.TermLike variable
-    -> EqualityPattern variable
-equalityPattern left right =
-    EqualityPattern
-        { left
-        , requires = Predicate.makeTruePredicate_
-        , right
-        , ensures = Predicate.makeTruePredicate_
-        , attributes = Default.def
-        }
-
-{-  | Equality-based rule pattern.
--}
-newtype EqualityRule variable =
-    EqualityRule { getEqualityRule :: EqualityPattern variable }
-    deriving (Eq, GHC.Generic, Ord, Show)
 
 instance NFData variable => NFData (EqualityRule variable)
 
@@ -150,58 +84,100 @@ instance Debug variable => Debug (EqualityRule variable)
 
 instance (Debug variable, Diff variable) => Diff (EqualityRule variable)
 
+instance InternalVariable variable => Unparse (EqualityRule variable) where
+    unparse = unparse . from @_ @(TermLike variable)
+    unparse2 = unparse2 . from @_ @(TermLike variable)
+
+instance InternalVariable variable => Pretty (EqualityRule variable) where
+    pretty rulePattern'@(EqualityRule _ _ _ _ _) =
+        Pretty.vsep
+            [ "requires:"
+            , Pretty.indent 4 (unparse requires)
+            , "left:"
+            , Pretty.indent 4 (unparse left)
+            , "right:"
+            , Pretty.indent 4 (unparse right)
+            , "ensures:"
+            , Pretty.indent 4 (unparse ensures)
+            ]
+      where
+        EqualityRule
+            { requires
+            , left
+            , right
+            , ensures
+            } = rulePattern'
+
+instance TopBottom (EqualityRule variable) where
+    isTop _ = False
+    isBottom _ = False
+
+instance
+    (InternalVariable variable, Typeable variable)
+    => SQL.Table (EqualityRule variable)
+
+instance
+    (InternalVariable variable, Typeable variable)
+    => SQL.Column (EqualityRule variable)
+  where
+    defineColumn = SQL.defineForeignKeyColumn
+    toColumn = SQL.toForeignKeyColumn
+
+-- | Creates a basic, unconstrained, Equality pattern
+equalityPattern
+    :: InternalVariable variable
+    => TermLike.TermLike variable
+    -> TermLike.TermLike variable
+    -> EqualityRule variable
+equalityPattern left right =
+    EqualityRule
+        { left
+        , requires = Predicate.makeTruePredicate_
+        , right
+        , ensures = Predicate.makeTruePredicate_
+        , attributes = Default.def
+        }
+
 instance
     InternalVariable variable
-    => Unparse (EqualityRule variable)
+    => From (EqualityRule variable) (TermLike variable)
   where
-    unparse = unparse . equalityRuleToTerm
-    unparse2 = unparse2 . equalityRuleToTerm
+    from equalityRule@(EqualityRule _ _ _ _ _)
+      | Predicate.PredicateTrue <- requires
+      , Predicate.PredicateTrue <- ensures
+      , TermLike.Ceil_ _ resultSort1 _ <- left
+      , TermLike.Top_ resultSort2 <- right
+      , resultSort1 == resultSort2
+      = left
 
+      | Predicate.PredicateTrue <- requires
+      , Predicate.PredicateTrue <- ensures
+      = TermLike.mkEquals_ left right
 
-{-| Reverses an 'EqualityRule' back into its 'Pattern' representation.
-  Should be the inverse of 'Rule.termToAxiomPattern'.
+      | otherwise =
+        TermLike.mkImplies
+            (Predicate.unwrapPredicate requires)
+            (TermLike.mkAnd
+                (TermLike.mkEquals_ left right)
+                (Predicate.unwrapPredicate ensures)
+            )
+
+      where
+        EqualityRule { left, requires, right, ensures } = equalityRule
+
+{- | Reverses an 'EqualityRule' back into its 'Pattern' representation.
+
+The inverse of 'Rule.termToAxiomPattern'.
+
 -}
 equalityRuleToTerm
     :: InternalVariable variable
     => EqualityRule variable
     -> TermLike.TermLike variable
-equalityRuleToTerm
-     (EqualityRule
-        (EqualityPattern
-            Predicate.PredicateTrue
-            left@(TermLike.Ceil_ _ resultSort1 _)
-            (TermLike.Top_ resultSort2)
-            Predicate.PredicateTrue
-            _
-        )
-    )
-  | resultSort1 == resultSort2 = left
+equalityRuleToTerm = from
 
-equalityRuleToTerm
-    (EqualityRule
-        (EqualityPattern
-            Predicate.PredicateTrue
-            left
-            right
-            Predicate.PredicateTrue
-            _
-        )
-    )
-  =
-    TermLike.mkEquals_ left right
-
-equalityRuleToTerm
-    (EqualityRule (EqualityPattern requires left right ensures _))
-  =
-    TermLike.mkImplies
-        (Predicate.unwrapPredicate requires)
-        (TermLike.mkAnd
-            (TermLike.mkEquals_ left right)
-            (Predicate.unwrapPredicate ensures)
-        )
-
-instance UnifyingRule EqualityPattern where
-    mapRuleVariables mapElemVar mapSetVar rule1@(EqualityPattern _ _ _ _ _) =
+instance UnifyingRule EqualityRule where
+    mapRuleVariables mapElemVar mapSetVar rule1@(EqualityRule _ _ _ _ _) =
         rule1
             { requires = mapPredicateVariables requires
             , left = mapTermLikeVariables left
@@ -209,7 +185,7 @@ instance UnifyingRule EqualityPattern where
             , ensures = mapPredicateVariables ensures
             }
       where
-        EqualityPattern { requires, left, right, ensures } = rule1
+        EqualityRule { requires, left, right, ensures } = rule1
         mapTermLikeVariables = TermLike.mapVariables mapElemVar mapSetVar
         mapPredicateVariables = Predicate.mapVariables mapElemVar mapSetVar
 
@@ -219,7 +195,7 @@ instance UnifyingRule EqualityPattern where
 
     refreshRule
         (FreeVariables.getFreeVariables -> avoid)
-        rule1@(EqualityPattern _ _ _ _ _)
+        rule1@(EqualityRule _ _ _ _ _)
       =
         let rename = Fresh.refreshVariables avoid originalFreeVariables
             subst = TermLike.mkVar <$> rename
@@ -236,31 +212,31 @@ instance UnifyingRule EqualityPattern where
                     }
         in (rename, rule2)
       where
-        EqualityPattern { left, requires, right, ensures } = rule1
+        EqualityRule { left, requires, right, ensures } = rule1
         originalFreeVariables =
             FreeVariables.getFreeVariables
             $ freeVariables rule1
 
 instance
     InternalVariable variable
-    => HasFreeVariables (EqualityPattern variable) variable
+    => HasFreeVariables (EqualityRule variable) variable
   where
-    freeVariables rule@(EqualityPattern _ _ _ _ _) = case rule of
-        EqualityPattern { left, requires, right, ensures } ->
+    freeVariables rule@(EqualityRule _ _ _ _ _) = case rule of
+        EqualityRule { left, requires, right, ensures } ->
             freeVariables left
             <> freeVariables requires
             <> freeVariables right
             <> freeVariables ensures
 
 isSimplificationRule :: EqualityRule variable -> Bool
-isSimplificationRule (EqualityRule EqualityPattern { attributes }) =
+isSimplificationRule EqualityRule { attributes } =
     isSimplification
   where
     Attribute.Simplification { isSimplification } =
         Attribute.simplification attributes
 
 getPriorityOfRule :: EqualityRule variable -> Integer
-getPriorityOfRule (EqualityRule EqualityPattern { attributes }) =
+getPriorityOfRule EqualityRule { attributes } =
     if isOwise
         then 200
         else fromMaybe 100 getPriority

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -341,11 +341,14 @@ guardImplies sideCondition solution requires1 = do
                 Condition.fromPredicate
                 $ Predicate.makeNotPredicate
                 $ Predicate.makeAndPredicate requires1 requires2
+            -- The substitution does not go under the negation: if the
+            -- implication holds only under the negation of the substitution,
+            -- then we say the rule does not apply.
             instantiation = Condition.fromSubstitution substitution
         simplified <-
             Simplifier.simplifyCondition sideCondition
-            $ instantiation <> notRequires
-        evaluated <- SMT.Evaluator.evaluate (withSideCondition simplified)
+            $ withSideCondition $ instantiation <> notRequires
+        evaluated <- SMT.Evaluator.evaluate simplified
         case evaluated of
             Just False -> empty
             _          -> return simplified

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -343,12 +343,23 @@ guardImplies sideCondition initial solution requires1 = do
             $ OrCondition.fromCondition
             $ Condition.andCondition solution
             $ Condition.fromPredicate requires1
+        initialAndRemainder =
+            Condition.andCondition initial
+            $ Condition.fromPredicate remainder
     notRequires <-
         simplifyConditionsWithSmt sideCondition
-        $ OrCondition.fromCondition
-        $ Condition.andCondition initial
-        $ Condition.fromPredicate remainder
-    Monad.guard (isBottom notRequires)
+        $ OrCondition.fromCondition initialAndRemainder
+    let message =
+            Pretty.vsep
+            [ "initialAndRemainder:"
+            , Pretty.indent 4 (unparse initialAndRemainder)
+            , "notRequires:"
+            , (Pretty.indent 4 . Pretty.vsep . map unparse)
+                (OrCondition.toConditions notRequires)
+            ]
+    if isBottom notRequires
+        then return ()
+        else traceShow message empty
 
 isMatchingSubstitution :: Ord variable => Substitution (Target variable) -> Bool
 isMatchingSubstitution =

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -29,8 +29,7 @@ import Data.Text
     )
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
-
-import qualified Branch as BranchT
+import qualified Branch
 import qualified Kore.Attribute.Pattern.Simplified as Attribute.Simplified
 import Kore.Attribute.Synthetic
 import qualified Kore.Internal.MultiOr as MultiOr
@@ -408,7 +407,7 @@ reevaluateFunctions
     -> simplifier (OrPattern variable)
 reevaluateFunctions sideCondition rewriting = do
     let (rewritingTerm, rewritingCondition) = Pattern.splitTerm rewriting
-    orResults <- BranchT.gather $ do
+    orResults <- Branch.gather $ do
         simplifiedTerm <- simplifyConditionalTerm sideCondition rewritingTerm
         simplifyCondition sideCondition
             $ Pattern.andCondition simplifiedTerm rewritingCondition
@@ -440,10 +439,10 @@ mergeWithConditionAndSubstitution
     (AttemptedAxiom.Applied AttemptedAxiomResults { results, remainders })
   = do
     evaluatedResults <- OrPattern.gather $ do
-        result <- BranchT.scatter results
+        result <- Branch.scatter results
         simplifyCondition sideCondition $ Pattern.andCondition result toMerge
     evaluatedRemainders <- OrPattern.gather $ do
-        remainder <- BranchT.scatter remainders
+        remainder <- Branch.scatter remainders
         simplifyCondition sideCondition (Pattern.andCondition remainder toMerge)
     return $ AttemptedAxiom.Applied AttemptedAxiomResults
         { results = evaluatedResults

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -61,8 +61,7 @@ import Kore.Sort
     , SortVariable (SortVariable)
     )
 import Kore.Step.EqualityPattern
-    ( EqualityPattern (..)
-    , EqualityRule (..)
+    ( EqualityRule (..)
     , equalityRuleToTerm
     )
 import Kore.Step.RulePattern
@@ -283,7 +282,7 @@ termToAxiomPattern attributes pat =
             )
           | isTop ensures || ensures == requires
           ->
-            pure $ FunctionAxiomPattern $ EqualityRule EqualityPattern
+            pure $ FunctionAxiomPattern $ EqualityRule
                 { requires = Predicate.wrapPredicate requires
                 , left
                 , right
@@ -297,7 +296,7 @@ termToAxiomPattern attributes pat =
                 ensures
             )
           ->
-            pure $ FunctionAxiomPattern $ EqualityRule EqualityPattern
+            pure $ FunctionAxiomPattern $ EqualityRule
                 { requires = Predicate.wrapPredicate requires
                 , left
                 , right
@@ -307,7 +306,7 @@ termToAxiomPattern attributes pat =
 
         -- function axioms: trivial pre- and post-conditions
         TermLike.Equals_ _ _ left right ->
-            pure $ FunctionAxiomPattern $ EqualityRule EqualityPattern
+            pure $ FunctionAxiomPattern $ EqualityRule
                 { requires = Predicate.makeTruePredicate_
                 , left
                 , right
@@ -316,7 +315,7 @@ termToAxiomPattern attributes pat =
                 }
         -- definedness axioms
         left@(TermLike.Ceil_ _ resultSort _) ->
-            pure $ FunctionAxiomPattern $ EqualityRule EqualityPattern
+            pure $ FunctionAxiomPattern $ EqualityRule
                 { requires = Predicate.makeTruePredicate_
                 , left
                 , right = TermLike.mkTop resultSort

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -88,7 +88,7 @@ instance InternalVariable variable => Evaluable (Predicate variable) where
 instance InternalVariable variable => Evaluable (Conditional variable term)
   where
     evaluate conditional =
-        assert (Conditional.isNormalized conditional)
+        Conditional.assertNormalized conditional
         $ evaluate (Conditional.predicate conditional)
 
 {- | Removes from a MultiOr all items refuted by an external SMT solver. -}

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -35,8 +35,7 @@ import Kore.Internal.TermLike
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Step.EqualityPattern
-    ( EqualityPattern (..)
-    , EqualityRule (..)
+    ( EqualityRule (..)
     )
 import Kore.Step.RulePattern
 import qualified Kore.Step.Simplification.Pattern as Pattern
@@ -59,25 +58,18 @@ simplifyFunctionAxioms
 simplifyFunctionAxioms =
     (traverse . traverse) simplifyEqualityRule
 
-simplifyEqualityRule
-    :: (InternalVariable variable, MonadSimplify simplifier)
-    => EqualityRule variable
-    -> simplifier (EqualityRule variable)
-simplifyEqualityRule (EqualityRule rule) =
-    EqualityRule <$> simplifyEqualityPattern rule
-
 {- | Simplify an 'EqualityPattern' using only matching logic rules.
 
 The original rule is returned unless the simplification result matches certain
 narrowly-defined criteria.
 
  -}
-simplifyEqualityPattern
+simplifyEqualityRule
     :: (InternalVariable variable, MonadSimplify simplifier)
-    => EqualityPattern variable
-    -> simplifier (EqualityPattern variable)
-simplifyEqualityPattern rule = do
-    let EqualityPattern { left } = rule
+    => EqualityRule variable
+    -> simplifier (EqualityRule variable)
+simplifyEqualityRule rule = do
+    let EqualityRule { left } = rule
     simplifiedLeft <- simplifyPattern left
     case OrPattern.toPatterns simplifiedLeft of
         [ Conditional { term, predicate, substitution } ]
@@ -86,15 +78,15 @@ simplifyEqualityPattern rule = do
                 left' = TermLike.substitute subst term
                 requires' = TermLike.substitute subst <$> requires
                   where
-                    EqualityPattern { requires = requires } = rule
+                    EqualityRule { requires = requires } = rule
                 rhs' = TermLike.substitute subst rhs
                   where
-                    EqualityPattern { right = rhs } = rule
+                    EqualityRule { right = rhs } = rule
                 ensures' = TermLike.substitute subst <$> ensures
                   where
-                    EqualityPattern { ensures = ensures } = rule
-                EqualityPattern { attributes } = rule
-            return EqualityPattern
+                    EqualityRule { ensures = ensures } = rule
+                EqualityRule { attributes } = rule
+            return EqualityRule
                 { left = left'
                 , requires = requires'
                 , right = rhs'

--- a/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Evaluate.hs
@@ -14,8 +14,6 @@ import Data.Generics.Wrapped
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
 import Kore.Attribute.Axiom.Concrete
-import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional as Conditional
 import Kore.Internal.OrPattern
     ( OrPattern
     )
@@ -85,10 +83,7 @@ test_evaluateAxioms =
         "Σ(X, Y) => A requires (X > 0 or not Y > 0) applies to Σ(Z, Z)"
         [axiom (sigma x y) a (positive x `orNot` positive y)]
         (sigma a a, makeTruePredicate_)
-        -- SMT not used to simplify trivial constraints
-        [ a `andRequires` positive a
-        , a `andRequires` makeNotPredicate (positive a)
-        ]
+        [Pattern.fromTermLike a]
     , doesn'tApply
         -- using SMT
         "f(X) => A requires (X > 0) doesn't apply to f(Z) and (not (Z > 0))"
@@ -137,13 +132,6 @@ andNot, orNot
     -> Predicate Variable
 andNot p1 p2 = makeAndPredicate p1 (makeNotPredicate p2)
 orNot p1 p2 = makeOrPredicate p1 (makeNotPredicate p2)
-
-andRequires
-    :: TermLike Variable
-    -> Predicate Variable
-    -> Pattern Variable
-andRequires term requires =
-    Conditional {term, predicate = requires, substitution = mempty}
 
 -- * Helpers
 

--- a/kore/test/Test/Kore/Step/EquationalStep.hs
+++ b/kore/test/Test/Kore/Step/EquationalStep.hs
@@ -335,27 +335,27 @@ test_applyEquationalRule_ =
             axiom = EqualityRule ruleId { ensures }
         actual <- applyEquationalRuleParallel_ initial axiom
         assertEqual "" expect actual
-    -- x => x requires g(x)=f(x)
-    -- vs
-    -- a
-    -- Expected: y1 and g(a)=f(a)
-    , testCase "conjoin rule requirement" $ do
+
+    , testCase "rule requirement" $ do
         let
             requires =
-                makeEqualsPredicate_
+                makeEqualsPredicate Mock.testSort
                     (Mock.functional11 (mkElemVar Mock.x))
                     (Mock.functional10 (mkElemVar Mock.x))
-            expect = Right
-                [ OrPattern.fromPatterns
-                    [ initialTerm
-                    `Pattern.withCondition` Condition.fromPredicate requires
-                    ]
-                ]
             initialTerm = mkElemVar Mock.x
-            initial = Pattern.fromTermLike initialTerm
             axiom = EqualityRule ruleId { requires }
-        actual <- applyEquationalRuleParallel_ initial axiom
-        assertEqual "" expect actual
+            apply x = applyEquationalRuleParallel_ x axiom
+
+        let initial1 = Pattern.fromTermLike initialTerm
+            expect1 = Right []
+        actual1 <- apply initial1
+        assertEqual "Expected rule would not apply without requirement"
+            expect1 actual1
+
+        let initial2 = initial1 { predicate = requires }
+            expect2 = Right [OrPattern.fromPattern initial2]
+        actual2 <- apply initial2
+        assertEqual "Expected rule would apply with requirement" expect2 actual2
 
     , testCase "rule a => \\bottom" $ do
         let expect = Right [ OrPattern.fromPatterns [] ]

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -3,7 +3,6 @@
 module Test.Kore.Step.Function.Integration
     ( test_functionIntegration
     , test_Nat
-    , test_short_circuit
     , test_List
     , test_lookupMap
     , test_updateMap
@@ -824,87 +823,6 @@ natSimplifiers =
         , factorialEvaluator
         ]
 
--- | Add an unsatisfiable requirement to the 'EqualityRule'.
-requiresBottom :: EqualityRule Variable -> EqualityRule Variable
-requiresBottom (EqualityRule rule) =
-    EqualityRule rule { requires = makeEqualsPredicate_ zero one }
-
-{- | Add an unsatisfiable @\\equals@ requirement to the 'EqualityRule'.
-
-In contrast to 'requiresBottom', @requiresFatalEquals@ also includes a
-requirement which results in a fatal error when evaluated.
-
- -}
-requiresFatalEquals :: EqualityRule Variable -> EqualityRule Variable
-requiresFatalEquals (EqualityRule rule) =
-    EqualityRule rule
-        { requires =
-            makeAndPredicate
-                (makeEqualsPredicate_ (fatal zero) one)
-                (makeEqualsPredicate_ zero         one)
-        }
-
-{- | Add an unsatisfiable @\\in@ requirement to the 'EqualityRule'.
-
-In contrast to 'requiresBottom', @requiresFatalEquals@ also includes a
-requirement which results in a fatal error when evaluated.
-
- -}
-requiresFatalIn :: EqualityRule Variable -> EqualityRule Variable
-requiresFatalIn (EqualityRule rule) =
-    EqualityRule rule
-        { requires =
-            makeAndPredicate
-                (makeEqualsPredicate_ (fatal zero) one)
-                (makeCeilPredicate_ (mkAnd zero one))
-        }
-
-{- | Test short-circuiting evaluation of function requirements.
-
-We want to check that functions are not evaluated in an 'EqualityRule'
-requirement if the pre-condition is known to be unsatisfiable without function
-evaluation. We check this by including a 'requires' clause with one
-unsatisfiable condition and one "fatal" condition (a condition producing a fatal
-error if evaluated). If we do function evaluation on the unsatisfiable
-requirement, a fatal error will be produced.
-
- -}
-test_short_circuit :: [TestTree]
-test_short_circuit =
-    [ notApplies  "requires 0 = 1 does not apply"
-        [requiresBottom plusZeroRule]
-        (plus zero one)
-    , notApplies  "requires fatal(0) = 1 ∧ 0 = 1 does not apply"
-        [requiresFatalEquals plusZeroRule]
-        (plus zero one)
-    , notApplies  "requires fatal(0) = 1 ∧ 0 ∈ 1 does not apply"
-        [requiresFatalIn plusZeroRule]
-        (plus zero one)
-    ]
-
-{- | A symbol which throws a fatal error when evaluated.
-
-@fatalSymbol@ is useful for checking that symbols in certain positions are never
-evaluated.
-
- -}
-fatalSymbol :: Symbol
-fatalSymbol = Mock.symbol "fatal" [natSort] natSort & function
-
-fatal :: TermLike Variable -> TermLike Variable
-fatal x = mkApplySymbol fatalSymbol [x]
-
-fatalEvaluator :: (AxiomIdentifier, BuiltinAndAxiomSimplifier)
-fatalEvaluator =
-    ( AxiomIdentifier.Application ident
-    , BuiltinAndAxiomSimplifier $ \_ _ -> error "fatal error"
-    )
-  where
-    ident = symbolConstructor fatalSymbol
-
-fatalSimplifiers :: BuiltinAndAxiomSimplifierMap
-fatalSimplifiers = uncurry Map.singleton fatalEvaluator
-
 test_List :: [TestTree]
 test_List =
     [ applies                  "lengthList([]) => ... ~ lengthList([])"
@@ -1464,7 +1382,6 @@ testEnv =
                 , natSimplifiers
                 , listSimplifiers
                 , mapSimplifiers
-                , fatalSimplifiers
                 ]
         , memo = Memo.forgetful
         , injSimplifier = testInjSimplifier

--- a/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
@@ -23,7 +23,6 @@ import Kore.Internal.Predicate
     , makeAndPredicate
     , makeEqualsPredicate
     , makeEqualsPredicate_
-    , makeTruePredicate
     , makeTruePredicate_
     )
 import qualified Kore.Internal.SideCondition as SideCondition
@@ -78,7 +77,7 @@ test_orPatternSimplification =
         let expected = OrPattern.fromPatterns
                 [ Conditional
                     { term = Mock.a
-                    , predicate = makeTruePredicate Mock.testSort
+                    , predicate = makeTruePredicate_
                     , substitution = mempty
                     }
                 ]


### PR DESCRIPTION
This is a proof-of-concept which completely disables branching during equality evaluation. It actually works, but it's pretty slow at the moment due to the extra load on the solver. I'm opening a draft pull request so I don't lose track of the branch.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
