### PR TITLE
mapVariables: Avoid capturing variables

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -137,6 +137,10 @@
       - Kore.Step.Step
       - SQL.SOP
 - ignore: {name: "Avoid lambda", within: [Kore.Step.Function.Memo]}
+- ignore:
+    name: "Redundant bracket"
+    within:
+      - Kore.Internal.TermLike.TermLike
 
 
 # Haskell names match K names

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -31,6 +31,7 @@ flags:
 
 dependencies:
   - base >=4.7
+  - adjunctions >=4.4
   - aeson >=1.4
   - array >=0.5
   - async >=2.2

--- a/kore/src/Kore/ASTVerifier/PatternVerifier.hs
+++ b/kore/src/Kore/ASTVerifier/PatternVerifier.hs
@@ -41,6 +41,7 @@ import Kore.ASTVerifier.SortVerifier
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables
     , freeVariables
+    , nullFreeVariables
     )
 import qualified Kore.Attribute.Sort as Attribute.Sort
 import qualified Kore.Attribute.Sort.HasDomainValues as Attribute.HasDomainValues
@@ -493,7 +494,7 @@ verifyDomainValue domain = do
     let freeVariables' :: FreeVariables Variable =
             foldMap freeVariables
                 (Internal.extractAttributes <$> verified)
-    Monad.unless (null freeVariables')
+    Monad.unless (nullFreeVariables freeVariables')
         (koreFail "Domain value must not contain free variables.")
     return verified
 

--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -67,7 +67,9 @@ import Kore.Sort
     ( Sort
     )
 import Kore.Variables.UnifiedVariable
-    ( UnifiedVariable (..)
+    ( ElementVariable
+    , SetVariable
+    , UnifiedVariable (..)
     )
 
 {- | @Pattern@ are the attributes of a pattern collected during verification.
@@ -174,10 +176,12 @@ See also: 'traverseVariables'
  -}
 mapVariables
     :: Ord variable2
-    => (variable1 -> variable2)
+    => (ElementVariable variable1 -> ElementVariable variable2)
+    -> (SetVariable variable1 -> SetVariable variable2)
     -> Pattern variable1 -> Pattern variable2
-mapVariables mapping =
-    Lens.over (field @"freeVariables") (mapFreeVariables mapping)
+mapVariables mapElemVar mapSetVar =
+    Lens.over (field @"freeVariables")
+        (mapFreeVariables mapElemVar mapSetVar)
 
 {- | Use the provided traversal to replace the free variables in a 'Pattern'.
 
@@ -187,11 +191,12 @@ See also: 'mapVariables'
 traverseVariables
     ::  forall m variable1 variable2.
         (Monad m, Ord variable2)
-    => (variable1 -> m variable2)
+    => (ElementVariable variable1 -> m (ElementVariable variable2))
+    -> (SetVariable variable1 -> m (SetVariable variable2))
     -> Pattern variable1
     -> m (Pattern variable2)
-traverseVariables traversing =
-    field @"freeVariables" (traverseFreeVariables traversing)
+traverseVariables trElemVar trSetVar =
+    field @"freeVariables" (traverseFreeVariables trElemVar trSetVar)
 
 {- | Delete the given variable from the set of free variables.
  -}

--- a/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
@@ -7,6 +7,7 @@ License     : NCSA
 module Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables (..)
     , HasFreeVariables (..)
+    , nullFreeVariables
     , freeVariable
     , isFreeVariable
     , bindVariable
@@ -15,7 +16,9 @@ module Kore.Attribute.Pattern.FreeVariables
     , getFreeElementVariables
     ) where
 
-import Prelude.Kore
+import Prelude.Kore hiding
+    ( null
+    )
 
 import Control.DeepSeq
 import Data.Functor.Const
@@ -31,13 +34,13 @@ import qualified GHC.Generics as GHC
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Syntax.ElementVariable
+import Kore.Syntax.SetVariable
 import Kore.Variables.UnifiedVariable
 
 newtype FreeVariables variable =
     FreeVariables { getFreeVariables :: Set (UnifiedVariable variable) }
     deriving GHC.Generic
     deriving (Eq, Show)
-    deriving Foldable
     deriving (Semigroup, Monoid)
 
 instance SOP.Generic (FreeVariables variable)
@@ -58,6 +61,10 @@ instance Synthetic (FreeVariables variable) (Const (UnifiedVariable variable))
   where
     synthetic (Const var) = freeVariable var
     {-# INLINE synthetic #-}
+
+nullFreeVariables :: FreeVariables variable -> Bool
+nullFreeVariables = Set.null . getFreeVariables
+{-# INLINE nullFreeVariables #-}
 
 bindVariable
     :: Ord variable
@@ -81,19 +88,23 @@ freeVariable variable = FreeVariables (Set.singleton variable)
 
 mapFreeVariables
     :: Ord variable2
-    => (variable1 -> variable2)
+    => (ElementVariable variable1 -> ElementVariable variable2)
+    -> (SetVariable variable1 -> SetVariable variable2)
     -> FreeVariables variable1 -> FreeVariables variable2
-mapFreeVariables mapping (FreeVariables freeVars) =
-    FreeVariables (Set.map (fmap mapping) freeVars)
+mapFreeVariables mapElemVar mapSetVar (FreeVariables freeVars) =
+    FreeVariables (Set.map (mapUnifiedVariable mapElemVar mapSetVar) freeVars)
 {-# INLINE mapFreeVariables #-}
 
 traverseFreeVariables
     :: (Applicative f, Ord variable2)
-    => (variable1 -> f variable2)
+    => (ElementVariable variable1 -> f (ElementVariable variable2))
+    -> (SetVariable variable1 -> f (SetVariable variable2))
     -> FreeVariables variable1 -> f (FreeVariables variable2)
-traverseFreeVariables traversing (FreeVariables freeVars) =
+traverseFreeVariables traverseElemVar traverseSetVar (FreeVariables freeVars) =
     FreeVariables . Set.fromList
-    <$> Traversable.traverse (traverse traversing) (Set.toList freeVars)
+    <$> Traversable.traverse traversal (Set.toList freeVars)
+  where
+    traversal = traverseUnifiedVariable traverseElemVar traverseSetVar
 {-# INLINE traverseFreeVariables #-}
 
 {- | Extracts the list of free element variables

--- a/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
@@ -102,6 +102,9 @@ getFreeElementVariables :: FreeVariables variable -> [ElementVariable variable]
 getFreeElementVariables =
     mapMaybe extractElementVariable . Set.toList . getFreeVariables
 
+-- TODO (thomas.tuegel): Use an associated type family with HasFreeVariables to
+-- fix type inference.
+
 -- | Class for extracting the free variables of a pattern, term, rule, ...
 class HasFreeVariables pat variable where
     freeVariables :: pat -> FreeVariables variable

--- a/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
+++ b/kore/src/Kore/Attribute/Pattern/FreeVariables.hs
@@ -16,9 +16,7 @@ module Kore.Attribute.Pattern.FreeVariables
     , getFreeElementVariables
     ) where
 
-import Prelude.Kore hiding
-    ( null
-    )
+import Prelude.Kore
 
 import Control.DeepSeq
 import Data.Functor.Const

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -481,6 +481,7 @@ normalizeAbstractElements (Domain.unwrapAc -> normalized) = do
 -- remains abstract.
 extractConcreteElement
     ::  Domain.AcWrapper collection
+    =>  Ord variable
     =>  Domain.Element collection (TermLike variable)
     ->  Either
             (TermLike Concrete, Domain.Value collection (TermLike variable))
@@ -679,7 +680,9 @@ disjointMap input =
     asMap = Map.fromList input
 
 splitVariableConcrete
-    :: [(TermLike variable, a)]
+    :: forall variable a
+    .  Ord variable
+    =>  [(TermLike variable, a)]
     -> ([(TermLike variable, a)], [(TermLike Concrete, a)])
 splitVariableConcrete terms =
     partitionEithers (map toConcreteEither terms)

--- a/kore/src/Kore/Builtin/AssociativeCommutative.hs
+++ b/kore/src/Kore/Builtin/AssociativeCommutative.hs
@@ -707,7 +707,7 @@ reject the definition.
 -}
 unifyEqualsNormalized
     :: forall normalized unifier variable
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , Traversable (Domain.Value normalized)
         , TermWrapper normalized
         , MonadUnify unifier
@@ -795,7 +795,7 @@ Currently allows at most one opaque term in the two arguments taken together.
 -}
 unifyEqualsNormalizedAc
     ::  forall normalized variable unifier
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , Traversable (Domain.Value normalized)
         , TermWrapper normalized
         , MonadUnify unifier
@@ -1195,7 +1195,7 @@ The keys of the two structures are assumend to be disjoint.
 -}
 unifyEqualsElementLists
     ::  forall normalized variable unifier
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , MonadUnify unifier
         , TermWrapper normalized
         , Traversable (Domain.Value normalized)
@@ -1332,7 +1332,7 @@ unifyEqualsElementLists
 unifyOpaqueVariable
     ::  ( MonadUnify unifier
         , TermWrapper normalized
-        , SimplifierVariable variable
+        , InternalVariable variable
         )
     => SmtMetadataTools Attribute.Symbol
     -> (forall a . Doc () -> unifier a)
@@ -1412,7 +1412,7 @@ unifyEqualsConcreteOrWithVariable
     ::  ( Domain.AcWrapper normalized
         , MonadUnify unifier
         , Traversable (Domain.Value normalized)
-        , SimplifierVariable variable
+        , InternalVariable variable
         )
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> ConcreteOrWithVariable normalized variable
@@ -1447,7 +1447,7 @@ unifyEqualsPair
     :: forall normalized unifier variable
     .   ( Domain.AcWrapper normalized
         , MonadUnify unifier
-        , SimplifierVariable variable
+        , InternalVariable variable
         , Traversable (Domain.Value normalized)
         )
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
@@ -1491,7 +1491,7 @@ Also returns the non-unified part os the lists (one of the two will be empty).
 unifyEqualsElementPermutations
     ::  ( Alternative unifier
         , Monad unifier
-        , SimplifierVariable variable
+        , InternalVariable variable
         )
     => (a -> b -> unifier (Conditional variable c))
     -> [a]

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -481,7 +481,7 @@ If the pattern is not concrete and normalized, the function is
 See also: 'Kore.Proof.Value.Value'
 
  -}
-toKey :: TermLike variable -> Maybe (TermLike Concrete)
+toKey :: Ord variable => TermLike variable -> Maybe (TermLike Concrete)
 toKey purePattern = do
     p <- TermLike.asConcrete purePattern
     -- TODO (thomas.tuegel): Use the return value as the term.

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -129,6 +129,8 @@ import qualified Kore.Unification.Unify as Monad.Unify
     )
 import Kore.Unparser
 
+-- TODO (thomas.tuegel): Include hook name here.
+
 type Function = BuiltinAndAxiomSimplifier
 
 notImplemented :: Function
@@ -167,7 +169,7 @@ unaryOperator
     .   (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Parse operand
     ->  (forall variable
-        . InternalVariable variable => Sort -> b -> Pattern variable
+        . SubstitutionVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -175,18 +177,13 @@ unaryOperator
     -> (a -> b)
     -- ^ Operation on builtin types
     -> Function
-unaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+unaryOperator extractVal asPattern ctx op =
     functionEvaluator unaryOperator0
   where
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     unaryOperator0
-        :: InternalVariable variable
+        :: SubstitutionVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]
@@ -215,7 +212,7 @@ binaryOperator
     .  (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Extract domain value
     ->  (forall variable
-        . InternalVariable variable => Sort -> b -> Pattern variable
+        . SubstitutionVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -223,18 +220,13 @@ binaryOperator
     -> (a -> a -> b)
     -- ^ Operation on builtin types
     -> Function
-binaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+binaryOperator extractVal asPattern ctx op =
     functionEvaluator binaryOperator0
   where
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     binaryOperator0
-        :: SimplifierVariable variable
+        :: SubstitutionVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]
@@ -263,7 +255,7 @@ ternaryOperator
     .  (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Extract domain value
     ->  (forall variable
-        . InternalVariable variable => Sort -> b -> Pattern variable
+        . SubstitutionVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -271,18 +263,13 @@ ternaryOperator
     -> (a -> a -> a -> b)
     -- ^ Operation on builtin types
     -> Function
-ternaryOperator
-    extractVal
-    asPattern
-    ctx
-    op
-  =
+ternaryOperator extractVal asPattern ctx op =
     functionEvaluator ternaryOperator0
   where
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     ternaryOperator0
-        :: SimplifierVariable variable
+        :: SubstitutionVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -114,8 +114,8 @@ import Kore.Step.Simplification.Simplify
     ( AttemptedAxiom (..)
     , AttemptedAxiomResults (AttemptedAxiomResults)
     , BuiltinAndAxiomSimplifier (BuiltinAndAxiomSimplifier)
+    , InternalVariable
     , MonadSimplify
-    , SimplifierVariable
     , applicationAxiomSimplifier
     )
 import qualified Kore.Step.Simplification.Simplify as AttemptedAxiomResults
@@ -169,7 +169,7 @@ unaryOperator
     .   (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Parse operand
     ->  (forall variable
-        . SubstitutionVariable variable => Sort -> b -> Pattern variable
+        . InternalVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -183,7 +183,7 @@ unaryOperator extractVal asPattern ctx op =
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     unaryOperator0
-        :: SubstitutionVariable variable
+        :: InternalVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]
@@ -212,7 +212,7 @@ binaryOperator
     .  (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Extract domain value
     ->  (forall variable
-        . SubstitutionVariable variable => Sort -> b -> Pattern variable
+        . InternalVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -226,7 +226,7 @@ binaryOperator extractVal asPattern ctx op =
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     binaryOperator0
-        :: SubstitutionVariable variable
+        :: InternalVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]
@@ -255,7 +255,7 @@ ternaryOperator
     .  (forall variable. Text -> Builtin (TermLike variable) -> a)
     -- ^ Extract domain value
     ->  (forall variable
-        . SubstitutionVariable variable => Sort -> b -> Pattern variable
+        . InternalVariable variable => Sort -> b -> Pattern variable
         )
     -- ^ Render result as pattern with given sort
     -> Text
@@ -269,7 +269,7 @@ ternaryOperator extractVal asPattern ctx op =
     get :: Builtin (TermLike variable) -> a
     get = extractVal ctx
     ternaryOperator0
-        :: SubstitutionVariable variable
+        :: InternalVariable variable
         => MonadSimplify m
         => Sort
         -> [TermLike variable]
@@ -285,7 +285,7 @@ ternaryOperator extractVal asPattern ctx op =
 
 type FunctionImplementation
     = forall variable simplifier
-        .  SimplifierVariable variable
+        .  InternalVariable variable
         => MonadSimplify simplifier
         => Sort
         -> [TermLike variable]
@@ -296,7 +296,7 @@ functionEvaluator impl =
     applicationAxiomSimplifier evaluator
   where
     evaluator
-        :: SimplifierVariable variable
+        :: InternalVariable variable
         => MonadSimplify simplifier
         => CofreeF
             (Application Symbol)
@@ -500,7 +500,7 @@ getAttemptedAxiom attempt =
 
 -- | Return an unsolved unification problem.
 unifyEqualsUnsolved
-    :: (MonadUnify unifier, SimplifierVariable variable)
+    :: (MonadUnify unifier, InternalVariable variable)
     => SimplificationType
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/Endianness.hs
+++ b/kore/src/Kore/Builtin/Endianness.hs
@@ -36,7 +36,7 @@ import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 import Kore.Syntax.Application
     ( Application (..)
@@ -89,7 +89,7 @@ bigEndianVerifier :: ApplicationVerifier Verified.Pattern
 bigEndianVerifier = endiannessVerifier BigEndian
 
 unifyEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/External.hs
+++ b/kore/src/Kore/Builtin/External.hs
@@ -34,6 +34,9 @@ import qualified Kore.Internal.Inj as Inj
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike
 import qualified Kore.Syntax.Pattern as Syntax
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 {- | Externalize the 'TermLike' into a 'Syntax.Pattern'.
 
@@ -44,7 +47,7 @@ See also: 'asPattern'
  -}
 externalize
     ::  forall variable
-    .   InternalVariable variable
+    .   (InternalVariable variable, FreshVariable variable)
     =>  TermLike variable
     ->  Syntax.Pattern variable Attribute.Null
 externalize =

--- a/kore/src/Kore/Builtin/External.hs
+++ b/kore/src/Kore/Builtin/External.hs
@@ -34,9 +34,6 @@ import qualified Kore.Internal.Inj as Inj
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike
 import qualified Kore.Syntax.Pattern as Syntax
-import Kore.Variables.Fresh
-    ( FreshVariable
-    )
 
 {- | Externalize the 'TermLike' into a 'Syntax.Pattern'.
 
@@ -47,7 +44,7 @@ See also: 'asPattern'
  -}
 externalize
     ::  forall variable
-    .   (InternalVariable variable, FreshVariable variable)
+    .   InternalVariable variable
     =>  TermLike variable
     ->  Syntax.Pattern variable Attribute.Null
 externalize =

--- a/kore/src/Kore/Builtin/Int/Int.hs
+++ b/kore/src/Kore/Builtin/Int/Int.hs
@@ -112,14 +112,14 @@ asTermLike builtin =
     Domain.InternalInt { builtinIntValue = int } = builtin
 
 asPattern
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => Sort  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
     -> Pattern variable
 asPattern resultSort = Pattern.fromTermLike . asInternal resultSort
 
 asPartialPattern
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => Sort  -- ^ resulting sort
     -> Maybe Integer  -- ^ builtin value to render
     -> Pattern variable

--- a/kore/src/Kore/Builtin/Int/Int.hs
+++ b/kore/src/Kore/Builtin/Int/Int.hs
@@ -54,6 +54,9 @@ import qualified Data.Text as Text
 import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike as TermLike
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 {- | Builtin name of the @Int@ sort.
  -}
@@ -69,7 +72,7 @@ See also: 'sort'
 
  -}
 asInternal
-    :: Ord variable
+    :: FreshVariable variable
     => Sort  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
     -> TermLike variable
@@ -109,14 +112,14 @@ asTermLike builtin =
     Domain.InternalInt { builtinIntValue = int } = builtin
 
 asPattern
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => Sort  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
     -> Pattern variable
 asPattern resultSort = Pattern.fromTermLike . asInternal resultSort
 
 asPartialPattern
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => Sort  -- ^ resulting sort
     -> Maybe Integer  -- ^ builtin value to render
     -> Pattern variable

--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -125,7 +125,7 @@ builtinFunctions =
     ]
 
 evalKEq
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => Bool
     -> CofreeF
         (Application Symbol)
@@ -170,7 +170,7 @@ evalKEq true (valid :< app) =
 
 evalKIte
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => CofreeF
         (Application Symbol)
         (Attribute.Pattern variable)

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -404,7 +404,7 @@ builtinFunctions =
  -}
 unifyEquals
     :: forall variable unifier
-    .  (SimplifierVariable variable, MonadUnify unifier)
+    .  (InternalVariable variable, MonadUnify unifier)
     => SimplificationType
     -> (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> TermLike variable

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -225,7 +225,8 @@ expectBuiltinList ctx =
         _ -> empty
 
 expectConcreteBuiltinList
-    :: Monad m
+    :: Ord variable
+    => Monad m
     => Text  -- ^ Context for error message
     -> TermLike variable  -- ^ Operand pattern
     -> MaybeT m (Seq (TermLike Concrete))

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -564,7 +564,7 @@ reject the definition.
 -}
 unifyEquals
     :: forall variable unifier
-    .  (SimplifierVariable variable, MonadUnify unifier)
+    .  (InternalVariable variable, MonadUnify unifier)
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/Map/Map.hs
+++ b/kore/src/Kore/Builtin/Map/Map.hs
@@ -61,9 +61,6 @@ import Kore.Internal.TermLike as TermLike
 import Kore.Sort
     ( Sort
     )
-import Kore.Variables.Fresh
-    ( FreshVariable
-    )
 
 concatKey :: IsString s => s
 concatKey = "MAP.concat"
@@ -207,7 +204,7 @@ isSymbolValues = Builtin.isSymbol valuesKey
  -}
 asTermLike
     :: forall variable
-    .  (InternalVariable variable, FreshVariable variable)
+    .  InternalVariable variable
     => Domain.InternalMap (TermLike Concrete) (TermLike variable)
     -> TermLike variable
 asTermLike builtin =

--- a/kore/src/Kore/Builtin/Map/Map.hs
+++ b/kore/src/Kore/Builtin/Map/Map.hs
@@ -61,6 +61,9 @@ import Kore.Internal.TermLike as TermLike
 import Kore.Sort
     ( Sort
     )
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 concatKey :: IsString s => s
 concatKey = "MAP.concat"
@@ -204,7 +207,7 @@ isSymbolValues = Builtin.isSymbol valuesKey
  -}
 asTermLike
     :: forall variable
-    .  InternalVariable variable
+    .  (InternalVariable variable, FreshVariable variable)
     => Domain.InternalMap (TermLike Concrete) (TermLike variable)
     -> TermLike variable
 asTermLike builtin =
@@ -249,6 +252,7 @@ asTermLike builtin =
         :: (TermLike Concrete, Domain.MapValue (TermLike variable))
         -> TermLike variable
     concreteElement (key, value) = element (TermLike.fromConcrete key, value)
+
     element
         :: (TermLike variable, Domain.MapValue (TermLike variable))
         -> TermLike variable

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -477,7 +477,7 @@ internalize tools termLike
  -}
 unifyEquals
     :: forall variable unifier
-    .  (SimplifierVariable variable, MonadUnify unifier)
+    .  (InternalVariable variable, MonadUnify unifier)
     => (TermLike variable -> TermLike variable -> unifier (Pattern variable))
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/Set/Set.hs
+++ b/kore/src/Kore/Builtin/Set/Set.hs
@@ -46,9 +46,6 @@ import Kore.IndexedModule.IndexedModule
     ( VerifiedModule
     )
 import Kore.Internal.TermLike as TermLike
-import Kore.Variables.Fresh
-    ( FreshVariable
-    )
 
 concatKey :: IsString s => s
 concatKey = "SET.concat"
@@ -125,7 +122,7 @@ isSymbolList2set = Builtin.isSymbol list2setKey
 -}
 asTermLike
     :: forall variable
-    .  (InternalVariable variable, FreshVariable variable)
+    .  InternalVariable variable
     => Domain.InternalSet (TermLike Concrete) (TermLike variable)
     -> TermLike variable
 asTermLike builtin =

--- a/kore/src/Kore/Builtin/Set/Set.hs
+++ b/kore/src/Kore/Builtin/Set/Set.hs
@@ -46,6 +46,9 @@ import Kore.IndexedModule.IndexedModule
     ( VerifiedModule
     )
 import Kore.Internal.TermLike as TermLike
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 concatKey :: IsString s => s
 concatKey = "SET.concat"
@@ -122,7 +125,7 @@ isSymbolList2set = Builtin.isSymbol list2setKey
 -}
 asTermLike
     :: forall variable
-    .  InternalVariable variable
+    .  (InternalVariable variable, FreshVariable variable)
     => Domain.InternalSet (TermLike Concrete) (TermLike variable)
     -> TermLike variable
 asTermLike builtin =
@@ -167,6 +170,7 @@ asTermLike builtin =
         :: (TermLike Concrete, Domain.SetValue (TermLike variable))
         -> TermLike variable
     concreteElement (key, value) = element (TermLike.fromConcrete key, value)
+
     element
         :: (TermLike variable, Domain.SetValue (TermLike variable))
         -> TermLike variable

--- a/kore/src/Kore/Builtin/Signedness.hs
+++ b/kore/src/Kore/Builtin/Signedness.hs
@@ -36,7 +36,7 @@ import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 import Kore.Syntax.Application
     ( Application (..)
@@ -89,7 +89,7 @@ unsignedVerifier :: ApplicationVerifier Verified.Pattern
 unsignedVerifier = signednessVerifier Unsigned
 
 unifyEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Builtin/String/String.hs
+++ b/kore/src/Kore/Builtin/String/String.hs
@@ -41,6 +41,9 @@ import Kore.Internal.Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike as TermLike
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 {- | Builtin name of the @String@ sort.
  -}
@@ -56,7 +59,7 @@ See also: 'sort'
 
  -}
 asInternal
-    :: Ord variable
+    :: FreshVariable variable
     => Sort  -- ^ resulting sort
     -> Text  -- ^ builtin value to render
     -> TermLike variable
@@ -96,7 +99,7 @@ asTermLike internal =
     Domain.InternalString { internalStringValue } = internal
 
 asPattern
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => Sort  -- ^ resulting sort
     -> Text  -- ^ builtin value to render
     -> Pattern variable
@@ -104,7 +107,7 @@ asPattern resultSort =
     Pattern.fromTermLike . asInternal resultSort
 
 asPartialPattern
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => Sort  -- ^ resulting sort
     -> Maybe Text  -- ^ builtin value to render
     -> Pattern variable

--- a/kore/src/Kore/Builtin/String/String.hs
+++ b/kore/src/Kore/Builtin/String/String.hs
@@ -99,7 +99,7 @@ asTermLike internal =
     Domain.InternalString { internalStringValue } = internal
 
 asPattern
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => Sort  -- ^ resulting sort
     -> Text  -- ^ builtin value to render
     -> Pattern variable
@@ -107,7 +107,7 @@ asPattern resultSort =
     Pattern.fromTermLike . asInternal resultSort
 
 asPartialPattern
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => Sort  -- ^ resulting sort
     -> Maybe Text  -- ^ builtin value to render
     -> Pattern variable

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -62,9 +62,6 @@ import qualified Kore.Internal.TermLike as TermLike
     ( simplifiedAttribute
     )
 import Kore.Internal.Variable
-import Kore.Substitute
-    ( SubstitutionVariable
-    )
 import Kore.Syntax
 import Kore.Variables.Fresh
     ( FreshVariable
@@ -165,7 +162,7 @@ The 'normalized' part becomes the normalized 'substitution', while the
 
  -}
 fromNormalizationSimplified
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Normalization variable
     -> Condition variable
 fromNormalizationSimplified Normalization { normalized, denormalized } =

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -152,10 +152,11 @@ toPredicate = from
 
 mapVariables
     :: (Ord variable1, FreshVariable variable2)
-    => (variable1 -> variable2)
+    => (ElementVariable variable1 -> ElementVariable variable2)
+    -> (SetVariable variable1 -> SetVariable variable2)
     -> Condition variable1
     -> Condition variable2
-mapVariables = Conditional.mapVariables (\_ () -> ())
+mapVariables = Conditional.mapVariables (\_ _ () -> ())
 
 {- | Create a new 'Condition' from the 'Normalization' of a substitution.
 

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -66,6 +66,9 @@ import Kore.Substitute
     ( SubstitutionVariable
     )
 import Kore.Syntax
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable
     )
@@ -148,7 +151,7 @@ toPredicate
 toPredicate = from
 
 mapVariables
-    :: (Ord variable1, Ord variable2)
+    :: (Ord variable1, FreshVariable variable2)
     => (variable1 -> variable2)
     -> Condition variable1
     -> Condition variable2

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -77,6 +77,9 @@ import Kore.TopBottom
     ( TopBottom (..)
     )
 import Kore.Unparser
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable
     )
@@ -408,7 +411,7 @@ isPredicate Conditional {term} = isTop term
 
 -}
 mapVariables
-    :: (Ord variableFrom, Ord variableTo)
+    :: (Ord variableFrom, FreshVariable variableTo)
     => ((variableFrom -> variableTo) -> termFrom -> termTo)
     -> (variableFrom -> variableTo)
     -> Conditional variableFrom termFrom

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -81,7 +81,9 @@ import Kore.Variables.Fresh
     ( FreshVariable
     )
 import Kore.Variables.UnifiedVariable
-    ( UnifiedVariable
+    ( ElementVariable
+    , SetVariable
+    , UnifiedVariable
     )
 import qualified SQL
 
@@ -412,19 +414,22 @@ isPredicate Conditional {term} = isTop term
 -}
 mapVariables
     :: (Ord variableFrom, FreshVariable variableTo)
-    => ((variableFrom -> variableTo) -> termFrom -> termTo)
-    -> (variableFrom -> variableTo)
+    => ((ElementVariable variableFrom -> ElementVariable variableTo) -> (SetVariable variableFrom -> SetVariable variableTo) -> termFrom -> termTo)
+    -> (ElementVariable variableFrom -> ElementVariable variableTo)
+    -> (SetVariable variableFrom -> SetVariable variableTo)
     -> Conditional variableFrom termFrom
     -> Conditional variableTo   termTo
 mapVariables
     mapTermVariables
-    mapVariable
+    mapElemVar
+    mapSetVar
     Conditional { term, predicate, substitution }
   =
     Conditional
-        { term = mapTermVariables mapVariable term
-        , predicate = Predicate.mapVariables mapVariable predicate
-        , substitution = Substitution.mapVariables mapVariable substitution
+        { term = mapTermVariables mapElemVar mapSetVar term
+        , predicate = Predicate.mapVariables mapElemVar mapSetVar predicate
+        , substitution =
+            Substitution.mapVariables mapElemVar mapSetVar substitution
         }
 
 splitTerm :: Conditional variable term -> (term, Conditional variable ())

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -77,6 +77,9 @@ import qualified Kore.Sort as Sort
 import Kore.TopBottom
     ( TopBottom (..)
     )
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 {- | The conjunction of a pattern, predicate, and substitution.
 
@@ -119,7 +122,7 @@ freeElementVariables =
 in an Pattern.
 -}
 mapVariables
-    :: (Ord variableFrom, Ord variableTo)
+    :: (Ord variableFrom, FreshVariable variableTo)
     => (variableFrom -> variableTo)
     -> Pattern variableFrom
     -> Pattern variableTo

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -61,6 +61,7 @@ import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
     ( ElementVariable
     , InternalVariable
+    , SetVariable
     , Sort
     , TermLike
     , mkAnd
@@ -123,18 +124,20 @@ in an Pattern.
 -}
 mapVariables
     :: (Ord variableFrom, FreshVariable variableTo)
-    => (variableFrom -> variableTo)
+    => (ElementVariable variableFrom -> ElementVariable variableTo)
+    -> (SetVariable variableFrom -> SetVariable variableTo)
     -> Pattern variableFrom
     -> Pattern variableTo
 mapVariables
-    variableMapper
+    mapElemVar
+    mapSetVar
     Conditional { term, predicate, substitution }
   =
     Conditional
-        { term = TermLike.mapVariables variableMapper term
-        , predicate = Predicate.mapVariables variableMapper predicate
+        { term = TermLike.mapVariables mapElemVar mapSetVar term
+        , predicate = Predicate.mapVariables mapElemVar mapSetVar predicate
         , substitution =
-            Substitution.mapVariables variableMapper substitution
+            Substitution.mapVariables mapElemVar mapSetVar substitution
         }
 
 {- | Convert an 'Pattern' to an ordinary 'TermLike'.

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -805,7 +805,7 @@ contain none of the targeted variables.
 
  -}
 substitute
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Map (UnifiedVariable variable) (TermLike variable)
     -> Predicate variable
     -> Predicate variable

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -707,10 +707,12 @@ isPredicate = Either.isRight . makePredicate
 -}
 mapVariables
     :: (Ord from, FreshVariable to)
-    => (from -> to)
+    => (ElementVariable from -> ElementVariable to)
+    -> (SetVariable from -> SetVariable to)
     -> Predicate from
     -> Predicate to
-mapVariables f = fmap (TermLike.mapVariables f)
+mapVariables mapElemVar mapSetVar =
+    fmap (TermLike.mapVariables mapElemVar mapSetVar)
 
 instance HasFreeVariables (Predicate variable) variable where
     freeVariables = freeVariables . unwrapPredicate
@@ -818,5 +820,6 @@ freshVariable
     => Predicate variable
     -> Predicate Variable
 freshVariable predicate =
-    externalizeFreshVariables . TermLike.mapVariables toVariable
+    externalizeFreshVariables
+    . TermLike.mapVariables (fmap toVariable) (fmap toVariable)
     <$> predicate

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -120,6 +120,9 @@ import Kore.TopBottom
     ( TopBottom (..)
     )
 import Kore.Unparser
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
@@ -702,7 +705,11 @@ isPredicate = Either.isRight . makePredicate
 
 {- | Replace all variables in a @Predicate@ using the provided mapping.
 -}
-mapVariables :: Ord to => (from -> to) -> Predicate from -> Predicate to
+mapVariables
+    :: (Ord from, FreshVariable to)
+    => (from -> to)
+    -> Predicate from
+    -> Predicate to
 mapVariables f = fmap (TermLike.mapVariables f)
 
 instance HasFreeVariables (Predicate variable) variable where

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -43,7 +43,9 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
     )
 import Kore.Internal.Variable
-    ( InternalVariable
+    ( ElementVariable
+    , InternalVariable
+    , SetVariable
     )
 import Kore.TopBottom
     ( TopBottom (..)
@@ -158,11 +160,12 @@ toRepresentation SideCondition { representation } = representation
 
 mapVariables
     :: (Ord variable1, InternalVariable variable2, FreshVariable variable2)
-    => (variable1 -> variable2)
+    => (ElementVariable variable1 -> ElementVariable variable2)
+    -> (SetVariable variable1 -> SetVariable variable2)
     -> SideCondition variable1
     -> SideCondition variable2
-mapVariables mapper condition@(SideCondition _ _) =
-    fromCondition (Condition.mapVariables mapper assumedTrue)
+mapVariables mapElemVar mapSetVar condition@(SideCondition _ _) =
+    fromCondition (Condition.mapVariables mapElemVar mapSetVar assumedTrue)
   where
     SideCondition { assumedTrue } = condition
 

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -54,9 +54,6 @@ import Kore.Unparser
     ( Unparse (..)
     , unparseToText
     )
-import Kore.Variables.Fresh
-    ( FreshVariable
-    )
 import qualified Pretty
 import qualified SQL
 
@@ -159,7 +156,7 @@ toRepresentation :: SideCondition variable -> SideCondition.Representation
 toRepresentation SideCondition { representation } = representation
 
 mapVariables
-    :: (Ord variable1, InternalVariable variable2, FreshVariable variable2)
+    :: (Ord variable1, InternalVariable variable2)
     => (ElementVariable variable1 -> ElementVariable variable2)
     -> (SetVariable variable1 -> SetVariable variable2)
     -> SideCondition variable1

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -52,6 +52,9 @@ import Kore.Unparser
     ( Unparse (..)
     , unparseToText
     )
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 import qualified Pretty
 import qualified SQL
 
@@ -154,7 +157,7 @@ toRepresentation :: SideCondition variable -> SideCondition.Representation
 toRepresentation SideCondition { representation } = representation
 
 mapVariables
-    :: (Ord variable1, InternalVariable variable2)
+    :: (Ord variable1, InternalVariable variable2, FreshVariable variable2)
     => (variable1 -> variable2)
     -> SideCondition variable1
     -> SideCondition variable2

--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -349,7 +349,7 @@ modify f = wrap . f . unwrap
 -- with the given function.
 mapVariables
     :: forall variableFrom variableTo
-    .  (Ord variableFrom, Ord variableTo)
+    .  (Ord variableFrom, FreshVariable variableTo)
     => (variableFrom -> variableTo)
     -> Substitution variableFrom
     -> Substitution variableTo

--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -350,21 +350,17 @@ modify f = wrap . f . unwrap
 mapVariables
     :: forall variableFrom variableTo
     .  (Ord variableFrom, FreshVariable variableTo)
-    => (variableFrom -> variableTo)
+    => (ElementVariable variableFrom -> ElementVariable variableTo)
+    -> (SetVariable variableFrom -> SetVariable variableTo)
     -> Substitution variableFrom
     -> Substitution variableTo
-mapVariables variableMapper =
-    modify (map (mapVariable variableMapper))
+mapVariables mapElemVar mapSetVar  =
+    modify (map mapSingleSubstitution)
   where
-    mapVariable
-        :: (variableFrom -> variableTo)
-        -> (UnifiedVariable variableFrom, TermLike variableFrom)
-        -> (UnifiedVariable variableTo, TermLike variableTo)
-    mapVariable
-        mapper
-        (substVariable, patt)
-      =
-        (mapper <$> substVariable, TermLike.mapVariables mapper patt)
+    mapSingleSubstitution =
+        Bifunctor.bimap
+            (mapUnifiedVariable mapElemVar mapSetVar)
+            (TermLike.mapVariables mapElemVar mapSetVar)
 
 mapTerms
     :: (TermLike variable -> TermLike variable)

--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -75,7 +75,7 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     )
 import Kore.Internal.TermLike
     ( InternalVariable
-    , SubstitutionVariable
+    , InternalVariable
     , TermLike
     , pattern Var_
     , mkVar
@@ -428,9 +428,7 @@ renormalizes, if needed.
 -}
 reverseIfRhsIsVar
     :: forall variable
-    .   ( InternalVariable variable
-        , FreshVariable variable
-        )
+    .  InternalVariable variable
     => UnifiedVariable variable
     -> Substitution variable
     -> Substitution variable
@@ -563,7 +561,7 @@ wrapNormalization Normalization { normalized, denormalized } =
 
 -- | Substitute the 'normalized' part into the 'denormalized' part.
 applyNormalized
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Normalization variable
     -> Normalization variable
 applyNormalized Normalization { normalized, denormalized } =

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -143,7 +143,6 @@ module Kore.Internal.TermLike
     , pattern Inj_
     -- * Re-exports
     , module Kore.Internal.Variable
-    , Substitute.SubstitutionVariable
     , FreshVariable (..)
     , Symbol (..)
     , Alias (..)
@@ -285,7 +284,7 @@ hasFreeVariable
 hasFreeVariable variable = isFreeVariable variable . freeVariables
 
 refreshVariables
-    :: Substitute.SubstitutionVariable variable
+    :: InternalVariable variable
     => FreeVariables variable
     -> TermLike variable
     -> TermLike variable
@@ -1886,7 +1885,7 @@ pattern Inj_ :: Inj (TermLike child) -> TermLike child
 pattern Inj_ inj <- (Recursive.project -> _ :< InjF inj)
 
 refreshBinder
-    :: Substitute.SubstitutionVariable variable
+    :: InternalVariable variable
     => (Set (UnifiedVariable variable) -> bound -> Maybe bound)
     -> (bound -> UnifiedVariable variable)
     -> FreeVariables variable
@@ -1909,14 +1908,14 @@ refreshBinder refreshBound mkUnified (getFreeVariables -> avoiding) binder =
     Binder { binderVariable, binderChild } = binder
 
 refreshElementBinder
-    :: Substitute.SubstitutionVariable variable
+    :: InternalVariable variable
     => FreeVariables variable
     -> Binder (ElementVariable variable) (TermLike variable)
     -> Binder (ElementVariable variable) (TermLike variable)
 refreshElementBinder = refreshBinder refreshElementVariable ElemVar
 
 refreshSetBinder
-    :: Substitute.SubstitutionVariable variable
+    :: InternalVariable variable
     => FreeVariables variable
     -> Binder (SetVariable variable) (TermLike variable)
     -> Binder (SetVariable variable) (TermLike variable)

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -144,6 +144,7 @@ module Kore.Internal.TermLike
     -- * Re-exports
     , module Kore.Internal.Variable
     , Substitute.SubstitutionVariable
+    , FreshVariable (..)
     , Symbol (..)
     , Alias (..)
     , SortedVariable (..)
@@ -270,6 +271,9 @@ import Kore.Unparser
     )
 import qualified Kore.Unparser as Unparser
 import Kore.Variables.Binding
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 import qualified Kore.Variables.Fresh as Fresh
 import Kore.Variables.UnifiedVariable
 
@@ -341,7 +345,7 @@ Otherwise, the argument is returned.
 
  -}
 withoutFreeVariable
-    :: (Ord variable, SortedVariable variable, Unparse variable)
+    :: InternalVariable variable
     => UnifiedVariable variable  -- ^ variable
     -> TermLike variable
     -> a  -- ^ result, if the variable does not occur free in the pattern
@@ -417,7 +421,7 @@ composes with other tree transformations without allocating intermediates.
 
  -}
 fromConcrete
-    :: Ord variable
+    :: FreshVariable variable
     => TermLike Concrete
     -> TermLike variable
 fromConcrete = mapVariables (\case {})
@@ -446,7 +450,7 @@ simplifiedAttribute :: TermLike variable -> Pattern.Simplified
 simplifiedAttribute = Attribute.simplifiedAttribute . extractAttributes
 
 assertConstructorLikeKeys
-    :: SortedVariable variable
+    :: InternalVariable variable
     => Foldable t
     => t (TermLike variable)
     -> a

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -377,7 +377,7 @@ asConcrete
     :: Ord variable
     => TermLike variable
     -> Maybe (TermLike Concrete)
-asConcrete = traverseVariables (\case { _ -> Nothing })
+asConcrete = traverseVariables (\case { _ -> Nothing }) (\case { _ -> Nothing })
 
 isConcrete :: Ord variable => TermLike variable -> Bool
 isConcrete = isJust . asConcrete
@@ -395,7 +395,7 @@ fromConcrete
     :: FreshVariable variable
     => TermLike Concrete
     -> TermLike variable
-fromConcrete = mapVariables (\case {})
+fromConcrete = mapVariables (\case {}) (\case {})
 
 isSimplified :: SideCondition.Representation -> TermLike variable -> Bool
 isSimplified sideCondition =

--- a/kore/src/Kore/Internal/TermLike/Renaming.hs
+++ b/kore/src/Kore/Internal/TermLike/Renaming.hs
@@ -66,6 +66,7 @@ askUnifiedVariable =
     \case
         SetVar setVar -> SetVar <$> askSetVariable setVar
         ElemVar elemVar -> ElemVar <$> askElementVariable elemVar
+{-# INLINE askUnifiedVariable #-}
 
 askElementVariable
     :: Monad m
@@ -76,6 +77,7 @@ askElementVariable elementVariable =
     -- fromJust is safe because the variable must be renamed
     fmap Maybe.fromJust
     $ Reader.asks (lookupRenamedElementVariable elementVariable)
+{-# INLINE askElementVariable #-}
 
 askSetVariable
     :: Monad m
@@ -85,3 +87,4 @@ askSetVariable
 askSetVariable setVariable =
     -- fromJust is safe because the variable must be renamed
     fmap Maybe.fromJust $ Reader.asks (lookupRenamedSetVariable setVariable)
+{-# INLINE askSetVariable #-}

--- a/kore/src/Kore/Internal/TermLike/Renaming.hs
+++ b/kore/src/Kore/Internal/TermLike/Renaming.hs
@@ -1,0 +1,89 @@
+{-|
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+{-# LANGUAGE UndecidableInstances #-}
+
+module Kore.Internal.TermLike.Renaming
+    ( RenamingT
+    , Renaming
+    , renameFreeVariables
+    , askUnifiedVariable
+    , askElementVariable
+    , askSetVariable
+    , module Kore.Variables.UnifiedVariable
+    ) where
+
+import Prelude.Kore
+
+import Control.Comonad.Trans.Env
+    ( Env
+    )
+import qualified Control.Monad as Monad
+import Control.Monad.Reader
+    ( ReaderT
+    )
+import qualified Control.Monad.Reader as Reader
+import qualified Data.Maybe as Maybe
+
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Internal.Variable
+import Kore.Variables.UnifiedVariable
+
+type RenamingT variable1 variable2 =
+    ReaderT (UnifiedVariableMap variable1 variable2)
+
+type Renaming variable1 variable2 =
+    Env (UnifiedVariableMap variable1 variable2)
+
+renameFreeVariables
+    :: Ord variable1
+    => Monad m
+    => (ElementVariable variable1 -> m (ElementVariable variable2))
+    -> (SetVariable variable1 -> m (SetVariable variable2))
+    -> FreeVariables variable1
+    -> m (UnifiedVariableMap variable1 variable2)
+renameFreeVariables trElemVar trSetVar =
+    Monad.foldM worker mempty . getFreeVariables
+  where
+    worker renaming =
+        \case
+            ElemVar elemVar ->
+                renameElementVariable elemVar
+                    <$> trElemVar elemVar
+                    <*> pure renaming
+            SetVar setVar ->
+                renameSetVariable setVar
+                    <$> trSetVar setVar
+                    <*> pure renaming
+
+askUnifiedVariable
+    :: Monad m
+    => Ord variable1
+    => UnifiedVariable variable1
+    -> RenamingT variable1 variable2 m (UnifiedVariable variable2)
+askUnifiedVariable =
+    \case
+        SetVar setVar -> SetVar <$> askSetVariable setVar
+        ElemVar elemVar -> ElemVar <$> askElementVariable elemVar
+
+askElementVariable
+    :: Monad m
+    => Ord variable1
+    => ElementVariable variable1
+    -> RenamingT variable1 variable2 m (ElementVariable variable2)
+askElementVariable elementVariable =
+    -- fromJust is safe because the variable must be renamed
+    fmap Maybe.fromJust
+    $ Reader.asks (lookupRenamedElementVariable elementVariable)
+
+askSetVariable
+    :: Monad m
+    => Ord variable1
+    => SetVariable variable1
+    -> RenamingT variable1 variable2 m (SetVariable variable2)
+askSetVariable setVariable =
+    -- fromJust is safe because the variable must be renamed
+    fmap Maybe.fromJust $ Reader.asks (lookupRenamedSetVariable setVariable)

--- a/kore/src/Kore/Internal/TermLike/Renaming.hs
+++ b/kore/src/Kore/Internal/TermLike/Renaming.hs
@@ -4,8 +4,6 @@ License     : NCSA
 
 -}
 
-{-# LANGUAGE UndecidableInstances #-}
-
 module Kore.Internal.TermLike.Renaming
     ( RenamingT
     , Renaming

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -721,9 +721,6 @@ returns. When composing multiple transformations with @traverseVariables@, the
 intermediate trees will be fully allocated; @mapVariables@ is more composable in
 this respect.
 
-__Warning__: @traverseVariables@ will capture variables if the provided
-traversal is not injective!
-
 See also: 'mapVariables'
 
  -}

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -945,34 +945,11 @@ traverseVariables trElemVar trSetVar termLike =
                 ExistsF <$> existsBinder (renameElementBinder avoiding) exists
             ForallF forall ->
                 ForallF <$> forallBinder (renameElementBinder avoiding) forall
-            MuF mu ->
-                MuF <$> muBinder (renameSetBinder avoiding) mu
-            NuF nu ->
-                NuF <$> nuBinder (renameSetBinder avoiding) nu
-            AndF andP -> AndF <$> sequence andP
-            ApplySymbolF applySymbolF -> ApplySymbolF <$> sequence applySymbolF
-            ApplyAliasF applyAliasF -> ApplyAliasF <$> sequence applyAliasF
-            BottomF botP -> BottomF <$> sequence botP
-            BuiltinF builtinP -> BuiltinF <$> sequence builtinP
-            CeilF ceilP -> CeilF <$> sequence ceilP
-            DomainValueF dvP -> DomainValueF <$> sequence dvP
-            EqualsF eqP -> EqualsF <$> sequence eqP
-            FloorF flrP -> FloorF <$> sequence flrP
-            IffF iffP -> IffF <$> sequence iffP
-            ImpliesF impP -> ImpliesF <$> sequence impP
-            InF inP -> InF <$> sequence inP
-            NextF nxtP -> NextF <$> sequence nxtP
-            NotF notP -> NotF <$> sequence notP
-            OrF orP -> OrF <$> sequence orP
-            RewritesF rewP -> RewritesF <$> sequence rewP
-            StringLiteralF strP -> StringLiteralF <$> sequence strP
-            InternalBytesF bytesP -> InternalBytesF <$> sequence bytesP
-            TopF topP -> TopF <$> sequence topP
-            InhabitantF s -> InhabitantF <$> sequence s
-            EvaluatedF childP -> EvaluatedF <$> sequence childP
-            EndiannessF endianness -> EndiannessF <$> sequence endianness
-            SignednessF signedness -> SignednessF <$> sequence signedness
-            InjF inj -> InjF <$> sequence inj
+            MuF mu -> MuF <$> muBinder (renameSetBinder avoiding) mu
+            NuF nu -> NuF <$> nuBinder (renameSetBinder avoiding) nu
+            _ ->
+                traverseVariablesF askElementVariable askSetVariable
+                =<< sequence termLikeF
         (pure . Recursive.embed) (attrs' :< termLikeF')
 
 {- | Reset the 'variableCounter' of all 'Variables'.

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -603,7 +603,7 @@ data UnifiedVariableMap variable1 variable2 =
     UnifiedVariableMap
         { setVariables
             :: !(VariableMap SetVariable variable1 variable2)
-        , renamedElementVariables
+        , elementVariables
             :: !(VariableMap ElementVariable variable1 variable2)
         }
     deriving (GHC.Generic)
@@ -614,7 +614,7 @@ instance
     (<>) a b =
         UnifiedVariableMap
             { setVariables = on (<>) setVariables a b
-            , renamedElementVariables = on (<>) renamedElementVariables a b
+            , elementVariables = on (<>) elementVariables a b
             }
 
 instance Ord variable1 => Monoid (UnifiedVariableMap variable1 variable2) where
@@ -645,7 +645,7 @@ renameElementVariable
     -> UnifiedVariableMap variable1 variable2
 renameElementVariable variable1 variable2 =
     Lens.over
-        (Lens.Product.field @"renamedElementVariables")
+        (Lens.Product.field @"elementVariables")
         (Map.insert variable1 variable2)
 
 renameFreeVariables
@@ -675,7 +675,7 @@ lookupRenamedElementVariable
     -> UnifiedVariableMap variable1 variable2
     -> Maybe (ElementVariable variable2)
 lookupRenamedElementVariable variable =
-    Map.lookup variable . renamedElementVariables
+    Map.lookup variable . elementVariables
 
 lookupRenamedSetVariable
     :: Ord variable1

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -870,9 +870,6 @@ traverseVariables trElemVar trSetVar termLike =
     renameFreeVariables trElemVar trSetVar (freeVariables termLike)
     >>= Reader.runReaderT (Recursive.fold worker termLike)
   where
-
-    impossible = error "The impossible happened!"
-
     renameElementBinder
         ::  Set.Set (UnifiedVariable variable2)
         ->  Binder
@@ -882,14 +879,10 @@ traverseVariables trElemVar trSetVar termLike =
                 (Binder (ElementVariable variable2) (TermLike variable2))
     renameElementBinder avoiding binder = do
         let Binder { binderVariable, binderChild } = binder
-        unifiedVariable2 <- ElemVar <$> Trans.lift (trElemVar binderVariable)
-        let unifiedVariable2' =
-                Fresh.refreshVariable avoiding unifiedVariable2
-                & fromMaybe unifiedVariable2
-            binderVariable' =
-                case unifiedVariable2' of
-                    ElemVar elemVar -> elemVar
-                    SetVar _ -> impossible
+        elementVariable2 <- Trans.lift $ trElemVar binderVariable
+        let binderVariable' =
+                refreshElementVariable avoiding elementVariable2
+                & fromMaybe elementVariable2
         binderChild' <-
             Reader.local
                 (renameElementVariable binderVariable binderVariable')

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -937,8 +937,10 @@ traverseVariables trElemVar trSetVar termLike =
             MuF mu -> MuF <$> muBinder (renameSetBinder avoiding) mu
             NuF nu -> NuF <$> nuBinder (renameSetBinder avoiding) nu
             _ ->
+                sequence termLikeF >>=
+                -- traverseVariablesF will not actually call the traversals
+                -- because all the cases with variables are handled above.
                 traverseVariablesF askElementVariable askSetVariable
-                =<< sequence termLikeF
         (pure . Recursive.embed) (attrs' :< termLikeF')
 
 {- | Reset the 'variableCounter' of all 'Variables'.

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -910,14 +910,10 @@ traverseVariables trElemVar trSetVar termLike =
                 (Binder (SetVariable variable2) (TermLike variable2))
     renameSetBinder avoiding binder = do
         let Binder { binderVariable, binderChild } = binder
-        unifiedVariable2 <- SetVar <$> Trans.lift (trSetVar binderVariable)
-        let unifiedVariable2' =
-                Fresh.refreshVariable avoiding unifiedVariable2
-                & fromMaybe unifiedVariable2
-            binderVariable' =
-                case unifiedVariable2' of
-                    SetVar setVar -> setVar
-                    ElemVar _ -> impossible
+        setVariable2 <- Trans.lift $ trSetVar binderVariable
+        let binderVariable' =
+                refreshSetVariable avoiding setVariable2
+                & fromMaybe setVariable2
         binderChild' <-
             Reader.local
                 (renameSetVariable binderVariable binderVariable')

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -805,6 +805,7 @@ renameElementBinder trElemVar avoiding binder = do
             , binderChild = binderChild'
             }
     pure binder'
+{-# INLINE renameElementBinder #-}
 
 renameSetBinder
     ::  Monad m
@@ -830,6 +831,7 @@ renameSetBinder trSetVar avoiding binder = do
             , binderChild = binderChild'
             }
     pure binder'
+{-# INLINE renameSetBinder #-}
 
 {- | Reset the 'variableCounter' of all 'Variables'.
 

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -601,7 +601,7 @@ type VariableMap meta variable1 variable2 =
 
 data UnifiedVariableMap variable1 variable2 =
     UnifiedVariableMap
-        { renamedSetVariables
+        { setVariables
             :: !(VariableMap SetVariable variable1 variable2)
         , renamedElementVariables
             :: !(VariableMap ElementVariable variable1 variable2)
@@ -613,7 +613,7 @@ instance
   where
     (<>) a b =
         UnifiedVariableMap
-            { renamedSetVariables = on (<>) renamedSetVariables a b
+            { setVariables = on (<>) setVariables a b
             , renamedElementVariables = on (<>) renamedElementVariables a b
             }
 
@@ -634,7 +634,7 @@ renameSetVariable
     -> UnifiedVariableMap variable1 variable2
 renameSetVariable variable1 variable2 =
     Lens.over
-        (Lens.Product.field @"renamedSetVariables")
+        (Lens.Product.field @"setVariables")
         (Map.insert variable1 variable2)
 
 renameElementVariable
@@ -683,7 +683,7 @@ lookupRenamedSetVariable
     -> UnifiedVariableMap variable1 variable2
     -> Maybe (SetVariable variable2)
 lookupRenamedSetVariable variable =
-    Map.lookup variable . renamedSetVariables
+    Map.lookup variable . setVariables
 
 askUnifiedVariable
     :: Monad m

--- a/kore/src/Kore/Internal/Variable.hs
+++ b/kore/src/Kore/Internal/Variable.hs
@@ -22,6 +22,9 @@ import Kore.Syntax.Variable
 import Kore.Unparser
     ( Unparse
     )
+import Kore.Variables.Fresh
+    ( FreshVariable
+    )
 
 {- | 'InternalVariable' is the basic constraint on variable types.
 
@@ -33,5 +36,5 @@ these constraints.
 type InternalVariable variable =
     ( Ord variable
     , Debug variable, Show variable, Unparse variable
-    , SortedVariable variable
+    , SortedVariable variable, FreshVariable variable
     )

--- a/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
+++ b/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
@@ -40,7 +40,7 @@ import Kore.Step.Step
     , mapRuleVariables
     )
 import Kore.Unification.Unify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 import Kore.Unparser
     ( unparse
@@ -92,7 +92,7 @@ instance Entry DebugAppliedRewriteRules where
 
 debugAppliedRewriteRules
     :: MonadLog log
-    => SimplifierVariable variable
+    => InternalVariable variable
     => Pattern (Target variable)
     -> [UnifiedRule (Target variable) (RulePattern (Target variable))]
     -> log ()

--- a/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
+++ b/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
@@ -102,12 +102,11 @@ debugAppliedRewriteRules initial rules =
         , appliedRewriteRules
         }
   where
-    configuration =
-        Conditional.mapVariables
-            TermLike.mapVariables
-            toVariable
-            initial
+    configuration = mapConditionalVariables TermLike.mapVariables initial
     appliedRewriteRules =
-        coerce
-        $ Conditional.mapVariables mapRuleVariables toVariable
-        <$> rules
+        coerce (mapConditionalVariables mapRuleVariables <$> rules)
+    mapConditionalVariables mapTermVariables =
+        Conditional.mapVariables
+            mapTermVariables
+            (fmap toVariable)
+            (fmap toVariable)

--- a/kore/src/Kore/Log/DebugAppliedRule.hs
+++ b/kore/src/Kore/Log/DebugAppliedRule.hs
@@ -103,7 +103,10 @@ debugAppliedRule
 debugAppliedRule =
     logM
     . DebugAppliedRule
-    . Conditional.mapVariables Equality.mapRuleVariables toVariable
+    . Conditional.mapVariables
+        Equality.mapRuleVariables
+        (fmap toVariable)
+        (fmap toVariable)
 
 {- | Options (from the command-line) specifying when to log specific rules.
 

--- a/kore/src/Kore/Log/WarnBottomHook.hs
+++ b/kore/src/Kore/Log/WarnBottomHook.hs
@@ -23,7 +23,7 @@ import GHC.Generics as GHC
 
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 import Kore.Unparser
     ( unparse
@@ -59,7 +59,7 @@ instance SQL.Table WarnBottomHook
 
 warnBottomHook
     :: MonadLog logger
-    => SimplifierVariable variable
+    => InternalVariable variable
     => Text
     -> TermLike variable
     -> logger ()

--- a/kore/src/Kore/Log/WarnBottomHook.hs
+++ b/kore/src/Kore/Log/WarnBottomHook.hs
@@ -63,5 +63,5 @@ warnBottomHook
     => Text
     -> TermLike variable
     -> logger ()
-warnBottomHook hook (mapVariables toVariable -> term) =
+warnBottomHook hook (mapVariables (fmap toVariable) (fmap toVariable) -> term) =
     logM WarnBottomHook { hook, term }

--- a/kore/src/Kore/Log/WarnSimplificationWithRemainder.hs
+++ b/kore/src/Kore/Log/WarnSimplificationWithRemainder.hs
@@ -106,10 +106,16 @@ warnSimplificationWithRemainder
     -> OrPattern variable  -- ^ remainders
     -> logger ()
 warnSimplificationWithRemainder
-    (TermLike.mapVariables toVariable -> inputPattern)
-    (SideCondition.mapVariables toVariable -> sideCondition)
-    (Results . fmap (Pattern.mapVariables toVariable) -> results)
-    (Remainders . fmap (Pattern.mapVariables toVariable) -> remainders)
+    (TermLike.mapVariables (fmap toVariable) (fmap toVariable) -> inputPattern)
+    (SideCondition.mapVariables (fmap toVariable) (fmap toVariable)
+        -> sideCondition
+    )
+    (Results . fmap (Pattern.mapVariables (fmap toVariable) (fmap toVariable))
+        -> results
+    )
+    (Remainders . fmap (Pattern.mapVariables (fmap toVariable) (fmap toVariable))
+        -> remainders
+    )
   =
     logM WarnSimplificationWithRemainder
         { inputPattern

--- a/kore/src/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/src/Kore/Step/Axiom/Evaluate.hs
@@ -154,7 +154,10 @@ evaluateAxioms equalityRules sideCondition termLike
     maybeNotApplicable = maybeT (return notApplicable) return
 
     unwrapEqualityRule (EqualityRule rule) =
-        EqualityPattern.mapRuleVariables fromVariable rule
+        EqualityPattern.mapRuleVariables
+            (fmap fromVariable)
+            (fmap fromVariable)
+            rule
 
     rejectNarrowing (Result.results -> results) =
         (Monad.guard . not) (any Step.isNarrowingResult results)

--- a/kore/src/Kore/Step/Axiom/Evaluate.hs
+++ b/kore/src/Kore/Step/Axiom/Evaluate.hs
@@ -57,8 +57,8 @@ import Kore.Step.Remainder
 import qualified Kore.Step.Result as Result
 import qualified Kore.Step.Simplification.OrPattern as OrPattern
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import qualified Kore.Step.Step as EqualityPattern
     ( mapRuleVariables
@@ -71,7 +71,7 @@ import Log
 
 evaluateAxioms
     :: forall variable simplifier
-    .  ( SimplifierVariable variable
+    .  ( InternalVariable variable
        , MonadSimplify simplifier
        )
     => [EqualityRule Variable]

--- a/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
+++ b/kore/src/Kore/Step/Axiom/EvaluationStrategy.hs
@@ -122,7 +122,7 @@ totalDefinitionEvaluation rules =
   where
     totalDefinitionEvaluationWorker
         :: forall variable simplifier
-        .  ( SimplifierVariable variable
+        .  ( InternalVariable variable
            , MonadSimplify simplifier
            )
         => TermLike variable
@@ -173,7 +173,7 @@ builtinEvaluation evaluator =
 
 evaluateBuiltin
     :: forall variable simplifier
-    .  ( SimplifierVariable variable
+    .  ( InternalVariable variable
        , MonadSimplify simplifier
        )
     => BuiltinAndAxiomSimplifier
@@ -238,7 +238,7 @@ data NonSimplifiability
 
 applyFirstSimplifierThatWorks
     :: forall variable simplifier
-    .  ( SimplifierVariable variable
+    .  ( InternalVariable variable
        , MonadSimplify simplifier
        )
     => [BuiltinAndAxiomSimplifier]
@@ -251,7 +251,7 @@ applyFirstSimplifierThatWorks evaluators multipleResults =
 
 applyFirstSimplifierThatWorksWorker
     :: forall variable simplifier
-    .  ( SimplifierVariable variable
+    .  ( InternalVariable variable
        , MonadSimplify simplifier
        )
     => [BuiltinAndAxiomSimplifier]

--- a/kore/src/Kore/Step/Axiom/Identifier.hs
+++ b/kore/src/Kore/Step/Axiom/Identifier.hs
@@ -41,6 +41,7 @@ import qualified Kore.Builtin.External as Builtin
 import Kore.Debug
 import Kore.Internal.TermLike
     ( CofreeF (..)
+    , FreshVariable
     , InternalVariable
     , TermLike
     )
@@ -102,7 +103,7 @@ recognize.
 
  -}
 matchAxiomIdentifier
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => TermLike variable
     -> Maybe AxiomIdentifier
 matchAxiomIdentifier = Recursive.fold matchWorker . Builtin.externalize

--- a/kore/src/Kore/Step/Axiom/Identifier.hs
+++ b/kore/src/Kore/Step/Axiom/Identifier.hs
@@ -41,7 +41,6 @@ import qualified Kore.Builtin.External as Builtin
 import Kore.Debug
 import Kore.Internal.TermLike
     ( CofreeF (..)
-    , FreshVariable
     , InternalVariable
     , TermLike
     )
@@ -103,7 +102,7 @@ recognize.
 
  -}
 matchAxiomIdentifier
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => TermLike variable
     -> Maybe AxiomIdentifier
 matchAxiomIdentifier = Recursive.fold matchWorker . Builtin.externalize

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -86,8 +86,8 @@ import Kore.Internal.TermLike hiding
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Step.Simplification.InjSimplifier as InjSimplifier
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import qualified Kore.Step.Simplification.Simplify as Simplifier
 import Kore.Variables.Binding
@@ -356,7 +356,7 @@ matchInj _ = empty
 
 -- * Implementation
 
-type MatchingVariable variable = SimplifierVariable variable
+type MatchingVariable variable = InternalVariable variable
 
 {- | The internal state of the matching algorithm.
  -}

--- a/kore/src/Kore/Step/EqualityPattern.hs
+++ b/kore/src/Kore/Step/EqualityPattern.hs
@@ -201,15 +201,17 @@ equalityRuleToTerm
         )
 
 instance UnifyingRule EqualityPattern where
-    mapRuleVariables mapping rule1@(EqualityPattern _ _ _ _ _) =
+    mapRuleVariables mapElemVar mapSetVar rule1@(EqualityPattern _ _ _ _ _) =
         rule1
-            { requires = Predicate.mapVariables mapping requires
-            , left = TermLike.mapVariables mapping left
-            , right = TermLike.mapVariables mapping right
-            , ensures = Predicate.mapVariables mapping ensures
+            { requires = mapPredicateVariables requires
+            , left = mapTermLikeVariables left
+            , right = mapTermLikeVariables right
+            , ensures = mapPredicateVariables ensures
             }
       where
         EqualityPattern { requires, left, right, ensures } = rule1
+        mapTermLikeVariables = TermLike.mapVariables mapElemVar mapSetVar
+        mapPredicateVariables = Predicate.mapVariables mapElemVar mapSetVar
 
     matchingPattern = left
 

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -133,7 +133,7 @@ isNarrowingResult Step.Result { appliedRule } =
  -}
 unwrapAndQuantifyConfiguration
     :: forall variable
-    .  InternalVariable variable
+    .  (InternalVariable variable, FreshVariable variable)
     => Pattern (Target variable)
     -> Pattern variable
 unwrapAndQuantifyConfiguration config@Conditional { substitution } =

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -156,7 +156,10 @@ unwrapAndQuantifyConfiguration config@Conditional { substitution } =
 
     unwrappedConfig :: Pattern variable
     unwrappedConfig =
-        Pattern.mapVariables Target.unwrapVariable configWithNewSubst
+        Pattern.mapVariables
+            (fmap Target.unwrapVariable)
+            (fmap Target.unwrapVariable)
+            configWithNewSubst
 
     targetVariables :: [ElementVariable variable]
     targetVariables =
@@ -339,7 +342,10 @@ finalizeRulesSequence sideCondition initial unifiedRules
         { results = Seq.fromList $ Foldable.fold results
         , remainders =
             OrPattern.fromPatterns
-            $ Pattern.mapVariables Target.unwrapVariable <$> remainders'
+            $ Pattern.mapVariables
+                (fmap Target.unwrapVariable)
+                (fmap Target.unwrapVariable)
+            <$> remainders'
         }
   where
     initialTerm = Conditional.term initial

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -99,8 +99,8 @@ import Kore.Unification.UnifierT
     )
 import qualified Kore.Unification.UnifierT as Unifier
 import Kore.Unification.Unify
-    ( MonadUnify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadUnify
     )
 import qualified Kore.Unification.Unify as Monad.Unify
     ( gather
@@ -133,7 +133,7 @@ isNarrowingResult Step.Result { appliedRule } =
  -}
 unwrapAndQuantifyConfiguration
     :: forall variable
-    .  (InternalVariable variable, FreshVariable variable)
+    .  InternalVariable variable
     => Pattern (Target variable)
     -> Pattern variable
 unwrapAndQuantifyConfiguration config@Conditional { substitution } =
@@ -186,7 +186,7 @@ See also: 'applyInitialConditions'
  -}
 finalizeAppliedRule
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -- ^ Top level condition
@@ -220,7 +220,7 @@ finalizeAppliedRule sideCondition renamedRule appliedConditions =
         return (finalTerm' `Pattern.withCondition` finalCondition)
 
 finalizeRule
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -258,7 +258,7 @@ implied by the configuration predicate.
 -}
 recoveryFunctionLikeResults
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => Simplifier.MonadSimplify simplifier
     => Pattern (Target variable)
     -> Results EqualityPattern variable
@@ -324,7 +324,7 @@ recoveryFunctionLikeResults initial results = do
 
 finalizeRulesSequence
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition (Target variable)
     -> Pattern (Target variable)
@@ -375,7 +375,7 @@ See also: 'applyRewriteRule'
  -}
 applyRulesSequence
     ::  forall unifier variable
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , MonadUnify unifier
         )
     => SideCondition (Target variable)
@@ -395,7 +395,7 @@ applyRulesSequence
 
 -- | Matches a list a rules against a configuration. See 'matchRule'.
 matchRules
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => UnifyingRule rule
     => SideCondition (Target variable)
@@ -423,7 +423,7 @@ unification. The substitution is not applied to the renamed rule.
 
  -}
 matchRule
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => UnifyingRule rule
     => SideCondition variable
@@ -468,7 +468,7 @@ matchRule sideCondition initial rule = do
  -}
 evaluateRequires
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -- ^ the side condition

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -95,7 +95,7 @@ import Kore.Unparser
 -- to add memoization to a function evaluator.
 evaluateApplication
     :: forall variable simplifier
-    .  ( SimplifierVariable variable
+    .  ( InternalVariable variable
        , MonadSimplify simplifier
        )
     => SideCondition variable
@@ -181,7 +181,7 @@ evaluateApplication
 -}
 evaluatePattern
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -- ^ The predicate from the configuration
@@ -211,7 +211,7 @@ Returns Nothing if there is no axiom for the pattern's identifier.
 -}
 maybeEvaluatePattern
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => Condition variable
     -- ^ Aggregated children predicate and substitution.
@@ -374,7 +374,7 @@ sortInjectionSorts symbol =
 was evaluated.
 -}
 reevaluateFunctions
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Pattern variable
@@ -391,7 +391,7 @@ reevaluateFunctions sideCondition rewriting = do
 {-| Ands the given condition-substitution to the given function evaluation.
 -}
 mergeWithConditionAndSubstitution
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -- ^ Top level condition.

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -70,7 +70,10 @@ remainder
     => MultiOr (Condition (Target variable))
     -> Predicate variable
 remainder =
-    Predicate.mapVariables Target.unwrapVariable . remainder'
+    Predicate.mapVariables
+        (fmap Target.unwrapVariable)
+        (fmap Target.unwrapVariable)
+    . remainder'
 
 {- | Negate the disjunction of unification solutions to form the /remainder/.
 

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -66,7 +66,7 @@ See also: 'remainder\''
 
  -}
 remainder
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => MultiOr (Condition (Target variable))
     -> Predicate variable
 remainder =

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -44,8 +44,8 @@ import Kore.Internal.TermLike
 import qualified Kore.Step.Simplification.AndPredicates as AndPredicates
 import qualified Kore.Step.Simplification.Ceil as Ceil
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify (..)
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify (..)
     )
 import Kore.Variables.Target
     ( Target
@@ -66,7 +66,7 @@ See also: 'remainder\''
 
  -}
 remainder
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => MultiOr (Condition (Target variable))
     -> Predicate variable
 remainder =
@@ -153,7 +153,7 @@ substitutionConditions subst =
 
 ceilChildOfApplicationOrTop
     :: forall variable m
-    .  (SimplifierVariable variable, MonadSimplify m)
+    .  (InternalVariable variable, MonadSimplify m)
     => SideCondition variable
     -> TermLike variable
     -> m (Condition variable)

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -68,8 +68,8 @@ import Kore.Step.Step
     , unifyRules
     )
 import Kore.Unification.Unify
-    ( MonadUnify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadUnify
     )
 import qualified Kore.Unification.Unify as Monad.Unify
     ( gather
@@ -90,7 +90,7 @@ withoutUnification = Conditional.term
  -}
 unwrapConfiguration
     :: forall variable
-    .  (InternalVariable variable, FreshVariable variable)
+    .  InternalVariable variable
     => Pattern (Target variable)
     -> Pattern variable
 unwrapConfiguration config@Conditional { substitution } =
@@ -120,7 +120,7 @@ See also: 'applyInitialConditions'
  -}
 finalizeAppliedRule
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => RulePattern variable
     -- ^ Applied rule
@@ -155,7 +155,7 @@ finalizeAppliedRule renamedRule appliedConditions =
         return (finalTerm' `Pattern.withCondition` finalCondition)
 
 finalizeRule
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -182,7 +182,7 @@ finalizeRule initial unifiedRule =
 
 finalizeRulesParallel
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => Pattern (Target variable)
     -> [UnifiedRule (Target variable) (RulePattern (Target variable))]
@@ -205,7 +205,7 @@ finalizeRulesParallel initial unifiedRules = do
 
 finalizeRulesSequence
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => Pattern (Target variable)
     -> [UnifiedRule (Target variable) (RulePattern (Target variable))]
@@ -253,7 +253,7 @@ See also: 'applyRewriteRule'
  -}
 applyRulesParallel
     ::  forall unifier variable
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -282,7 +282,7 @@ See also: 'applyRewriteRule'
  -}
 applyRewriteRulesParallel
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => UnificationProcedure
     -> [RewriteRule variable]
@@ -307,7 +307,7 @@ See also: 'applyRewriteRule'
  -}
 applyRulesSequence
     ::  forall unifier variable
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , Log.WithLog Log.LogMessage unifier
         , MonadUnify unifier
         )
@@ -336,7 +336,7 @@ See also: 'applyRewriteRulesParallel'
  -}
 applyRewriteRulesSequence
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => UnificationProcedure
     -> Pattern variable

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -94,7 +94,10 @@ unwrapConfiguration
     => Pattern (Target variable)
     -> Pattern variable
 unwrapConfiguration config@Conditional { substitution } =
-    Pattern.mapVariables Target.unwrapVariable configWithNewSubst
+    Pattern.mapVariables
+        (fmap Target.unwrapVariable)
+        (fmap Target.unwrapVariable)
+        configWithNewSubst
   where
     substitution' =
         Substitution.filter (foldMapVariable Target.isNonTarget)
@@ -194,7 +197,10 @@ finalizeRulesParallel initial unifiedRules = do
         { results = Seq.fromList results
         , remainders =
             OrPattern.fromPatterns
-            $ Pattern.mapVariables Target.unwrapVariable <$> remainders'
+            $ Pattern.mapVariables
+                (fmap Target.unwrapVariable)
+                (fmap Target.unwrapVariable)
+            <$> remainders'
         }
 
 finalizeRulesSequence
@@ -216,7 +222,10 @@ finalizeRulesSequence initial unifiedRules
         { results = Seq.fromList $ Foldable.fold results
         , remainders =
             OrPattern.fromPatterns
-            $ Pattern.mapVariables Target.unwrapVariable <$> remainders'
+            $ Pattern.mapVariables
+                (fmap Target.unwrapVariable)
+                (fmap Target.unwrapVariable)
+            <$> remainders'
         }
   where
     initialTerm = Conditional.term initial

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -90,7 +90,7 @@ withoutUnification = Conditional.term
  -}
 unwrapConfiguration
     :: forall variable
-    .  InternalVariable variable
+    .  (InternalVariable variable, FreshVariable variable)
     => Pattern (Target variable)
     -> Pattern variable
 unwrapConfiguration config@Conditional { substitution } =

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -85,9 +85,6 @@ import Kore.Step.RulePattern
 import Kore.Step.Simplification.ExpandAlias
     ( substituteInAlias
     )
-import Kore.Substitute
-    ( SubstitutionVariable
-    )
 import qualified Kore.Syntax.Definition as Syntax
 import Kore.Syntax.Id
     ( Id (..)
@@ -207,7 +204,7 @@ fromSentenceAxiom (attributes, sentenceAxiom) =
 not encode a normal rewrite or function axiom.
 -}
 termToAxiomPattern
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Attribute.Axiom Internal.Symbol.Symbol
     -> TermLike.TermLike variable
     -> Either (Error AxiomPatternError) (QualifiedAxiomPattern variable)

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -63,7 +63,6 @@ import qualified Kore.Step.RulePattern as RulePattern
 import qualified Kore.Step.RulePattern as Rule.DoNotUse
 import Kore.Step.Simplification.Simplify
     ( MonadSimplify
-    , SimplifierVariable
     , simplifyCondition
     )
 import qualified Kore.Step.SMT.Evaluator as SMT
@@ -71,9 +70,6 @@ import qualified Kore.Step.SMT.Evaluator as SMT
     )
 import Kore.Step.Step
     ( refreshRule
-    )
-import Kore.Substitute
-    ( SubstitutionVariable
     )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable
@@ -95,7 +91,7 @@ is the same as applying @(L1 and P) => Rn@.
 See docs/2019-09-09-Combining-Rewrite-Axioms.md for details.
 -}
 mergeRulesPredicate
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => [RewriteRule variable]
     -> Predicate variable
 mergeRulesPredicate rules =
@@ -103,7 +99,7 @@ mergeRulesPredicate rules =
     $ renameRulesVariables rules
 
 mergeDisjointVarRulesPredicate
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => [RewriteRule variable]
     -> Predicate variable
 mergeDisjointVarRulesPredicate rules =
@@ -139,14 +135,14 @@ mergeRulePairPredicate
     error "AntiLeft(priority-based rules) not handled when merging yet."
 
 renameRulesVariables
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => [RewriteRule variable]
     -> [RewriteRule variable]
 renameRulesVariables
     = List.reverse . snd . List.foldl' renameRuleVariable (Set.empty, [])
 
 renameRuleVariable
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => (Set (UnifiedVariable variable), [RewriteRule variable])
     -> RewriteRule variable
     -> (Set (UnifiedVariable variable), [RewriteRule variable])
@@ -168,7 +164,7 @@ renameRuleVariable
         refreshRule (FreeVariables usedVariables) rulePattern
 
 mergeRules
-    :: (MonadSimplify simplifier, SimplifierVariable variable)
+    :: (MonadSimplify simplifier, InternalVariable variable)
     => NonEmpty (RewriteRule variable)
     -> simplifier [RewriteRule variable]
 mergeRules (a :| []) = return [a]
@@ -212,7 +208,7 @@ first merges rules 1, 2, 3 and 4 into rule 4', then rules 4', 5, 6, 7
 into rule 7', then returns the result of merging 7', 8 and 9.
 -}
 mergeRulesConsecutiveBatches
-    :: (MonadSimplify simplifier, SimplifierVariable variable)
+    :: (MonadSimplify simplifier, InternalVariable variable)
     => Int
     -- ^ Batch size
     -> NonEmpty (RewriteRule variable)

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -64,8 +64,8 @@ import qualified Kore.Step.Simplification.Pattern as Pattern
     ( simplifyTopConfiguration
     )
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import Kore.Syntax.Variable
     ( Variable
@@ -79,7 +79,7 @@ class SimplifyRuleLHS rule where
         => rule
         -> simplifier (MultiAnd rule)
 
-instance SimplifierVariable variable => SimplifyRuleLHS (RulePattern variable)
+instance InternalVariable variable => SimplifyRuleLHS (RulePattern variable)
   where
     simplifyRuleLhs rule@(RulePattern _ _ _ _ _) = do
         let lhsWithPredicate = Pattern.fromTermLike left
@@ -131,7 +131,7 @@ instance SimplifyRuleLHS (ReachabilityRule Variable) where
         (fmap . fmap) AllPath $ simplifyRuleLhs rule
 
 simplifyClaimRule
-    :: (MonadSimplify simplifier, SimplifierVariable variable)
+    :: (MonadSimplify simplifier, InternalVariable variable)
     => RulePattern variable
     -> simplifier (MultiAnd (RulePattern variable))
 simplifyClaimRule rule@(RulePattern _ _ _ _ _) =

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -767,15 +767,15 @@ instance UnifyingRule RulePattern where
         originalFreeVariables =
             FreeVariables.getFreeVariables $ freeVariables rule1
 
-    mapRuleVariables mapping rule1@(RulePattern _ _ _ _ _) =
+    mapRuleVariables mapElemVar mapSetVar rule1@(RulePattern _ _ _ _ _) =
         rule1
-            { left = TermLike.mapVariables mapping left
-            , antiLeft = fmap (TermLike.mapVariables mapping) antiLeft
-            , requires = Predicate.mapVariables mapping requires
+            { left = mapTermLikeVariables left
+            , antiLeft = mapTermLikeVariables <$> antiLeft
+            , requires = mapPredicateVariables requires
             , rhs = RHS
-                { existentials = fmap mapping <$> existentials
-                , right = TermLike.mapVariables mapping right
-                , ensures = Predicate.mapVariables mapping ensures
+                { existentials = mapElemVar <$> existentials
+                , right = mapTermLikeVariables right
+                , ensures = mapPredicateVariables ensures
                 }
             }
       where
@@ -783,3 +783,5 @@ instance UnifyingRule RulePattern where
             { left, antiLeft, requires
             , rhs = RHS { existentials, right, ensures }
             } = rule1
+        mapTermLikeVariables = TermLike.mapVariables mapElemVar mapSetVar
+        mapPredicateVariables = Predicate.mapVariables mapElemVar mapSetVar

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -108,9 +108,6 @@ import Kore.Sort
 import Kore.Step.Step
     ( UnifyingRule (..)
     )
-import Kore.Substitute
-    ( SubstitutionVariable
-    )
 import qualified Kore.Syntax.Definition as Syntax
 import Kore.Syntax.Id
     ( AstLocation (..)
@@ -160,7 +157,7 @@ renaming them (if needed) to avoid clashing with the given free variables.
 -}
 topExistsToImplicitForall
     :: forall variable
-    .  SubstitutionVariable variable
+    .  InternalVariable variable
     => FreeVariables variable
     -> RHS variable
     -> Pattern variable
@@ -341,7 +338,7 @@ isFreeOf rule =
 {- | Apply the substitution to the right-hand-side of a rule.
  -}
 rhsSubstitute
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Map (UnifiedVariable variable) (TermLike.TermLike variable)
     -> RHS variable
     -> RHS variable
@@ -357,7 +354,7 @@ rhsSubstitute subst RHS { existentials, right, ensures } =
 {- | Apply the substitution to the rule.
  -}
 substitute
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Map (UnifiedVariable variable) (TermLike.TermLike variable)
     -> RulePattern variable
     -> RulePattern variable
@@ -376,7 +373,7 @@ i.e. there is no substitution variable left in the rule.
 -}
 applySubstitution
     :: HasCallStack
-    => SubstitutionVariable variable
+    => InternalVariable variable
     => Substitution variable
     -> RulePattern variable
     -> RulePattern variable

--- a/kore/src/Kore/Step/Search.hs
+++ b/kore/src/Kore/Step/Search.hs
@@ -132,7 +132,7 @@ searchGraph Config { searchType, bound } match executionGraph = do
 
 matchWith
     :: forall variable m
-    .  (SimplifierVariable variable, MonadSimplify m)
+    .  (InternalVariable variable, MonadSimplify m)
     => SideCondition variable
     -> Pattern variable
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -115,7 +115,7 @@ Also, we have
     the same for two string literals and two chars
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> And Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -140,7 +140,7 @@ to carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable
@@ -159,7 +159,7 @@ simplifyEvaluated sideCondition first second
     return (OrPattern.fromPatterns result)
 
 simplifyEvaluatedMultiple
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> [OrPattern variable]
     -> simplifier (OrPattern variable)
@@ -172,7 +172,7 @@ simplifyEvaluatedMultiple sideCondition (pat : patterns) =
 See the comment for 'simplify' to find more details.
 -}
 makeEvaluate
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , HasCallStack
         , MonadSimplify simplifier
         )
@@ -187,7 +187,7 @@ makeEvaluate sideCondition first second
   | otherwise = makeEvaluateNonBool sideCondition first second
 
 makeEvaluateNonBool
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , HasCallStack
         , MonadSimplify simplifier
         )
@@ -264,7 +264,7 @@ The comment for 'simplify' describes all the special cases handled by this.
 -}
 termAnd
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => HasCallStack
     => TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/AndPredicates.hs
+++ b/kore/src/Kore/Step/Simplification/AndPredicates.hs
@@ -43,14 +43,14 @@ import Kore.Internal.SideCondition
     ( SideCondition
     )
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import qualified Kore.Step.Substitution as Substitution
 
 simplifyEvaluatedMultiPredicate
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> MultiAnd (OrCondition variable)
     -> simplifier (OrCondition variable)

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -602,11 +602,9 @@ See also: 'equalAndEquals'
 -- TODO (thomas.tuegel): This unification case assumes that \dv is injective,
 -- but it is not.
 domainValueAndEqualsAssumesDifferent
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
+    :: HasCallStack
+    => InternalVariable variable
     => MonadUnify unifier
-    => HasCallStack
     => TermLike variable
     -> TermLike variable
     -> MaybeT unifier a
@@ -632,11 +630,9 @@ cannotUnifyDistinctDomainValues :: Pretty.Doc ()
 cannotUnifyDistinctDomainValues = "Cannot unify distinct domain values."
 
 cannotUnifyDomainValues
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
+    :: HasCallStack
+    => InternalVariable variable
     => MonadUnify unifier
-    => HasCallStack
     => TermLike variable
     -> TermLike variable
     -> unifier a
@@ -657,11 +653,9 @@ See also: 'equalAndEquals'
 
  -}
 stringLiteralAndEqualsAssumesDifferent
-    :: Eq variable
-    => SortedVariable variable
-    => Unparse variable
+    :: HasCallStack
+    => InternalVariable variable
     => MonadUnify unifier
-    => HasCallStack
     => TermLike variable
     -> TermLike variable
     -> MaybeT unifier a

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -108,7 +108,7 @@ the special cases handled by this.
 -}
 termUnification
     :: forall variable unifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => TermLike variable
@@ -135,7 +135,7 @@ termUnification =
         Error.maybeT unsupportedPatternsError pure maybeTermUnification
 
 maybeTermEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => TermSimplifier variable unifier
@@ -146,7 +146,7 @@ maybeTermEquals
 maybeTermEquals = maybeTransformTerm equalsFunctions
 
 maybeTermAnd
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => TermSimplifier variable unifier
@@ -158,7 +158,7 @@ maybeTermAnd = maybeTransformTerm andFunctions
 
 andFunctions
     :: forall variable unifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => [TermTransformationOld variable unifier]
@@ -177,7 +177,7 @@ andFunctions =
 
 equalsFunctions
     :: forall variable unifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => [TermTransformationOld variable unifier]
@@ -196,7 +196,7 @@ equalsFunctions =
 
 andEqualsFunctions
     :: forall variable unifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => HasCallStack
     => [(SimplificationTarget, TermTransformation variable unifier)]
@@ -312,7 +312,7 @@ maybeTransformTerm topTransformers childTransformers first second =
 -- | Simplify the conjunction of terms where one is a predicate.
 boolAnd
     :: MonadUnify unifier
-    => SimplifierVariable variable
+    => InternalVariable variable
     => TermLike variable
     -> TermLike variable
     -> MaybeT unifier (Pattern variable)
@@ -329,7 +329,7 @@ boolAnd first second
 
 explainBoolAndBottom
     :: MonadUnify unifier
-    => SimplifierVariable variable
+    => InternalVariable variable
     => TermLike variable
     -> TermLike variable
     -> MaybeT unifier ()
@@ -338,7 +338,7 @@ explainBoolAndBottom term1 term2 =
 
 -- | Unify two identical ('==') patterns.
 equalAndEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => Monad unifier
     => TermLike variable
     -> TermLike variable
@@ -350,7 +350,7 @@ equalAndEquals _ _ = empty
 
 -- | Unify two patterns where the first is @\\bottom@.
 bottomTermEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -> TermLike variable
@@ -389,7 +389,7 @@ See also: 'bottomTermEquals'
 
  -}
 termBottomEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -> TermLike variable
@@ -404,7 +404,7 @@ See also: 'isFunctionPattern'
 
  -}
 variableFunctionAndEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -> SimplificationType
@@ -460,7 +460,7 @@ See also: 'variableFunctionAndEquals'
 
  -}
 functionVariableAndEquals
-    :: (SimplifierVariable variable, MonadUnify unifier)
+    :: (InternalVariable variable, MonadUnify unifier)
     => SideCondition variable
     -> SimplificationType
     -> TermLike variable
@@ -517,7 +517,7 @@ returns @\\bottom@.
 
  -}
 constructorSortInjectionAndEquals
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => TermLike variable
     -> TermLike variable
@@ -531,7 +531,7 @@ constructorSortInjectionAndEquals first@(App_ symbol1 _) second@(Inj_ _)
 constructorSortInjectionAndEquals _ _ = empty
 
 noConfusionInjectionConstructor
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => TermLike variable
     -> TermLike variable
@@ -547,7 +547,7 @@ sort with constructors.
 
 -}
 domainValueAndConstructorErrors
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => Monad unifier
     => HasCallStack
     => TermLike variable
@@ -671,7 +671,7 @@ The function patterns are unified by creating an @\\equals@ predicate.
 
 -}
 functionAnd
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => TermLike variable
     -> TermLike variable
     -> Maybe (Pattern variable)

--- a/kore/src/Kore/Step/Simplification/Application.hs
+++ b/kore/src/Kore/Step/Simplification/Application.hs
@@ -61,7 +61,7 @@ predicates ans substitutions, applying functions on the Application(terms),
 then merging everything into an Pattern.
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Application Symbol (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -89,7 +89,7 @@ simplify sideCondition application = do
     childrenCrossProduct = MultiOr.fullCrossProduct children
 
 makeAndEvaluateApplications
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Symbol
     -> [Pattern variable]
@@ -98,7 +98,7 @@ makeAndEvaluateApplications =
     makeAndEvaluateSymbolApplications
 
 makeAndEvaluateSymbolApplications
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Symbol
     -> [Pattern variable]
@@ -112,7 +112,7 @@ makeAndEvaluateSymbolApplications sideCondition symbol children = do
     return (MultiOr.mergeAll orResults)
 
 evaluateApplicationFunction
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -- ^ The predicate from the configuration
     -> ExpandedApplication variable
@@ -128,7 +128,7 @@ evaluateApplicationFunction
         term
 
 makeExpandedApplication
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Symbol
     -> [Pattern variable]

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -82,7 +82,7 @@ A ceil(or) is equal to or(ceil). We also take into account that
 * ceil transforms terms into predicates
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Ceil Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -109,7 +109,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> OrPattern variable
@@ -121,7 +121,7 @@ simplifyEvaluated sideCondition child =
 for details.
 -}
 makeEvaluate
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Pattern variable
@@ -132,7 +132,7 @@ makeEvaluate sideCondition child
   | otherwise              = makeEvaluateNonBoolCeil sideCondition child
 
 makeEvaluateNonBoolCeil
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Pattern variable
@@ -161,7 +161,7 @@ makeEvaluateNonBoolCeil sideCondition patt@Conditional {term}
 -- signature.
 makeEvaluateTerm
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> TermLike variable
@@ -234,7 +234,7 @@ makeEvaluateTerm
 -}
 makeEvaluateBuiltin
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Builtin (TermLike variable)
@@ -269,7 +269,7 @@ makeEvaluateBuiltin _ (Domain.BuiltinString _) = Just $ return OrCondition.top
 
 makeEvaluateNormalizedAc
     :: forall normalized variable simplifier
-    .   ( SimplifierVariable variable
+    .   ( InternalVariable variable
         , MonadSimplify simplifier
         , Traversable (Domain.Value normalized)
         , Domain.AcWrapper normalized
@@ -382,7 +382,7 @@ know how to simplify @ceil(g(x))@, the return value will be
 
 -}
 makeSimplifiedCeil
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Maybe SideCondition.Representation
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/Ceil.hs-boot
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs-boot
@@ -20,11 +20,11 @@ import Kore.Internal.TermLike
     )
 import Kore.Step.Simplification.Simplify
     ( MonadSimplify
-    , SimplifierVariable
+    , InternalVariable
     )
 
 makeEvaluate
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Pattern variable
@@ -32,7 +32,7 @@ makeEvaluate
 
 makeEvaluateTerm
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/Ceil.hs-boot
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs-boot
@@ -19,8 +19,8 @@ import Kore.Internal.TermLike
     ( TermLike
     )
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , InternalVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 
 makeEvaluate

--- a/kore/src/Kore/Step/Simplification/Condition.hs
+++ b/kore/src/Kore/Step/Simplification/Condition.hs
@@ -59,7 +59,7 @@ unmodified.
 simplify
     ::  forall simplifier variable any
     .   ( HasCallStack
-        , SimplifierVariable variable
+        , InternalVariable variable
         , MonadSimplify simplifier
         )
     =>  SubstitutionSimplifier simplifier
@@ -109,7 +109,7 @@ See also: 'simplify'
 -}
 simplifyPredicate
     ::  ( HasCallStack
-        , SimplifierVariable variable
+        , InternalVariable variable
         , MonadSimplify simplifier
         )
     =>  SideCondition variable

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -11,7 +11,7 @@ Portability : portable
 {-# LANGUAGE UndecidableInstances #-}
 
 module Kore.Step.Simplification.Data
-    ( MonadSimplify (..), SimplifierVariable
+    ( MonadSimplify (..), InternalVariable
     , Simplifier
     , TermSimplifier
     , SimplifierT, runSimplifierT

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -163,7 +163,7 @@ Normalization of the compared terms is not implemented yet, so
 Equals(a and b, b and a) will not be evaluated to Top.
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -184,7 +184,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable
@@ -217,7 +217,7 @@ simplifyEvaluated sideCondition first second
 
 makeEvaluateFunctionalOr
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Pattern variable
     -> [Pattern variable]
@@ -257,7 +257,7 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
 See 'simplify' for detailed documentation.
 -}
 makeEvaluate
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => Pattern variable
     -> Pattern variable
     -> SideCondition variable
@@ -311,7 +311,7 @@ makeEvaluate
 -- Do not export this. This not valid as a standalone function, it
 -- assumes that some extra conditions will be added on the outside
 makeEvaluateTermsAssumesNoBottom
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> simplifier (OrPattern variable)
@@ -335,7 +335,7 @@ makeEvaluateTermsAssumesNoBottom firstTerm secondTerm = do
 -- assumes that some extra conditions will be added on the outside
 makeEvaluateTermsAssumesNoBottomMaybe
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> MaybeT simplifier (OrPattern variable)
@@ -354,7 +354,7 @@ because it returns an 'or').
 See 'simplify' for detailed documentation.
 -}
 makeEvaluateTermsToPredicate
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
     -> SideCondition variable
@@ -390,7 +390,7 @@ the special cases handled by this.
 
  -}
 termEquals
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => HasCallStack
     => TermLike variable
     -> TermLike variable
@@ -404,7 +404,7 @@ termEquals first second = MaybeT $ do
 
 termEqualsAnd
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => HasCallStack
     => TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -135,7 +135,7 @@ The simplification of exists x . (pat and pred and subst) is equivalent to:
     (pat' and (pred' and (exists x . predX and substX)) and subst')
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Exists Sort variable (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -156,7 +156,7 @@ even more useful to carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> ElementVariable variable
     -> OrPattern variable
@@ -177,7 +177,7 @@ See 'simplify' for detailed documentation.
 -}
 makeEvaluate
     :: forall simplifier variable
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> [ElementVariable variable]
     -> Pattern variable
@@ -241,7 +241,7 @@ makeEvaluate sideCondition variables original = do
 
 
 matchesToVariableSubstitution
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => ElementVariable variable
     -> Pattern variable
     -> simplifier Bool
@@ -297,7 +297,7 @@ See also: 'quantifyPattern'
 
  -}
 makeEvaluateBoundLeft
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> ElementVariable variable  -- ^ quantified variable
     -> TermLike variable  -- ^ substituted term
@@ -332,7 +332,7 @@ See also: 'quantifyPattern'
  -}
 makeEvaluateBoundRight
     :: forall variable simplifier
-    . (SimplifierVariable variable, MonadSimplify simplifier)
+    . (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> ElementVariable variable  -- ^ variable to be quantified
     -> Substitution variable  -- ^ free substitution
@@ -369,7 +369,7 @@ The result is a pair of:
 
  -}
 splitSubstitution
-    :: (SimplifierVariable variable, HasCallStack)
+    :: (InternalVariable variable, HasCallStack)
     => ElementVariable variable
     -> Substitution variable
     ->  ( Either (TermLike variable) (Substitution variable)

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -26,7 +26,7 @@ import Kore.Internal.Pattern
     )
 import Kore.Internal.TermLike
     ( pattern ApplyAlias_
-    , SubstitutionVariable
+    , InternalVariable
     , TermLike
     , Variable
     , mapVariables
@@ -44,7 +44,7 @@ import Kore.Variables.UnifiedVariable
 
 expandAlias
     :: forall variable unifier
-    .  SubstitutionVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => (   TermLike variable
         -> TermLike variable
@@ -59,7 +59,7 @@ expandAlias recurse t1 t2 =
         (t1', t2') -> recurse (fromMaybe t1 t1') (fromMaybe t2 t2')
 
 expandSingleAlias
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => TermLike variable
     -> Maybe (TermLike variable)
 expandSingleAlias =
@@ -71,7 +71,7 @@ expandSingleAlias =
 -- with the *bounded* variables in the rhs is empty (because we can't currently
 -- handle things like \mu.
 substituteInAlias
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Alias (TermLike Variable)
     -> [TermLike variable]
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -38,6 +38,9 @@ import Kore.Syntax.Variable
 import Kore.Unification.Unify
     ( MonadUnify
     )
+import Kore.Variables.UnifiedVariable
+    ( mapUnifiedVariable
+    )
 
 expandAlias
     :: forall variable unifier
@@ -74,9 +77,10 @@ substituteInAlias
     -> TermLike variable
 substituteInAlias Alias { aliasLeft, aliasRight } children =
     assert (length aliasLeft == length children)
-        $ substitute
-            substitutionMap
-            (mapVariables fromVariable aliasRight)
+    $ substitute substitutionMap
+    $ mapVariables (fmap fromVariable) (fmap fromVariable) aliasRight
   where
+    aliasLeft' =
+        mapUnifiedVariable (fmap fromVariable) (fmap fromVariable) <$> aliasLeft
     substitutionMap =
-        Map.fromList $ zip (fmap fromVariable <$> aliasLeft) children
+        Map.fromList $ zip aliasLeft' children

--- a/kore/src/Kore/Step/Simplification/Iff.hs
+++ b/kore/src/Kore/Step/Simplification/Iff.hs
@@ -43,7 +43,7 @@ Right now this has special cases only for top and bottom children
 and for children with top terms.
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Iff Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -68,7 +68,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable

--- a/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/kore/src/Kore/Step/Simplification/Implies.hs
@@ -49,7 +49,7 @@ Right now this uses the following simplifications:
 and it has a special case for children with top terms.
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Implies Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -78,7 +78,7 @@ carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable
@@ -93,7 +93,7 @@ simplifyEvaluated sideCondition first second
     return (MultiOr.flatten results)
 
 simplifyEvaluateHalfImplies
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> Pattern variable
@@ -113,7 +113,7 @@ simplifyEvaluateHalfImplies
             distributeEvaluateImplies sideCondition firstPatterns second
 
 distributeEvaluateImplies
-    :: (MonadSimplify simplifier, SimplifierVariable variable)
+    :: (MonadSimplify simplifier, InternalVariable variable)
     => SideCondition variable
     -> [Pattern variable]
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -47,7 +47,7 @@ Right now this uses the following simplifications:
 TODO(virgil): It does not have yet a special case for children with top terms.
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> In Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -72,7 +72,7 @@ carry around.
 -}
 simplifyEvaluatedIn
     :: forall variable simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> OrPattern variable
@@ -89,7 +89,7 @@ simplifyEvaluatedIn sideCondition first second
                             (makeEvaluateIn sideCondition <$> first <*> second)
 
 makeEvaluateIn
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Pattern variable
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/Inj.hs
+++ b/kore/src/Kore/Step/Simplification/Inj.hs
@@ -31,7 +31,7 @@ import Kore.Step.Simplification.Simplify as Simplifier
 
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => Inj (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify injOrPattern = do

--- a/kore/src/Kore/Step/Simplification/InternalBytes.hs
+++ b/kore/src/Kore/Step/Simplification/InternalBytes.hs
@@ -14,8 +14,8 @@ import Kore.Internal.OrPattern
     )
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 
-simplify :: SimplifierVariable variable => InternalBytes -> OrPattern variable
+simplify :: InternalVariable variable => InternalBytes -> OrPattern variable
 simplify = pure . pure . mkInternalBytes'

--- a/kore/src/Kore/Step/Simplification/NoConfusion.hs
+++ b/kore/src/Kore/Step/Simplification/NoConfusion.hs
@@ -37,7 +37,7 @@ See also: 'Attribute.isInjective', 'Attribute.isSortInjection',
 
  -}
 equalInjectiveHeadsAndEquals
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , MonadUnify unifier
         )
     => HasCallStack

--- a/kore/src/Kore/Step/Simplification/Not.hs
+++ b/kore/src/Kore/Step/Simplification/Not.hs
@@ -76,7 +76,7 @@ Right now this uses the following:
 
 -}
 simplify
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Not Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
@@ -102,7 +102,7 @@ to carry around.
 
 -}
 simplifyEvaluated
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)
@@ -113,7 +113,7 @@ simplifyEvaluated sideCondition simplified =
         mkMultiAndPattern sideCondition andPattern
 
 simplifyEvaluatedPredicate
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => OrCondition variable
     -> simplifier (OrCondition variable)
 simplifyEvaluatedPredicate notChild =
@@ -228,7 +228,7 @@ scatterAnd = scatter . distributeAnd
 {- | Conjoin and simplify a 'MultiAnd' of 'Pattern'.
  -}
 mkMultiAndPattern
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> MultiAnd (Pattern variable)
     -> BranchT simplifier (Pattern variable)
@@ -238,7 +238,7 @@ mkMultiAndPattern sideCondition patterns =
 {- | Conjoin and simplify a 'MultiAnd' of 'Condition'.
  -}
 mkMultiAndPredicate
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MultiAnd (Condition variable)
     -> BranchT simplifier (Condition variable)
 mkMultiAndPredicate predicates =

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -58,8 +58,8 @@ import qualified Kore.Internal.SideCondition as SideCondition
     , top
     )
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     , simplifyCondition
     )
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
@@ -71,7 +71,7 @@ import Kore.TopBottom
 
 simplifyConditionsWithSmt
     ::  forall variable simplifier
-    .   (MonadSimplify simplifier, SimplifierVariable variable)
+    .   (MonadSimplify simplifier, InternalVariable variable)
     => SideCondition variable
     -> OrPattern variable
     -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Simplification/Overloading.hs
+++ b/kore/src/Kore/Step/Simplification/Overloading.hs
@@ -46,7 +46,7 @@ otherwise, return bottom, as the constructors are incompatible
 
  -}
 overloadedConstructorSortInjectionAndEquals
-    :: (SimplifierVariable variable, MonadUnify unifier)
+    :: (InternalVariable variable, MonadUnify unifier)
     => HasCallStack
     => TermSimplifier variable unifier
     -> TermLike variable
@@ -93,7 +93,7 @@ overloadedConstructorSortInjectionAndEquals
 overloadedConstructorSortInjectionAndEquals _ _ _ = empty
 
 overloadedAndEqualsOverloading
-    :: (SimplifierVariable variable, MonadUnify unifier)
+    :: (InternalVariable variable, MonadUnify unifier)
     => HasCallStack
     => TermSimplifier variable unifier
     -> TermLike variable

--- a/kore/src/Kore/Step/Simplification/Pattern.hs
+++ b/kore/src/Kore/Step/Simplification/Pattern.hs
@@ -31,8 +31,8 @@ import Kore.Internal.TermLike
     ( pattern Exists_
     )
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     , simplifyCondition
     , simplifyConditionalTermToOr
     )
@@ -42,7 +42,7 @@ and removes the exists quantifiers at the top.
 -}
 simplifyTopConfiguration
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => Pattern variable
     -> simplifier (OrPattern variable)
@@ -58,7 +58,7 @@ simplifyTopConfiguration patt = do
 {-| Simplifies an 'Pattern', returning an 'OrPattern'.
 -}
 simplify
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> Pattern variable

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -42,8 +42,8 @@ import Kore.Step.RulePattern
 import qualified Kore.Step.Simplification.Pattern as Pattern
 import qualified Kore.Step.Simplification.Simplifier as Simplifier
 import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import qualified Kore.Step.Simplification.Simplify as Simplifier
 
@@ -53,14 +53,14 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyFunctionAxioms
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => Map identifier [EqualityRule variable]
     -> simplifier (Map identifier [EqualityRule variable])
 simplifyFunctionAxioms =
     (traverse . traverse) simplifyEqualityRule
 
 simplifyEqualityRule
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => EqualityRule variable
     -> simplifier (EqualityRule variable)
 simplifyEqualityRule (EqualityRule rule) =
@@ -73,7 +73,7 @@ narrowly-defined criteria.
 
  -}
 simplifyEqualityPattern
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => EqualityPattern variable
     -> simplifier (EqualityPattern variable)
 simplifyEqualityPattern rule = do
@@ -113,7 +113,7 @@ See also: 'simplifyRulePattern'
 
  -}
 simplifyRewriteRule
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => RewriteRule variable
     -> simplifier (RewriteRule variable)
 simplifyRewriteRule (RewriteRule rule) =
@@ -126,7 +126,7 @@ narrowly-defined criteria.
 
  -}
 simplifyRulePattern
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => RulePattern variable
     -> simplifier (RulePattern variable)
 simplifyRulePattern rule = do
@@ -166,7 +166,7 @@ simplifyRulePattern rule = do
 
 -- | Simplify a 'TermLike' using only matching logic rules.
 simplifyPattern
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> simplifier (OrPattern variable)
 simplifyPattern termLike =

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -90,6 +90,7 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike
     ( pattern App_
+    , FreshVariable
     , SubstitutionVariable
     , Symbol
     , TermLike
@@ -405,7 +406,7 @@ type BuiltinAndAxiomSimplifierMap =
 
 lookupAxiomSimplifier
     :: MonadSimplify simplifier
-    => InternalVariable variable
+    => (InternalVariable variable, FreshVariable variable)
     => TermLike variable
     -> MaybeT simplifier BuiltinAndAxiomSimplifier
 lookupAxiomSimplifier termLike = do

--- a/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -86,6 +86,7 @@ import Kore.Internal.Substitution
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
     ( And (..)
+    , InternalVariable
     , TermLike
     , TermLikeF (..)
     , mkAnd
@@ -95,9 +96,6 @@ import Kore.Step.Simplification.Simplify
     ( MonadSimplify
     , simplifyConditionalTerm
     , simplifyConditionalTermToOr
-    )
-import Kore.Substitute
-    ( SubstitutionVariable
     )
 import qualified Kore.TopBottom as TopBottom
 import Kore.Unification.SubstitutionNormalization
@@ -112,7 +110,7 @@ newtype SubstitutionSimplifier simplifier =
     SubstitutionSimplifier
         { simplifySubstitution
             :: forall variable
-            .  SubstitutionVariable variable
+            .  InternalVariable variable
             => SideCondition variable
             -> Substitution variable
             -> simplifier (OrCondition variable)
@@ -134,7 +132,7 @@ substitutionSimplifier =
   where
     wrapper
         :: forall variable
-        .  SubstitutionVariable variable
+        .  InternalVariable variable
         => SideCondition variable
         -> Substitution variable
         -> simplifier (OrCondition variable)
@@ -155,7 +153,7 @@ newtype MakeAnd monad =
     MakeAnd
         { makeAnd
             :: forall variable
-            .  SubstitutionVariable variable
+            .  InternalVariable variable
             => TermLike variable
             -> TermLike variable
             -> SideCondition variable
@@ -177,7 +175,7 @@ simplifierMakeAnd =
 
 simplifyAnds
     ::  forall variable monad
-    .   ( SubstitutionVariable variable
+    .   ( InternalVariable variable
         , Monad monad
         )
     => MakeAnd monad
@@ -210,7 +208,7 @@ simplifyAnds MakeAnd { makeAnd } (NonEmpty.sort -> patterns) =
 
 deduplicateSubstitution
     :: forall variable monad
-    .   ( SubstitutionVariable variable
+    .   ( InternalVariable variable
         , Monad monad
         )
     =>  MakeAnd monad
@@ -271,7 +269,7 @@ deduplicateSubstitution makeAnd' =
 
 simplifySubstitutionWorker
     :: forall variable simplifier
-    .  SubstitutionVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> MakeAnd simplifier
@@ -401,7 +399,7 @@ substitution in unsatisfiable (@\\bottom@) then the entire substitution is also.
 type Impl variable simplifier = StateT (Private variable) (MaybeT simplifier)
 
 addCondition
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Monad simplifier
     => Condition variable
     -> Impl variable simplifier ()
@@ -411,21 +409,21 @@ addCondition condition
     Lens.modifying (field @"accum") (mappend condition)
 
 addPredicate
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Monad simplifier
     => Predicate variable
     -> Impl variable simplifier ()
 addPredicate = addCondition . Condition.fromPredicate
 
 addSubstitution
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Monad simplifier
     => Substitution variable
     -> Impl variable simplifier ()
 addSubstitution = addCondition . Condition.fromSubstitution
 
 takeSubstitution
-    :: SubstitutionVariable variable
+    :: InternalVariable variable
     => Monad simplifier
     => Impl variable simplifier (Substitution variable)
 takeSubstitution = do

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -156,7 +156,7 @@ import qualified Kore.Variables.Binding as Binding
 -}
 simplify
     ::  ( HasCallStack
-        , SimplifierVariable variable
+        , InternalVariable variable
         , MonadSimplify simplifier
         )
     =>  TermLike variable
@@ -171,7 +171,7 @@ simplify patt sideCondition = do
 -}
 simplifyToOr
     ::  ( HasCallStack
-        , SimplifierVariable variable
+        , InternalVariable variable
         , MonadSimplify simplifier
         )
     =>  SideCondition variable
@@ -187,7 +187,7 @@ simplifyToOr sideCondition term =
 simplifyInternal
     ::  forall variable simplifier
     .   ( HasCallStack
-        , SimplifierVariable variable
+        , InternalVariable variable
         , MonadSimplify simplifier
         )
     =>  TermLike variable

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -82,7 +82,6 @@ import Kore.Internal.TermLike
     , FreshVariable
     , InternalVariable
     , SetVariable
-    , SubstitutionVariable
     , TermLike
     )
 import qualified Kore.Internal.TermLike as TermLike
@@ -94,7 +93,6 @@ import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
 import qualified Kore.TopBottom as TopBottom
 import Kore.Unification.Unify
     ( MonadUnify
-    , SimplifierVariable
     )
 import qualified Kore.Unification.Unify as Monad.Unify
     ( gather
@@ -116,7 +114,7 @@ import Kore.Variables.UnifiedVariable
 newtype UnificationProcedure =
     UnificationProcedure
         ( forall variable unifier
-        .  (SimplifierVariable variable, MonadUnify unifier)
+        .  (InternalVariable variable, MonadUnify unifier)
         => SideCondition variable
         -> TermLike variable
         -> TermLike variable
@@ -151,7 +149,7 @@ class UnifyingRule rule where
     renamed to avoid collision with any variables in the given set.
      -}
     refreshRule
-        :: SubstitutionVariable variable
+        :: InternalVariable variable
         => FreeVariables variable  -- ^ Variables to avoid
         -> rule variable
         -> (Renaming variable, rule variable)
@@ -169,7 +167,7 @@ class UnifyingRule rule where
 
 -- |Unifies/matches a list a rules against a configuration. See 'unifyRule'.
 unifyRules
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => UnifyingRule rule
     => UnificationProcedure
@@ -198,7 +196,7 @@ unification. The substitution is not applied to the renamed rule.
 
  -}
 unifyRule
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => MonadUnify unifier
     => UnifyingRule rule
     => UnificationProcedure
@@ -276,8 +274,8 @@ unwrapRule =
 
 -- |Errors if configuration or matching pattern are not function-like
 assertFunctionLikeResults
-    :: SimplifierVariable variable
-    => SimplifierVariable variable'
+    :: InternalVariable variable
+    => InternalVariable variable'
     => Monad m
     => UnifyingRule rule
     => Eq (rule (Target variable'))
@@ -337,7 +335,7 @@ the axiom variables from the substitution and unwrap all the 'Target's.
 -}
 checkSubstitutionCoverage
     :: forall variable unifier rule
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => UnifyingRule rule
     => Pretty.Pretty (rule (Target variable))
@@ -387,7 +385,7 @@ The rule is considered to apply if the result is not @\\bottom@.
  -}
 applyInitialConditions
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -- ^ Top-level conditions
@@ -422,7 +420,7 @@ toConfigurationVariables =
 
 -- |Renames configuration variables to distinguish them from those in the rule.
 toConfigurationVariablesCondition
-    :: (InternalVariable variable, FreshVariable variable)
+    :: InternalVariable variable
     => SideCondition variable
     -> SideCondition (Target variable)
 toConfigurationVariablesCondition =
@@ -433,7 +431,7 @@ toConfigurationVariablesCondition =
  -}
 applyRemainder
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -- ^ Top level condition
@@ -451,7 +449,7 @@ applyRemainder sideCondition initial remainder = do
 -- | Simplifies the predicate obtained upon matching/unification.
 simplifyPredicate
     :: forall unifier variable term
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => SideCondition variable
     -> Maybe (Condition variable)

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -78,7 +78,8 @@ import qualified Kore.Internal.SideCondition as SideCondition
     )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
-    ( InternalVariable
+    ( FreshVariable
+    , InternalVariable
     , SubstitutionVariable
     , TermLike
     )
@@ -157,7 +158,7 @@ class UnifyingRule rule where
     distinguishing rule variables from configuration variables.
     -}
     mapRuleVariables
-        :: Ord variable2
+        :: (Ord variable1, FreshVariable variable2)
         => (variable1 -> variable2)
         -> rule variable1
         -> rule variable2
@@ -253,7 +254,7 @@ wouldNarrowWith unified =
 
 -- |Renames variables to be distinguishable from those in configuration
 toAxiomVariables
-    :: Ord variable
+    :: FreshVariable variable
     => UnifyingRule rule
     => rule variable
     -> rule (Target variable)
@@ -262,7 +263,7 @@ toAxiomVariables = mapRuleVariables Target.Target
 {- | Unwrap the variables in a 'RulePattern'. Inverse of 'toAxiomVariables'.
  -}
 unwrapRule
-    :: Ord variable
+    :: FreshVariable variable
     => UnifyingRule rule
     => rule (Target variable) -> rule variable
 unwrapRule = mapRuleVariables Target.unwrapVariable
@@ -407,14 +408,14 @@ applyInitialConditions sideCondition initial unification = do
 
 -- |Renames configuration variables to distinguish them from those in the rule.
 toConfigurationVariables
-    :: Ord variable
+    :: FreshVariable variable
     => Pattern variable
     -> Pattern (Target variable)
 toConfigurationVariables = Pattern.mapVariables Target.NonTarget
 
 -- |Renames configuration variables to distinguish them from those in the rule.
 toConfigurationVariablesCondition
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => SideCondition variable
     -> SideCondition (Target variable)
 toConfigurationVariablesCondition = SideCondition.mapVariables Target.NonTarget

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -78,8 +78,10 @@ import qualified Kore.Internal.SideCondition as SideCondition
     )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike
-    ( FreshVariable
+    ( ElementVariable
+    , FreshVariable
     , InternalVariable
+    , SetVariable
     , SubstitutionVariable
     , TermLike
     )
@@ -159,7 +161,8 @@ class UnifyingRule rule where
     -}
     mapRuleVariables
         :: (Ord variable1, FreshVariable variable2)
-        => (variable1 -> variable2)
+        => (ElementVariable variable1 -> ElementVariable variable2)
+        -> (SetVariable variable1 -> SetVariable variable2)
         -> rule variable1
         -> rule variable2
 
@@ -258,7 +261,7 @@ toAxiomVariables
     => UnifyingRule rule
     => rule variable
     -> rule (Target variable)
-toAxiomVariables = mapRuleVariables Target.Target
+toAxiomVariables = mapRuleVariables (fmap Target.Target) (fmap Target.Target)
 
 {- | Unwrap the variables in a 'RulePattern'. Inverse of 'toAxiomVariables'.
  -}
@@ -266,7 +269,10 @@ unwrapRule
     :: FreshVariable variable
     => UnifyingRule rule
     => rule (Target variable) -> rule variable
-unwrapRule = mapRuleVariables Target.unwrapVariable
+unwrapRule =
+    mapRuleVariables
+        (fmap Target.unwrapVariable)
+        (fmap Target.unwrapVariable)
 
 -- |Errors if configuration or matching pattern are not function-like
 assertFunctionLikeResults
@@ -411,14 +417,16 @@ toConfigurationVariables
     :: FreshVariable variable
     => Pattern variable
     -> Pattern (Target variable)
-toConfigurationVariables = Pattern.mapVariables Target.NonTarget
+toConfigurationVariables =
+    Pattern.mapVariables (fmap Target.NonTarget) (fmap Target.NonTarget)
 
 -- |Renames configuration variables to distinguish them from those in the rule.
 toConfigurationVariablesCondition
     :: (InternalVariable variable, FreshVariable variable)
     => SideCondition variable
     -> SideCondition (Target variable)
-toConfigurationVariablesCondition = SideCondition.mapVariables Target.NonTarget
+toConfigurationVariablesCondition =
+    SideCondition.mapVariables (fmap Target.NonTarget) (fmap Target.NonTarget)
 
 {- | Apply the remainder predicate to the given initial configuration.
 

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -39,13 +39,13 @@ import Kore.Step.Simplification.SubstitutionSimplifier
     )
 import qualified Kore.Step.Simplification.SubstitutionSimplifier as SubstitutionSimplifier
 import Kore.Unification.Unify
-    ( SimplifierVariable
+    ( InternalVariable
     )
 
 -- | Normalize the substitution and predicate of 'expanded'.
 normalize
     :: forall variable term simplifier
-    .  (SimplifierVariable variable, MonadSimplify simplifier)
+    .  (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Conditional variable term
     -> BranchT simplifier (Conditional variable term)
@@ -68,7 +68,7 @@ predicates and redo the merge.
 -}
 mergePredicatesAndSubstitutions
     :: forall variable simplifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify simplifier
     => SideCondition variable
     -> [Predicate variable]

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -115,8 +115,8 @@ import qualified Kore.Step.RulePattern as RulePattern
     ( RulePattern (..)
     )
 import Kore.Step.Simplification.Data
-    ( MonadSimplify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadSimplify
     )
 import qualified Kore.Step.Simplification.Exists as Exists
 import Kore.Step.Simplification.Pattern
@@ -955,7 +955,7 @@ withConfiguration goal = handle (throw . WithConfiguration configuration)
  -}
 removalPredicate
     :: forall variable m
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadSimplify m
     => Pattern variable
     -- ^ Destination

--- a/kore/src/Kore/Substitute.hs
+++ b/kore/src/Kore/Substitute.hs
@@ -5,8 +5,7 @@ License     : NCSA
  -}
 
 module Kore.Substitute
-    ( SubstitutionVariable
-    , substitute
+    ( substitute
     ) where
 
 import Prelude.Kore
@@ -40,20 +39,6 @@ import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
 
-{- | 'SubstitutionVariable' constrains variable types that can be substituted.
-
-'SubstitutionVariable' is an extension of 'InternalVariable'; we require in
-addition that variables be 'FreshVariable', i.e. that we can refresh bound
-variables to avoid capturing while substituting. In practice, all variable types
-are both 'InternalVariable's and 'FreshVariable's, but we reserve the right to
-make 'SubstitutionVariable' even more restrictive in the future.
-
- -}
-type SubstitutionVariable variable =
-    ( InternalVariable variable
-    , FreshVariable variable
-    )
-
 {- | Traverse the pattern from the top down and apply substitutions.
 
 The 'freeVariables' annotation is used to avoid traversing subterms that
@@ -65,7 +50,7 @@ may appear in the right-hand side of any substitution, but this is not checked.
  -}
 substitute
     ::  forall patternType patternBase attribute variable.
-        ( SubstitutionVariable variable
+        ( InternalVariable variable
         , Corecursive patternType, Recursive patternType
         , CofreeF patternBase attribute ~ Base patternType
         , Binding patternType

--- a/kore/src/Kore/Unification/Error.hs
+++ b/kore/src/Kore/Unification/Error.hs
@@ -83,7 +83,7 @@ instance Debug UnificationError
 instance Diff UnificationError
 
 unsupportedPatterns
-    :: SortedVariable variable
+    :: InternalVariable variable
     => String -> TermLike variable -> TermLike variable -> UnificationError
 unsupportedPatterns message =
     UnsupportedPatterns message `on` mapVariables toVariable

--- a/kore/src/Kore/Unification/Error.hs
+++ b/kore/src/Kore/Unification/Error.hs
@@ -86,7 +86,8 @@ unsupportedPatterns
     :: InternalVariable variable
     => String -> TermLike variable -> TermLike variable -> UnificationError
 unsupportedPatterns message =
-    UnsupportedPatterns message `on` mapVariables toVariable
+    on (UnsupportedPatterns message)
+    $ mapVariables (fmap toVariable) (fmap toVariable)
 
 instance Pretty UnificationError where
     pretty UnsupportedPatterns { message, first, second } =

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -39,8 +39,8 @@ import Kore.Step.Simplification.Simplify
     )
 import qualified Kore.TopBottom as TopBottom
 import Kore.Unification.Unify
-    ( MonadUnify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadUnify
     )
 import qualified Kore.Unification.Unify as Monad.Unify
 import Kore.Unparser
@@ -51,7 +51,7 @@ import qualified Log
 -- If successful, it also produces a proof of how the substitution was obtained.
 -- If failing, it gives a 'UnificationError' reason for the failure.
 unificationProcedure
-    ::  ( SimplifierVariable variable
+    ::  ( InternalVariable variable
         , MonadUnify unifier
         )
     => SideCondition variable

--- a/kore/src/Kore/Unification/SubstitutionNormalization.hs
+++ b/kore/src/Kore/Unification/SubstitutionNormalization.hs
@@ -52,9 +52,6 @@ import Kore.Internal.Substitution
 import qualified Kore.Internal.Substitution as Substitution
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike as TermLike
-import Kore.Substitute
-    ( SubstitutionVariable
-    )
 import Kore.TopBottom
 import Kore.Unification.Error
     ( SubstitutionError (..)
@@ -73,7 +70,7 @@ x = f(x) or something equivalent).
 -}
 normalizeSubstitution
     :: forall variable
-    .  SubstitutionVariable variable
+    .  InternalVariable variable
     => Map (UnifiedVariable variable) (TermLike variable)
     -> Either SubstitutionError (Condition variable)
 normalizeSubstitution substitution =
@@ -101,7 +98,7 @@ constructor cycles with element variables.
  -}
 normalize
     ::  forall variable
-    .   SubstitutionVariable variable
+    .   InternalVariable variable
     =>  Map (UnifiedVariable variable) (TermLike variable)
     -- ^ De-duplicated substitution
     ->  Maybe (Normalization variable)
@@ -210,7 +207,7 @@ Every substitution must be satisfiable, see 'isSatisfiableSubstitution'.
  -}
 backSubstitute
     :: forall variable
-    .  SubstitutionVariable variable
+    .  InternalVariable variable
     => UnwrappedSubstitution variable
     -- ^ Topologically-sorted substitution
     -> UnwrappedSubstitution variable

--- a/kore/src/Kore/Unification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Unification/SubstitutionSimplifier.hs
@@ -43,9 +43,6 @@ import Kore.Step.Simplification.SubstitutionSimplifier
     , deduplicateSubstitution
     , simplifySubstitutionWorker
     )
-import Kore.Substitute
-    ( SubstitutionVariable
-    )
 import qualified Kore.TopBottom as TopBottom
 import Kore.Unification.Error
 import Kore.Unification.Unify
@@ -65,7 +62,7 @@ substitutionSimplifier =
   where
     wrapper
         :: forall variable
-        .  SubstitutionVariable variable
+        .  InternalVariable variable
         => SideCondition variable
         -> Substitution variable
         -> unifier (OrCondition variable)
@@ -80,7 +77,7 @@ substitutionSimplifier =
         worker = simplifySubstitutionWorker sideCondition unificationMakeAnd
 
     fromNormalization
-        :: SimplifierVariable variable
+        :: InternalVariable variable
         => Normalization variable
         -> unifier (Condition variable)
     fromNormalization normalization@Normalization { denormalized }

--- a/kore/src/Kore/Unification/UnifierImpl.hs
+++ b/kore/src/Kore/Unification/UnifierImpl.hs
@@ -53,8 +53,8 @@ import Kore.Unification.SubstitutionNormalization
     ( normalizeSubstitution
     )
 import Kore.Unification.Unify
-    ( MonadUnify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadUnify
     )
 import qualified Kore.Unification.Unify as Unifier
 import Kore.Variables.UnifiedVariable
@@ -63,7 +63,7 @@ import Kore.Variables.UnifiedVariable
 
 simplifyAnds
     :: forall variable unifier
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => NonEmpty (TermLike variable)
     -> unifier (Pattern variable)
@@ -90,7 +90,7 @@ simplifyAnds (NonEmpty.sort -> patterns) = do
 
 deduplicateSubstitution
     ::  forall variable unifier
-    .   SimplifierVariable variable
+    .   InternalVariable variable
     =>  MonadUnify unifier
     =>  Substitution variable
     ->  unifier
@@ -141,7 +141,7 @@ deduplicateSubstitution =
 
 normalizeOnce
     :: forall unifier variable term
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => Conditional variable term
     -> unifier (Conditional variable term)
@@ -172,7 +172,7 @@ normalizeOnce Conditional { term, predicate, substitution } = do
 
 normalizeExcept
     :: forall unifier variable term
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => Conditional variable term
     -> unifier (Conditional variable term)

--- a/kore/src/Kore/Unification/UnifierT.hs
+++ b/kore/src/Kore/Unification/UnifierT.hs
@@ -40,8 +40,8 @@ import Kore.Step.Simplification.AndTerms
 import qualified Kore.Step.Simplification.Condition as ConditionSimplifier
 import Kore.Step.Simplification.Simplify
     ( ConditionSimplifier (..)
+    , InternalVariable
     , MonadSimplify (..)
-    , SimplifierVariable
     )
 import qualified Kore.Step.Simplification.Simplify as Simplifier
 import Kore.Step.Simplification.SubstitutionSimplifier

--- a/kore/src/Kore/Unification/Unify.hs
+++ b/kore/src/Kore/Unification/Unify.hs
@@ -17,7 +17,7 @@ import Data.Text.Prettyprint.Doc
     )
 
 import Kore.Internal.TermLike
-    ( SortedVariable
+    ( InternalVariable
     , TermLike
     )
 import Kore.Step.Simplification.Simplify
@@ -25,9 +25,6 @@ import Kore.Step.Simplification.Simplify
     , SimplifierVariable
     )
 import Kore.Unification.Error
-import Kore.Unparser
-    ( Unparse
-    )
 
 -- | @MonadUnify@ is used throughout the step and unification modules. Its main
 -- goal is to abstract over an 'ExceptT' over a 'UnificationOrSubstitutionError'
@@ -61,7 +58,7 @@ class (Alternative unifier, MonadSimplify unifier) => MonadUnify unifier where
     scatter :: Traversable t => t a -> unifier a
 
     explainBottom
-        :: (SortedVariable variable, Unparse variable)
+        :: InternalVariable variable
         => Doc ()
         -> TermLike variable
         -> TermLike variable
@@ -69,7 +66,7 @@ class (Alternative unifier, MonadSimplify unifier) => MonadUnify unifier where
     explainBottom _ _ _ = pure ()
 
     explainAndReturnBottom
-        :: (SortedVariable variable, Unparse variable)
+        :: InternalVariable variable
         => Doc ()
         -> TermLike variable
         -> TermLike variable

--- a/kore/src/Kore/Unification/Unify.hs
+++ b/kore/src/Kore/Unification/Unify.hs
@@ -4,7 +4,7 @@ License     : NCSA
 -}
 
 module Kore.Unification.Unify
-    ( MonadUnify (..), SimplifierVariable
+    ( MonadUnify (..), InternalVariable
     ) where
 
 import Prelude.Kore
@@ -22,7 +22,6 @@ import Kore.Internal.TermLike
     )
 import Kore.Step.Simplification.Simplify
     ( MonadSimplify (..)
-    , SimplifierVariable
     )
 import Kore.Unification.Error
 

--- a/kore/src/Kore/Variables/Binding.hs
+++ b/kore/src/Kore/Variables/Binding.hs
@@ -128,6 +128,8 @@ data Binder variable child =
         { binderVariable :: variable
         , binderChild :: !child
         }
+    deriving (Eq, Ord, Show)
+    deriving (Functor, Foldable, Traversable)
     deriving (GHC.Generic)
 
 {- | A 'Lens.Lens' to view an 'Exists' as a 'Binder'.

--- a/kore/src/Kore/Variables/Fresh.hs
+++ b/kore/src/Kore/Variables/Fresh.hs
@@ -67,6 +67,9 @@ instance FreshVariable Variable where
         pivotMin = variable { variableCounter = Nothing }
         fixSort var = var { variableSort = variableSort variable }
 
+instance FreshVariable Concrete where
+    refreshVariable _ = \case {}
+
 {- | Rename one set of variables while avoiding another.
 
 If any of the variables to rename occurs in the set of avoided variables, it

--- a/kore/src/Kore/Variables/UnifiedVariable.hs
+++ b/kore/src/Kore/Variables/UnifiedVariable.hs
@@ -38,10 +38,10 @@ import Data.Generics.Product
     ( field
     )
 import Data.Hashable
-import Data.Map
+import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Set
     ( Set
     )

--- a/kore/src/Kore/Variables/UnifiedVariable.hs
+++ b/kore/src/Kore/Variables/UnifiedVariable.hs
@@ -17,6 +17,11 @@ module Kore.Variables.UnifiedVariable
     , refreshSetVariable
     , mapUnifiedVariable
     , traverseUnifiedVariable
+    -- * UnifiedVariableMap
+    , VariableMap
+    , UnifiedVariableMap
+    , renameElementVariable, renameSetVariable
+    , lookupRenamedElementVariable, lookupRenamedSetVariable
     ) where
 
 import Prelude.Kore
@@ -24,8 +29,19 @@ import Prelude.Kore
 import Control.DeepSeq
     ( NFData
     )
+import qualified Control.Lens as Lens
+import Data.Function
+    ( on
+    )
 import Data.Functor.Const
+import Data.Generics.Product
+    ( field
+    )
 import Data.Hashable
+import Data.Map
+    ( Map
+    )
+import qualified Data.Map as Map
 import Data.Set
     ( Set
     )
@@ -182,3 +198,65 @@ traverseUnifiedVariable traverseElemVar traverseSetVar =
     \case
         ElemVar elemVar -> ElemVar <$> traverseElemVar elemVar
         SetVar  setVar  -> SetVar <$> traverseSetVar setVar
+
+type VariableMap meta variable1 variable2 =
+    Map (meta variable1) (meta variable2)
+
+data UnifiedVariableMap variable1 variable2 =
+    UnifiedVariableMap
+        { setVariables
+            :: !(VariableMap SetVariable variable1 variable2)
+        , elementVariables
+            :: !(VariableMap ElementVariable variable1 variable2)
+        }
+    deriving (Generic)
+
+instance
+    Ord variable1 => Semigroup (UnifiedVariableMap variable1 variable2)
+  where
+    (<>) a b =
+        UnifiedVariableMap
+            { setVariables = on (<>) setVariables a b
+            , elementVariables = on (<>) elementVariables a b
+            }
+
+instance Ord variable1 => Monoid (UnifiedVariableMap variable1 variable2) where
+    mempty = UnifiedVariableMap mempty mempty
+
+renameSetVariable
+    :: Ord variable1
+    => SetVariable variable1
+    -> SetVariable variable2
+    -> UnifiedVariableMap variable1 variable2
+    -> UnifiedVariableMap variable1 variable2
+renameSetVariable variable1 variable2 =
+    Lens.over
+        (field @"setVariables")
+        (Map.insert variable1 variable2)
+
+renameElementVariable
+    :: Ord variable1
+    => ElementVariable variable1
+    -> ElementVariable variable2
+    -> UnifiedVariableMap variable1 variable2
+    -> UnifiedVariableMap variable1 variable2
+renameElementVariable variable1 variable2 =
+    Lens.over
+        (field @"elementVariables")
+        (Map.insert variable1 variable2)
+
+lookupRenamedElementVariable
+    :: Ord variable1
+    => ElementVariable variable1
+    -> UnifiedVariableMap variable1 variable2
+    -> Maybe (ElementVariable variable2)
+lookupRenamedElementVariable variable =
+    Map.lookup variable . elementVariables
+
+lookupRenamedSetVariable
+    :: Ord variable1
+    => SetVariable variable1
+    -> UnifiedVariableMap variable1 variable2
+    -> Maybe (SetVariable variable2)
+lookupRenamedSetVariable variable =
+    Map.lookup variable . setVariables

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -39,6 +39,7 @@ import qualified Kore.Attribute.Constructor as Attribute.Constructor
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables
     , freeVariables
+    , nullFreeVariables
     )
 import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
@@ -872,7 +873,7 @@ acGenerator mapSort keySort valueGenerator childGenerator = do
     let variableKeys :: [TermLike Variable]
         variableKeys =
             filter
-                (not . null . freeVariables')
+                (not . nullFreeVariables . freeVariables')
                 (catMaybes (Set.toList mixedKeys))
     maybeVariablePairs <- mapM variablePair variableKeys
     let variablePairs :: [Domain.Element normalized (TermLike Variable)]

--- a/kore/test/Test/Kore/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin.hs
@@ -115,10 +115,10 @@ test_internalize =
     mkSet = Set.asInternal . Data.Set.fromList
     s = mkElemVar (elemVarS "s" setSort)
 
-    mkInt :: Ord variable => Integer -> TermLike variable
+    mkInt :: FreshVariable variable => Integer -> TermLike variable
     mkInt = Int.asInternal
     intSort = Builtin.intSort
-    zero, one :: Ord variable => TermLike variable
+    zero, one :: FreshVariable variable => TermLike variable
     zero = mkInt 0
     one = mkInt 1
     x = mkElemVar (elemVarS "x" intSort)

--- a/kore/test/Test/Kore/Builtin/Int.hs
+++ b/kore/test/Test/Kore/Builtin/Int.hs
@@ -363,7 +363,7 @@ intLiteral :: Integer -> TermLike Variable
 intLiteral = asInternal
 
 -- | Specialize 'Int.asInternal' to the builtin sort 'intSort'.
-asInternal :: Ord variable => Integer -> TermLike variable
+asInternal :: FreshVariable variable => Integer -> TermLike variable
 asInternal = Int.asInternal intSort
 
 -- | Specialize 'asInternal' to the builtin sort 'intSort'.

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -1183,7 +1183,8 @@ test_renormalize =
   where
     x = mkIntVar (testId "x")
     v = mkIntVar (testId "v")
-    k1, k2 :: Ord variable => TermLike variable
+
+    k1, k2 :: FreshVariable variable => TermLike variable
     k1 = Test.Int.asInternal 1
     k2 = Test.Int.asInternal 2
 

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -7,6 +7,7 @@ import Prelude.Kore
 
 import Test.Tasty
 
+import qualified Data.Set as Set
 import Data.Text.Prettyprint.Doc
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
@@ -157,6 +158,14 @@ instance SortedVariable V where
     fromVariable = undefined
     toVariable = undefined
 
+instance FreshVariable V where
+    refreshVariable avoiding v@(V name)
+      | Set.notMember v avoiding = Nothing
+      | otherwise =
+        Just ((head . dropWhile (flip Set.member avoiding)) (V <$> names' ))
+      where
+        names' = iterate (+ 1) name
+
 newtype W = W String
     deriving (Show, Eq, Ord, GHC.Generic)
 
@@ -176,6 +185,14 @@ instance SortedVariable W where
     sortedVariableSort _ = sortVariable
     fromVariable = undefined
     toVariable = undefined
+
+instance FreshVariable W where
+    refreshVariable avoiding w@(W name)
+      | Set.notMember w avoiding = Nothing
+      | otherwise =
+        Just ((head . dropWhile (flip Set.member avoiding)) (W <$> names' ))
+      where
+        names' = iterate (<> "\'") name
 
 showVar :: V -> W
 showVar (V i) = W (show i)

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -60,7 +60,7 @@ test_expandedPattern =
                 , substitution = Substitution.wrap
                     [(ElemVar . ElementVariable $ W "4", war "5")]
                 }
-            (Pattern.mapVariables showVar
+            (Pattern.mapVariables (fmap showVar) (fmap showVar)
                 Conditional
                     { term = var 1
                     , predicate = makeEquals (var 2) (var 3)

--- a/kore/test/Test/Kore/Internal/Predicate.hs
+++ b/kore/test/Test/Kore/Internal/Predicate.hs
@@ -286,9 +286,8 @@ test_predicate =
     , testCase "freeVariables"
         ( do
             assertBool "top has no free variables"
-                $ (null :: FreeVariables.FreeVariables Variable -> Bool)
-                $ freeVariables
-                    (makeTruePredicate_ :: Predicate Variable)
+                $ FreeVariables.nullFreeVariables @Variable
+                $ freeVariables (makeTruePredicate_ :: Predicate Variable)
             assertEqual "equals predicate has two variables"
                 (Set.fromList
                     [ ElemVar $ a Mock.testSort

--- a/kore/test/Test/Kore/Internal/Substitution.hs
+++ b/kore/test/Test/Kore/Internal/Substitution.hs
@@ -132,19 +132,19 @@ mapVariablesTests =
     [ testCase "map id over empty is empty"
         $ assertEqual ""
             (wrap mempty)
-            . mapVariables id $ emptySubst
+            . mapVariables id id $ emptySubst
     , testCase "map id over wrap empty is normalized empty"
         $ assertEqual ""
             (wrap mempty)
-            . mapVariables id $ wrap emptyRawSubst
+            . mapVariables id id $ wrap emptyRawSubst
     , testCase "map id over singleton == id"
         $ assertEqual ""
             (wrap singletonSubst)
-            . mapVariables id $ wrap singletonSubst
+            . mapVariables id id $ wrap singletonSubst
     , testCase "map id over normalized singletonSubst"
         $ assertEqual ""
             (wrap singletonSubst)
-            . mapVariables id $ unsafeWrap singletonSubst
+            . mapVariables id id $ unsafeWrap singletonSubst
     ]
 
 isNormalizedTests :: TestTree

--- a/kore/test/Test/Kore/Internal/TermLike.hs
+++ b/kore/test/Test/Kore/Internal/TermLike.hs
@@ -372,13 +372,13 @@ test_renaming =
     , testSet "\\nu" mkNu
     ]
   where
-    mapElementVariables' v = mapVariables (const $ getElementVariable v)
-    mapSetVariables' v = mapVariables (const $ getSetVariable v)
+    mapElementVariables' v = mapVariables (const v) id
+    mapSetVariables' v = mapVariables id (const v)
 
     traverseElementVariables' v =
-        runIdentity . traverseVariables (const . return $ getElementVariable v)
+        runIdentity . traverseVariables (const $ return v) pure
     traverseSetVariables' v =
-        runIdentity . traverseVariables (const . return $ getSetVariable v)
+        runIdentity . traverseVariables pure (const $ return v)
 
     doesNotCapture
         :: HasCallStack

--- a/kore/test/Test/Kore/Step/EquationalStep.hs
+++ b/kore/test/Test/Kore/Step/EquationalStep.hs
@@ -45,8 +45,8 @@ import Kore.Unification.Error
     ( UnificationOrSubstitutionError (..)
     )
 import Kore.Unification.UnifierT
-    ( MonadUnify
-    , SimplifierVariable
+    ( InternalVariable
+    , MonadUnify
     , runUnifierT
     )
 import Kore.Variables.UnifiedVariable
@@ -435,7 +435,7 @@ test_applyEquationalRule_ =
 
 applyEquationalRulesSequence_
     :: forall unifier variable
-    .  SimplifierVariable variable
+    .  InternalVariable variable
     => MonadUnify unifier
     => Pattern variable
     -- ^ Configuration being rewritten

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -103,7 +103,6 @@ import Kore.Syntax.Definition hiding
     ( Symbol (..)
     )
 import Kore.Unparser
-import Kore.Variables.Fresh
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -1347,13 +1347,15 @@ appliedMockEvaluator result =
         }
 
 mapVariables
-    ::  ( FreshVariable variable
-        , SortedVariable variable
-        )
+    :: forall variable
+    .  (FreshVariable variable, SortedVariable variable)
     => Pattern Variable
     -> Pattern variable
 mapVariables =
-    Pattern.mapVariables $ \v ->
+    Pattern.mapVariables worker worker
+  where
+    worker :: Functor f => f Variable -> f variable
+    worker = fmap $ \v ->
         fromVariable v { variableCounter = Just (Element 1) }
 
 mockEvaluator

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -73,7 +73,8 @@ import Kore.Internal.Symbol hiding
     ( sortInjection
     )
 import Kore.Internal.TermLike
-    ( InternalVariable
+    ( FreshVariable
+    , InternalVariable
     , TermLike
     )
 import qualified Kore.Internal.TermLike as Internal
@@ -1658,7 +1659,7 @@ builtinSet child =
         }
 
 builtinInt
-    :: InternalVariable variable
+    :: FreshVariable variable
     => Integer
     -> TermLike variable
 builtinInt = Builtin.Int.asInternal intSort
@@ -1670,7 +1671,7 @@ builtinBool
 builtinBool = Builtin.Bool.asInternal boolSort
 
 builtinString
-    :: InternalVariable variable
+    :: FreshVariable variable
     => Text
     -> TermLike variable
 builtinString = Builtin.String.asInternal stringSort

--- a/kore/test/Test/Kore/Step/Simplification/Application.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Application.hs
@@ -222,7 +222,7 @@ test_applicationSimplification =
                     zvar = fromVariable <$> z'
                     result
                         :: forall variable
-                        .  SimplifierVariable variable
+                        .  InternalVariable variable
                         => AttemptedAxiom variable
                     result = AttemptedAxiom.Applied AttemptedAxiomResults
                         { results = OrPattern.fromPatterns

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -596,7 +596,7 @@ mockEvaluator
 mockEvaluator evaluation _ _ = return evaluation
 
 mapVariables
-    :: InternalVariable variable
+    :: (InternalVariable variable, FreshVariable variable)
     => Pattern Variable
     -> Pattern variable
 mapVariables =

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -596,11 +596,15 @@ mockEvaluator
 mockEvaluator evaluation _ _ = return evaluation
 
 mapVariables
-    :: (InternalVariable variable, FreshVariable variable)
+    :: forall variable
+    .  (InternalVariable variable, FreshVariable variable)
     => Pattern Variable
     -> Pattern variable
 mapVariables =
-    Pattern.mapVariables $ \v ->
+    Pattern.mapVariables worker worker
+  where
+    worker :: Functor f => f Variable -> f variable
+    worker = fmap $ \v ->
         fromVariable v { variableCounter = Just (Sup.Element 1) }
 
 makeCeil

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -597,7 +597,7 @@ mockEvaluator evaluation _ _ = return evaluation
 
 mapVariables
     :: forall variable
-    .  (InternalVariable variable, FreshVariable variable)
+    .  InternalVariable variable
     => Pattern Variable
     -> Pattern variable
 mapVariables =

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -292,14 +292,14 @@ simplificationEvaluator
 simplificationEvaluator = firstFullEvaluation
 
 makeEvaluator
-    :: (forall variable. SimplifierVariable variable
+    :: (forall variable. InternalVariable variable
         => [(TermLike variable, TermLike variable)]
         )
     -> BuiltinAndAxiomSimplifier
 makeEvaluator mapping = BuiltinAndAxiomSimplifier $ simpleEvaluator mapping
 
 simpleEvaluator
-    :: (SimplifierVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => [(TermLike variable, TermLike variable)]
     -> TermLike variable
     -> SideCondition variable

--- a/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/kore/test/Test/Kore/Step/Simplifier.hs
@@ -24,7 +24,7 @@ import Kore.Syntax.Variable
     )
 
 mockSimplifier
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => [(TermLike variable, [Pattern variable])]
     -> TermLikeSimplifier
 mockSimplifier values =
@@ -32,7 +32,7 @@ mockSimplifier values =
         $ const $ mockSimplifierHelper Pattern.fromTermLike values
 
 mockConditionSimplifier
-    :: SimplifierVariable variable
+    :: InternalVariable variable
     => [(TermLike variable, [Pattern variable])]
     -> TermLikeSimplifier
 mockConditionSimplifier values =
@@ -47,8 +47,8 @@ mockConditionSimplifier values =
         values
 
 mockSimplifierHelper
-    ::  ( SimplifierVariable variable0
-        , SimplifierVariable variable
+    ::  ( InternalVariable variable0
+        , InternalVariable variable
         , MonadSimplify m
         )
     => (TermLike variable -> Pattern variable)

--- a/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/kore/test/Test/Kore/Step/Simplifier.hs
@@ -84,7 +84,9 @@ convertTermLikeVariables
     => TermLike variable
     -> TermLike variable0
 convertTermLikeVariables =
-    TermLike.mapVariables (fromVariable . toVariable)
+    TermLike.mapVariables
+        (fmap $ fromVariable . toVariable)
+        (fmap $ fromVariable . toVariable)
 
 convertPatternVariables
     ::  ( Ord variable
@@ -95,4 +97,6 @@ convertPatternVariables
     => Pattern variable
     -> Pattern variable0
 convertPatternVariables =
-    Pattern.mapVariables (fromVariable . toVariable)
+    Pattern.mapVariables
+        (fmap $ fromVariable . toVariable)
+        (fmap $ fromVariable . toVariable)

--- a/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/kore/test/Test/Kore/Step/Simplifier.hs
@@ -76,9 +76,10 @@ mockSimplifierHelper
         unevaluatedPatt
 
 convertTermLikeVariables
-    ::  ( Ord variable0
+    ::  ( Ord variable
         , SortedVariable variable
         , SortedVariable variable0
+        , FreshVariable variable0
         )
     => TermLike variable
     -> TermLike variable0
@@ -87,9 +88,9 @@ convertTermLikeVariables =
 
 convertPatternVariables
     ::  ( Ord variable
-        , Ord variable0
         , SortedVariable variable
         , SortedVariable variable0
+        , FreshVariable variable0
         )
     => Pattern variable
     -> Pattern variable0

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -534,7 +534,9 @@ test_unification =
         (assertEqual ""
             [(ElemVar $ ElementVariable $ W "1", war' "2")]
             (Substitution.unwrap
-                . Substitution.mapVariables showVar
+                . Substitution.mapVariables
+                    (fmap showVar)
+                    (fmap showVar)
                 . Substitution.wrap
                 $ [(ElemVar $ ElementVariable $ V 1, var' 2)]
             )

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -19,6 +19,7 @@ import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text
     ( Text
     )
@@ -687,6 +688,14 @@ instance Unparse V where
     unparse = error "Not implemented"
     unparse2 = error "Not implemented"
 
+instance FreshVariable V where
+    refreshVariable avoiding v@(V name)
+      | Set.notMember v avoiding = Nothing
+      | otherwise =
+        Just ((head . dropWhile (flip Set.member avoiding)) (V <$> names' ))
+      where
+        names' = iterate (+ 1) name
+
 newtype W = W String
     deriving (Eq, GHC.Generic, Ord, Show)
 
@@ -706,6 +715,14 @@ instance SortedVariable W where
 instance Unparse W where
     unparse = error "Not implemented"
     unparse2 = error "Not implemented"
+
+instance FreshVariable W where
+    refreshVariable avoiding w@(W name)
+      | Set.notMember w avoiding = Nothing
+      | otherwise =
+        Just ((head . dropWhile (flip Set.member avoiding)) (W <$> names' ))
+      where
+        names' = iterate (<> "\'") name
 
 showVar :: V -> W
 showVar (V i) = W (show i)

--- a/kore/test/Test/Kore/Variables/Fresh.hs
+++ b/kore/test/Test/Kore/Variables/Fresh.hs
@@ -30,6 +30,7 @@ import Kore.Variables.Target
     )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
+    , mapUnifiedVariable
     )
 
 import Test.Kore
@@ -288,10 +289,13 @@ test_refreshVariable =
     setNonTargetOriginal  = NonTarget <$> setOriginal
     avoidST = Set.singleton setTargetOriginal
 
+    unifiedTarget = mapUnifiedVariable (fmap Target) (fmap Target)
+    unifiedNonTarget = mapUnifiedVariable (fmap NonTarget) (fmap NonTarget)
+
     -- UnifiedVariable (Target Variable)
-    unifiedElemTargetOriginal    = Target <$> unifiedElemOriginal
-    unifiedElemNonTargetOriginal = NonTarget <$> unifiedElemOriginal
-    unifiedSetTargetOriginal     = Target <$> unifiedSetOriginal
-    unifiedSetNonTargetOriginal  = NonTarget <$> unifiedSetOriginal
+    unifiedElemTargetOriginal    = unifiedTarget unifiedElemOriginal
+    unifiedElemNonTargetOriginal = unifiedNonTarget unifiedElemOriginal
+    unifiedSetTargetOriginal     = unifiedTarget  unifiedSetOriginal
+    unifiedSetNonTargetOriginal  = unifiedNonTarget unifiedSetOriginal
     avoidUET = Set.singleton unifiedElemNonTargetOriginal
     avoidUST = Set.singleton unifiedSetTargetOriginal


### PR DESCRIPTION
This pull request fixes `mapVariables` and `traverseVariables` (on `TermLike`) so that they will not capture variables. That is, they are not naive mappings. This makes them significantly more useful! Unfortunately, this pull request has grown larger than I would like, and there is not a clear way to break it up.

Summary:

- `mapVariables` and `traverseVariables` will not capture variables.
- `mapVariables` and `traverseVariables` now take a separate mapping or traversal for `ElementVariable` and `SetVariable`.
- To avoid capturing variables, `mapVariable` and `traverseVariable` now require a `FreshVariable` constraint on the result's variable type.
- Due to its proliferation, the `FreshVariable` constraint is added to `InternalVariable`.

See also: #1399 
~After: #1503~

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
