### PR TITLE
Separate SubstitutionOrd from Ord

### DIFF
--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -73,13 +73,12 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
     )
 import Kore.Internal.TermLike
-    ( InternalVariable
-    , InternalVariable
-    , TermLike
+    ( TermLike
     , pattern Var_
     , mkVar
     )
 import qualified Kore.Internal.TermLike as TermLike
+import Kore.Internal.Variable
 import Kore.TopBottom
     ( TopBottom (..)
     )
@@ -246,9 +245,10 @@ toMultiMap =
         let push = (termLike :|) . maybe [] Foldable.toList
         in Map.alter (Just . push) variable multiMap
 
-{- | Apply a normal order to variable-renaming substitutions.
+{- | Apply a normal order to a single substitution.
 
-A variable-renaming substitution has one of the forms,
+In practice, this means sorting variable-renaming substitutions.
+A variable-renaming substitution is one of the forms,
 
 @
 x:S{} = y:S{}
@@ -275,11 +275,13 @@ orderRenaming
 orderRenaming (uVar1, Var_ uVar2)
   | ElemVar eVar1 <- uVar1
   , ElemVar eVar2 <- uVar2
-  , eVar2 < eVar1 = (uVar2, mkVar uVar1)
+  , LT <- compareSubstitution eVar2 eVar1
+  = (uVar2, mkVar uVar1)
 
   | SetVar sVar1 <- uVar1
   , SetVar sVar2 <- uVar2
-  , sVar2 < sVar1 = (uVar2, mkVar uVar1)
+  , LT <- compareSubstitution sVar2 sVar1
+  = (uVar2, mkVar uVar1)
 orderRenaming subst = subst
 
 fromMap

--- a/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
+++ b/kore/src/Kore/Log/DebugAppliedRewriteRules.hs
@@ -46,7 +46,7 @@ import Kore.Unparser
     ( unparse
     )
 import Kore.Variables.Target
-    ( Target (..)
+    ( Target
     )
 import Log
 

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -91,7 +91,7 @@ import Kore.Step.Step
     , wouldNarrowWith
     )
 import qualified Kore.Step.Step as EqualityPattern
-    ( toAxiomVariables
+    ( renameRuleVariables
     )
 import Kore.Unification.UnifierT
     ( UnifierT
@@ -388,7 +388,7 @@ applyRulesSequence sideCondition initial rules =
     >>= finalizeRulesSequence sideCondition initial
   where
     avoidConfigVars = freeVariables sideCondition <> freeVariables initial
-    rules' = EqualityPattern.toAxiomVariables avoidConfigVars <$> rules
+    rules' = EqualityPattern.renameRuleVariables avoidConfigVars <$> rules
 
 -- | Matches a list a rules against a configuration. See 'matchRule'.
 matchRules

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -62,8 +62,8 @@ import Kore.Step.Step
     , applyRemainder
     , assertFunctionLikeResults
     , checkSubstitutionCoverage
+    , renameRuleVariables
     , simplifyPredicate
-    , toAxiomVariables
     , toConfigurationVariables
     , unifyRules
     )
@@ -266,7 +266,7 @@ applyRulesParallel
 applyRulesParallel unificationProcedure rules initial = do
     let sideCondition = SideCondition.topTODO
         configurationVariables = freeVariables initial
-        rules' = toAxiomVariables configurationVariables <$> rules
+        rules' = renameRuleVariables configurationVariables <$> rules
     results <- unifyRules unificationProcedure sideCondition initial rules'
     debugAppliedRewriteRules initial results
     finalizeRulesParallel initial results
@@ -316,7 +316,7 @@ applyRulesSequence
 applyRulesSequence unificationProcedure initial rules = do
     let sideCondition = SideCondition.topTODO
         configurationVariables = freeVariables initial
-        rules' = toAxiomVariables configurationVariables <$> rules
+        rules' = renameRuleVariables configurationVariables <$> rules
     results <- unifyRules unificationProcedure sideCondition initial rules'
     debugAppliedRewriteRules initial results
     finalizeRulesSequence initial results

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -263,17 +263,13 @@ applyRulesParallel
     -> Pattern (Target variable)
     -- ^ Configuration being rewritten
     -> unifier (Results RulePattern variable)
-applyRulesParallel
-    unificationProcedure
-    -- Wrap the rule and configuration so that unification prefers to substitute
-    -- axiom variables.
-    (map toAxiomVariables -> rules)
-    initial
-  = do
-      results <-
-          unifyRules unificationProcedure SideCondition.topTODO initial rules
-      debugAppliedRewriteRules initial results
-      finalizeRulesParallel initial results
+applyRulesParallel unificationProcedure rules initial = do
+    let sideCondition = SideCondition.topTODO
+        configurationVariables = freeVariables initial
+        rules' = toAxiomVariables configurationVariables <$> rules
+    results <- unifyRules unificationProcedure sideCondition initial rules'
+    debugAppliedRewriteRules initial results
+    finalizeRulesParallel initial results
 
 {- | Apply the given rewrite rules to the initial configuration in parallel.
 
@@ -317,17 +313,13 @@ applyRulesSequence
     -> [RulePattern variable]
     -- ^ Rewrite rules
     -> unifier (Results RulePattern variable)
-applyRulesSequence
-    unificationProcedure
-    initial
-    -- Wrap the rules so that unification prefers to substitute
-    -- axiom variables.
-    (map toAxiomVariables -> rules)
-  = do
-      results <-
-          unifyRules unificationProcedure SideCondition.topTODO initial rules
-      debugAppliedRewriteRules initial results
-      finalizeRulesSequence initial results
+applyRulesSequence unificationProcedure initial rules = do
+    let sideCondition = SideCondition.topTODO
+        configurationVariables = freeVariables initial
+        rules' = toAxiomVariables configurationVariables <$> rules
+    results <- unifyRules unificationProcedure sideCondition initial rules'
+    debugAppliedRewriteRules initial results
+    finalizeRulesSequence initial results
 
 {- | Apply the given rewrite rules to the initial configuration in sequence.
 

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -16,7 +16,7 @@ module Kore.Step.Step
     , applyInitialConditions
     , applyRemainder
     , simplifyPredicate
-    , toAxiomVariables
+    , renameRuleVariables
     , toConfigurationVariables
     , toConfigurationVariablesCondition
     , unwrapRule
@@ -253,18 +253,18 @@ targets for substitution and the axiom's variables are renamed to avoid any free
 variables from the configuration and side condition.
 
  -}
-toAxiomVariables
+renameRuleVariables
     :: InternalVariable variable
     => UnifyingRule rule
     => FreeVariables (Target variable)
     -> rule variable
     -> rule (Target variable)
-toAxiomVariables avoiding =
+renameRuleVariables avoiding =
     snd
     . refreshRule avoiding
     . mapRuleVariables Target.mkElementTarget Target.mkSetTarget
 
-{- | Unwrap the variables in a 'RulePattern'. Inverse of 'toAxiomVariables'.
+{- | Unwrap the variables in a 'RulePattern'. Inverse of 'renameRuleVariables'.
  -}
 unwrapRule
     :: FreshVariable variable

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -38,9 +38,6 @@ import Kore.Step.Simplification.SubstitutionSimplifier
     ( SubstitutionSimplifier (..)
     )
 import qualified Kore.Step.Simplification.SubstitutionSimplifier as SubstitutionSimplifier
-import Kore.Unification.Unify
-    ( InternalVariable
-    )
 
 -- | Normalize the substitution and predicate of 'expanded'.
 normalize

--- a/kore/src/Kore/Variables/Target.hs
+++ b/kore/src/Kore/Variables/Target.hs
@@ -15,6 +15,9 @@ module Kore.Variables.Target
 
 import Prelude.Kore
 
+import Data.Function
+    ( on
+    )
 import Data.Hashable
     ( Hashable
     )
@@ -23,6 +26,7 @@ import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
 import Kore.Debug
+import Kore.Internal.Variable
 import Kore.Syntax.Variable
     ( SortedVariable (..)
     )
@@ -60,6 +64,16 @@ instance SOP.HasDatatypeInfo (Target variable)
 instance Debug variable => Debug (Target variable)
 
 instance (Debug variable, Diff variable) => Diff (Target variable)
+
+{- | Prefer substitutions for 'isTarget' variables.
+ -}
+instance
+    SubstitutionOrd variable => SubstitutionOrd (Target variable)
+  where
+    compareSubstitution (Target _) (NonTarget _) = LT
+    compareSubstitution (NonTarget _) (Target _) = GT
+    compareSubstitution variable1 variable2 =
+        on compareSubstitution unwrapVariable variable1 variable2
 
 unwrapVariable :: Target variable -> variable
 unwrapVariable (Target variable) = variable

--- a/kore/src/Kore/Variables/Target.hs
+++ b/kore/src/Kore/Variables/Target.hs
@@ -23,7 +23,7 @@ import Data.Function
     ( on
     )
 import Data.Hashable
-    ( Hashable
+    ( Hashable (hashWithSalt)
     )
 import qualified Data.Set as Set
 import qualified Generics.SOP as SOP
@@ -55,15 +55,19 @@ instead of 'NonTarget' variables.
 data Target variable
     = Target !variable
     | NonTarget !variable
-    deriving (Eq, GHC.Generic, Show, Functor)
+    deriving (GHC.Generic, Show, Functor)
+
+instance Eq variable => Eq (Target variable) where
+    (==) = on (==) unwrapVariable
+    {-# INLINE (==) #-}
 
 instance Ord variable => Ord (Target variable) where
-    compare (Target var1) (Target var2) = compare var1 var2
-    compare (Target _) (NonTarget _) = LT
-    compare (NonTarget var1) (NonTarget var2) = compare var1 var2
-    compare (NonTarget _) (Target _) = GT
+    compare = on compare unwrapVariable
+    {-# INLINE compare #-}
 
-instance Hashable variable => Hashable (Target variable)
+instance Hashable variable => Hashable (Target variable) where
+    hashWithSalt salt target = hashWithSalt salt (unwrapVariable target)
+    {-# INLINE hashWithSalt #-}
 
 instance SOP.Generic (Target variable)
 

--- a/kore/src/Kore/Variables/Target.hs
+++ b/kore/src/Kore/Variables/Target.hs
@@ -9,7 +9,11 @@ Target specific variables for unification.
 module Kore.Variables.Target
     ( Target (..)
     , unwrapVariable
+    , mkElementTarget
+    , mkSetTarget
     , isTarget
+    , mkElementNonTarget
+    , mkSetNonTarget
     , isNonTarget
     ) where
 
@@ -35,6 +39,10 @@ import Kore.Unparser
     )
 import Kore.Variables.Fresh
     ( FreshVariable (..)
+    )
+import Kore.Variables.UnifiedVariable
+    ( ElementVariable
+    , SetVariable
     )
 
 {- | Distinguish variables by their source.
@@ -79,9 +87,29 @@ unwrapVariable :: Target variable -> variable
 unwrapVariable (Target variable) = variable
 unwrapVariable (NonTarget variable) = variable
 
+mkElementTarget
+    :: ElementVariable variable
+    -> ElementVariable (Target variable)
+mkElementTarget = fmap Target
+
+mkSetTarget
+    :: SetVariable variable
+    -> SetVariable (Target variable)
+mkSetTarget = fmap Target
+
 isTarget :: Target variable -> Bool
 isTarget (Target _) = True
 isTarget (NonTarget _) = False
+
+mkElementNonTarget
+    :: ElementVariable variable
+    -> ElementVariable (Target variable)
+mkElementNonTarget = fmap NonTarget
+
+mkSetNonTarget
+    :: SetVariable variable
+    -> SetVariable (Target variable)
+mkSetNonTarget = fmap NonTarget
 
 isNonTarget :: Target variable -> Bool
 isNonTarget = not . isTarget

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -20,11 +20,8 @@ module Test.Kore
     , predicateChildGen
     , elementVariableGen
     , setVariableGen
-    , targetElementVariableGen
     , elementTargetVariableGen
-    , targetSetVariableGen
     , setTargetVariableGen
-    , targetUnifiedVariableGen
     , unifiedTargetVariableGen
     , unifiedVariableGen
     , genBuiltin
@@ -83,7 +80,11 @@ import Kore.Parser
 import Kore.Syntax.Definition
 import qualified Kore.Syntax.PatternF as Syntax
 import Kore.Variables.Target
-    ( Target (..)
+    ( Target
+    , mkElementNonTarget
+    , mkElementTarget
+    , mkSetNonTarget
+    , mkSetTarget
     )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
@@ -262,44 +263,22 @@ unifiedVariableGen sort = Gen.choice
     , SetVar <$> setVariableGen sort
     ]
 
-targetElementVariableGen :: Sort -> Gen (Target (ElementVariable Variable))
-targetElementVariableGen sort = Gen.choice
-    [ Target <$> elementVariableGen sort
-    , NonTarget <$> elementVariableGen sort
-    ]
-
 elementTargetVariableGen :: Sort -> Gen (ElementVariable (Target Variable))
 elementTargetVariableGen sort = Gen.choice
-    [ (fmap . fmap) Target $ elementVariableGen sort
-    , (fmap . fmap) NonTarget $ elementVariableGen sort
-    ]
-
-targetSetVariableGen :: Sort -> Gen (Target (SetVariable Variable))
-targetSetVariableGen sort = Gen.choice
-    [ Target <$> setVariableGen sort
-    , NonTarget <$> setVariableGen sort
+    [ mkElementTarget    <$> elementVariableGen sort
+    , mkElementNonTarget <$> elementVariableGen sort
     ]
 
 setTargetVariableGen :: Sort -> Gen (SetVariable (Target Variable))
 setTargetVariableGen sort = Gen.choice
-    [ (fmap . fmap) Target $ setVariableGen sort
-    , (fmap . fmap) NonTarget $ setVariableGen sort
-    ]
-
-targetUnifiedVariableGen :: Sort -> Gen (Target (UnifiedVariable Variable))
-targetUnifiedVariableGen sort = Gen.choice
-    [ Target . ElemVar <$> elementVariableGen sort
-    , Target . SetVar <$> setVariableGen sort
-    , NonTarget . ElemVar <$> elementVariableGen sort
-    , NonTarget . SetVar <$> setVariableGen sort
+    [ mkSetTarget    <$> setVariableGen sort
+    , mkSetNonTarget <$> setVariableGen sort
     ]
 
 unifiedTargetVariableGen :: Sort -> Gen (UnifiedVariable (Target Variable))
 unifiedTargetVariableGen sort = Gen.choice
-    [ ElemVar . fmap Target <$> elementVariableGen sort
-    , ElemVar . fmap NonTarget <$> elementVariableGen sort
-    , SetVar . fmap Target <$> setVariableGen sort
-    , SetVar . fmap NonTarget <$> setVariableGen sort
+    [ ElemVar <$> elementTargetVariableGen sort
+    , SetVar  <$> setTargetVariableGen     sort
     ]
 
 unaryOperatorGen

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -166,6 +166,9 @@ instance FreshVariable V where
       where
         names' = iterate (+ 1) name
 
+instance SubstitutionOrd V where
+    compareSubstitution = compare
+
 newtype W = W String
     deriving (Show, Eq, Ord, GHC.Generic)
 
@@ -193,6 +196,9 @@ instance FreshVariable W where
         Just ((head . dropWhile (flip Set.member avoiding)) (W <$> names' ))
       where
         names' = iterate (<> "\'") name
+
+instance SubstitutionOrd W where
+    compareSubstitution = compare
 
 showVar :: V -> W
 showVar (V i) = W (show i)

--- a/kore/test/Test/Kore/Step/Remainder.hs
+++ b/kore/test/Test/Kore/Step/Remainder.hs
@@ -16,8 +16,6 @@ import Kore.Syntax.Variable
     ( Variable
     )
 import Kore.Variables.Target
-    ( Target (..)
-    )
 
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Terse
@@ -33,14 +31,14 @@ test_existentiallyQuantifyTarget =
 target :: Predicate (Target Variable)
 target =
     Predicate.makeEqualsPredicate_
-        (mkElemVar $ NonTarget <$> Mock.x)
+        (mkElemVar $ mkElementNonTarget Mock.x)
         (Mock.sigma
-            (mkElemVar $ Target <$> Mock.y)
-            (mkElemVar $ Target <$> Mock.z)
+            (mkElemVar $ mkElementTarget Mock.y)
+            (mkElemVar $ mkElementTarget Mock.z)
         )
 
 quantified :: Predicate (Target Variable)
 quantified =
     Predicate.makeMultipleExists
-        [Target <$> Mock.y, Target <$> Mock.z]
+        [mkElementTarget Mock.y, mkElementTarget Mock.z]
         target

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -1,6 +1,6 @@
 module Test.Kore.Step.RewriteStep
     ( test_applyInitialConditions
-    , test_toAxiomVariables
+    , test_renameRuleVariables
     , test_unifyRule
     , test_applyRewriteRule_
     , test_applyRewriteRulesParallel
@@ -170,8 +170,8 @@ unifyRule initial rule =
   where
     unificationProcedure = UnificationProcedure Unification.unificationProcedure
 
-test_toAxiomVariables :: [TestTree]
-test_toAxiomVariables =
+test_renameRuleVariables :: [TestTree]
+test_renameRuleVariables =
     [ testCase "renames axiom left variables" $ do
         let initial =
                 Step.toConfigurationVariables
@@ -186,7 +186,7 @@ test_toAxiomVariables =
                     , rhs = injectTermIntoRHS (Mock.g (mkElemVar Mock.x))
                     , attributes = Default.def
                     }
-            actual = Step.toAxiomVariables initialFreeVariables axiom
+            actual = Step.renameRuleVariables initialFreeVariables axiom
             initialFreeVariables = freeVariables initial
             actualFreeVariables = freeVariables actual
         assertEqual "Expected no common free variables"

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -1,5 +1,6 @@
 module Test.Kore.Step.RewriteStep
     ( test_applyInitialConditions
+    , test_toAxiomVariables
     , test_unifyRule
     , test_applyRewriteRule_
     , test_applyRewriteRulesParallel
@@ -15,6 +16,10 @@ import Data.Default as Default
     ( def
     )
 import qualified Data.Foldable as Foldable
+import Data.Function
+    ( on
+    )
+import qualified Data.Set as Set
 
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Internal.Condition as Condition
@@ -165,10 +170,13 @@ unifyRule initial rule =
   where
     unificationProcedure = UnificationProcedure Unification.unificationProcedure
 
-test_unifyRule :: [TestTree]
-test_unifyRule =
+test_toAxiomVariables :: [TestTree]
+test_toAxiomVariables =
     [ testCase "renames axiom left variables" $ do
-        let initial = pure (Mock.f (mkElemVar Mock.x))
+        let initial =
+                Step.toConfigurationVariables
+                $ Pattern.fromTermLike
+                $ Mock.f (mkElemVar Mock.x)
             axiom =
                 RulePattern
                     { left = Mock.f (mkElemVar Mock.x)
@@ -178,13 +186,20 @@ test_unifyRule =
                     , rhs = injectTermIntoRHS (Mock.g (mkElemVar Mock.x))
                     , attributes = Default.def
                     }
-        Right unified <- unifyRule initial axiom
-        let actual = Conditional.term <$> unified
-        assertBool ""
-            $ Foldable.all (not . FreeVariables.isFreeVariable (ElemVar Mock.x))
-            $ freeVariables <$> actual
+            actual = Step.toAxiomVariables initialFreeVariables axiom
+            initialFreeVariables = freeVariables initial
+            actualFreeVariables = freeVariables actual
+        assertEqual "Expected no common free variables"
+            Set.empty
+            $ on Set.intersection FreeVariables.getFreeVariables
+                initialFreeVariables
+                actualFreeVariables
 
-    , testCase "performs unification with initial term" $ do
+    ]
+
+test_unifyRule :: [TestTree]
+test_unifyRule =
+    [ testCase "performs unification with initial term" $ do
         let initial = pure (Mock.functionalConstr10 Mock.a)
             axiom =
                 RulePattern

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -698,6 +698,9 @@ instance FreshVariable V where
       where
         names' = iterate (+ 1) name
 
+instance SubstitutionOrd V where
+    compareSubstitution = compare
+
 newtype W = W String
     deriving (Eq, GHC.Generic, Ord, Show)
 
@@ -725,6 +728,9 @@ instance FreshVariable W where
         Just ((head . dropWhile (flip Set.member avoiding)) (W <$> names' ))
       where
         names' = iterate (<> "\'") name
+
+instance SubstitutionOrd W where
+    compareSubstitution = compare
 
 showVar :: V -> W
 showVar (V i) = W (show i)

--- a/kore/test/Test/Kore/Variables/Fresh.hs
+++ b/kore/test/Test/Kore/Variables/Fresh.hs
@@ -26,8 +26,6 @@ import Kore.Syntax.SetVariable
     )
 import Kore.Variables.Fresh
 import Kore.Variables.Target
-    ( Target (..)
-    )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     , mapUnifiedVariable
@@ -181,8 +179,7 @@ test_refreshVariable =
                 (elemTargetOriginal < fresh0 elemTargetOriginal)
 
         , testCase "refreshVariable - avoid original (ignore Target constructor)" $
-            assertBool
-                "Expected fresh variable"
+            assertBool "Expected fresh variable"
                 (elemTargetOriginal < fresh avoidET elemTargetOriginal)
 
         , testCase "refreshVariable - avoid fresh" $
@@ -203,8 +200,7 @@ test_refreshVariable =
                 (setNonTargetOriginal < fresh0 setNonTargetOriginal)
 
         , testCase "refreshVariable - avoid original (ignore Target constructor)" $
-            assertBool
-                "Expected fresh variable"
+            assertBool "Expected fresh variable"
                 (setNonTargetOriginal < fresh avoidST setNonTargetOriginal)
 
         , testCase "refreshVariable - avoid fresh" $
@@ -281,16 +277,17 @@ test_refreshVariable =
     avoidT = Set.singleton nonTargetOriginal
 
     -- ElementVariable (Target Variable)
-    elemTargetOriginal    = Target <$> elemOriginal
-    elemNonTargetOriginal = NonTarget <$> elemOriginal
+    elemTargetOriginal    = mkElementTarget elemOriginal
+    elemNonTargetOriginal = mkElementNonTarget elemOriginal
     avoidET = Set.singleton elemNonTargetOriginal
     -- SetVariable (Target Variable)
-    setTargetOriginal     = Target <$> setOriginal
-    setNonTargetOriginal  = NonTarget <$> setOriginal
+    setTargetOriginal     = mkSetTarget setOriginal
+    setNonTargetOriginal  = mkSetNonTarget setOriginal
     avoidST = Set.singleton setTargetOriginal
 
-    unifiedTarget = mapUnifiedVariable (fmap Target) (fmap Target)
-    unifiedNonTarget = mapUnifiedVariable (fmap NonTarget) (fmap NonTarget)
+    unifiedTarget = mapUnifiedVariable mkElementTarget mkSetTarget
+
+    unifiedNonTarget = mapUnifiedVariable mkElementNonTarget mkSetNonTarget
 
     -- UnifiedVariable (Target Variable)
     unifiedElemTargetOriginal    = unifiedTarget unifiedElemOriginal


### PR DESCRIPTION
This pull request uses a new class `SubstitutionOrd` to sort substitutions instead of relying on `Ord`, decoupling "generating fresh variables" from "choosing variables to instantiate".

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
