### PR TITLE
toRepresentationCondition: Use layoutOneLine

### DIFF
--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -50,7 +50,6 @@ import Kore.TopBottom
     )
 import Kore.Unparser
     ( Unparse (..)
-    , unparseToText
     )
 import qualified Pretty
 import qualified SQL
@@ -172,4 +171,7 @@ toRepresentationCondition
     => Condition variable
     -> SideCondition.Representation
 toRepresentationCondition condition =
-    SideCondition.Representation.fromText $ unparseToText condition
+    SideCondition.Representation.fromText
+    $ Pretty.renderText
+    $ Pretty.layoutOneLine
+    $ unparse condition


### PR DESCRIPTION
layoutOneLine is faster than unparseToText, which does "smart" rendering
internally.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
