### PR TITLE
Factor class VariableName out of SortedVariable

### DIFF
--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -89,6 +89,9 @@ data Pattern variable =
         }
     deriving (Eq, GHC.Generic, Show)
 
+-- TODO (thomas.tuegel): Lift 'simplified' to the 'Conditional' level once we
+-- treat the latter as an aggregate root.
+
 instance NFData variable => NFData (Pattern variable)
 
 instance Hashable variable => Hashable (Pattern variable)

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -36,9 +36,6 @@ import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Predicate
     ( Predicate
     )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition.Representation
-    ( fromText
-    )
 import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
     )
@@ -46,13 +43,14 @@ import Kore.Internal.Variable
     ( ElementVariable
     , InternalVariable
     , SetVariable
+    , Variable
+    , toVariable
     )
 import Kore.TopBottom
     ( TopBottom (..)
     )
 import Kore.Unparser
     ( Unparse (..)
-    , unparseToText
     )
 import qualified Pretty
 import qualified SQL
@@ -175,4 +173,5 @@ toRepresentationCondition
     => Condition variable
     -> SideCondition.Representation
 toRepresentationCondition condition =
-    SideCondition.Representation.fromText $ unparseToText condition
+    from @(Condition Variable)
+    $ Condition.mapVariables (fmap toVariable) (fmap toVariable) condition

--- a/kore/src/Kore/Internal/SideCondition/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition/SideCondition.hs
@@ -11,43 +11,81 @@ module Kore.Internal.SideCondition.SideCondition
 import Prelude.Kore
 
 import Control.DeepSeq
-    ( NFData
+    ( NFData (..)
     )
 import Data.Hashable
-    ( Hashable
+    ( Hashable (..)
     , Hashed
     , hashed
     )
 import Data.Text
     ( Text
     )
-import qualified Generics.SOP as SOP
-    ( Generic
-    , HasDatatypeInfo
-    )
-import qualified GHC.Generics as GHC
 
+import Data.Type.Equality
+    ( (:~:) (..)
+    , testEquality
+    )
 import Kore.Debug
-    ( Debug
+    ( Debug (..)
     , Diff (..)
     )
+import Type.Reflection
+    ( SomeTypeRep (..)
+    , TypeRep
+    , Typeable
+    , typeRep
+    )
 
-newtype Representation =
-    Representation
-        { getRepresentation :: Hashed Text
-        }
-    deriving (Eq, GHC.Generic, Hashable, NFData, Ord, Show)
+data Representation where
+    Representation :: Ord a => !(TypeRep a) -> !(Hashed a) -> Representation
 
-instance SOP.Generic Representation
+instance Eq Representation where
+    (==) (Representation typeRep1 hashed1) (Representation typeRep2 hashed2) =
+        case testEquality typeRep1 typeRep2 of
+            Nothing -> False
+            Just Refl -> hashed1 == hashed2
+    {-# INLINE (==) #-}
 
-instance SOP.HasDatatypeInfo Representation
+instance Ord Representation where
+    compare
+        (Representation typeRep1 hashed1)
+        (Representation typeRep2 hashed2)
+      =
+        case testEquality typeRep1 typeRep2 of
+            Nothing -> compare (SomeTypeRep typeRep1) (SomeTypeRep typeRep2)
+            Just Refl -> compare hashed1 hashed2
+    {-# INLINE compare #-}
 
-instance Debug Representation
+instance Show Representation where
+    showsPrec prec (Representation typeRep1 _) =
+        showParen (prec >= 10)
+        $ showString "Representation " . shows typeRep1 . showString " _"
+    {-# INLINE showsPrec #-}
 
-instance Diff Representation
+instance Hashable Representation where
+    hashWithSalt salt (Representation typeRep1 hashed1) =
+        salt `hashWithSalt` typeRep1 `hashWithSalt` hashed1
+    {-# INLINE hashWithSalt #-}
 
-instance From Text Representation where
-    from = Representation . hashed
+instance NFData Representation where
+    rnf (Representation typeRep1 hashed1) = typeRep1 `seq` hashed1 `seq` ()
+    {-# INLINE rnf #-}
+
+mkRepresentation :: (Ord a, Hashable a, Typeable a) => a -> Representation
+mkRepresentation = Representation typeRep . hashed
+
+instance Debug Representation where
+    debugPrec _ _ = "_"
+    {-# INLINE debugPrec #-}
+
+instance Diff Representation where
+    diffPrec _ _ = Nothing
+    {-# INLINE diffPrec #-}
+
+instance (Ord a, Hashable a, Typeable a) => From a Representation where
+    from = mkRepresentation
+    {-# INLINE from #-}
 
 fromText :: Text -> Representation
 fromText = from

--- a/kore/src/Kore/Internal/SideCondition/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition/SideCondition.hs
@@ -5,7 +5,6 @@ License     : NCSA
 
 module Kore.Internal.SideCondition.SideCondition
     ( Representation
-    , fromText
     ) where
 
 import Prelude.Kore
@@ -17,9 +16,6 @@ import Data.Hashable
     ( Hashable (..)
     , Hashed
     , hashed
-    )
-import Data.Text
-    ( Text
     )
 
 import Data.Type.Equality
@@ -86,6 +82,3 @@ instance Diff Representation where
 instance (Ord a, Hashable a, Typeable a) => From a Representation where
     from = mkRepresentation
     {-# INLINE from #-}
-
-fromText :: Text -> Representation
-fromText = from

--- a/kore/src/Kore/Internal/Variable.hs
+++ b/kore/src/Kore/Internal/Variable.hs
@@ -81,5 +81,5 @@ these constraints.
 type InternalVariable variable =
     ( Ord variable, SubstitutionOrd variable
     , Debug variable, Show variable, Unparse variable
-    , SortedVariable variable, FreshVariable variable
+    , VariableName variable, SortedVariable variable, FreshVariable variable
     )

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -385,8 +385,7 @@ applyRulesSequence sideCondition initial rules =
     matchRules sideCondition initial rules'
     >>= finalizeRulesSequence sideCondition initial
   where
-    -- TODO (thomas.tuegel): Include freeVariables sideCondition
-    avoidConfigVars = freeVariables initial
+    avoidConfigVars = freeVariables sideCondition <> freeVariables initial
     rules' = EqualityPattern.targetRuleVariables avoidConfigVars <$> rules
 
 -- | Matches a list a rules against a configuration. See 'matchRule'.

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -385,8 +385,7 @@ applyRulesSequence sideCondition initial rules =
     matchRules sideCondition initial rules'
     >>= finalizeRulesSequence sideCondition initial
   where
-    avoidConfigVars = freeVariables sideCondition <> freeVariables initial
-    rules' = EqualityPattern.targetRuleVariables avoidConfigVars <$> rules
+    rules' = EqualityPattern.targetRuleVariables sideCondition initial <$> rules
 
 -- | Matches a list a rules against a configuration. See 'matchRule'.
 matchRules

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -251,8 +251,7 @@ applyRulesWithFinalizer
     -> unifier (Results RulePattern variable)
 applyRulesWithFinalizer finalize unificationProcedure rules initial = do
     let sideCondition = SideCondition.topTODO
-        configurationVariables = freeVariables initial
-        rules' = targetRuleVariables configurationVariables <$> rules
+        rules' = targetRuleVariables sideCondition initial <$> rules
     results <- unifyRules unificationProcedure sideCondition initial rules'
     debugAppliedRewriteRules initial results
     finalize initial results

--- a/kore/src/Kore/Step/Simplification/ExpandAlias.hs
+++ b/kore/src/Kore/Step/Simplification/ExpandAlias.hs
@@ -33,7 +33,7 @@ import Kore.Internal.TermLike
     , substitute
     )
 import Kore.Syntax.Variable
-    ( SortedVariable (..)
+    ( fromVariable
     )
 import Kore.Unification.Unify
     ( MonadUnify

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -48,6 +48,7 @@ import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Branch
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables (..)
+    , HasFreeVariables (freeVariables)
     )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import Kore.Internal.Condition
@@ -257,13 +258,16 @@ The rule's variables are:
 targetRuleVariables
     :: InternalVariable variable
     => UnifyingRule rule
-    => FreeVariables (Target variable)
+    => SideCondition (Target variable)
+    -> Pattern (Target variable)
     -> rule variable
     -> rule (Target variable)
-targetRuleVariables avoiding =
+targetRuleVariables sideCondition initial =
     snd
     . refreshRule avoiding
     . mapRuleVariables Target.mkElementTarget Target.mkSetTarget
+  where
+    avoiding = freeVariables sideCondition <> freeVariables initial
 
 {- | Unwrap the variables in a 'RulePattern'. Inverse of 'targetRuleVariables'.
  -}

--- a/kore/src/Kore/Variables/Target.hs
+++ b/kore/src/Kore/Variables/Target.hs
@@ -129,9 +129,16 @@ instance
   where
     sortedVariableSort (Target variable) = sortedVariableSort variable
     sortedVariableSort (NonTarget variable) = sortedVariableSort variable
-    fromVariable = Target . fromVariable
-    toVariable (Target var) = toVariable var
-    toVariable (NonTarget var) = toVariable var
+
+instance VariableName variable => VariableName (Target variable)
+
+instance From variable1 variable2 => From variable1 (Target variable2) where
+    from = Target . from @variable1 @variable2
+    {-# INLINE from #-}
+
+instance From variable1 variable2 => From (Target variable1) variable2 where
+    from = from @variable1 @variable2 . unTarget
+    {-# INLINE from #-}
 
 {- | Ensures that fresh variables are unique under 'unwrapStepperVariable'.
  -}

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier.hs
@@ -85,6 +85,7 @@ import qualified Kore.Internal.TermLike as Internal
 import Kore.Sort
 import Kore.Syntax hiding
     ( PatternF (..)
+    , VariableName
     )
 import Kore.Syntax.Definition
 import qualified Kore.Syntax.PatternF as Syntax

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -155,8 +155,14 @@ instance Unparse V where
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVariable
-    fromVariable = undefined
-    toVariable = undefined
+
+instance From Variable V where
+    from = error "Not implemented"
+
+instance From V Variable where
+    from = error "Not implemented"
+
+instance VariableName V
 
 instance FreshVariable V where
     refreshVariable avoiding v@(V name)
@@ -186,8 +192,14 @@ instance Unparse W where
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVariable
-    fromVariable = undefined
-    toVariable = undefined
+
+instance From Variable W where
+    from = error "Not implemented"
+
+instance From W Variable where
+    from = error "Not implemented"
+
+instance VariableName W
 
 instance FreshVariable W where
     refreshVariable avoiding w@(W name)

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -1348,7 +1348,7 @@ appliedMockEvaluator result =
 
 mapVariables
     :: forall variable
-    .  (FreshVariable variable, SortedVariable variable)
+    .  (FreshVariable variable, VariableName variable)
     => Pattern Variable
     -> Pattern variable
 mapVariables =

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -21,6 +21,9 @@ import Data.Function
     )
 import qualified Data.Set as Set
 
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables
+    )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.Conditional as Conditional
@@ -80,6 +83,9 @@ import Kore.Unification.UnifierT
     )
 import Kore.Variables.Fresh
     ( nextVariable
+    )
+import Kore.Variables.Target
+    ( Target
     )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
@@ -186,7 +192,8 @@ test_renameRuleVariables =
                     , rhs = injectTermIntoRHS (Mock.g (mkElemVar Mock.x))
                     , attributes = Default.def
                     }
-            actual = Step.targetRuleVariables initialFreeVariables axiom
+            actual = Step.targetRuleVariables SideCondition.top initial axiom
+            initialFreeVariables :: FreeVariables (Target Variable)
             initialFreeVariables = freeVariables initial
             actualFreeVariables = freeVariables actual
         assertEqual "Expected no common free variables"

--- a/kore/test/Test/Kore/Step/Simplifier.hs
+++ b/kore/test/Test/Kore/Step/Simplifier.hs
@@ -19,9 +19,6 @@ import Kore.Internal.Predicate
     )
 import Kore.Internal.TermLike as TermLike
 import Kore.Step.Simplification.Simplify
-import Kore.Syntax.Variable
-    ( SortedVariable (..)
-    )
 
 mockSimplifier
     :: InternalVariable variable
@@ -76,9 +73,8 @@ mockSimplifierHelper
         unevaluatedPatt
 
 convertTermLikeVariables
-    ::  ( Ord variable
-        , SortedVariable variable
-        , SortedVariable variable0
+    ::  ( VariableName variable
+        , VariableName variable0
         , FreshVariable variable0
         )
     => TermLike variable
@@ -89,9 +85,8 @@ convertTermLikeVariables =
         (fmap $ fromVariable . toVariable)
 
 convertPatternVariables
-    ::  ( Ord variable
-        , SortedVariable variable
-        , SortedVariable variable0
+    ::  ( VariableName variable
+        , VariableName variable0
         , FreshVariable variable0
         )
     => Pattern variable

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -683,8 +683,14 @@ instance Diff V
 
 instance SortedVariable V where
     sortedVariableSort _ = sortVar
-    fromVariable = error "Not implemented"
-    toVariable = error "Not implemented"
+
+instance From Variable V where
+    from = error "Not implemented"
+
+instance From V Variable where
+    from = error "Not implemented"
+
+instance VariableName V
 
 instance Unparse V where
     unparse = error "Not implemented"
@@ -714,8 +720,14 @@ instance Diff W
 
 instance SortedVariable W where
     sortedVariableSort _ = sortVar
-    fromVariable = error "Not implemented"
-    toVariable = error "Not implemented"
+
+instance From Variable W where
+    from = error "Not implemented"
+
+instance From W Variable where
+    from = error "Not implemented"
+
+instance VariableName W
 
 instance Unparse W where
     unparse = error "Not implemented"


### PR DESCRIPTION
After: #1537 

This long-awaited refactoring of the `SortedVariable` class is necessary to (safely) state certain injectivity properties of `toVariable`. That allows us to change `SideCondition.Representation` in turn, yielding a 46% speed-up of the `sum-to-n` proof.

See also: #1399 
Fixes: #1472 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
