### PR TITLE
mergeRules: Do not rename rule variables twice

### DIFF
--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -140,13 +140,12 @@ renameRulesVariables
 renameRulesVariables rules =
     evalState (traverse renameRule rules) mempty
   where
-    -- TODO (thomas.tuegel): instance UnifyingRule RewriteRule
     renameRule
         :: RewriteRule variable
         -> State (FreeVariables variable) (RewriteRule variable)
-    renameRule (RewriteRule rulePattern) = State.state $ \used ->
-        let (_, rulePattern') = refreshRule used rulePattern in
-        (RewriteRule rulePattern', used <> freeVariables rulePattern')
+    renameRule rewriteRule = State.state $ \used ->
+        let (_, rewriteRule') = refreshRule used rewriteRule in
+        (rewriteRule', used <> freeVariables rewriteRule')
 
 mergeRules
     :: (MonadSimplify simplifier, InternalVariable variable)

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -177,7 +177,7 @@ mergeRules (renameRulesVariables . Foldable.toList -> rules) =
 
         return (RewriteRule finalRule)
   where
-    mergedPredicate = mergeRulesPredicate rules
+    mergedPredicate = mergeDisjointVarRulesPredicate rules
     firstRule = head rules
     RewriteRule RulePattern
         {left = firstLeft, requires = firstRequires, antiLeft = firstAntiLeft}

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -7,6 +7,7 @@ module Kore.Step.Rule.Combine
     ( mergeRules
     , mergeRulesConsecutiveBatches
     , mergeRulesPredicate
+    , renameRulesVariables
     ) where
 
 import Prelude.Kore

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -789,3 +789,18 @@ instance UnifyingRule RulePattern where
             } = rule1
         mapTermLikeVariables = TermLike.mapVariables mapElemVar mapSetVar
         mapPredicateVariables = Predicate.mapVariables mapElemVar mapSetVar
+
+instance UnifyingRule RewriteRule where
+    matchingPattern (RewriteRule rule) = matchingPattern rule
+    {-# INLINE matchingPattern #-}
+
+    precondition (RewriteRule rule) = precondition rule
+    {-# INLINE precondition #-}
+
+    refreshRule avoiding (RewriteRule rule) =
+        RewriteRule <$> refreshRule avoiding rule
+    {-# INLINE refreshRule #-}
+
+    mapRuleVariables mapElemVar mapSetVar (RewriteRule rule) =
+        RewriteRule (mapRuleVariables mapElemVar mapSetVar rule)
+    {-# INLINE mapRuleVariables #-}

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -432,6 +432,13 @@ instance
     unparse = unparse . rewriteRuleToTerm
     unparse2 = unparse2 . rewriteRuleToTerm
 
+instance
+    InternalVariable variable
+    => HasFreeVariables (RewriteRule variable) variable
+  where
+    freeVariables (RewriteRule rule) = freeVariables rule
+    {-# INLINE freeVariables #-}
+
 {-  | Implication-based pattern.
 -}
 newtype ImplicationRule variable =

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -238,6 +238,17 @@ test_combineRules =
             ]
 
         assertEqual "" expected actual
+    , testCase "renameRulesVariables" $ do
+        let original =
+                [ Mock.functionalConstr10 x `rewritesTo` x
+                , Mock.functionalConstr11 x `rewritesTo` x
+                ]
+            expected =
+                [ Mock.functionalConstr10 x `rewritesTo` x
+                , Mock.functionalConstr11 x0 `rewritesTo` x0
+                ]
+            actual = renameRulesVariables original
+        assertEqual "" expected actual
     , testCase "Renames variables" $ do
         let expected =
                 [   Mock.functionalConstr10 (Mock.functionalConstr11 x0)


### PR DESCRIPTION
In the current implementation of `refreshVariables`, the renamed variables get the same name, but after #1539 they will get new names. That breaks some tests.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
