### PR TITLE
Add makefile rule for running the REPL for spec tests

### DIFF
--- a/test/include.mk
+++ b/test/include.mk
@@ -103,6 +103,9 @@ PATTERN_OPTS = --pattern "$$(cat $*.k)"
 %.save-proofs.kore: %.out
 	[ -f $@ ]
 
+%-spec.k.repl: $(TEST_DIR)/%-spec.k $(KORE_REPL) $(TEST_DEPS)
+	$(KPROVE) $(KPROVE_REPL_OPTS) $<
+
 %-repl-spec.k.out: KPROVE_OPTS = $(KPROVE_REPL_OPTS)
 
 %-repl-script-spec.k.out: %-repl-script-spec.k.repl


### PR DESCRIPTION
I noticed this seems to be missing. Our tests are obviously not using it, but I think it's nice to have for debugging and people wanting to try out our REPL.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
