### PR TITLE
Jenkinsfile: Set integration test timeout to 24 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         }
         stage('Integration Tests') {
           options {
-            timeout(time: 32, unit: 'MINUTES')
+            timeout(time: 24, unit: 'MINUTES')
           }
           steps {
             sh '''


### PR DESCRIPTION
The backend has gotten too fast. We should reduce the timeout to catch potential regressions.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
