### PR TITLE
Simplify claims with side conditions

### DIFF
--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -23,6 +23,7 @@ module Kore.Internal.Pattern
     , Kore.Internal.Pattern.freeElementVariables
     , isSimplified
     , simplifiedAttribute
+    , requireDefined
     -- * Re-exports
     , Conditional (..)
     , Conditional.andCondition
@@ -296,3 +297,26 @@ syncSort
     :: (HasCallStack, InternalVariable variable)
     => Pattern variable -> Pattern variable
 syncSort patt = coerceSort (patternSort patt) patt
+
+{- | Add a 'Predicate' requiring that the 'term' of a 'Pattern' is defined.
+
+@requireDefined@ effectively implements:
+
+@
+φ = φ ∧ ⌈φ⌉
+@
+
+ -}
+requireDefined
+    :: InternalVariable variable
+    => Pattern variable -> Pattern variable
+requireDefined Conditional { term, predicate, substitution } =
+    Conditional
+        { term
+        , substitution
+        , predicate =
+            Predicate.makeAndPredicate predicate
+            $ Predicate.makeCeilPredicate sort term
+        }
+  where
+    sort = termLikeSort term

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -8,6 +8,7 @@ License     : NCSA
 
 module Kore.Internal.SideCondition
     ( SideCondition  -- Constructor not exported on purpose
+    , fromCondition
     , andCondition
     , assumeTrueCondition
     , assumeTruePredicate
@@ -20,6 +21,16 @@ module Kore.Internal.SideCondition
 
 import Prelude.Kore
 
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Hashable
+    ( Hashable
+    )
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Debug
 import Kore.Attribute.Pattern.FreeVariables
     ( HasFreeVariables (..)
     )
@@ -68,6 +79,20 @@ data SideCondition variable =
         , assumedTrue :: !(Condition variable)
         }
     deriving (Eq, Show)
+    deriving (GHC.Generic)
+
+instance SOP.Generic (SideCondition variable)
+
+instance SOP.HasDatatypeInfo (SideCondition variable)
+
+instance Hashable variable => Hashable (SideCondition variable)
+
+instance NFData variable => NFData (SideCondition variable)
+
+instance Debug variable => Debug (SideCondition variable)
+
+instance
+    (InternalVariable variable, Diff variable) => Diff (SideCondition variable)
 
 instance InternalVariable variable => SQL.Column (SideCondition variable) where
     defineColumn = SQL.defineTextColumn

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -42,7 +42,6 @@ import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
     ( Predicate
     , makeAndPredicate
-    , makeCeilPredicate
     )
 import qualified Kore.Internal.Predicate as Predicate
     ( coerceSort
@@ -148,7 +147,7 @@ simplifyClaimRule =
         :: Pattern variable
         -> BranchT simplifier (Pattern variable)
     worker =
-        (return . requireDefined)
+        (return . Pattern.requireDefined)
         >=> simplify
         >=> simplifyWithSolver
     simplify =
@@ -158,20 +157,6 @@ simplifyClaimRule =
         (return . OrPattern.fromPattern)
         >=> simplifyConditionsWithSmt SideCondition.top
         >=> Branch.scatter
-
-requireDefined
-    :: InternalVariable variable
-    => Pattern variable -> Pattern variable
-requireDefined Pattern.Conditional { term, predicate, substitution } =
-    Pattern.Conditional
-        { term
-        , substitution
-        , predicate =
-            makeAndPredicate predicate
-            $ makeCeilPredicate sort term
-        }
-  where
-    sort = termLikeSort term
 
 {- | A 'Lens\'' to view the left-hand side of a 'RulePattern' as a 'Pattern'.
  -}

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -41,9 +41,6 @@ import Kore.Internal.Predicate
 import qualified Kore.Internal.Predicate as Predicate
     ( coerceSort
     )
-import qualified Kore.Internal.SideCondition as SideCondition
-    ( top
-    )
 import Kore.Internal.TermLike
     ( termLikeSort
     )
@@ -58,9 +55,6 @@ import qualified Kore.Step.RulePattern as RulePattern
     ( RulePattern (..)
     , applySubstitution
     , leftPattern
-    )
-import Kore.Step.Simplification.OrPattern
-    ( simplifyConditionsWithSmt
     )
 import qualified Kore.Step.Simplification.Pattern as Pattern
 import Kore.Step.Simplification.Simplify
@@ -86,10 +80,7 @@ instance InternalVariable variable => SimplifyRuleLHS (RulePattern variable)
         let lhsWithPredicate = Pattern.fromTermLike left
         simplifiedTerms <-
             Pattern.simplifyTopConfiguration lhsWithPredicate
-        fullySimplified <-
-            simplifyConditionsWithSmt
-                SideCondition.top
-                simplifiedTerms
+        fullySimplified <- SMT.Evaluator.filterMultiOr simplifiedTerms
         let rules =
                 map (setRuleLeft rule) (MultiOr.extractPatterns fullySimplified)
         return (MultiAnd.make rules)

--- a/kore/test/Test/Kore/Step/Rule/Simplify.hs
+++ b/kore/test/Test/Kore/Step/Rule/Simplify.hs
@@ -1,27 +1,37 @@
 module Test.Kore.Step.Rule.Simplify
     ( test_simplifyRule
+    , test_simplifyClaimRule
     ) where
 
 import Prelude.Kore
 
 import Test.Tasty
 
+import qualified Control.Lens as Lens
 import Data.Default
     ( def
     )
+import Data.Generics.Product
+    ( field
+    )
 
+import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.MultiAnd as MultiAnd
     ( extractPatterns
     )
+import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Predicate
     ( Predicate
     , makeAndPredicate
     , makeCeilPredicate
+    , makeEqualsPredicate
     , makeEqualsPredicate_
     , makeNotPredicate
     , makeTruePredicate
     , makeTruePredicate_
     )
+import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
 import Kore.Internal.TermLike
     ( TermLike
     , mkAnd
@@ -33,19 +43,29 @@ import Kore.Internal.TermLike
 import Kore.Log
     ( emptyLogger
     )
+import Kore.Sort
+    ( predicateSort
+    )
 import Kore.Step.Rule.Simplify
 import Kore.Step.RulePattern
-    ( OnePathRule (OnePathRule)
+    ( OnePathRule (..)
     , RHS (..)
     , RulePattern (RulePattern)
+    , rulePattern
     )
 import qualified Kore.Step.RulePattern as Rule.DoNotUse
 import Kore.Step.Simplification.Data
-    ( runSimplifier
+    ( Env (..)
+    , runSimplifier
+    )
+import Kore.Step.Simplification.Simplify
+    ( emptyConditionSimplifier
+    , termLikeSimplifier
     )
 import qualified Kore.Step.SMT.Declaration.All as SMT.All
 import Kore.Syntax.Variable
     ( Variable
+    , fromVariable
     )
 import qualified SMT
 
@@ -223,3 +243,76 @@ runSimplifyRule rule =
     $ runSimplifier Mock.env $ do
         SMT.All.declare Mock.smtDeclarations
         simplifyRuleLhs rule
+
+test_simplifyClaimRule :: [TestTree]
+test_simplifyClaimRule =
+    [ test "infers definedness"
+        rule1
+        [rule1']
+    , test "includes side condition"
+        rule2
+        [rule2']
+    ]
+  where
+    rule1, rule2, rule2' :: RulePattern Variable
+    rule1 = rulePattern (Mock.f Mock.a) Mock.b
+    rule1' = rule1 & requireDefined
+    rule2 =
+        rulePattern @Variable (Mock.g Mock.a) Mock.b
+        & Lens.set (field @"requires") requires
+    rule2' =
+        rule2
+        & requireDefined
+        & Lens.set (field @"left") (Mock.f Mock.a)
+
+    requires :: Predicate Variable
+    requires = makeEqualsPredicate Mock.testSort Mock.a Mock.b
+
+    requireDefined rule =
+        Lens.over
+            (field @"requires")
+            (flip makeAndPredicate
+                (makeCeilPredicate sort left)
+            )
+            rule
+      where
+        left = Lens.view (field @"left") rule
+        sort = termLikeSort left
+
+    test
+        :: HasCallStack
+        => TestName
+        -> RulePattern Variable
+        -> [RulePattern Variable]
+        -> TestTree
+    test name (OnePathRule -> input) (map OnePathRule -> expect) =
+        -- Test simplifyClaimRule through the OnePathRule instance.
+        testCase name $ do
+            actual <- run $ simplifyRuleLhs input
+            assertEqual "" expect (MultiAnd.extractPatterns actual)
+      where
+        run = SMT.runNoSMT emptyLogger . runSimplifier env
+        env =
+            Mock.env
+                { simplifierTermLike
+                , simplifierCondition = emptyConditionSimplifier
+                , simplifierAxioms = mempty
+                }
+        simplifierTermLike = termLikeSimplifier $ \sideCondition termLike -> do
+            let rule = getOnePathRule input
+                left = Lens.view (field @"left") rule
+                sort = termLikeSort left
+                expectSideCondition =
+                    makeAndPredicate requires (makeCeilPredicate sort left)
+                    & Predicate.mapVariables
+                        (fmap fromVariable)
+                        (fmap fromVariable)
+                    & Predicate.coerceSort predicateSort
+                    & Condition.fromPredicate
+                    & SideCondition.fromCondition
+            return . OrPattern.fromTermLike
+                $ if
+                    (termLike == Mock.g Mock.a)
+                    && (sideCondition == expectSideCondition)
+                    then Mock.f Mock.a
+                    else termLike


### PR DESCRIPTION
Include the `requires` clause of a claim as its side condition during initial simplification.

Fixes: #1547

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
