### PR TITLE
LTS Haskell 14.27 and install ghcide with Stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-14.16
+resolver: lts-14.27
 
 nix:
   packages:
@@ -48,6 +48,8 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - ghc-trace-events-0.1.0
+  - witherable-0.3.5@sha256:6590a15735b50ac14dcc138d4265ff1585d5f3e9d3047d5ebc5abf4cd5f50084,1476
+  - witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
 
   # ghcide must use the same compiler as Stack.
   # That is trickier than it may first appear: We must use the same *exactly*

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,6 +49,21 @@ packages:
 extra-deps:
   - ghc-trace-events-0.1.0
 
+  # ghcide must use the same compiler as Stack.
+  # That is trickier than it may first appear: We must use the same *exactly*
+  # the same compiler, not just the same *version* of the compiler, because
+  # ghcide loads the compiler's shared object files into GHCi.
+  # We set up extra-deps so that we can `stack install ghcide`.
+  - git: https://github.com/digital-asset/ghcide
+    commit: 6f3bd734de52f933000ea92ff4a8a3dea3b95add
+  - fuzzy-0.1.0.0@sha256:123b9581c587ae5422b67bbad7e81186b1ecbf86941a8049f921ddf136f2234e,833
+  - haddock-library-1.8.0@sha256:293544a80c3d817a021fec69c430e808914a9d86db0c6bd6e96a386607a66627,3850
+  - haskell-lsp-0.20.0.1@sha256:fd4f773c9a32c6e76d57381956b3c2e1302230ae2ad784722ce85ff6e7d64ceb,5315
+  - haskell-lsp-types-0.20.0.0@sha256:24dcd72f3d39260b9ebb447e89175e09f2244a17d24eca8bf6dbea3f9cf20977,2941
+  - hie-bios-0.4.0
+  - regex-base-0.94.0.0@sha256:d514eab2aa9ba4b9d14900ac40cbdea1993372466a6cc6ffeeab59a1975563c0,2166
+  - regex-tdfa-1.3.1.0@sha256:c77808a0d68d275c75fb84dc9ced340536574c9aa7961604036a606a232d585b,6274
+  - shake-0.18.5@sha256:a4775c96499e1ed89462903cac292ba209420af85665f34fc792630734025353,15340
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,10 +47,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  - ghc-trace-events-0.0.0.1@sha256:cef5cffd2d749b07ba948b27970c45b6e96705575853f9c14719ad2b9b3397e2
+  - ghc-trace-events-0.1.0
 
-# TODO (thomas.tuegel): Remove this when stylish-haskell is updated upstream.
-allow-newer: true
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,76 @@ packages:
       sha256: 2f1cd7f170129e0fc6806fd5a5828f80bc2d82c60d9000297871909e0bae6569
   original:
     hackage: ghc-trace-events-0.1.0
+- completed:
+    cabal-file:
+      size: 7311
+      sha256: 30ce06cf09dc22cd89dd795bd1589567648108b800f30fdaa828d8c9e8b9bcea
+    name: ghcide
+    version: 0.1.0
+    git: https://github.com/digital-asset/ghcide
+    pantry-tree:
+      size: 5445
+      sha256: 5bd341d5043878faae307a80b22513f129776b6a04e2d2ca52129e328447c35d
+    commit: 6f3bd734de52f933000ea92ff4a8a3dea3b95add
+  original:
+    git: https://github.com/digital-asset/ghcide
+    commit: 6f3bd734de52f933000ea92ff4a8a3dea3b95add
+- completed:
+    hackage: fuzzy-0.1.0.0@sha256:123b9581c587ae5422b67bbad7e81186b1ecbf86941a8049f921ddf136f2234e,833
+    pantry-tree:
+      size: 261
+      sha256: 97019c97e95f2a91089acec705243e1fa5b8529ae112658757e0ab3574905f3c
+  original:
+    hackage: fuzzy-0.1.0.0@sha256:123b9581c587ae5422b67bbad7e81186b1ecbf86941a8049f921ddf136f2234e,833
+- completed:
+    hackage: haddock-library-1.8.0@sha256:293544a80c3d817a021fec69c430e808914a9d86db0c6bd6e96a386607a66627,3850
+    pantry-tree:
+      size: 3397
+      sha256: 2fb23fd09565829807a0368011cd57ea13e9a79fa4c65a47810aaf9a528427c2
+  original:
+    hackage: haddock-library-1.8.0@sha256:293544a80c3d817a021fec69c430e808914a9d86db0c6bd6e96a386607a66627,3850
+- completed:
+    hackage: haskell-lsp-0.20.0.1@sha256:fd4f773c9a32c6e76d57381956b3c2e1302230ae2ad784722ce85ff6e7d64ceb,5315
+    pantry-tree:
+      size: 1726
+      sha256: f541056204ef590eb6f4c4352b3446a222f169f887b55ae0d28d97fb3ed520d1
+  original:
+    hackage: haskell-lsp-0.20.0.1@sha256:fd4f773c9a32c6e76d57381956b3c2e1302230ae2ad784722ce85ff6e7d64ceb,5315
+- completed:
+    hackage: haskell-lsp-types-0.20.0.0@sha256:24dcd72f3d39260b9ebb447e89175e09f2244a17d24eca8bf6dbea3f9cf20977,2941
+    pantry-tree:
+      size: 2451
+      sha256: 8d4a6011264f75f301e14549d40327f90bd7524b0c647983cd571bf3419f7945
+  original:
+    hackage: haskell-lsp-types-0.20.0.0@sha256:24dcd72f3d39260b9ebb447e89175e09f2244a17d24eca8bf6dbea3f9cf20977,2941
+- completed:
+    hackage: hie-bios-0.4.0@sha256:01bb3a9c99173ad6a7c7bd3f2f58ef5019c415b365ae5d573dc489e0940a39f3,8389
+    pantry-tree:
+      size: 6579
+      sha256: 13f9434b6afdff43d50504feac07baae55e4e85b379ca14f2922041e37852693
+  original:
+    hackage: hie-bios-0.4.0
+- completed:
+    hackage: regex-base-0.94.0.0@sha256:d514eab2aa9ba4b9d14900ac40cbdea1993372466a6cc6ffeeab59a1975563c0,2166
+    pantry-tree:
+      size: 483
+      sha256: d147c3c3e3df525bd3909327ee287911f29c9fdf671350cae9e9c4164ceeaea6
+  original:
+    hackage: regex-base-0.94.0.0@sha256:d514eab2aa9ba4b9d14900ac40cbdea1993372466a6cc6ffeeab59a1975563c0,2166
+- completed:
+    hackage: regex-tdfa-1.3.1.0@sha256:c77808a0d68d275c75fb84dc9ced340536574c9aa7961604036a606a232d585b,6274
+    pantry-tree:
+      size: 2566
+      sha256: 706ad120cb4b38ca5cff79a2e2ed961812076fc29aa1866cc3b7c4bda158b5d1
+  original:
+    hackage: regex-tdfa-1.3.1.0@sha256:c77808a0d68d275c75fb84dc9ced340536574c9aa7961604036a606a232d585b,6274
+- completed:
+    hackage: shake-0.18.5@sha256:a4775c96499e1ed89462903cac292ba209420af85665f34fc792630734025353,15340
+    pantry-tree:
+      size: 12063
+      sha256: 511b4a363bffa7d84dbf5bbea6ae5be580f68fb275e10d2c06d71ebb190d26fd
+  original:
+    hackage: shake-0.18.5@sha256:a4775c96499e1ed89462903cac292ba209420af85665f34fc792630734025353,15340
 snapshots:
 - completed:
     size: 524804

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: ghc-trace-events-0.0.0.1@sha256:cef5cffd2d749b07ba948b27970c45b6e96705575853f9c14719ad2b9b3397e2,1991
+    hackage: ghc-trace-events-0.1.0@sha256:e7375b8f9e7bd72bb233c496acd1c4d1a78d80414334fa908ce04fdf152f9298,3102
     pantry-tree:
-      size: 647
-      sha256: 94a3fbef9c432f270715865d0e1d239d1390738e90312147571dd0f3a19ed76e
+      size: 710
+      sha256: 2f1cd7f170129e0fc6806fd5a5828f80bc2d82c60d9000297871909e0bae6569
   original:
-    hackage: ghc-trace-events-0.0.0.1@sha256:cef5cffd2d749b07ba948b27970c45b6e96705575853f9c14719ad2b9b3397e2
+    hackage: ghc-trace-events-0.1.0
 snapshots:
 - completed:
     size: 524804

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,20 @@ packages:
   original:
     hackage: ghc-trace-events-0.1.0
 - completed:
+    hackage: witherable-0.3.5@sha256:6590a15735b50ac14dcc138d4265ff1585d5f3e9d3047d5ebc5abf4cd5f50084,1476
+    pantry-tree:
+      size: 271
+      sha256: b99f21dbac28da031eb7c787fbffbe5e77e0aee42b64b5dda082470e907d5ab5
+  original:
+    hackage: witherable-0.3.5@sha256:6590a15735b50ac14dcc138d4265ff1585d5f3e9d3047d5ebc5abf4cd5f50084,1476
+- completed:
+    hackage: witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
+    pantry-tree:
+      size: 277
+      sha256: e99696bf95da593a3892c7b9a28db09ffd139b4b1b313f32cec9d26979aa7ce2
+  original:
+    hackage: witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
+- completed:
     cabal-file:
       size: 7311
       sha256: 30ce06cf09dc22cd89dd795bd1589567648108b800f30fdaa828d8c9e8b9bcea
@@ -83,7 +97,7 @@ packages:
     hackage: shake-0.18.5@sha256:a4775c96499e1ed89462903cac292ba209420af85665f34fc792630734025353,15340
 snapshots:
 - completed:
-    size: 524804
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/16.yaml
-    sha256: 4d1519a4372d051d47a5eae2241cf3fb54e113d7475f89707ddb6ec06add2888
-  original: lts-14.16
+    size: 524996
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
+    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
+  original: lts-14.27


### PR DESCRIPTION
ghcide must use the same compiler as Stack. That is trickier than it may first appear: We must use the same *exactly* the same compiler, not just the same *version* of the compiler, because ghcide loads the compiler's shared object files into GHCi. We set up extra-deps so that we can `stack install ghcide`.

The changes to `stack.yaml` also cause several dependencies to be rebuilt, so I took this opportunity to update the LTS Haskell revision. I did not update to LTS Haskell 15.x because it uses GHC 8.8, and right now that seems like a release we should skip.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
