### PR TITLE
Exec and search with priority rules

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -226,7 +226,7 @@ applyKoreSearchOptions koreSearchOptions@(Just koreSearchOpts) koreExecOpts =
         { koreSearchOptions
         , strategy =
             -- Search relies on exploring the entire space of states.
-            allRewrites
+            priorityAllStrategy
         , depthLimit = min depthLimit searchTypeDepthLimit
         }
   where
@@ -342,15 +342,15 @@ parseKoreExecOptions =
             <> long "strategy"
             -- TODO (thomas.tuegel): Make defaultStrategy the default when it
             -- works correctly.
-            <> value anyRewrite
+            <> value priorityAnyStrategy
             <> help "Select rewrites using STRATEGY."
             )
       where
         strategies =
-            [ ("any", anyRewrite)
-            , ("all", allRewrites)
-            , ("any-heating-cooling", heatingCooling anyRewrite)
-            , ("all-heating-cooling", heatingCooling allRewrites)
+            [ ("any", priorityAnyStrategy)
+            , ("all", priorityAllStrategy)
+            , ("any-heating-cooling", heatingCooling priorityAnyStrategy)
+            , ("all-heating-cooling", heatingCooling priorityAllStrategy)
             ]
     breadth =
         option auto

--- a/kore/bench/exec/Main.hs
+++ b/kore/bench/exec/Main.hs
@@ -38,7 +38,7 @@ import Kore.Parser
     , parseKorePattern
     )
 import Kore.Step
-    ( anyRewrite
+    ( priorityAnyStrategy
     )
 import Kore.Syntax.Module
     ( ModuleName (..)
@@ -178,7 +178,7 @@ execBenchmark root kFile definitionFile mainModuleName test =
       where
         unlimited :: Limit Natural
         unlimited = Limit.Unlimited
-        strategy = Limit.replicate unlimited . anyRewrite
+        strategy = Limit.replicate unlimited . priorityAnyStrategy
     kompile = myShell $ (kBin </> "kompile")
         ++ " --backend haskell -d " ++ root
         ++ " " ++ (root </> kFile)

--- a/kore/src/Kore/Attribute/Priority.hs
+++ b/kore/src/Kore/Attribute/Priority.hs
@@ -52,9 +52,9 @@ prioritySymbol =
         }
 
 -- | Kore pattern representing a @priority@ attribute.
-priorityAttribute :: Text -> AttributePattern
+priorityAttribute :: Integer -> AttributePattern
 priorityAttribute name =
-    attributePattern prioritySymbol [attributeString name]
+    attributePattern prioritySymbol [attributeInteger name]
 
 instance ParseAttributes Priority where
     parseAttribute =
@@ -73,4 +73,4 @@ instance From Priority Attributes where
     from =
         maybe def toAttribute . getPriority
       where
-        toAttribute = from @AttributePattern . priorityAttribute . pack . show
+        toAttribute = from @AttributePattern . priorityAttribute

--- a/kore/src/Kore/Attribute/Priority.hs
+++ b/kore/src/Kore/Attribute/Priority.hs
@@ -11,10 +11,6 @@ module Kore.Attribute.Priority
 import Prelude.Kore
 
 import qualified Control.Monad as Monad
-import Data.Text
-    ( Text
-    , pack
-    )
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 

--- a/kore/src/Kore/Attribute/Priority.hs
+++ b/kore/src/Kore/Attribute/Priority.hs
@@ -5,6 +5,7 @@ License     : NCSA
 -}
 module Kore.Attribute.Priority
     ( Priority (..)
+    , defaultPriority, owisePriority
     , priorityId, prioritySymbol, priorityAttribute
     ) where
 
@@ -39,6 +40,15 @@ instance NFData Priority
 
 instance Default Priority where
     def = Priority Nothing
+
+-- | Default priority for 'EqualityRule' and 'RulePattern'.
+defaultPriority :: Integer
+defaultPriority = 50
+
+-- | Priority for 'EqualityRule' and 'RulePattern' with the
+-- 'owise' attribute.
+owisePriority :: Integer
+owisePriority = 200
 
 -- | Kore identifier representing the @priority@ attribute symbol.
 priorityId :: Id

--- a/kore/src/Kore/Attribute/Priority.hs
+++ b/kore/src/Kore/Attribute/Priority.hs
@@ -18,6 +18,11 @@ import Kore.Attribute.Parser as Parser
 import Kore.Debug
 
 {- | @Priority@ represents the @priority@ attribute.
+
+    It is unsafe to use this directly when handling the priorities of
+    rules with a 'RulePattern' or a 'EqualityRule' representation.
+    'Kore.Step.RulePattern.getPriorityOfRule'
+    or 'Kore.Step.EqualityPattern.getPriorityOfRule' should be used instead.
  -}
 newtype Priority = Priority { getPriority :: Maybe Integer }
     deriving (Eq, GHC.Generic, Ord, Show)

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -49,7 +49,7 @@ import Kore.Step.RulePattern
     ( RewriteRule (..)
     , RulePattern
     , ToRulePattern (..)
-    , getPriority
+    , getPriorityOfRule
     , isCoolingRule
     , isHeatingRule
     , isNormalRule
@@ -178,7 +178,7 @@ priorityAllStrategy rewrites =
   where
     priorityGroups =
         groupSortOn
-            (getPriority . toRulePattern)
+            (getPriorityOfRule . toRulePattern)
             rewrites
 
 priorityAnyStrategy
@@ -190,7 +190,7 @@ priorityAnyStrategy rewrites =
   where
     sortedRewrites =
         sortOn
-            (getPriority . toRulePattern)
+            (getPriorityOfRule . toRulePattern)
             rewrites
 
 {- | Heat the configuration, apply a normal rewrite, and cool the result.

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -174,8 +174,7 @@ priorityAllStrategy
     => [rewrite]
     -> Strategy (Prim rewrite)
 priorityAllStrategy rewrites =
-    trace (show (fmap length priorityGroups))
-    $ Strategy.any (fmap allRewrites priorityGroups)
+    Strategy.any (fmap allRewrites priorityGroups)
   where
     priorityGroups =
         groupSortOn
@@ -200,9 +199,10 @@ priorityAnyStrategy rewrites =
 -- rules must have side conditions if encoded as \rewrites, or they must be
 -- \equals rules, which are not handled by this strategy.
 heatingCooling
-    :: ( forall rewrite. ToRulePattern rewrite
-        => [rewrite] -> Strategy (Prim rewrite)
-       )
+    ::  ( forall rewrite
+         .  ToRulePattern rewrite
+         => [rewrite] -> Strategy (Prim rewrite)
+        )
     -- ^ 'allRewrites' or 'anyRewrite'
     -> [RewriteRule Variable]
     -> Strategy (Prim (RewriteRule Variable))

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -174,7 +174,7 @@ priorityAllStrategy
     => [rewrite]
     -> Strategy (Prim rewrite)
 priorityAllStrategy rewrites =
-    Strategy.any (fmap allRewrites priorityGroups)
+    Strategy.first (fmap allRewrites priorityGroups)
   where
     priorityGroups =
         groupSortOn

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -200,8 +200,8 @@ priorityAnyStrategy rewrites =
 -- \equals rules, which are not handled by this strategy.
 heatingCooling
     ::  ( forall rewrite
-         .  ToRulePattern rewrite
-         => [rewrite] -> Strategy (Prim rewrite)
+        .  ToRulePattern rewrite
+        => [rewrite] -> Strategy (Prim rewrite)
         )
     -- ^ 'allRewrites' or 'anyRewrite'
     -> [RewriteRule Variable]

--- a/kore/src/Kore/Step/EqualityPattern.hs
+++ b/kore/src/Kore/Step/EqualityPattern.hs
@@ -35,6 +35,7 @@ import Kore.Attribute.Pattern.FreeVariables
     ( HasFreeVariables (..)
     )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+import qualified Kore.Attribute.Priority as Attribute
 import Kore.Debug
 import Kore.Internal.Predicate
     ( Predicate
@@ -262,8 +263,8 @@ isSimplificationRule (EqualityRule EqualityPattern { attributes }) =
 getPriorityOfRule :: EqualityRule variable -> Integer
 getPriorityOfRule (EqualityRule EqualityPattern { attributes }) =
     if isOwise
-        then 200
-        else fromMaybe 100 getPriority
+        then Attribute.owisePriority
+        else fromMaybe Attribute.defaultPriority getPriority
   where
     Attribute.Priority { getPriority } =
         Attribute.priority attributes

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -21,7 +21,7 @@ module Kore.Step.RulePattern
     , isHeatingRule
     , isCoolingRule
     , isNormalRule
-    , getPriority
+    , getPriorityOfRule
     , applySubstitution
     , topExistsToImplicitForall
     , isFreeOf
@@ -71,6 +71,7 @@ import Data.Text.Prettyprint.Doc
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
+import qualified Kore.Attribute.Owise as Attribute
 
 import qualified Kore.Attribute.Axiom as Attribute
 import Kore.Attribute.Pattern.FreeVariables
@@ -303,8 +304,16 @@ isNormalRule RulePattern { attributes } =
         Attribute.Normal -> True
         _ -> False
 
-getPriority :: RulePattern variable -> Attribute.Priority
-getPriority = Attribute.priority . attributes
+getPriorityOfRule :: RulePattern variable -> Integer
+getPriorityOfRule RulePattern { attributes } =
+    if isOwise
+        then 200
+        else fromMaybe 100 getPriority
+  where
+    Attribute.Priority { getPriority } =
+        Attribute.priority attributes
+    Attribute.Owise { isOwise } =
+        Attribute.owise attributes
 
 -- | Converts the 'RHS' back to the term form.
 rhsToTerm

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -71,14 +71,14 @@ import Data.Text.Prettyprint.Doc
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
-import qualified Kore.Attribute.Owise as Attribute
-
 import qualified Kore.Attribute.Axiom as Attribute
+import qualified Kore.Attribute.Owise as Attribute
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables (..)
     , HasFreeVariables (..)
     )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+import qualified Kore.Attribute.Priority as Attribute
 import Kore.Debug
 import Kore.Internal.Alias
     ( Alias (..)
@@ -307,8 +307,8 @@ isNormalRule RulePattern { attributes } =
 getPriorityOfRule :: RulePattern variable -> Integer
 getPriorityOfRule RulePattern { attributes } =
     if isOwise
-        then 200
-        else fromMaybe 100 getPriority
+        then Attribute.owisePriority
+        else fromMaybe Attribute.defaultPriority getPriority
   where
     Attribute.Priority { getPriority } =
         Attribute.priority attributes

--- a/kore/src/Kore/Step/RulePattern.hs
+++ b/kore/src/Kore/Step/RulePattern.hs
@@ -602,6 +602,8 @@ instance TopBottom (AllPathRule variable) where
     isTop _ = False
     isBottom _ = False
 
+instance ToRulePattern (RewriteRule Variable)
+
 instance ToRulePattern (OnePathRule Variable)
 
 instance ToRulePattern (AllPathRule Variable)

--- a/kore/src/Kore/Step/Strategy.hs
+++ b/kore/src/Kore/Step/Strategy.hs
@@ -20,6 +20,7 @@ module Kore.Step.Strategy
     , all
     , or
     , try
+    , first
     , any
     , many
     , some
@@ -54,7 +55,6 @@ import Prelude.Kore hiding
     , any
     , many
     , or
-    , replicate
     , seq
     , sequence
     , some
@@ -183,8 +183,11 @@ any [] === stuck
 @
 
  -}
+first :: [Strategy prim] -> Strategy prim
+first = foldr or stuck
+
 any :: [Strategy prim] -> Strategy prim
-any = foldr or stuck
+any = first
 
 -- | Attempt the given strategy once.
 try :: Strategy prim -> Strategy prim

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -319,7 +319,7 @@ instance Goal (OnePathRule Variable) where
       where
         rewrites =
             sortOn
-                (RulePattern.getPriority . toRulePattern)
+                (RulePattern.getPriorityOfRule . toRulePattern)
                 rules
         coinductiveRewrites =
             OnePathRewriteRule
@@ -384,7 +384,7 @@ instance Goal (AllPathRule Variable) where
       where
         priorityGroups =
             groupSortOn
-                (RulePattern.getPriority . toRulePattern)
+                (RulePattern.getPriorityOfRule . toRulePattern)
                 rules
         coinductiveRewrites =
             AllPathRewriteRule

--- a/kore/test/Test/Kore/Attribute/Priority.hs
+++ b/kore/test/Test/Kore/Attribute/Priority.hs
@@ -5,8 +5,6 @@ module Test.Kore.Attribute.Priority
     , test_zeroArguments
     , test_twoArguments
     , test_negative
-    , test_string
-    , test_space
     ) where
 
 import Prelude.Kore
@@ -27,14 +25,14 @@ test_priority =
     testCase "[priority{}(\"123\")] :: Priority"
         $ expectSuccess Priority { getPriority = Just 123 }
         $ parsePriority
-        $ Attributes [ priorityAttribute "123" ]
+        $ Attributes [ priorityAttribute 123 ]
 
 test_Attributes :: TestTree
 test_Attributes =
     testCase "[priority{}(\"123\")] :: Attributes"
         $ expectSuccess attrs $ parseAttributes attrs
   where
-    attrs = Attributes [ priorityAttribute "123"]
+    attrs = Attributes [ priorityAttribute 123]
 
 test_duplicate :: TestTree
 test_duplicate =
@@ -42,7 +40,7 @@ test_duplicate =
         $ expectFailure
         $ parsePriority $ Attributes [ attr, attr]
   where
-    attr = priorityAttribute "123"
+    attr = priorityAttribute 123
 
 test_zeroArguments :: TestTree
 test_zeroArguments =
@@ -72,21 +70,4 @@ test_negative =
     testCase "[priority{}(\"-32\")]"
         $ expectSuccess Priority { getPriority = Just (-32) }
         $ parsePriority
-        $ Attributes [ priorityAttribute "-32"]
-
-test_string :: TestTree
-test_string =
-    testCase "[priority{}(\"abc\")]"
-        $ expectFailure
-        $ parsePriority $ Attributes [ attr ]
-  where
-    attr = priorityAttribute "abc"
-
-
-test_space :: TestTree
-test_space =
-    testCase "[priority{}(\" \")]"
-        $ expectFailure
-        $ parsePriority $ Attributes [ attr ]
-  where
-    attr = priorityAttribute " "
+        $ Attributes [ priorityAttribute (-32)]

--- a/kore/test/Test/Kore/Exec.hs
+++ b/kore/test/Test/Kore/Exec.hs
@@ -38,7 +38,6 @@ import System.Exit
 import Kore.ASTVerifier.DefinitionVerifier
     ( verifyAndIndexDefinition
     )
-import qualified Kore.Attribute.Axiom as Attribute.Axiom
 import Kore.Attribute.Constructor
 import Kore.Attribute.Function
 import Kore.Attribute.Functional
@@ -161,7 +160,7 @@ test_searchPriority =
     unlimited :: Limit Integer
     unlimited = Unlimited
     makeTestCase searchType =
-        testCase ("searchpriority " <> show searchType) (assertion searchType)
+        testCase ("searchPriority " <> show searchType) (assertion searchType)
     assertion searchType =
         actual searchType >>= assertEqual "" (expected searchType)
     actual searchType = do
@@ -220,7 +219,7 @@ test_search =
     unlimited :: Limit Integer
     unlimited = Unlimited
     makeTestCase searchType =
-        testCase (show searchType) (assertion searchType)
+        testCase ("search " <> show searchType) (assertion searchType)
     assertion searchType =
         actual searchType >>= assertEqual "" (expected searchType)
     actual searchType = do
@@ -469,7 +468,10 @@ rewriteAxiom lhsName rhsName =
 
 rewriteAxiomPriority :: Text -> Text -> Integer -> Verified.Sentence
 rewriteAxiomPriority lhsName rhsName priority =
-    (Syntax.SentenceAxiomSentence . axiomWithAttribute (Attribute.Axiom.priorityAttribute priority) . TermLike.mkAxiom_)
+    ( Syntax.SentenceAxiomSentence
+    . axiomWithAttribute (Attribute.Axiom.priorityAttribute priority)
+    . TermLike.mkAxiom_
+    )
     $ rewriteRuleToTerm
     $ RewriteRule RulePattern
         { left = applyToNoArgs mySort lhsName
@@ -477,8 +479,6 @@ rewriteAxiomPriority lhsName rhsName priority =
         , requires = makeTruePredicate_
         , rhs = injectTermIntoRHS (applyToNoArgs mySort rhsName)
         , attributes = def
-            { Attribute.Axiom.priority = Attribute.Axiom.Priority (Just priority)
-            }
         }
 
 axiomWithAttribute
@@ -486,7 +486,12 @@ axiomWithAttribute
     -> SentenceAxiom (TermLike variable)
     -> SentenceAxiom (TermLike variable)
 axiomWithAttribute attribute axiom =
-    axiom { sentenceAxiomAttributes = sentenceAxiomAttributes axiom <> Attributes [attribute] }
+    axiom
+        { sentenceAxiomAttributes =
+            currentAttributes <> Attributes [attribute]
+        }
+  where
+    currentAttributes = sentenceAxiomAttributes axiom
 
 applyToNoArgs :: Sort -> Text -> TermLike Variable
 applyToNoArgs sort name =

--- a/kore/test/Test/Kore/Step.hs
+++ b/kore/test/Test/Kore/Step.hs
@@ -148,7 +148,7 @@ takeSteps (Start start, wrappedAxioms) =
         Strategy.runStrategy
             Unlimited
             transitionRule
-            (repeat $ allRewrites axioms)
+            (repeat $ priorityAllStrategy axioms)
             (pure configuration)
 
 compareTo
@@ -532,7 +532,7 @@ runStep
 runStep configuration axioms =
     (<$>) pickFinal
     $ runSimplifier mockEnv
-    $ runStrategy Unlimited transitionRule [allRewrites axioms] configuration
+    $ runStrategy Unlimited transitionRule [priorityAllStrategy axioms] configuration
 
 runStepMockEnv
     :: Pattern Variable
@@ -542,4 +542,4 @@ runStepMockEnv
 runStepMockEnv configuration axioms =
     (<$>) pickFinal
     $ runSimplifier Mock.env
-    $ runStrategy Unlimited transitionRule [allRewrites axioms] configuration
+    $ runStrategy Unlimited transitionRule [priorityAllStrategy axioms] configuration

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -309,7 +309,7 @@ testDef =
             , sentenceAxiomAttributes =
                 Attributes
                     [ simplificationAttribute
-                    , Attribute.priorityAttribute "3"
+                    , Attribute.priorityAttribute 3
                     ]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies
@@ -327,7 +327,7 @@ testDef =
             , sentenceAxiomAttributes =
                 Attributes
                     [ simplificationAttribute
-                    , Attribute.priorityAttribute "1"
+                    , Attribute.priorityAttribute 1
                     ]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies
@@ -345,7 +345,7 @@ testDef =
             , sentenceAxiomAttributes =
                 Attributes
                     [ simplificationAttribute
-                    , Attribute.priorityAttribute "2"
+                    , Attribute.priorityAttribute 2
                     ]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -200,7 +200,7 @@ testDef =
         , SentenceAxiomSentence SentenceAxiom
             { sentenceAxiomParameters = [sortVar]
             , sentenceAxiomAttributes =
-                Attributes [Attribute.priorityAttribute "2"]
+                Attributes [Attribute.priorityAttribute 2]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies
                     (mkTop sortVarS)
@@ -215,7 +215,7 @@ testDef =
         , SentenceAxiomSentence SentenceAxiom
             { sentenceAxiomParameters = [sortVar]
             , sentenceAxiomAttributes =
-                Attributes [Attribute.priorityAttribute "3"]
+                Attributes [Attribute.priorityAttribute 3]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies
                     (mkTop sortVarS)
@@ -245,7 +245,7 @@ testDef =
         , SentenceAxiomSentence SentenceAxiom
             { sentenceAxiomParameters = [sortVar]
             , sentenceAxiomAttributes =
-                Attributes [Attribute.priorityAttribute "1"]
+                Attributes [Attribute.priorityAttribute 1]
             , sentenceAxiomPattern =
                 Builtin.externalize $ mkImplies
                     (mkTop sortVarS)

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -21,6 +21,10 @@ import Data.Text
 
 import Kore.ASTVerifier.DefinitionVerifier
 import qualified Kore.Attribute.Owise as Attribute
+import Kore.Attribute.Priority
+    ( defaultPriority
+    , owisePriority
+    )
 import qualified Kore.Attribute.Priority as Attribute
 import Kore.Attribute.Simplification
     ( simplificationAttribute
@@ -393,7 +397,7 @@ test_functionRegistry =
            (case Map.lookup axiomId testProcessedAxiomPatterns of
                 Just PartitionedEqualityRules { functionRules } ->
                     assertEqual ""
-                        [1, 2, 3, 100, 200]
+                        [1, 2, 3, defaultPriority, owisePriority]
                         (fmap getPriorityOfRule functionRules)
                 _ -> assertFailure "Should find equality rules for f"
             )

--- a/test/priority/priority.k
+++ b/test/priority/priority.k
@@ -10,7 +10,7 @@ module PRIORITY
   rule func1(X:Int) => four
     requires X ==Int 4        
   rule func1(4)     => four
-  rule func1(_:Int) => seven  [priority(99)] 
+  rule func1(_:Int) => seven  [priority(49)] 
 
   syntax S ::= func2(Int)     [function]
   rule func2(4)     => four   
@@ -18,9 +18,9 @@ module PRIORITY
 
   syntax S ::= func3(Int)     [function]
   rule func3(X:Int) => four
-    requires X >=Int 4        [priority(70)]
+    requires X >=Int 4        [priority(30)]
   rule func3(X:Int) => five
-    requires X >Int 4         [priority(53)]
+    requires X >Int 4         [priority(23)]
   rule func3(6)     => six
   rule func3(_:Int) => seven  [owise]
 


### PR DESCRIPTION
Fixes https://github.com/kframework/kore/issues/1587

Also modifies `priorityAttribute` to receive an Integer instead of a String.

Fixes default priorities bug in https://github.com/kframework/kore/pull/1580 as well.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
