### PR TITLE
Remove constructors of Conditional used in pattern-matching. 

### DIFF
--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -192,5 +192,5 @@ coerceSort
     Conditional
         { term = ()
         , predicate = Predicate.coerceSort sort (predicate condition)
-        , substitution = (substitution condition)
+        , substitution = substitution condition
         }

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -68,23 +68,23 @@ import Kore.Variables.UnifiedVariable
 type Condition variable = Conditional variable ()
 
 isSimplified :: SideCondition.Representation -> Condition variable -> Bool
-isSimplified sideCondition Conditional {term = (), predicate, substitution} =
-    Predicate.isSimplified sideCondition predicate
-    && Substitution.isSimplified sideCondition substitution
+isSimplified sideCondition conditional =
+    Predicate.isSimplified sideCondition (predicate conditional)
+    && Substitution.isSimplified sideCondition (substitution conditional)
 
 simplifiedAttribute :: Condition variable -> Attribute.Simplified
-simplifiedAttribute Conditional {term = (), predicate, substitution} =
-    Predicate.simplifiedAttribute predicate
-    <> Substitution.simplifiedAttribute substitution
+simplifiedAttribute conditional =
+    Predicate.simplifiedAttribute (predicate conditional)
+    <> Substitution.simplifiedAttribute (substitution conditional)
 
 forgetSimplified
     :: InternalVariable variable
     => Condition variable -> Condition variable
-forgetSimplified Conditional { term = (), predicate, substitution } =
+forgetSimplified condition =
     Conditional
         { term = ()
-        , predicate = Predicate.forgetSimplified predicate
-        , substitution = Substitution.forgetSimplified substitution
+        , predicate = Predicate.forgetSimplified (predicate condition)
+        , substitution = Substitution.forgetSimplified (substitution condition)
         }
 
 -- | Erase the @Conditional@ 'term' to yield a 'Condition'.
@@ -179,18 +179,18 @@ fromNormalizationSimplified Normalization { normalized, denormalized } =
                 childrenList
 
 conditionSort :: Condition variable -> Sort
-conditionSort Conditional {term = (), predicate} =
-    Predicate.predicateSort predicate
+conditionSort condition =
+    Predicate.predicateSort (predicate condition)
 
 coerceSort
     :: (HasCallStack, InternalVariable variable)
     => Sort -> Condition variable -> Condition variable
 coerceSort
     sort
-    Conditional {term = (), predicate, substitution}
+    condition
   =
     Conditional
         { term = ()
-        , predicate = Predicate.coerceSort sort predicate
-        , substitution
+        , predicate = Predicate.coerceSort sort (predicate condition)
+        , substitution = (substitution condition)
         }

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -133,7 +133,6 @@ mapVariables
 mapVariables
     mapElemVar
     mapSetVar
-    --Conditional { term, predicate, substitution }
     conditional
   =
     Conditional
@@ -241,24 +240,6 @@ fromTermLike term
         , substitution = mempty
         }
 
-{-
-withCondition
-    :: InternalVariable variable
-    => TermLike variable
-    -> Conditional variable ()
-    -- ^ Condition
-    -> Pattern variable
-withCondition
-    term
-    Conditional
-        { term = ()
-        , predicate
-        , substitution
-        }
-  = syncSort
-    Conditional { term, predicate, substitution }
--}
-
 withCondition
     :: InternalVariable variable
     => TermLike variable
@@ -270,10 +251,9 @@ withCondition
   = syncSort
     Conditional
         { term
-        , predicate = (predicate condition)
-        , substitution = (substitution condition)
+        , predicate = predicate condition
+        , substitution = substitution condition
         }
-
 
 withConditionUnsorted
     :: TermLike variable
@@ -285,8 +265,8 @@ withConditionUnsorted
   =
     Conditional
         { term
-        , predicate = (predicate condition)
-        , substitution = (substitution condition)
+        , predicate = predicate condition
+        , substitution = substitution condition
         }
 
 splitTerm :: Pattern variable -> (TermLike variable, Condition variable)
@@ -306,7 +286,7 @@ coerceSort
         -- Need to override this since a 'ceil' (say) over a predicate is that
         -- predicate with a different sort.
         , predicate = Predicate.coerceSort sort (predicate conditional)
-        , substitution = (substitution conditional)
+        , substitution = substitution conditional
         }
 
 patternSort :: Pattern variable -> Sort

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -36,9 +36,6 @@ import Kore.Internal.Condition
     ( Condition
     )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional
-    ( Conditional (Conditional)
-    )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrCondition
@@ -135,7 +132,7 @@ unwrapAndQuantifyConfiguration
     .  InternalVariable variable
     => Pattern (Target variable)
     -> Pattern variable
-unwrapAndQuantifyConfiguration config@Conditional { substitution } =
+unwrapAndQuantifyConfiguration config =
     if List.null targetVariables
     then unwrappedConfig
     else
@@ -146,6 +143,7 @@ unwrapAndQuantifyConfiguration config@Conditional { substitution } =
                 targetVariables
             )
   where
+    substitution = Conditional.substitution config
     substitution' =
         Substitution.filter (foldMapVariable Target.isNonTarget)
             substitution
@@ -213,7 +211,7 @@ finalizeAppliedRule sideCondition renamedRule appliedConditions =
         -- Apply the normalized substitution to the right-hand side of the
         -- axiom.
         let
-            Conditional { substitution } = finalCondition
+            substitution = Conditional.substitution finalCondition
             substitution' = Substitution.toMap substitution
             finalTerm' = TermLike.substitute substitution' finalTerm
         return (finalTerm' `Pattern.withCondition` finalCondition)
@@ -281,8 +279,8 @@ recoveryFunctionLikeResults initial results = do
                             \simplification are built from a single rule."
                             ]
 
-            Conditional { term = ruleTerm, substitution = ruleSubstitution } =
-                appliedRule
+            ruleTerm = Conditional.term appliedRule
+            ruleSubstitution = Conditional.substitution appliedRule
             EqualityPattern { left = alpha_t', requires = alpha_p'} = ruleTerm
 
             substitution' = Substitution.toMap ruleSubstitution

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -331,8 +331,8 @@ maybeEvaluatePattern
     unchangedPatt =
         Conditional
             { term         = termLike
-            , predicate    = (predicate childrenCondition)
-            , substitution = (substitution childrenCondition)
+            , predicate    = predicate childrenCondition
+            , substitution = substitution childrenCondition
             }
 
     simplifyIfNeeded :: Pattern variable -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -331,11 +331,9 @@ maybeEvaluatePattern
     unchangedPatt =
         Conditional
             { term         = termLike
-            , predicate    = predicate
-            , substitution = substitution
+            , predicate    = (predicate childrenCondition)
+            , substitution = (substitution childrenCondition)
             }
-      where
-        Conditional { term = (), predicate, substitution } = childrenCondition
 
     simplifyIfNeeded :: Pattern variable -> simplifier (OrPattern variable)
     simplifyIfNeeded toSimplify

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -21,6 +21,7 @@ import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
     ( Conditional (Conditional)
     )
+import Kore.Internal.Conditional as Conditional
 import Kore.Internal.MultiAnd
     ( MultiAnd
     )
@@ -133,9 +134,11 @@ unificationConditions
     => Condition (Target variable)
     -- ^ Unification solution
     -> MultiAnd (Predicate (Target variable))
-unificationConditions Conditional { predicate, substitution } =
+unificationConditions conditional =
     pure predicate <|> substitutionConditions substitution'
   where
+    predicate = Conditional.predicate conditional
+    substitution = Conditional.substitution conditional
     substitution' =
         Substitution.filter (foldMapVariable Target.isNonTarget)
             substitution

--- a/kore/src/Kore/Step/Rule/Combine.hs
+++ b/kore/src/Kore/Step/Rule/Combine.hs
@@ -34,9 +34,8 @@ import qualified Kore.Internal.Condition as Condition
     ( fromPredicate
     )
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional (..)
     )
-import qualified Kore.Internal.Conditional as Conditional.DoNotUse
 import Kore.Internal.Predicate
     ( Predicate
     , makeAndPredicate
@@ -154,18 +153,18 @@ mergeRules
 mergeRules (a :| []) = return [a]
 mergeRules (renameRulesVariables . Foldable.toList -> rules) =
     BranchT.gather $ do
-        Conditional {term = (), predicate, substitution} <-
+        condition <-
             simplifyCondition SideCondition.topTODO . Condition.fromPredicate
             $ makeAndPredicate firstRequires mergedPredicate
-        evaluation <- SMT.evaluate predicate
+        evaluation <- SMT.evaluate (predicate condition)
         evaluatedPredicate <- case evaluation of
-            Nothing -> return predicate
+            Nothing -> return (predicate condition)
             Just True -> return makeTruePredicate_
             Just False -> empty
 
         let finalRule =
                 RulePattern.applySubstitution
-                    substitution
+                    (substitution condition)
                     RulePattern
                         { left = firstLeft
                         , requires = evaluatedPredicate

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -95,7 +95,7 @@ instance InternalVariable variable => SimplifyRuleLHS (RulePattern variable)
             RulePattern.applySubstitution
                 (substitution conditional)
                 rulePattern
-                    { RulePattern.left = (term conditional)
+                    { RulePattern.left = term conditional
                     , RulePattern.requires =
                         Predicate.coerceSort (termLikeSort (term conditional))
                         $ makeAndPredicate (predicate conditional) requires'

--- a/kore/src/Kore/Step/Rule/Simplify.hs
+++ b/kore/src/Kore/Step/Rule/Simplify.hs
@@ -19,9 +19,6 @@ import Branch
     )
 import qualified Branch
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
-    )
-import qualified Kore.Internal.Conditional as Conditional.DoNotUse
     ( Conditional (..)
     )
 import Kore.Internal.MultiAnd
@@ -93,15 +90,15 @@ instance InternalVariable variable => SimplifyRuleLHS (RulePattern variable)
             -> RulePattern variable
         setRuleLeft
             rulePattern@RulePattern {requires = requires'}
-            Conditional {term, predicate, substitution}
+            conditional
           =
             RulePattern.applySubstitution
-                substitution
+                (substitution conditional)
                 rulePattern
-                    { RulePattern.left = term
+                    { RulePattern.left = (term conditional)
                     , RulePattern.requires =
-                        Predicate.coerceSort (termLikeSort term)
-                        $ makeAndPredicate predicate requires'
+                        Predicate.coerceSort (termLikeSort (term conditional))
+                        $ makeAndPredicate (predicate conditional) requires'
                     }
 
 instance SimplifyRuleLHS (RewriteRule Variable) where

--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -197,10 +197,10 @@ makeEvaluateNonBool
     -> BranchT simplifier (Pattern variable)
 makeEvaluateNonBool
     sideCondition
-    first@Conditional { term = firstTerm }
-    second@Conditional { term = secondTerm }
+    first
+    second
   = do
-    terms <- termAnd firstTerm secondTerm
+    terms <- termAnd (term first) (term second)
     let firstCondition = Conditional.withoutTerm first
         secondCondition = Conditional.withoutTerm second
         initialConditions = firstCondition <> secondCondition

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -364,8 +364,9 @@ bottomTermEquals
 
     case MultiOr.extractPatterns secondCeil of
         [] -> return Pattern.top
-        [ Conditional { predicate = PredicateTrue, substitution } ]
-          | substitution == mempty -> do
+        [ conditional ]
+          | PredicateTrue <- predicate conditional
+          , substitution conditional == mempty -> do
             explainBottom
                 "Cannot unify bottom with non-bottom pattern."
                 first

--- a/kore/src/Kore/Step/Simplification/Application.hs
+++ b/kore/src/Kore/Step/Simplification/Application.hs
@@ -120,12 +120,16 @@ evaluateApplicationFunction
     -> simplifier (OrPattern variable)
 evaluateApplicationFunction
     sideCondition
-    Conditional { term, predicate, substitution }
+    conditional
   =
     evaluateApplication
         sideCondition
-        Conditional { term = (), predicate, substitution }
-        term
+        Conditional
+        { term = ()
+        , predicate = (predicate conditional)
+        , substitution = (substitution conditional)
+        }
+        (term conditional)
 
 makeExpandedApplication
     :: (InternalVariable variable, MonadSimplify simplifier)

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -137,12 +137,12 @@ makeEvaluateNonBoolCeil
     => SideCondition variable
     -> Pattern variable
     -> simplifier (OrPattern variable)
-makeEvaluateNonBoolCeil sideCondition patt@Conditional {term}
-  | isTop term =
+makeEvaluateNonBoolCeil sideCondition patt
+  | isTop (term patt) =
     return $ OrPattern.fromPattern
         patt {term = mkTop_} -- erase the term's sort.
   | otherwise = do
-    termCeil <- makeEvaluateTerm sideCondition term
+    termCeil <- makeEvaluateTerm sideCondition (term patt)
     result <-
         And.simplifyEvaluatedMultiPredicate
             sideCondition

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -216,26 +216,26 @@ makeEvaluateTerm
                 <$> makeSimplifiedCeil sideCondition maybeCondition term
             )
         return (fmap toCondition evaluation)
-    
-    toCondition 
-        :: Conditional variable (TermLike variable) 
+
+    toCondition
+        :: Conditional variable (TermLike variable)
         -> Condition.Condition variable
 
-    toCondition conditional = case Conditional.term conditional of 
-        Top_ _ -> 
-            Conditional 
+    toCondition conditional = case Conditional.term conditional of
+        Top_ _ ->
+            Conditional
                 { term = ()
                 , predicate = predicate conditional
                 , substitution = substitution conditional
                 }
-        _      -> 
+        _      ->
             error
                 (  "Ceil simplification is expected to result in a predicate,"
                 ++ "but  got (" ++ show conditional ++ ")."
                 ++ " The most likely cases are: evaluating predicate symbols, "
                 ++ " and predicate symbols are currently unrecognized as such, "
                 ++ "and programming errors."
-                )  
+                )
 
 ceilSimplifierTermLike
     ::  InternalVariable variable

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -30,6 +30,8 @@ import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
     ( Conditional (..)
     )
+
+import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiAnd as MultiAnd
     ( make
     )
@@ -218,17 +220,26 @@ makeEvaluateTerm
                 <$> makeSimplifiedCeil sideCondition maybeCondition term
             )
         return (fmap toCondition evaluation)
+    
+    toCondition 
+        :: Conditional variable (TermLike variable) 
+        -> Condition.Condition variable
 
-    toCondition Conditional {term = Top_ _, predicate, substitution} =
-        Conditional {term = (), predicate, substitution}
-    toCondition patt =
-        error
-            (  "Ceil simplification is expected to result ai a predicate, but"
-            ++ " got (" ++ show patt ++ ")."
-            ++ " The most likely cases are: evaluating predicate symbols, "
-            ++ " and predicate symbols are currently unrecognized as such, "
-            ++ "and programming errors."
-            )
+    toCondition conditional = case Conditional.term conditional of 
+        Top_ _ -> 
+            Conditional 
+                { term = ()
+                , predicate = predicate conditional
+                , substitution = substitution conditional
+                }
+        _      -> 
+            error
+                (  "Ceil simplification is expected to result in a predicate,"
+                ++ "but  got (" ++ show conditional ++ ")."
+                ++ " The most likely cases are: evaluating predicate symbols, "
+                ++ " and predicate symbols are currently unrecognized as such, "
+                ++ "and programming errors."
+                )  
 
 {-| Evaluates the ceil of a domain value.
 -}

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -256,12 +256,15 @@ makeEvaluateFunctionalOr sideCondition first seconds = do
 
 See 'simplify' for detailed documentation.
 -}
+
+
 makeEvaluate
     :: (InternalVariable variable, MonadSimplify simplifier)
     => Pattern variable
     -> Pattern variable
     -> SideCondition variable
     -> simplifier (OrPattern variable)
+
 makeEvaluate
     first@Conditional { term = Top_ _ }
     second@Conditional { term = Top_ _ }
@@ -309,6 +312,9 @@ makeEvaluate
     firstTerm = term first
     secondTerm = term second
     termsAreEqual = firstTerm == secondTerm
+
+
+
 
 -- Do not export this. This not valid as a standalone function, it
 -- assumes that some extra conditions will be added on the outside

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -247,7 +247,7 @@ matchesToVariableSubstitution
     -> simplifier Bool
 matchesToVariableSubstitution
     variable
-    Conditional {term, predicate, substitution = boundSubstitution}
+    conditional
   | Equals_ _sort1 _sort2 first second <-
         Predicate.fromPredicate predicateSort predicate
   , Substitution.null boundSubstitution
@@ -258,6 +258,10 @@ matchesToVariableSubstitution
         Nothing -> return False
         Just results ->
             return (singleVariableSubstitution variable results)
+  where
+    term = Conditional.term conditional
+    predicate = Conditional.predicate conditional
+    boundSubstitution = Conditional.substitution conditional
 
 matchesToVariableSubstitution _ _ = return False
 

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -33,7 +33,7 @@ import Kore.Internal.Condition
     )
 import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional (..)
     )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiAnd as MultiAnd
@@ -194,7 +194,7 @@ makeEvaluate sideCondition variables original = do
         -> BranchT simplifier (Pattern variable)
     makeEvaluateWorker variable original' = do
         normalized <- simplifyCondition sideCondition original'
-        let Conditional { substitution = normalizedSubstitution } = normalized
+        let normalizedSubstitution = substitution normalized
         case splitSubstitution variable normalizedSubstitution of
             (Left boundTerm, freeSubstitution) ->
                 makeEvaluateBoundLeft
@@ -405,7 +405,7 @@ quantifyPattern
     => ElementVariable variable
     -> Pattern variable
     -> Pattern variable
-quantifyPattern variable original@Conditional { term, predicate, substitution }
+quantifyPattern variable original
   | quantifyTerm, quantifyPredicate
   = (error . unlines)
     [ "Quantifying both the term and the predicate probably means that there's"
@@ -422,6 +422,9 @@ quantifyPattern variable original@Conditional { term, predicate, substitution }
     $ Predicate.makeExistsPredicate variable predicate'
   | otherwise = original
   where
+    term = Conditional.term original
+    predicate = Conditional.predicate original
+    substitution = Conditional.substitution original
     quantifyTerm = TermLike.hasFreeVariable (ElemVar variable) term
     predicate' =
         Predicate.makeAndPredicate predicate

--- a/kore/src/Kore/Step/Simplification/Floor.hs
+++ b/kore/src/Kore/Step/Simplification/Floor.hs
@@ -93,11 +93,11 @@ makeEvaluateNonBoolFloor patt@Conditional { term = Top_ _ } =
 -- TODO(virgil): Also evaluate functional patterns to bottom for non-singleton
 -- sorts, and maybe other cases also
 makeEvaluateNonBoolFloor
-    Conditional {term, predicate, substitution}
+    conditional
   =
     OrPattern.fromPattern Conditional
         { term = mkTop_
         , predicate = Predicate.markSimplified
-            $ makeAndPredicate (makeFloorPredicate_ term) predicate
-        , substitution = substitution
+            $ makeAndPredicate (makeFloorPredicate_ (term conditional)) (predicate conditional)
+        , substitution = substitution conditional
         }

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -24,7 +24,7 @@ import qualified Kore.Internal.Condition as Condition
     , toPredicate
     )
 import Kore.Internal.Conditional
-    ( Conditional ()
+    ( Conditional
     )
 import qualified Kore.Internal.Conditional as Conditional
     ( Conditional (..)

--- a/kore/src/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/src/Kore/Step/Simplification/OrPattern.hs
@@ -24,7 +24,7 @@ import qualified Kore.Internal.Condition as Condition
     , toPredicate
     )
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional ()
     )
 import qualified Kore.Internal.Conditional as Conditional
     ( Conditional (..)
@@ -164,5 +164,5 @@ simplifyConditionsWithSmt sideCondition unsimplified =
     sidePredicate = SideCondition.toPredicate sideCondition
 
     addPredicate :: Conditional variable term -> Conditional variable term
-    addPredicate c@Conditional {predicate} =
-        c {Conditional.predicate = makeAndPredicate predicate sidePredicate}
+    addPredicate c =
+        c {Conditional.predicate = makeAndPredicate (Conditional.predicate c) sidePredicate}

--- a/kore/src/Kore/Step/Simplification/Rule.hs
+++ b/kore/src/Kore/Step/Simplification/Rule.hs
@@ -15,7 +15,7 @@ import Data.Map.Strict
     ( Map
     )
 
-import Kore.Internal.Conditional
+import Kore.Internal.Conditional as Conditional
     ( Conditional (..)
     )
 import Kore.Internal.OrPattern
@@ -81,7 +81,7 @@ simplifyEqualityPattern rule = do
     let EqualityPattern { left } = rule
     simplifiedLeft <- simplifyPattern left
     case OrPattern.toPatterns simplifiedLeft of
-        [ Conditional { term, predicate, substitution } ]
+        [ conditional ]
           | PredicateTrue <- predicate -> do
             let subst = Substitution.toMap substitution
                 left' = TermLike.substitute subst term
@@ -102,11 +102,16 @@ simplifyEqualityPattern rule = do
                 , ensures = Predicate.forgetSimplified ensures'
                 , attributes = attributes
                 }
+          where
+            term = Conditional.term conditional
+            predicate = Conditional.predicate conditional
+            substitution = Conditional.substitution conditional
         _ ->
             -- Unable to simplify the given rule pattern, so we return the
             -- original pattern in the hope that we can do something with it
             -- later.
             return rule
+
 
 {- | Simplify a 'Rule' using only matching logic rules.
 
@@ -134,7 +139,7 @@ simplifyRulePattern rule = do
     let RulePattern { left } = rule
     simplifiedLeft <- simplifyPattern left
     case OrPattern.toPatterns simplifiedLeft of
-        [ Conditional { term, predicate, substitution } ]
+        [ conditional ]
           | PredicateTrue <- predicate -> do
             -- TODO (virgil): Dropping the substitution for equations
             -- and for rewrite rules where the substituted variables occur
@@ -159,6 +164,11 @@ simplifyRulePattern rule = do
                 , rhs = rhsForgetSimplified rhs'
                 , attributes = attributes
                 }
+          where
+            term = Conditional.term conditional
+            predicate = Conditional.predicate conditional
+            substitution = Conditional.substitution conditional
+
         _ ->
             -- Unable to simplify the given rule pattern, so we return the
             -- original pattern in the hope that we can do something with it

--- a/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -54,7 +54,7 @@ import Kore.Internal.Condition
     )
 import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional (..)
     )
 import qualified Kore.Internal.Conditional as Conditional
 import Kore.Internal.OrCondition
@@ -248,10 +248,10 @@ deduplicateSubstitution makeAnd' =
         let -- Substitutions de-duplicated by simplification.
             substitutions' = toMultiMap $ Conditional.term simplified
             -- New conditions produced by simplification.
-            Conditional { predicate = predicate' } = simplified
+            predicate' = Conditional.predicate simplified
             predicate'' = Predicate.makeAndPredicate predicate predicate'
             -- New substitutions produced by simplification.
-            Conditional { substitution } = simplified
+            substitution = Conditional.substitution simplified
             substitutions'' =
                 Map.unionWith (<>) substitutions'
                 $ Substitution.toMultiMap substitution

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -34,8 +34,8 @@ import Kore.Internal.Conditional
     ( Conditional (Conditional)
     )
 import qualified Kore.Internal.Conditional as Conditional
-    ( andCondition
-    , Conditional (..)
+    ( Conditional (..)
+    , andCondition
     )
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrPattern
@@ -293,7 +293,7 @@ simplifyInternal term sideCondition = do
           =
             Conditional
                 { term =
-                    TermLike.substitute (Substitution.toMap substitution) 
+                    TermLike.substitute (Substitution.toMap substitution)
                                         (Conditional.term conditional)
                 , predicate = predicate
                 , substitution = substitution
@@ -310,7 +310,7 @@ simplifyInternal term sideCondition = do
                 hasPredicateTerm conditional
                   | isTop term' || isBottom term' = False
                   | otherwise                     = Predicate.isPredicate term'
-                  where 
+                  where
                     term' = Conditional.term conditional
 
                 unsimplified =
@@ -371,9 +371,7 @@ simplifyInternal term sideCondition = do
           | otherwise = continuation
           where
             (resultTerm, resultPredicate) = Pattern.splitTerm result
-            resultSubstitutionIsEmpty =
-                case resultPredicate of
-                    Conditional {substitution} -> substitution == mempty
+            resultSubstitutionIsEmpty = (substitution resultPredicate) == mempty
             termAsPredicate =
                 Condition.fromPredicate <$> Predicate.makePredicate term
 

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -56,7 +56,7 @@ import Kore.Internal.Condition
     )
 import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional (..)
     )
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
@@ -245,10 +245,9 @@ wouldNarrowWith unified =
     leftAxiomVariables =
         FreeVariables.getFreeVariables $ TermLike.freeVariables leftAxiom
       where
-        Conditional { term = axiom } = unified
+        axiom = term unified
         leftAxiom = matchingPattern axiom
-    Conditional { substitution } = unified
-    substitutionVariables = Map.keysSet (Substitution.toMap substitution)
+    substitutionVariables = Map.keysSet (Substitution.toMap (substitution unified))
 
 {- | Prepare a rule for unification or matching with the configuration.
 
@@ -316,14 +315,14 @@ checkFunctionLike unifiedRules pat
     , Pretty.indent 4 (unparse pat)
     ]
   where
-    checkFunctionLikeRule Conditional { term }
+    checkFunctionLikeRule conditional
       | TermLike.isFunctionPattern left = return ()
       | otherwise = Left . show . Pretty.vsep $
         [ "Expected function-like left-hand side of rule, but found:"
         , Pretty.indent 4 (unparse left)
         ]
       where
-        left = matchingPattern term
+        left = matchingPattern (term conditional)
 
 {- | Check that the final substitution covers the applied rule appropriately.
 
@@ -374,7 +373,7 @@ checkSubstitutionCoverage initial unified
         , "in the left-hand side of the axiom."
         ]
   where
-    Conditional { term = axiom } = unified
+    axiom = term unified
     unifier :: Pattern (Target variable)
     unifier = TermLike.mkTop_ <$ Conditional.withoutTerm unified
     Conditional { substitution } = unified

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -376,8 +376,7 @@ checkSubstitutionCoverage initial unified
     axiom = term unified
     unifier :: Pattern (Target variable)
     unifier = TermLike.mkTop_ <$ Conditional.withoutTerm unified
-    Conditional { substitution } = unified
-    substitutionVariables = Map.keysSet (Substitution.toMap substitution)
+    substitutionVariables = Map.keysSet (Substitution.toMap (substitution unified))
     uncovered = wouldNarrowWith unified
     isCoveringSubstitution = Set.null uncovered
     isSymbolic =

--- a/kore/src/Kore/Step/Substitution.hs
+++ b/kore/src/Kore/Step/Substitution.hs
@@ -46,9 +46,9 @@ normalize
     => SideCondition variable
     -> Conditional variable term
     -> BranchT simplifier (Conditional variable term)
-normalize sideCondition conditional@Conditional { substitution } = do
+normalize sideCondition conditional = do
     results <- Monad.Trans.lift $
-        simplifySubstitution sideCondition substitution
+        simplifySubstitution sideCondition (substitution conditional)
     scatter (applyTermPredicate <$> results)
   where
     applyTermPredicate =

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -1026,7 +1026,7 @@ removalPredicate
           , Pretty.indent 4 (unparse destTerm)
           ]
   where
-    Conditional { term = destTerm } = destination
+    destTerm = term destination
     (configTerm, configPredicate) = Pattern.splitTerm configuration
     sideCondition = SideCondition.assumeTrueCondition configPredicate
     -- The variables of the destination that are missing from the

--- a/kore/test/Test/Kore/Step/Simplification.hs
+++ b/kore/test/Test/Kore/Step/Simplification.hs
@@ -30,7 +30,7 @@ import Kore.Internal.Condition
     ( Condition
     )
 import Kore.Internal.Conditional
-    ( Conditional (Conditional)
+    ( Conditional (..)
     )
 import qualified Kore.Internal.Conditional as Conditional.DoNotUse
 import Kore.Internal.OrCondition
@@ -104,12 +104,15 @@ simplifiedCondition
     :: InternalVariable variable
     => Condition variable
     -> Condition variable
-simplifiedCondition Conditional { term = (), predicate, substitution } =
+simplifiedCondition conditional =
     Conditional
         { term = ()
         , predicate = simplifiedPredicate predicate
         , substitution = simplifiedSubstitution substitution
         }
+    where 
+      predicate = Conditional.DoNotUse.predicate conditional
+      substitution = Conditional.DoNotUse.substitution conditional
 
 simplifiedPattern
     :: InternalVariable variable

--- a/kore/test/Test/Kore/Step/Simplification.hs
+++ b/kore/test/Test/Kore/Step/Simplification.hs
@@ -110,7 +110,7 @@ simplifiedCondition conditional =
         , predicate = simplifiedPredicate predicate
         , substitution = simplifiedSubstitution substitution
         }
-    where 
+    where
       predicate = Conditional.DoNotUse.predicate conditional
       substitution = Conditional.DoNotUse.substitution conditional
 

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -591,7 +591,7 @@ makeAnd first second =
 
 findSort :: [Pattern Variable] -> Sort
 findSort [] = testSort
-findSort ( Conditional {term} : _ ) = termLikeSort term
+findSort ( conditional : _ ) = termLikeSort (term conditional)
 
 evaluate :: And Sort (OrPattern Variable) -> IO (OrPattern Variable)
 evaluate = runSimplifier Mock.env . simplify SideCondition.top

--- a/kore/test/Test/Kore/Step/Simplification/Equals.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Equals.hs
@@ -896,17 +896,17 @@ assertTermEqualsMultiGeneric expectPure first second = do
             , substitution = mempty
             }
     predSubstToPattern :: Condition Variable -> Pattern Variable
-    predSubstToPattern
-        Conditional {predicate = PredicateFalse}
+    predSubstToPattern condition
+      | PredicateFalse <- predicate condition
       =
         Conditional.bottom
-    predSubstToPattern
-        Conditional {predicate, substitution}
+
+      | otherwise
       =
         Conditional
             { term = mkTop_
-            , predicate = predicate
-            , substitution = substitution
+            , predicate = predicate condition
+            , substitution = substitution condition
             }
 
 fOfA :: TermLike Variable

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -81,12 +81,12 @@ test_simplify =
                     (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.z))
                     (Mock.functional20 (mkElemVar Mock.y) (mkElemVar Mock.z))
             }
-    quantifyPredicate predicated@Conditional { predicate } =
+    quantifyPredicate predicated =
         predicated
             { Conditional.predicate =
-                Predicate.makeExistsPredicate Mock.x predicate
+                Predicate.makeExistsPredicate Mock.x (Conditional.predicate predicated)
             }
-    quantifySubstitution predicated@Conditional { predicate, substitution } =
+    quantifySubstitution predicated  =
         predicated
             { Conditional.predicate =
                 Predicate.makeAndPredicate predicate
@@ -94,6 +94,10 @@ test_simplify =
                 $ Substitution.toPredicate substitution
             , Conditional.substitution = mempty
             }
+        where
+          predicate = Conditional.predicate predicated
+          substitution = Conditional.substitution predicated
+
     substForX =
         (Pattern.topOf Mock.testSort)
             { Conditional.substitution = Substitution.unsafeWrap

--- a/kore/test/Test/Kore/Step/Simplification/Next.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Next.hs
@@ -82,7 +82,7 @@ test_nextSimplification =
 
 findSort :: [Pattern Variable] -> Sort
 findSort [] = Mock.testSort
-findSort ( Conditional {term} : _ ) = termLikeSort term
+findSort ( conditional : _ ) = termLikeSort (term conditional)
 
 evaluate :: Next Sort (OrPattern Variable) -> OrPattern Variable
 evaluate = simplify

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -285,7 +285,7 @@ unificationProcedureSuccessWithSimplifiers
                 -> ([Assignment Variable], Predicate Variable)
             normalize conditional =
                 (Substitution.unwrap substitution, predicate)
-              where 
+              where
                 substitution = Conditional.substitution conditional
                 predicate = Conditional.predicate conditional
 

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -25,6 +25,7 @@ import Data.Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
 import qualified Kore.Internal.Condition as Condition
+import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
@@ -282,8 +283,12 @@ unificationProcedureSuccessWithSimplifiers
             normalize
                 :: Condition Variable
                 -> ([Assignment Variable], Predicate Variable)
-            normalize Conditional { substitution, predicate } =
+            normalize conditional =
                 (Substitution.unwrap substitution, predicate)
+              where 
+                substitution = Conditional.substitution conditional
+                predicate = Conditional.predicate conditional
+
         assertEqual ""
             expect
             (map normalize results)


### PR DESCRIPTION
I've started replacing occurrences of Conditional constructors with field accessors, where appropriate. Replacing occurrences on the rhs with a smart-constructor will happen in a separate PR. 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
