### PR TITLE
Add a "release" flag

### DIFF
--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -28,6 +28,10 @@ flags:
     description: Use the threaded runtime. Recommended to disable for profiling.
     manual: true
     default: true
+  release:
+    description: Build a faster runtime, at the expense of a slower build.
+    manual: true
+    default: true
 
 dependencies:
   - base >=4.7
@@ -133,6 +137,12 @@ ghc-options:
   - -Wpartial-fields
   - -Wredundant-constraints
   - -Wmissing-export-lists
+
+when:
+  - condition: "!flag(release)"
+    ghc-options:
+      - -fno-specialise
+
 
 library:
   source-dirs: src


### PR DESCRIPTION
The "release" flag is enabled by default. When disabled, the build is about 25%
faster, but the build products are 5-10% slower. For developers, this is a good
trade-off.

After this is merged, I will update the kframework/k release job to force the `release` flag. Then I will make another pull request to disable it by default in the backend, so that builds are faster for our developers.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
