### PR TITLE
Kore.Log.withAsyncLogAction: Raise exceptions in main thread

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         }
         stage('Integration Tests') {
           options {
-            timeout(time: 24, unit: 'MINUTES')
+            timeout(time: 32, unit: 'MINUTES')
           }
           steps {
             sh '''

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -208,11 +208,12 @@ withAsyncLogger logAction continue = do
         a <- atomically $ readTChan tChan
         logAction Colog.<& a
     mainAsync <- async $ continue asyncLogAction
-    (_, b) <- Async.waitBoth logAsync mainAsync
+    (_, b) <- tryAgain $ Async.waitBoth logAsync mainAsync
     return b
   where
     untilDone = Exception.handle ignoreBlockedIndefinitelyOnSTM . forever
     ignoreBlockedIndefinitelyOnSTM BlockedIndefinitelyOnSTM = return ()
+    tryAgain f = Exception.handle (\BlockedIndefinitelyOnSTM -> f) f
 
 -- Creates a kore logger which:
 --     * adds timestamps

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -211,9 +211,11 @@ withAsyncLogger logAction continue = do
     (_, b) <- tryAgain $ Async.waitBoth logAsync mainAsync
     return b
   where
-    untilDone = Exception.handle ignoreBlockedIndefinitelyOnSTM . forever
-    ignoreBlockedIndefinitelyOnSTM BlockedIndefinitelyOnSTM = return ()
-    tryAgain f = Exception.handle (\BlockedIndefinitelyOnSTM -> f) f
+    handleBlockedIndefinitelyOnSTM handler =
+        Exception.handle $ \BlockedIndefinitelyOnSTM -> handler
+    ignore = return ()
+    untilDone = handleBlockedIndefinitelyOnSTM ignore . forever
+    tryAgain action = handleBlockedIndefinitelyOnSTM action action
 
 -- Creates a kore logger which:
 --     * adds timestamps


### PR DESCRIPTION
Exceptions from child threads are not raised until Async.wait is
called. Instead of running the main thread to termination before caling
Async.wait, immediately call Async.waitBoth to raise exceptions.

@ana-pantilie I think this will fix the problem you were having with log thread exceptions not being raised before the main thread terminates.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
