### PR TITLE
Replace Data.List.nub with Data.Containers.ListUtils.nubOrd in makeMultipleAnd(/Or)Predicate.

### DIFF
--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -80,6 +80,8 @@ import Data.Map.Strict
 import Data.Set
     ( Set
     )
+import Data.Containers.ListUtils
+
 import qualified Data.Set as Set
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
@@ -276,7 +278,7 @@ makeMultipleAndPredicate
     => [Predicate variable]
     -> Predicate variable
 makeMultipleAndPredicate =
-    foldl' makeAndPredicate makeTruePredicate_ . ordNub
+    foldl' makeAndPredicate makeTruePredicate_ . nubOrd
     -- 'and' is idempotent so we eliminate duplicates
 
 {- | Flatten a 'Predicate' with 'And' at the top.
@@ -301,7 +303,7 @@ makeMultipleOrPredicate
     => [Predicate variable]
     -> Predicate variable
 makeMultipleOrPredicate =
-    foldl' makeOrPredicate makeFalsePredicate_ . ordNub
+    foldl' makeOrPredicate makeFalsePredicate_ . nubOrd
     -- 'or' is idempotent so we eliminate duplicates
 
 {-| 'makeAndPredicate' combines two Predicates with an 'and', doing some

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -73,7 +73,6 @@ import Data.Functor.Foldable
 import qualified Data.Functor.Foldable as Recursive
 import Data.List
     ( foldl'
-    , nub
     )
 import Data.Map.Strict
     ( Map
@@ -271,21 +270,20 @@ binaryOperator operator (GenericPredicate first) (GenericPredicate second) =
 {-| 'makeMultipleAndPredicate' combines a list of Predicates with 'and',
 doing some simplification.
 -}
+
 makeMultipleAndPredicate
     :: (HasCallStack, InternalVariable variable)
     => [Predicate variable]
     -> Predicate variable
 makeMultipleAndPredicate =
-    foldl' makeAndPredicate makeTruePredicate_ . nub
+    foldl' makeAndPredicate makeTruePredicate_ . ordNub
     -- 'and' is idempotent so we eliminate duplicates
-    -- TODO: This is O(n^2), consider doing something better.
 
 {- | Flatten a 'Predicate' with 'And' at the top.
-
 'getMultiAndPredicate' is the inverse of 'makeMultipleAndPredicate', up to
 associativity.
-
  -}
+
 getMultiAndPredicate
     :: Predicate variable
     -> [Predicate variable]
@@ -295,7 +293,6 @@ getMultiAndPredicate original@(GenericPredicate termLike) =
             concatMap (getMultiAndPredicate . GenericPredicate) [left, right]
         _ -> [original]
 
-
 {-| 'makeMultipleOrPredicate' combines a list of Predicates with 'or',
 doing some simplification.
 -}
@@ -304,9 +301,8 @@ makeMultipleOrPredicate
     => [Predicate variable]
     -> Predicate variable
 makeMultipleOrPredicate =
-    foldl' makeOrPredicate makeFalsePredicate_ . nub
+    foldl' makeOrPredicate makeFalsePredicate_ . ordNub
     -- 'or' is idempotent so we eliminate duplicates
-    -- TODO: This is O(n^2), consider doing something better.
 
 {-| 'makeAndPredicate' combines two Predicates with an 'and', doing some
 simplification.

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -66,6 +66,8 @@ import Control.DeepSeq
     ( NFData
     )
 import Data.Containers.ListUtils
+    ( nubOrd
+    )
 import qualified Data.Either as Either
 import qualified Data.Foldable as Foldable
 import Data.Functor.Foldable

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -65,6 +65,7 @@ import Prelude.Kore
 import Control.DeepSeq
     ( NFData
     )
+import Data.Containers.ListUtils
 import qualified Data.Either as Either
 import qualified Data.Foldable as Foldable
 import Data.Functor.Foldable
@@ -80,7 +81,6 @@ import Data.Map.Strict
 import Data.Set
     ( Set
     )
-import Data.Containers.ListUtils
 
 import qualified Data.Set as Set
 import qualified Generics.SOP as SOP

--- a/kore/src/Prelude/Kore.hs
+++ b/kore/src/Prelude/Kore.hs
@@ -9,6 +9,7 @@ module Prelude.Kore
     , module Debug.Trace
     -- * Ord
     , minMax
+    , ordNub
     -- * Functions
     , (&)
     , on
@@ -72,6 +73,7 @@ import Data.Maybe
     , isJust
     , isNothing
     )
+import Data.Set as Set
 import Data.Witherable
     ( Filterable (..)
     )
@@ -93,3 +95,12 @@ minMax :: Ord a => a -> a -> (a, a)
 minMax a b
   | a < b     = (a, b)
   | otherwise = (b, a)
+
+{- | O(n log n) nub
+-}
+ordNub :: (Ord a) => [a] -> [a]
+ordNub l = go Set.empty l
+  where
+    go _ [] = []
+    go s (x:xs) = if x `Set.member` s then go s xs
+                                      else x : go (Set.insert x s) xs

--- a/kore/src/Prelude/Kore.hs
+++ b/kore/src/Prelude/Kore.hs
@@ -9,7 +9,6 @@ module Prelude.Kore
     , module Debug.Trace
     -- * Ord
     , minMax
-    , ordNub
     -- * Functions
     , (&)
     , on
@@ -73,7 +72,6 @@ import Data.Maybe
     , isJust
     , isNothing
     )
-import Data.Set as Set
 import Data.Witherable
     ( Filterable (..)
     )
@@ -95,12 +93,3 @@ minMax :: Ord a => a -> a -> (a, a)
 minMax a b
   | a < b     = (a, b)
   | otherwise = (b, a)
-
-{- | O(n log n) nub
--}
-ordNub :: (Ord a) => [a] -> [a]
-ordNub l = go Set.empty l
-  where
-    go _ [] = []
-    go s (x:xs) = if x `Set.member` s then go s xs
-                                      else x : go (Set.insert x s) xs


### PR DESCRIPTION
`Data.List.nub` has quadratic complexity. Predicate is an instance of Ord, so we can use `Data.Containers.ListUtils.nubOrd` to make it `O(n log n)` instead.

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
