### PR TITLE
Add logWhile method to MonadLog

### DIFF
--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -494,6 +494,7 @@ instance MonadLog m => MonadLog (UnifierWithExplanation m) where
     {-# INLINE logEntry #-}
     logWhile entry ma =
         UnifierWithExplanation $ logWhile entry (getUnifierWithExplanation ma)
+        {-# INLINE logWhile #-}
 
 deriving instance MonadSimplify m => MonadSimplify (UnifierWithExplanation m)
 

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -492,6 +492,8 @@ deriving instance MonadProfiler m => MonadProfiler (UnifierWithExplanation m)
 instance MonadLog m => MonadLog (UnifierWithExplanation m) where
     logEntry entry = UnifierWithExplanation $ logEntry entry
     {-# INLINE logEntry #-}
+    logWhile entry ma =
+        UnifierWithExplanation $ logWhile entry (getUnifierWithExplanation ma)
 
 deriving instance MonadSimplify m => MonadSimplify (UnifierWithExplanation m)
 

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -494,7 +494,7 @@ instance MonadLog m => MonadLog (UnifierWithExplanation m) where
     {-# INLINE logEntry #-}
     logWhile entry ma =
         UnifierWithExplanation $ logWhile entry (getUnifierWithExplanation ma)
-        {-# INLINE logWhile #-}
+    {-# INLINE logWhile #-}
 
 deriving instance MonadSimplify m => MonadSimplify (UnifierWithExplanation m)
 

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -98,16 +98,6 @@ instance MonadTrans SimplifierT where
     lift smt = SimplifierT (lift smt)
     {-# INLINE lift #-}
 
-mapSimplifierT
-    :: forall m b
-    .  Monad m
-    => (forall a . m a -> m a)
-    -> SimplifierT m b
-    -> SimplifierT m b
-mapSimplifierT f simplifierT =
-    SimplifierT
-    $ Morph.hoist f (runSimplifierT simplifierT)
-
 instance MonadLog log => MonadLog (SimplifierT log) where
     logWhile entry = mapSimplifierT $ logWhile entry
 
@@ -252,3 +242,13 @@ evalSimplifier verifiedModule simplifier = do
             , injSimplifier
             , overloadSimplifier
             }
+
+mapSimplifierT
+    :: forall m b
+    .  Monad m
+    => (forall a . m a -> m a)
+    -> SimplifierT m b
+    -> SimplifierT m b
+mapSimplifierT f simplifierT =
+    SimplifierT
+    $ Morph.hoist f (runSimplifierT simplifierT)

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -98,11 +98,18 @@ instance MonadTrans SimplifierT where
     lift smt = SimplifierT (lift smt)
     {-# INLINE lift #-}
 
-instance Morph.MFunctor SimplifierT where
-    hoist f simplifierT = undefined
-        -- Morph.hoist f (runSimplifierT simplifierT)
+mapSimplifierT
+    :: forall m b
+    .  Monad m
+    => (forall a . m a -> m a)
+    -> SimplifierT m b
+    -> SimplifierT m b
+mapSimplifierT f simplifierT =
+    SimplifierT
+    $ Morph.hoist f (runSimplifierT simplifierT)
 
-instance MonadLog log => MonadLog (SimplifierT log)
+instance MonadLog log => MonadLog (SimplifierT log) where
+    logWhile entry = mapSimplifierT $ logWhile entry
 
 instance (MonadProfiler m) => MonadProfiler (SimplifierT m) where
     profile event duration =

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -98,6 +98,10 @@ instance MonadTrans SimplifierT where
     lift smt = SimplifierT (lift smt)
     {-# INLINE lift #-}
 
+instance Morph.MFunctor SimplifierT where
+    hoist f simplifierT = undefined
+        -- Morph.hoist f (runSimplifierT simplifierT)
+
 instance MonadLog log => MonadLog (SimplifierT log)
 
 instance (MonadProfiler m) => MonadProfiler (SimplifierT m) where

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -85,7 +85,8 @@ newtype TransitionT rule m a =
         , Typeable
         )
 
-instance MonadLog m => MonadLog (TransitionT rule m)
+instance MonadLog m => MonadLog (TransitionT rule m) where
+    logWhile entry = mapTransitionT $ logWhile entry
 
 instance MonadTrans (TransitionT rule) where
     lift = TransitionT . Monad.Trans.lift . Monad.Trans.lift

--- a/kore/src/ListT.hs
+++ b/kore/src/ListT.hs
@@ -118,7 +118,8 @@ instance MonadTrans ListT where
     lift m = ListT $ \yield next -> m >>= \a -> yield a next
     {-# INLINE lift #-}
 
-instance MonadLog log => MonadLog (ListT log)
+instance MonadLog log => MonadLog (ListT log) where
+    logWhile entry = mapListT $ logWhile entry
 
 instance MonadReader r m => MonadReader r (ListT m) where
     ask = lift ask

--- a/kore/src/Log.hs
+++ b/kore/src/Log.hs
@@ -44,12 +44,17 @@ import Control.Monad.Except
     ( ExceptT
     )
 import qualified Control.Monad.Except as Except
+import Control.Monad.Morph
+    ( MFunctor
+    )
+import qualified Control.Monad.Morph as Monad.Morph
 import Control.Monad.Trans
     ( MonadTrans
     )
 import qualified Control.Monad.Trans as Monad.Trans
 import Control.Monad.Trans.Accum
     ( AccumT
+    , mapAccumT
     )
 import Control.Monad.Trans.Identity
     ( IdentityT
@@ -183,7 +188,18 @@ class Monad m => MonadLog m where
     logEntry = Monad.Trans.lift . logEntry
     {-# INLINE logEntry #-}
 
-instance (Monoid acc, MonadLog log) => MonadLog (AccumT acc log)
+    logWhile :: Entry entry => entry -> m a -> m a
+    default logWhile
+        :: Entry entry
+        => (MFunctor t, MonadLog log, m ~ t log)
+        => entry
+        -> m a
+        -> m a
+    logWhile entry = Monad.Morph.hoist $ logWhile entry
+
+instance (Monoid acc, MonadLog log)
+  => MonadLog (AccumT acc log) where
+      logWhile = mapAccumT . logWhile
 
 instance MonadLog log => MonadLog (CounterT log)
 
@@ -204,6 +220,7 @@ newtype LoggerT m a =
 
 instance Monad m => MonadLog (LoggerT m) where
     logEntry entry = LoggerT $ ask >>= Monad.Trans.lift . (<& toEntry entry)
+    logWhile _ = id
 
 instance MonadTrans LoggerT where
     lift = LoggerT . Monad.Trans.lift

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -227,6 +227,7 @@ instance MonadLog NoSMT where
     logEntry entry =
         NoSMT $ ReaderT $ \logger ->
             Colog.unLogAction logger (Log.toEntry entry)
+    logWhile _ = id
 
 instance MonadSMT NoSMT where
     withSolver = id

--- a/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
+++ b/kore/test/Test/Kore/Strategies/AllPath/AllPath.hs
@@ -427,6 +427,7 @@ newtype AllPathIdentity a = AllPathIdentity { unAllPathIdentity :: Identity a }
 
 instance MonadLog AllPathIdentity where
     logEntry = undefined
+    logWhile = undefined
 
 instance MonadSMT AllPathIdentity where
     withSolver = undefined


### PR DESCRIPTION
Part of https://github.com/kframework/kore/issues/1491:
"Add a logWhile :: Entry entry => entry -> m a -> m a, which will add the entry to the "call stack". Give a default implementation in terms of MFunctor. Give a no-op implementation for LoggerT."

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
