### PR TITLE
Use ActualEntry instead of SomeEntry in the logger

### DIFF
--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -371,7 +371,7 @@ proveWithRepl
     -- ^ The spec module
     -> Maybe (VerifiedModule StepperAttributes)
     -- ^ The module containing the claims that were proven in a previous run.
-    -> MVar (Log.LogAction IO Log.SomeEntry)
+    -> MVar (Log.LogAction IO Log.ActualEntry)
     -> Repl.Data.ReplScript
     -- ^ Optional script
     -> Repl.Data.ReplMode

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -201,7 +201,7 @@ runLoggerT :: KoreLogOptions -> LoggerT IO a -> IO a
 runLoggerT options loggerT =
     withLogger options $ \logAction ->
     withAsyncLogger logAction $ \asyncLogAction ->
-        runLogger (Colog.cmap (from @ActualEntry) asyncLogAction)
+        runLogger (fromLogAction asyncLogAction)
   where
     runLogger = runReaderT . getLoggerT $ loggerT
 

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -201,7 +201,7 @@ runLoggerT :: KoreLogOptions -> LoggerT IO a -> IO a
 runLoggerT options loggerT =
     withLogger options $ \logAction ->
     withAsyncLogger logAction $ \asyncLogAction ->
-        runLogger (fromLogAction asyncLogAction)
+        runLogger (fromLogAction @SomeEntry asyncLogAction)
   where
     runLogger = runReaderT . getLoggerT $ loggerT
 

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -193,7 +193,7 @@ runLoggerT :: KoreLogOptions -> LoggerT IO a -> IO a
 runLoggerT options loggerT =
     withLogger options $ \logAction ->
     withAsyncLogger logAction $ \asyncLogAction ->
-        runLogger asyncLogAction
+        runLogger (Colog.cmap (from @ActualEntry) asyncLogAction)
   where
     runLogger = runReaderT . getLoggerT $ loggerT
 

--- a/kore/src/Kore/Log/DebugSolver.hs
+++ b/kore/src/Kore/Log/DebugSolver.hs
@@ -41,7 +41,8 @@ import Options.Applicative
     )
 
 import Log
-    ( Entry (..)
+    ( ActualEntry
+    , Entry (..)
     , LogAction (..)
     , Severity (Debug)
     , SomeEntry
@@ -77,14 +78,14 @@ instance Entry DebugSolverRecv where
     entrySeverity _ = Debug
 
 logDebugSolverSendWith
-    :: LogAction m SomeEntry
+    :: LogAction m ActualEntry
     -> SExpr
     -> m ()
 logDebugSolverSendWith logger sExpr =
     logWith logger $ DebugSolverSend sExpr
 
 logDebugSolverRecvWith
-    :: LogAction m SomeEntry
+    :: LogAction m ActualEntry
     -> Text
     -> m ()
 logDebugSolverRecvWith logger smtText =

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -99,7 +99,7 @@ runRepl
     -- ^ list of axioms to used in the proof
     -> [claim]
     -- ^ list of claims to be proven
-    -> MVar (Log.LogAction IO Log.SomeEntry)
+    -> MVar (Log.LogAction IO Log.ActualEntry)
     -> ReplScript
     -- ^ optional script
     -> ReplMode

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -358,10 +358,9 @@ helpText =
                                               \ types entry1 or entry2 as well as entries of\
                                               \ severity <severity>.\n\
     \                                         See available entry types below.\n\
-    \                                         <type> can be 'stderr' or\n\
+    \                                         <type> can be 'stderr' or 'file filename'\n\
     \                                         <switch-timestamp> can be enable-log-timestamps\
                                               \ or disable-log-timestamps\n\
-    \                                         'file filename'\n\
     \exit                                     exits the repl\
     \\n\n\
     \Available modifiers:\n\

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -469,7 +469,7 @@ data Config claim m = Config
     -- ^ Unifier function, it is a partially applied 'unificationProcedure'
     --   where we discard the result since we are looking for unification
     --   failures
-    , logger  :: MVar (LogAction IO SomeEntry)
+    , logger  :: MVar (LogAction IO ActualEntry)
     -- ^ Logger function, see 'logging'.
     , outputFile :: OutputFile
     -- ^ Output resulting pattern to this file.

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -488,7 +488,7 @@ liftSimplifierWithLogger mLogger simplifier = do
                 textLogger
     _ <-
         Monad.Trans.lift . liftIO
-        $ swapMVar mLogger (Log.fromLogAction logger)
+        $ swapMVar mLogger (Log.fromLogAction @Log.SomeEntry logger)
     result <- Monad.Trans.lift simplifier
     maybe (pure ()) (Monad.Trans.lift . liftIO . hClose) maybeHandle
     pure result

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -32,7 +32,6 @@ module Kore.Repl.State
 
 import Prelude.Kore
 
-import Colog
 import Control.Concurrent.MVar
 import qualified Control.Lens as Lens
 import Control.Monad.Error.Class
@@ -489,7 +488,7 @@ liftSimplifierWithLogger mLogger simplifier = do
                 textLogger
     _ <-
         Monad.Trans.lift . liftIO
-        $ swapMVar mLogger (Colog.cmap (from @Log.ActualEntry) logger)
+        $ swapMVar mLogger (Log.fromLogAction logger)
     result <- Monad.Trans.lift simplifier
     maybe (pure ()) (Monad.Trans.lift . liftIO . hClose) maybeHandle
     pure result

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -32,6 +32,7 @@ module Kore.Repl.State
 
 import Prelude.Kore
 
+import Colog
 import Control.Concurrent.MVar
 import qualified Control.Lens as Lens
 import Control.Monad.Error.Class
@@ -473,7 +474,7 @@ liftSimplifierWithLogger
     => MonadSimplify m
     => MonadIO m
     => Monad.Trans.MonadTrans t
-    => MVar (Log.LogAction IO Log.SomeEntry)
+    => MVar (Log.LogAction IO Log.ActualEntry)
     -> m a
     -> t m a
 liftSimplifierWithLogger mLogger simplifier = do
@@ -486,7 +487,9 @@ liftSimplifierWithLogger mLogger simplifier = do
                 exeName
                 timestampsSwitch
                 textLogger
-    _ <- Monad.Trans.lift . liftIO $ swapMVar mLogger logger
+    _ <-
+        Monad.Trans.lift . liftIO
+        $ swapMVar mLogger (Colog.cmap (from @Log.ActualEntry) logger)
     result <- Monad.Trans.lift simplifier
     maybe (pure ()) (Monad.Trans.lift . liftIO . hClose) maybeHandle
     pure result

--- a/kore/src/Log.hs
+++ b/kore/src/Log.hs
@@ -18,6 +18,7 @@ module Log
     , LogAction (..)
     , liftLogAction
     , hoistLogAction
+    , fromLogAction
     -- * Messages (Deprecated)
     , LogMessage (..)
     , log
@@ -222,7 +223,7 @@ newtype LoggerT m a =
 instance Monad m => MonadLog (LoggerT m) where
     logEntry entry = LoggerT $ do
         logAction <- ask
-        let entryLogger = cmap (from @SomeEntry) logAction
+        let entryLogger = fromLogAction logAction
         Monad.Trans.lift $ entryLogger <& toEntry entry
     logWhile _ = id
 
@@ -236,5 +237,7 @@ logWith
     -> entry
     -> m ()
 logWith logger entry =
-    let entryLogger = cmap (from @SomeEntry) logger
-     in entryLogger Colog.<& toEntry entry
+    fromLogAction logger Colog.<& toEntry entry
+
+fromLogAction :: From b a => LogAction m a -> LogAction m b
+fromLogAction = cmap from

--- a/kore/src/Log.hs
+++ b/kore/src/Log.hs
@@ -223,7 +223,7 @@ newtype LoggerT m a =
 instance Monad m => MonadLog (LoggerT m) where
     logEntry entry = LoggerT $ do
         logAction <- ask
-        let entryLogger = fromLogAction logAction
+        let entryLogger = fromLogAction @ActualEntry logAction
         Monad.Trans.lift $ entryLogger <& toEntry entry
     logWhile _ = id
 
@@ -237,7 +237,7 @@ logWith
     -> entry
     -> m ()
 logWith logger entry =
-    fromLogAction logger Colog.<& toEntry entry
+    fromLogAction @ActualEntry logger Colog.<& toEntry entry
 
-fromLogAction :: From b a => LogAction m a -> LogAction m b
+fromLogAction :: forall a b m . From b a => LogAction m a -> LogAction m b
 fromLogAction = cmap from

--- a/kore/src/Log/Entry.hs
+++ b/kore/src/Log/Entry.hs
@@ -79,8 +79,8 @@ entryTypeText (SomeEntry entry) =
 
 data ActualEntry =
     ActualEntry
-        { actualEntry :: SomeEntry
-        , entryContext :: Seq SomeEntry
+        { actualEntry :: !SomeEntry
+        , entryContext :: !(Seq SomeEntry)
         }
 
 instance From ActualEntry SomeEntry where

--- a/kore/src/Log/Entry.hs
+++ b/kore/src/Log/Entry.hs
@@ -11,6 +11,7 @@ module Log.Entry
     -- * Entry
     , Entry (..)
     , SomeEntry (..)
+    , ActualEntry (..)
     , someEntry
     , entryTypeText
     ) where
@@ -24,6 +25,10 @@ import qualified Control.Lens as Lens
 import Control.Lens.Prism
     ( Prism
     )
+import Data.Sequence
+    ( Seq
+    )
+import qualified Data.Sequence as Seq
 import Data.Text
     ( Text
     )
@@ -71,6 +76,19 @@ someEntry = Lens.prism' toEntry fromEntry
 entryTypeText :: SomeEntry -> Text
 entryTypeText (SomeEntry entry) =
     Text.pack . show . Reflection.typeOf $ entry
+
+data ActualEntry =
+    ActualEntry
+        { actualEntry :: SomeEntry
+        , entryContext :: Seq SomeEntry
+        }
+
+instance From ActualEntry SomeEntry where
+    from ActualEntry { actualEntry } = actualEntry
+
+instance From SomeEntry ActualEntry where
+    from actualEntry =
+        ActualEntry { actualEntry, entryContext = Seq.empty }
 
 prettySeverity :: Severity -> Pretty.Doc ann
 prettySeverity = Pretty.pretty . show

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -83,7 +83,6 @@ import Data.Text
     ( Text
     )
 
-import From
 import Kore.Profiler.Data
     ( MonadProfiler (..)
     , profileEvent
@@ -95,7 +94,6 @@ import ListT
 import Log
     ( LoggerT (..)
     , MonadLog (..)
-    , SomeEntry
     )
 import qualified Log
 import SMT.SimpleSMT
@@ -229,7 +227,7 @@ runNoSMT logger noSMT = runReaderT (getNoSMT noSMT) logger
 instance MonadLog NoSMT where
     logEntry entry = NoSMT $ do
         logAction <- ask
-        let entryLogger = Colog.cmap (from @SomeEntry) logAction
+        let entryLogger = Log.fromLogAction logAction
         Trans.lift $ entryLogger Colog.<& Log.toEntry entry
     logWhile _ = id
 

--- a/kore/src/SMT.hs
+++ b/kore/src/SMT.hs
@@ -227,7 +227,7 @@ runNoSMT logger noSMT = runReaderT (getNoSMT noSMT) logger
 instance MonadLog NoSMT where
     logEntry entry = NoSMT $ do
         logAction <- ask
-        let entryLogger = Log.fromLogAction logAction
+        let entryLogger = Log.fromLogAction @Log.ActualEntry logAction
         Trans.lift $ entryLogger Colog.<& Log.toEntry entry
     logWhile _ = id
 

--- a/kore/src/SMT/SimpleSMT.hs
+++ b/kore/src/SMT/SimpleSMT.hs
@@ -211,7 +211,6 @@ import Text.Read
     ( readMaybe
     )
 
-import From
 import Kore.Debug hiding
     ( debug
     )
@@ -298,12 +297,9 @@ logMessageWith
     -> Text
     -> IO ()
 logMessageWith severity Solver { logger } a =
-    logger Colog.<& message
+    Log.fromLogAction logger Colog.<& message
   where
-    message =
-        from @Log.SomeEntry
-        $ Log.SomeEntry
-        $ Log.LogMessage a severity callStack
+    message = Log.SomeEntry $ Log.LogMessage a severity callStack
 
 debug :: HasCallStack => Solver -> Text -> IO ()
 debug = logMessageWith Log.Debug

--- a/kore/src/SMT/SimpleSMT.hs
+++ b/kore/src/SMT/SimpleSMT.hs
@@ -211,6 +211,7 @@ import Text.Read
     ( readMaybe
     )
 
+import From
 import Kore.Debug hiding
     ( debug
     )
@@ -250,7 +251,7 @@ data Value =  Bool  !Bool           -- ^ Boolean value
 
 --------------------------------------------------------------------------------
 
-type Logger = Log.LogAction IO Log.SomeEntry
+type Logger = Log.LogAction IO Log.ActualEntry
 
 -- | An interactive solver process.
 data Solver = Solver
@@ -299,7 +300,10 @@ logMessageWith
 logMessageWith severity Solver { logger } a =
     logger Colog.<& message
   where
-    message = Log.SomeEntry $ Log.LogMessage a severity callStack
+    message =
+        from @Log.SomeEntry
+        $ Log.SomeEntry
+        $ Log.LogMessage a severity callStack
 
 debug :: HasCallStack => Solver -> Text -> IO ()
 debug = logMessageWith Log.Debug

--- a/kore/src/SMT/SimpleSMT.hs
+++ b/kore/src/SMT/SimpleSMT.hs
@@ -297,7 +297,7 @@ logMessageWith
     -> Text
     -> IO ()
 logMessageWith severity Solver { logger } a =
-    Log.fromLogAction logger Colog.<& message
+    Log.fromLogAction @Log.ActualEntry logger Colog.<& message
   where
     message = Log.SomeEntry $ Log.LogMessage a severity callStack
 

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -13,7 +13,6 @@ import Test.Tasty.HUnit
     , (@?=)
     )
 
-import qualified Colog
 import Control.Concurrent.MVar
 import qualified Control.Lens as Lens
 import Control.Monad.Reader
@@ -596,7 +595,7 @@ runWithState command axioms claims claim stateTransformer = do
     let state = stateTransformer $ mkState axioms claims claim
     let config = mkConfig mvar
     (c, s) <-
-        liftSimplifier (Colog.cmap (from @Log.ActualEntry) (Log.swappableLogger mvar))
+        liftSimplifier (Log.swappableLogger mvar)
         $ flip runStateT state
         $ flip runReaderT config
         $ replInterpreter0
@@ -687,7 +686,7 @@ mkState axioms claims claim =
     graph' = emptyExecutionGraph claim
 
 mkConfig
-    :: MVar (Log.LogAction IO Log.SomeEntry)
+    :: MVar (Log.LogAction IO Log.ActualEntry)
     -> Config Claim Simplifier
 mkConfig logger =
     Config

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -13,6 +13,7 @@ import Test.Tasty.HUnit
     , (@?=)
     )
 
+import qualified Colog
 import Control.Concurrent.MVar
 import qualified Control.Lens as Lens
 import Control.Monad.Reader
@@ -595,7 +596,7 @@ runWithState command axioms claims claim stateTransformer = do
     let state = stateTransformer $ mkState axioms claims claim
     let config = mkConfig mvar
     (c, s) <-
-        liftSimplifier (Log.swappableLogger mvar)
+        liftSimplifier (Colog.cmap (from @Log.ActualEntry) (Log.swappableLogger mvar))
         $ flip runStateT state
         $ flip runReaderT config
         $ replInterpreter0


### PR DESCRIPTION
Part of https://github.com/kframework/kore/issues/1491

- Add a data type data ActualEntry = ActualEntry { entryContext :: Seq SomeEntry, actualEntry :: SomeEntry }.
- Define instances From ActualEntry SomeEntry and From SomeEntry ActualEntry which forget the entryContext and add an empty entryContext respectively.
- LoggerT should carry a LogAction IO ActualEntry instead of LogAction IO SomeEntry. Use Colog.contramap (from @SomeEntry) and Colog.contramap (from @ActualEntry) as necessary to fix type errors.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
