### PR TITLE
Refactor UnificationProcedure

### DIFF
--- a/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
+++ b/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
@@ -1,3 +1,9 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
 module Kore.Log.ErrorRewritesInstantiation
     ( ErrorRewritesInstantiation (..)
     , errorRewritesInstantiation

--- a/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
+++ b/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
@@ -1,0 +1,68 @@
+module Kore.Log.ErrorRewritesInstantiation
+    ( ErrorRewritesInstantiation (..)
+    , errorRewritesInstantiation
+    ) where
+
+import Prelude.Kore
+
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Internal.Pattern
+    ( Pattern
+    )
+import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.Variable
+    ( InternalVariable
+    , Variable
+    , toVariable
+    )
+import Kore.Unification.Error
+import Kore.Unparser
+    ( unparse
+    )
+import Log
+import Pretty
+    ( Pretty
+    )
+import qualified Pretty
+
+data ErrorRewritesInstantiation =
+    ErrorRewritesInstantiation
+        { unificationError :: !UnificationError
+        , configuration :: !(Pattern Variable)
+        }
+    deriving (GHC.Generic)
+
+instance SOP.Generic ErrorRewritesInstantiation
+
+instance SOP.HasDatatypeInfo ErrorRewritesInstantiation
+
+instance Entry ErrorRewritesInstantiation where
+    entrySeverity _ = Error
+
+instance Pretty ErrorRewritesInstantiation where
+    pretty ErrorRewritesInstantiation { unificationError, configuration } =
+        Pretty.vsep
+            [ "While rewriting the configuration:"
+            , Pretty.indent 4 (unparse configuration)
+            , Pretty.indent 2 "unification error:"
+            , Pretty.indent 4 (Pretty.pretty unificationError)
+            , Pretty.indent 2
+                "The unification error above prevented instantiation of \
+                \a semantic rule, so execution cannot continue."
+            ]
+
+errorRewritesInstantiation
+    :: HasCallStack
+    => MonadLog log
+    => InternalVariable variable
+    => Pattern variable
+    -> UnificationError
+    -> log a
+errorRewritesInstantiation configuration' unificationError = do
+    logEntry ErrorRewritesInstantiation { unificationError, configuration }
+    error "Aborting execution"
+  where
+    mapVariables = Pattern.mapVariables (fmap toVariable) (fmap toVariable)
+    configuration = mapVariables configuration'

--- a/kore/src/Kore/Log/InfoAttemptUnification.hs
+++ b/kore/src/Kore/Log/InfoAttemptUnification.hs
@@ -1,3 +1,9 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
 module Kore.Log.InfoAttemptUnification
     ( InfoAttemptUnification (..)
     , infoAttemptUnification

--- a/kore/src/Kore/Log/InfoAttemptUnification.hs
+++ b/kore/src/Kore/Log/InfoAttemptUnification.hs
@@ -1,0 +1,59 @@
+module Kore.Log.InfoAttemptUnification
+    ( InfoAttemptUnification (..)
+    , infoAttemptUnification
+    ) where
+
+import Prelude.Kore
+
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , TermLike
+    , Variable
+    , toVariable
+    )
+import qualified Kore.Internal.TermLike as TermLike
+import Kore.Unparser
+    ( unparse
+    )
+import Log
+import Pretty
+    ( Pretty
+    )
+import qualified Pretty
+
+data InfoAttemptUnification =
+    InfoAttemptUnification { term1, term2 :: !(TermLike Variable) }
+    deriving (GHC.Generic)
+
+instance SOP.Generic InfoAttemptUnification
+
+instance SOP.HasDatatypeInfo InfoAttemptUnification
+
+instance Entry InfoAttemptUnification where
+    entrySeverity _ = Info
+
+instance Pretty InfoAttemptUnification where
+    pretty InfoAttemptUnification { term1, term2 } =
+        Pretty.vsep
+            [ "Attempting to unify"
+            , Pretty.indent 4 $ unparse term1
+            , Pretty.indent 2 "with"
+            , Pretty.indent 4 $ unparse term2
+            ]
+
+infoAttemptUnification
+    :: MonadLog log
+    => InternalVariable variable
+    => TermLike variable
+    -> TermLike variable
+    -> log a
+    -> log a
+infoAttemptUnification term1' term2' =
+    logWhile InfoAttemptUnification { term1, term2 }
+  where
+    mapVariables = TermLike.mapVariables (fmap toVariable) (fmap toVariable)
+    term1 = mapVariables term1'
+    term2 = mapVariables term2'

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -20,6 +20,7 @@ module Kore.Log.Registry
     , warnFunctionWithoutEvaluatorsType
     , debugSkipSimplificationType
     , infoAttemptUnificationType
+    , errorRewritesInstantiationType
     ) where
 
 import Prelude.Kore
@@ -73,6 +74,9 @@ import Kore.Log.DebugSolver
 import Kore.Log.ErrorException
     ( ErrorException
     )
+import Kore.Log.ErrorRewritesInstantiation
+    ( ErrorRewritesInstantiation
+    )
 import Kore.Log.InfoAttemptUnification
     ( InfoAttemptUnification
     )
@@ -114,6 +118,7 @@ registry =
                 , register criticalExecutionErrorType
                 , register logMessageType
                 , register infoAttemptUnificationType
+                , register errorRewritesInstantiationType
                 ]
         typeToText = makeInverse textToType
     in if textToType `eq2` makeInverse typeToText
@@ -152,6 +157,7 @@ debugAppliedRuleType
   , criticalExecutionErrorType
   , logMessageType
   , infoAttemptUnificationType
+  , errorRewritesInstantiationType
   :: SomeTypeRep
 
 debugAppliedRuleType =
@@ -180,6 +186,8 @@ logMessageType =
     someTypeRep (Proxy :: Proxy LogMessage)
 infoAttemptUnificationType =
     someTypeRep (Proxy :: Proxy InfoAttemptUnification)
+errorRewritesInstantiationType =
+    someTypeRep (Proxy :: Proxy ErrorRewritesInstantiation)
 
 lookupTextFromTypeWithError :: SomeTypeRep -> Text
 lookupTextFromTypeWithError type' =

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -19,6 +19,7 @@ module Kore.Log.Registry
     , warnBottomHookType
     , warnFunctionWithoutEvaluatorsType
     , debugSkipSimplificationType
+    , infoAttemptUnificationType
     ) where
 
 import Prelude.Kore
@@ -72,6 +73,9 @@ import Kore.Log.DebugSolver
 import Kore.Log.ErrorException
     ( ErrorException
     )
+import Kore.Log.InfoAttemptUnification
+    ( InfoAttemptUnification
+    )
 import Kore.Log.WarnBottomHook
     ( WarnBottomHook
     )
@@ -109,6 +113,7 @@ registry =
                 , register logDebugEvaluateConditionType
                 , register criticalExecutionErrorType
                 , register logMessageType
+                , register infoAttemptUnificationType
                 ]
         typeToText = makeInverse textToType
     in if textToType `eq2` makeInverse typeToText
@@ -146,6 +151,7 @@ debugAppliedRuleType
   , logDebugEvaluateConditionType
   , criticalExecutionErrorType
   , logMessageType
+  , infoAttemptUnificationType
   :: SomeTypeRep
 
 debugAppliedRuleType =
@@ -172,6 +178,8 @@ criticalExecutionErrorType =
     someTypeRep (Proxy :: Proxy ErrorException)
 logMessageType =
     someTypeRep (Proxy :: Proxy LogMessage)
+infoAttemptUnificationType =
+    someTypeRep (Proxy :: Proxy InfoAttemptUnification)
 
 lookupTextFromTypeWithError :: SomeTypeRep -> Text
 lookupTextFromTypeWithError type' =

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -18,8 +18,7 @@ module Kore.ModelChecker.Step
 import Prelude.Kore
 
 import Control.Error
-    ( ExceptT
-    , runExceptT
+    ( runExceptT
     )
 import Control.Monad
     ( when
@@ -72,10 +71,7 @@ import qualified Kore.Step.Strategy as Strategy
 import Kore.Syntax.Variable
     ( Variable
     )
-import Kore.Unification.Error
 import qualified Kore.Unification.Procedure as Unification
-import Kore.Unification.UnificationProcedure
-import qualified Kore.Unification.UnifierT as Monad.Unify
 
 data Prim patt rewrite =
       CheckProofState
@@ -216,11 +212,7 @@ transitionRule
     transitionComputeWeakNext _ (GoalRemLHS _)
       = return (GoalLHS Pattern.bottom)
 
-    unificationProcedure :: UnificationProcedure (ExceptT UnificationError m)
-    unificationProcedure =
-        Step.UnificationProcedure $ \sideCondition term1 term2 ->
-            Unification.unificationProcedure sideCondition term1 term2
-            & Monad.Unify.getUnifierT
+    unificationProcedure = Unification.unificationProcedure
 
     transitionComputeWeakNextHelper
         :: [RewriteRule Variable]

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -214,8 +214,7 @@ transitionRule
     transitionComputeWeakNext _ (GoalRemLHS _)
       = return (GoalLHS Pattern.bottom)
 
-    unificationProcedure
-        :: UnificationProcedure (ExceptT UnificationOrSubstitutionError m)
+    unificationProcedure :: UnificationProcedure (ExceptT UnificationError m)
     unificationProcedure =
         Step.UnificationProcedure $ \sideCondition term1 term2 ->
             Unification.unificationProcedure sideCondition term1 term2

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -42,6 +42,9 @@ import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike
     ( TermLike
     )
+import Kore.Log.ErrorRewritesInstantiation
+    ( errorRewritesInstantiation
+    )
 import Kore.ModelChecker.Simplification
     ( checkImplicationIsTop
     )
@@ -73,7 +76,6 @@ import Kore.Unification.Error
 import qualified Kore.Unification.Procedure as Unification
 import Kore.Unification.UnificationProcedure
 import qualified Kore.Unification.UnifierT as Monad.Unify
-import Kore.Unparser
 
 data Prim patt rewrite =
       CheckProofState
@@ -234,14 +236,8 @@ transitionRule
                 config
             & lift . lift . runExceptT
         case eitherResults of
-            Left _ ->
-                (error . show . Pretty.vsep)
-                [ "Not implemented error:"
-                , "while applying a \\rewrite axiom to the pattern:"
-                , Pretty.indent 4 (unparse config)
-                ,   "We decided to end the execution because we don't \
-                    \understand this case well enough at the moment."
-                ]
+            Left unificationError ->
+                errorRewritesInstantiation config unificationError
             Right results -> do
                 let
                     mapRules =

--- a/kore/src/Kore/Repl.hs
+++ b/kore/src/Kore/Repl.hs
@@ -78,7 +78,7 @@ import Kore.Strategies.Goal
 import Kore.Strategies.Verification
 import Kore.Syntax.Variable
 import Kore.Unification.Procedure
-    ( unificationProcedure
+    ( unificationProcedureWorker
     )
 import Kore.Unparser
     ( unparseToString
@@ -170,7 +170,7 @@ runRepl axioms' claims' logger replScript replMode outputFile = do
     config =
         Config
             { stepper    = stepper0
-            , unifier    = unificationProcedure
+            , unifier    = unificationProcedureWorker
             , logger
             , outputFile
             }

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -67,7 +67,7 @@ import qualified Kore.Step.Strategy as Strategy
 import qualified Kore.Step.Transition as Transition
 import Kore.Syntax.Variable
 import Kore.Unification.Error
-    ( UnificationOrSubstitutionError
+    ( UnificationError
     )
 import qualified Kore.Unification.Procedure as Unification
 import Kore.Unification.UnificationProcedure
@@ -120,8 +120,7 @@ transitionRule =
         configs <- lift $ Pattern.simplifyTopConfiguration config
         filteredConfigs <- SMT.Evaluator.filterMultiOr configs
         Foldable.asum (pure <$> filteredConfigs)
-    unificationProcedure
-        :: UnificationProcedure (ExceptT UnificationOrSubstitutionError m)
+    unificationProcedure :: UnificationProcedure (ExceptT UnificationError m)
     unificationProcedure =
         UnificationProcedure $ \sideCondition term1 term2 ->
             Unification.unificationProcedure sideCondition term1 term2

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -27,6 +27,10 @@ module Kore.Step
 
 import Prelude.Kore
 
+import Control.Error
+    ( ExceptT
+    , runExceptT
+    )
 import qualified Data.Foldable as Foldable
 import Data.List.Extra
     ( groupSortOn
@@ -39,9 +43,6 @@ import Numeric.Natural
 
 import Kore.Internal.Pattern
     ( Pattern
-    )
-import qualified Kore.Step.Result as Result
-    ( mergeResults
     )
 import qualified Kore.Step.RewriteStep as Step
 import Kore.Step.RulePattern
@@ -65,7 +66,11 @@ import Kore.Step.Strategy
 import qualified Kore.Step.Strategy as Strategy
 import qualified Kore.Step.Transition as Transition
 import Kore.Syntax.Variable
+import Kore.Unification.Error
+    ( UnificationOrSubstitutionError
+    )
 import qualified Kore.Unification.Procedure as Unification
+import Kore.Unification.UnificationProcedure
 import qualified Kore.Unification.UnifierT as Monad.Unify
 import Kore.Unparser
 
@@ -99,7 +104,8 @@ rewriteStep a =
 'Strategy.runStrategy'.
  -}
 transitionRule
-    :: HasCallStack
+    :: forall m
+    .  HasCallStack
     => MonadSimplify m
     => Prim (RewriteRule Variable)
     -> Pattern Variable
@@ -114,13 +120,17 @@ transitionRule =
         configs <- lift $ Pattern.simplifyTopConfiguration config
         filteredConfigs <- SMT.Evaluator.filterMultiOr configs
         Foldable.asum (pure <$> filteredConfigs)
+    unificationProcedure
+        :: UnificationProcedure (ExceptT UnificationOrSubstitutionError m)
+    unificationProcedure =
+        UnificationProcedure $ \sideCondition term1 term2 ->
+            Unification.unificationProcedure sideCondition term1 term2
+            & Monad.Unify.getUnifierT
     transitionRewrite rule config = do
         Transition.addRule rule
-        let unificationProcedure =
-                Step.UnificationProcedure Unification.unificationProcedure
         eitherResults <-
-            lift . Monad.Unify.runUnifierT
-            $ Step.applyRewriteRulesParallel unificationProcedure [rule] config
+            Step.applyRewriteRulesParallel unificationProcedure [rule] config
+            & lift . runExceptT
         case eitherResults of
             Left err ->
                 (error . show . Pretty.vsep)
@@ -133,7 +143,7 @@ transitionRule =
                     ]
             Right results ->
                 Foldable.asum
-                    (pure <$> Step.gatherResults (Result.mergeResults results))
+                    (pure <$> Step.gatherResults results)
 
 
 {- | A strategy that applies all the rewrites in parallel.

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -70,6 +70,9 @@ import qualified Kore.Step.Remainder as Remainder
 import qualified Kore.Step.Result as Result
 import qualified Kore.Step.Result as Results
 import qualified Kore.Step.Result as Step
+import Kore.Step.Simplification.Simplify
+    ( MonadSimplify
+    )
 import qualified Kore.Step.Simplification.Simplify as Simplifier
 import qualified Kore.Step.SMT.Evaluator as SMT.Evaluator
 import Kore.Step.Step
@@ -186,7 +189,7 @@ See also: 'applyInitialConditions'
 finalizeAppliedRule
     :: forall unifier variable
     .  InternalVariable variable
-    => MonadUnify unifier
+    => MonadSimplify unifier
     => SideCondition variable
     -- ^ Top level condition
     -> EqualityPattern variable
@@ -195,7 +198,7 @@ finalizeAppliedRule
     -- ^ Conditions of applied rule
     -> unifier (OrPattern variable)
 finalizeAppliedRule sideCondition renamedRule appliedConditions =
-    fmap OrPattern.fromPatterns . Branch.gather
+    MultiOr.gather
     $ finalizeAppliedRuleWorker =<< Branch.scatter appliedConditions
   where
     finalizeAppliedRuleWorker appliedCondition = do
@@ -233,7 +236,7 @@ finalizeRule
     -- TODO (virgil): This is broken, it should take advantage of the unifier's
     -- branching and not return a list.
 finalizeRule sideCondition initial unifiedRule =
-    Monad.Unify.gather $ do
+    Branch.gather $ do
         let initialCondition = Conditional.withoutTerm initial
         let unificationCondition = Conditional.withoutTerm unifiedRule
         applied <- applyInitialConditions

--- a/kore/src/Kore/Step/EquationalStep.hs
+++ b/kore/src/Kore/Step/EquationalStep.hs
@@ -195,8 +195,8 @@ finalizeAppliedRule
     -- ^ Conditions of applied rule
     -> unifier (OrPattern variable)
 finalizeAppliedRule sideCondition renamedRule appliedConditions =
-    fmap OrPattern.fromPatterns . Monad.Unify.gather
-    $ finalizeAppliedRuleWorker =<< Monad.Unify.scatter appliedConditions
+    fmap OrPattern.fromPatterns . Branch.gather
+    $ finalizeAppliedRuleWorker =<< Branch.scatter appliedConditions
   where
     finalizeAppliedRuleWorker appliedCondition = do
         -- Combine the initial conditions, the unification conditions, and the
@@ -335,8 +335,9 @@ finalizeRulesSequence sideCondition initial unifiedRules
         State.runStateT
             (traverse finalizeRuleSequence' unifiedRules)
             (Conditional.withoutTerm initial)
-    remainders' <- Monad.Unify.gather $
+    remainders' <-
         applyRemainder sideCondition initial remainder
+        & Branch.gather
     return Step.Results
         { results = Seq.fromList $ Foldable.fold results
         , remainders =

--- a/kore/src/Kore/Step/RewriteStep.hs
+++ b/kore/src/Kore/Step/RewriteStep.hs
@@ -243,7 +243,7 @@ applyRulesWithFinalizer
     .  InternalVariable variable
     => MonadUnify unifier
     => Finalizer unifier variable
-    -> UnificationProcedure
+    -> UnificationProcedure unifier
     -> [RulePattern variable]
     -- ^ Rewrite rules
     -> Pattern (Target variable)
@@ -266,7 +266,7 @@ applyRulesParallel
     :: forall unifier variable
     .  InternalVariable variable
     => MonadUnify unifier
-    => UnificationProcedure
+    => UnificationProcedure unifier
     -> [RulePattern variable]
     -- ^ Rewrite rules
     -> Pattern (Target variable)
@@ -283,7 +283,7 @@ applyRewriteRulesParallel
     :: forall unifier variable
     .  InternalVariable variable
     => MonadUnify unifier
-    => UnificationProcedure
+    => UnificationProcedure unifier
     -> [RewriteRule variable]
     -- ^ Rewrite rules
     -> Pattern variable
@@ -308,7 +308,7 @@ applyRulesSequence
     :: forall unifier variable
     .  InternalVariable variable
     => MonadUnify unifier
-    => UnificationProcedure
+    => UnificationProcedure unifier
     -> [RulePattern variable]
     -- ^ Rewrite rules
     -> Pattern (Target variable)
@@ -325,7 +325,7 @@ applyRewriteRulesSequence
     :: forall unifier variable
     .  InternalVariable variable
     => MonadUnify unifier
-    => UnificationProcedure
+    => UnificationProcedure unifier
     -> Pattern variable
     -- ^ Configuration being rewritten
     -> [RewriteRule variable]

--- a/kore/src/Kore/Step/Search.hs
+++ b/kore/src/Kore/Step/Search.hs
@@ -65,7 +65,7 @@ import Kore.Step.Substitution
     )
 import Kore.TopBottom
 import Kore.Unification.Procedure
-    ( unificationProcedure
+    ( unificationProcedureWorker
     )
 import qualified Kore.Unification.UnifierT as Unifier
 
@@ -139,7 +139,7 @@ matchWith
 matchWith sideCondition e1 e2 = do
     eitherUnifiers <-
         lift $ Unifier.runUnifierT
-        $ unificationProcedure sideCondition t1 t2
+        $ unificationProcedureWorker sideCondition t1 t2
     let
         maybeUnifiers :: Maybe [Condition variable]
         maybeUnifiers = hush eitherUnifiers

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -213,7 +213,9 @@ unifyRule unificationProcedure sideCondition initial rule = do
     -- Unify the left-hand side of the rule with the term of the initial
     -- configuration.
     let ruleLeft = matchingPattern rule
-    unification <- unifyTermLikes mergedSideCondition initialTerm ruleLeft
+    unification <-
+        unifyTermLikes mergedSideCondition initialTerm ruleLeft
+        & Branch.alternate
     -- Combine the unification solution with the rule's requirement clause,
     let ruleRequires = precondition rule
         requires' = Condition.fromPredicate ruleRequires

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -159,15 +159,15 @@ class UnifyingRule rule where
 -- |Unifies/matches a list a rules against a configuration. See 'unifyRule'.
 unifyRules
     :: InternalVariable variable
-    => MonadSimplify unifier
+    => MonadSimplify simplifier
     => UnifyingRule rule
-    => UnificationProcedure unifier
+    => UnificationProcedure simplifier
     -> SideCondition (Target variable)
     -> Pattern (Target variable)
     -- ^ Initial configuration
     -> [rule (Target variable)]
     -- ^ Rule
-    -> unifier [UnifiedRule (Target variable) (rule (Target variable))]
+    -> simplifier [UnifiedRule (Target variable) (rule (Target variable))]
 unifyRules unificationProcedure sideCondition initial rules =
     Branch.gather $ do
         rule <- Branch.scatter rules
@@ -377,18 +377,18 @@ The rule is considered to apply if the result is not @\\bottom@.
 
  -}
 applyInitialConditions
-    :: forall unifier variable
+    :: forall simplifier variable
     .  InternalVariable variable
-    => MonadSimplify unifier
+    => MonadSimplify simplifier
     => SideCondition variable
     -- ^ Top-level conditions
     -> Maybe (Condition variable)
     -- ^ Initial conditions
     -> Condition variable
     -- ^ Unification conditions
-    -> BranchT unifier (OrCondition variable)
-    -- TODO(virgil): This should take advantage of the unifier's branching and
-    -- not return an Or.
+    -> BranchT simplifier (OrCondition variable)
+    -- TODO(virgil): This should take advantage of the BranchT and not return
+    -- an OrCondition.
 applyInitialConditions sideCondition initial unification = do
     -- Combine the initial conditions and the unification conditions.
     -- The axiom requires clause is included in the unification conditions.

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -903,7 +903,7 @@ derivePar rules goal = withConfiguration goal $ do
 
 unificationProcedure
     :: MonadSimplify simplifier
-    => UnificationProcedure (ExceptT UnificationOrSubstitutionError simplifier)
+    => UnificationProcedure (ExceptT UnificationError simplifier)
 unificationProcedure =
     Step.UnificationProcedure $ \sideCondition term1 term2 ->
         Unification.unificationProcedure sideCondition term1 term2

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -946,13 +946,13 @@ deriveResults goal results = do
             Result.traverseConfigs
                 (pure . GoalRewritten)
                 (pure . GoalRemainder)
-    let onePathResults =
+    let reachabilityResults =
             Result.mapConfigs
                 (flip (configurationDestinationToRule goal) destination)
                 (flip (configurationDestinationToRule goal) destination)
                 results
     results' <-
-        traverseConfigs (mapRules onePathResults)
+        traverseConfigs (mapRules reachabilityResults)
     Result.transitionResults results'
   where
     destination = getDestination goal

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -901,10 +901,12 @@ deriveWith
     -> [Rule goal]
     -> goal
     -> Strategy.TransitionT (Rule goal) m (ProofState goal goal)
-deriveWith takeStep rules goal = withConfiguration goal $ do
-    (lift . runExceptT) (takeStep rewrites configuration) >>= either
-        (errorRewritesInstantiation configuration)
-        (deriveResults goal)
+deriveWith takeStep rules goal =
+    withConfiguration goal
+        $ (lift . runExceptT) (takeStep rewrites configuration)
+        >>= either
+            (errorRewritesInstantiation configuration)
+            (deriveResults goal)
   where
     configuration :: Pattern Variable
     configuration = getConfiguration goal

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -41,9 +41,7 @@ import qualified Kore.Step.Simplification.Ceil as Ceil
     )
 import Kore.Step.Simplification.Simplify
     ( MonadSimplify
-    )
-import Kore.Step.Simplification.Simplify
-    ( simplifyCondition
+    , simplifyCondition
     )
 import qualified Kore.TopBottom as TopBottom
 import Kore.Unification.Error

--- a/kore/src/Kore/Unification/UnificationProcedure.hs
+++ b/kore/src/Kore/Unification/UnificationProcedure.hs
@@ -7,6 +7,9 @@ module Kore.Unification.UnificationProcedure
     ( UnificationProcedure (..)
     ) where
 
+import Branch
+    ( BranchT
+    )
 import Kore.Internal.Condition
     ( Condition
     )
@@ -27,5 +30,5 @@ newtype UnificationProcedure unifier =
             => SideCondition variable
             -> TermLike variable
             -> TermLike variable
-            -> unifier (Condition variable)
+            -> BranchT unifier (Condition variable)
         }

--- a/kore/src/Kore/Unification/UnificationProcedure.hs
+++ b/kore/src/Kore/Unification/UnificationProcedure.hs
@@ -1,0 +1,31 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+
+ -}
+module Kore.Unification.UnificationProcedure
+    ( UnificationProcedure (..)
+    ) where
+
+import Kore.Internal.Condition
+    ( Condition
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , TermLike
+    )
+
+-- | Unifies two 'TermLike' patterns under the given 'SideCondition'.
+newtype UnificationProcedure unifier =
+    UnificationProcedure
+        { runUnificationProcedure
+            :: forall variable
+            .  InternalVariable variable
+            => SideCondition variable
+            -> TermLike variable
+            -> TermLike variable
+            -> unifier (Condition variable)
+        }

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -297,11 +297,7 @@ runStepResult
     -- ^ configuration
     -> RewriteRule Variable
     -- ^ axiom
-    -> SMT
-        (Either
-            UnificationError
-            (Step.Results RulePattern Variable)
-        )
+    -> SMT (Either UnificationError (Step.Results RulePattern Variable))
 runStepResult configuration axiom =
     Step.applyRewriteRulesParallel
         unificationProcedure
@@ -311,7 +307,7 @@ runStepResult configuration axiom =
 
 unificationProcedure
     :: MonadSimplify simplifier
-    => UnificationProcedure (ExceptT UnificationOrSubstitutionError simplifier)
+    => UnificationProcedure (ExceptT UnificationError simplifier)
 unificationProcedure =
     Step.UnificationProcedure $ \sideCondition term1 term2 ->
         Unification.unificationProcedure sideCondition term1 term2

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -120,7 +120,6 @@ import Kore.Unification.Error
     )
 import qualified Kore.Unification.Procedure as Unification
 import Kore.Unification.UnificationProcedure
-import qualified Kore.Unification.UnifierT as Monad.Unify
 import Kore.Unparser
     ( unparseToString
     )
@@ -308,10 +307,7 @@ runStepResult configuration axiom =
 unificationProcedure
     :: MonadSimplify simplifier
     => UnificationProcedure (ExceptT UnificationError simplifier)
-unificationProcedure =
-    Step.UnificationProcedure $ \sideCondition term1 term2 ->
-        Unification.unificationProcedure sideCondition term1 term2
-        & Monad.Unify.getUnifierT
+unificationProcedure = Unification.unificationProcedure
 
 -- | Test unparsing internalized patterns.
 hpropUnparse

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -77,7 +77,7 @@ import Kore.Syntax.Variable
     ( Variable
     )
 import Kore.Unification.Procedure
-    ( unificationProcedure
+    ( unificationProcedureWorker
     )
 import Kore.Unification.Unify
     ( explainBottom
@@ -691,7 +691,7 @@ mkConfig
 mkConfig logger =
     Config
         { stepper     = stepper0
-        , unifier     = unificationProcedure
+        , unifier     = unificationProcedureWorker
         , logger
         , outputFile  = OutputFile Nothing
         }

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -12,8 +12,7 @@ import Prelude.Kore
 import Test.Tasty
 
 import Control.Error
-    ( ExceptT
-    , runExceptT
+    ( runExceptT
     )
 import qualified Control.Exception as Exception
 import Data.Default as Default
@@ -69,21 +68,12 @@ import Kore.Step.RulePattern
     , rulePattern
     )
 import qualified Kore.Step.RulePattern as RulePattern
-import Kore.Step.Simplification.Simplify
-    ( MonadSimplify
-    )
-import Kore.Step.Step
-    ( UnificationProcedure (..)
-    )
 import qualified Kore.Step.Step as Step
 import Kore.Unification.Error
     ( UnificationError (..)
     , unsupportedPatterns
     )
 import qualified Kore.Unification.Procedure as Unification
-import Kore.Unification.UnifierT
-    ( getUnifierT
-    )
 import Kore.Variables.Fresh
     ( nextVariable
     )
@@ -165,17 +155,13 @@ unifyRule
             [Conditional Variable (RulePattern Variable)]
         )
 unifyRule initial rule =
-    Step.unifyRule unificationProcedure SideCondition.top initial rule
+    Step.unifyRule
+        Unification.unificationProcedure
+        SideCondition.top
+        initial
+        rule
     & runExceptT . Branch.gather
     & runSimplifier Mock.env
-
-unificationProcedure
-    :: MonadSimplify simplifier
-    => UnificationProcedure (ExceptT UnificationError simplifier)
-unificationProcedure =
-    UnificationProcedure $ \sideCondition term1 term2 ->
-        Unification.unificationProcedure sideCondition term1 term2
-        & getUnifierT
 
 test_renameRuleVariables :: [TestTree]
 test_renameRuleVariables =
@@ -810,7 +796,7 @@ applyRewriteRulesParallel
       )
 applyRewriteRulesParallel initial rules =
     Step.applyRewriteRulesParallel
-        unificationProcedure
+        Unification.unificationProcedure
         rules
         (simplifiedPattern initial)
     & runSimplifierNoSMT Mock.env . runExceptT
@@ -1199,7 +1185,7 @@ applyRewriteRulesSequence
       )
 applyRewriteRulesSequence initial rules =
     Step.applyRewriteRulesSequence
-        unificationProcedure
+        Unification.unificationProcedure
         (simplifiedPattern initial)
         rules
     & runSimplifier Mock.env . runExceptT

--- a/kore/test/Test/Kore/Unification/Unifier.hs
+++ b/kore/test/Test/Kore/Unification/Unifier.hs
@@ -275,10 +275,13 @@ unificationProcedureSuccessWithSimplifiers
     testCase message $ do
         let mockEnv = testEnv { simplifierAxioms = axiomIdToSimplifier }
         Right results <-
-            runSMT
-            $ runSimplifier mockEnv
-            $ Monad.Unify.runUnifierT
-            $ unificationProcedure SideCondition.topTODO term1 term2
+            unificationProcedureWorker
+                SideCondition.topTODO
+                term1
+                term2
+            & Monad.Unify.runUnifierT
+            & runSimplifier mockEnv
+            & runSMT
         let
             normalize
                 :: Condition Variable


### PR DESCRIPTION
~Please review #1668 first.~

This pull request removes unused `MonadUnify` constraints from code that applies `\rewrites` rules. The unifier introduces a redundant means of branching during rule application. Applying a rule should always return a single `Results` value, not a disjunction of `Results`es. This will eliminate some `error` cases in #1659.

I also added some proper log entries to reduce duplication between modules that apply `\rewrites` rules.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
