### PR TITLE
Replace "K framework" with "Kore" for " --version"

### DIFF
--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -270,13 +270,8 @@ mainGlobal
     -> IO      (MainOptions options)
 mainGlobal exeName localOptionsParser modifiers = do
     options <- commandLineParse exeName localOptionsParser modifiers
-    when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion name)
+    when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion)
     return options
-  where
-    name
-      | getExeName exeName == "kore-exec" = "Kore"
-      | otherwise = "K framework"
-
 
 defaultMainGlobal :: IO (MainOptions options)
 defaultMainGlobal =
@@ -284,10 +279,10 @@ defaultMainGlobal =
 
 
 -- | main function to print version information
-mainVersion :: String -> ZonedTime -> IO ()
-mainVersion name time =
+mainVersion :: ZonedTime -> IO ()
+mainVersion time =
       mapM_ putStrLn
-      [ name ++ " version " ++ packageVersion
+      [ "Kore version " ++ packageVersion
       , "Git:"
       , "  revision:\t"     ++ $gitHash
       , "  branch:\t"       ++ $gitBranch

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -282,12 +282,12 @@ defaultMainGlobal =
 mainVersion :: ZonedTime -> IO ()
 mainVersion time =
       mapM_ putStrLn
-      [ "Kore version " ++ packageVersion
+      [ "Kore version "    ++ packageVersion
       , "Git:"
-      , "  revision:\t"     ++ $gitHash
-      , "  branch:\t"       ++ $gitBranch
-      , "  last commit:\t"  ++  gitTime
-      , "Build date:\t"     ++  exeTime
+      , "  revision:\t"    ++ $gitHash
+      , "  branch:\t"      ++ $gitBranch
+      , "  last commit:\t" ++  gitTime
+      , "Build date:\t"    ++  exeTime
       ]
     where
       packageVersion = showVersion MetaData.version

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -269,9 +269,13 @@ mainGlobal
     -> InfoMod (MainOptions options) -- ^ option parser information
     -> IO      (MainOptions options)
 mainGlobal exeName localOptionsParser modifiers = do
-  options <- commandLineParse exeName localOptionsParser modifiers
-  when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion)
-  return options
+    options <- commandLineParse exeName localOptionsParser modifiers
+    when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion name)
+    return options
+  where
+    name
+      | getExeName exeName == "kore-exec" = "Kore"
+      | otherwise = "K framework"
 
 
 defaultMainGlobal :: IO (MainOptions options)
@@ -280,15 +284,15 @@ defaultMainGlobal =
 
 
 -- | main function to print version information
-mainVersion :: ZonedTime -> IO ()
-mainVersion time =
+mainVersion :: String -> ZonedTime -> IO ()
+mainVersion name time =
       mapM_ putStrLn
-      [ "K framework version " ++ packageVersion
+      [ name ++ " version " ++ packageVersion
       , "Git:"
-      , "  revision:\t"    ++ $gitHash
-      , "  branch:\t"      ++ $gitBranch
-      , "  last commit:\t" ++  gitTime
-      , "Build date:\t"    ++  exeTime
+      , "  revision:\t"     ++ $gitHash
+      , "  branch:\t"       ++ $gitBranch
+      , "  last commit:\t"  ++  gitTime
+      , "Build date:\t"     ++  exeTime
       ]
     where
       packageVersion = showVersion MetaData.version


### PR DESCRIPTION
---
see #1599 
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
