### PR TITLE
Add Map.inclusion hook.

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -565,9 +565,8 @@ the result is the given default.
 
 If the given key is in the map, the result is `\dv{Bool{}}("true")`; otherwise
 the result is `\dv{Bool{}}("false")`.
-
 ~~~
-    hooked-symbol inKeys{}(Map{}, Key{}) : Bool{}
+    hooked-symbol inKeys{}(Key{}, Map{}) : Bool{}
         [hook{}("MAP.in_keys")]
 ~~~
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -597,6 +597,16 @@ Takes a map and returns a list of its values.
         [hook{}("MAP.values")]
 ~~~
 
+### MAP.inclusion
+
+If the first map is a submap of the second, the result is`\dv{Bool{}}("true")`;
+otherwise the result is `\dv{Bool{}}("false")`.
+
+~~~
+    hooked-symbol inclusion{}(Map{}, Map{}) : Bool{}
+        [hook{}("MAP.inclusion")]
+~~~
+
 ## LIST
 
 Depends on `INT`.

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -192,6 +192,9 @@ symbolVerifiers =
     , ( Map.valuesKey
       , Builtin.verifySymbol Builtin.List.assertSort [assertSort]
       )
+    , ( Map.inclusionKey
+      , Builtin.verifySymbol Bool.assertSort [assertSort, assertSort]
+      )
     ]
 
 {- | Abort function evaluation if the argument is not a Map domain value.
@@ -379,6 +382,23 @@ evalInKeys =
                 $ Bool.asPattern resultSort
                 $ Map.member _key _map
 
+evalInclusion :: Builtin.Function
+evalInclusion =
+    Builtin.functionEvaluator evalInclusion0
+  where
+    evalInclusion0 resultSort = \arguments ->
+        Builtin.getAttemptedAxiom $ do
+            let (_mapLeft, _mapRight) =
+                    case arguments of
+                        [_mapLeft, _mapRight] -> (_mapLeft, _mapRight)
+                        _ -> Builtin.wrongArity Map.inclusionKey
+            _mapLeft <- expectConcreteBuiltinMap Map.inclusionKey _mapLeft
+            _mapRight <- expectConcreteBuiltinMap Map.inclusionKey _mapRight
+
+            Builtin.appliedFunction
+                $ Bool.asPattern resultSort
+                $ Map.isSubmapOf _mapLeft _mapRight
+
 evalKeys :: Builtin.Function
 evalKeys =
     Builtin.functionEvaluator evalKeys0
@@ -516,6 +536,7 @@ builtinFunctions =
         , (Map.removeAllKey, evalRemoveAll)
         , (Map.sizeKey, evalSize)
         , (Map.valuesKey, evalValues)
+        , (Map.inclusionKey, evalInclusion)
         ]
 
 {- | Convert a Map-sorted 'TermLike' to its internal representation.

--- a/kore/src/Kore/Builtin/Map/Map.hs
+++ b/kore/src/Kore/Builtin/Map/Map.hs
@@ -15,6 +15,7 @@ module Kore.Builtin.Map.Map
     , lookupSymbolRemoveAll
     , lookupSymbolSize
     , lookupSymbolValues
+    , lookupSymbolInclusion
     , isSymbolConcat
     , isSymbolElement
     , isSymbolUnit
@@ -22,6 +23,7 @@ module Kore.Builtin.Map.Map
     , isSymbolRemoveAll
     , isSymbolSize
     , isSymbolValues
+    , isSymbolInclusion
     -- * Keys
     , concatKey
     , elementKey
@@ -36,6 +38,7 @@ module Kore.Builtin.Map.Map
     , updateKey
     , sizeKey
     , valuesKey
+    , inclusionKey
     ) where
 
 import Prelude.Kore
@@ -101,6 +104,9 @@ sizeKey = "MAP.size"
 valuesKey :: IsString s => s
 valuesKey = "MAP.values"
 
+inclusionKey :: IsString s => s
+inclusionKey = "MAP.inclusion"
+
 {- | Find the symbol hooked to @MAP.update@ in an indexed module.
  -}
 lookupSymbolUpdate
@@ -165,6 +171,14 @@ lookupSymbolValues
     -> Either (Kore.Error e) Symbol
 lookupSymbolValues = Builtin.lookupSymbol valuesKey
 
+{- | Find the symbol hooked to @MAP.inclusion@ in an indexed module.
+ -}
+lookupSymbolInclusion
+    :: Sort
+    -> VerifiedModule Attribute.Symbol
+    -> Either (Kore.Error e) Symbol
+lookupSymbolInclusion = Builtin.lookupSymbol inclusionKey
+
 {- | Check if the given symbol is hooked to @MAP.concat@.
  -}
 isSymbolConcat :: Symbol -> Bool
@@ -199,6 +213,11 @@ isSymbolSize = Builtin.isSymbol sizeKey
 -}
 isSymbolValues :: Symbol -> Bool
 isSymbolValues = Builtin.isSymbol valuesKey
+
+{- | Check if the given symbol is hooked to @MAP.inclusion@.
+-}
+isSymbolInclusion :: Symbol -> Bool
+isSymbolInclusion = Builtin.isSymbol inclusionKey
 
 {- | Externalizes a 'Domain.InternalMap' as a 'TermLike'.
  -}

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -462,6 +462,10 @@ valuesMapSymbol :: Internal.Symbol
 valuesMapSymbol =
     builtinSymbol "valuesMap" listSort [mapSort] & hook "MAP.values"
 
+inclusionMapSymbol :: Internal.Symbol
+inclusionMapSymbol =
+    builtinSymbol "inclusionMap" boolSort [mapSort, mapSort] & hook "MAP.inclusion"
+
 unitMap :: TermLike Variable
 unitMap = mkApplySymbol unitMapSymbol []
 
@@ -535,6 +539,12 @@ valuesMap
     :: TermLike Variable
     -> TermLike Variable
 valuesMap map' = mkApplySymbol valuesMapSymbol [map']
+
+inclusionMap
+    :: TermLike Variable
+    -> TermLike Variable
+    -> TermLike Variable
+inclusionMap mapLeft mapRight = mkApplySymbol inclusionMapSymbol [mapLeft, mapRight]
 
 -- ** Pair
 
@@ -1505,6 +1515,7 @@ mapModule =
             , hookedSymbolDecl removeAllMapSymbol
             , hookedSymbolDecl sizeMapSymbol
             , hookedSymbolDecl valuesMapSymbol
+            , hookedSymbolDecl inclusionMapSymbol
             ]
         }
 

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -552,6 +552,37 @@ test_inclusion =
             (===) (Test.Bool.asPattern True) =<< evaluateT patInclusion
             (===) Pattern.top                =<< evaluateT predicate
         )
+     , testPropertyWithSolver
+        "MAP.inclusion success: empty map <= empty map"
+        (do
+            let
+                patInclusion = inclusionMap unitMap unitMap
+                predicate = mkEquals_ (Test.Bool.asInternal True) patInclusion
+            (===) (Test.Bool.asPattern True) =<< evaluateT patInclusion
+            (===) Pattern.top                =<< evaluateT predicate
+        )
+    , testPropertyWithSolver
+        "MAP.inclusion success: empty map <= any map"
+        (do
+            patSomeMap <- forAll genMapPattern
+            let
+                patInclusion = inclusionMap unitMap patSomeMap
+                predicate = mkEquals_ (Test.Bool.asInternal True) patInclusion
+            (===) (Test.Bool.asPattern True) =<< evaluateT patInclusion
+            (===) Pattern.top                =<< evaluateT predicate
+        )
+    , testPropertyWithSolver
+        "MAP.inclusion failure: !(some map <= empty map)"
+        (do
+            patKey1 <- forAll genIntegerPattern
+            patVal1 <- forAll genIntegerPattern
+            let
+                patSomeMap = elementMap patKey1 patVal1
+                patInclusion = inclusionMap patSomeMap unitMap
+                predicate = mkEquals_ (Test.Bool.asInternal False) patInclusion
+            (===) (Test.Bool.asPattern False) =<< evaluateT patInclusion
+            (===) Pattern.top                =<< evaluateT predicate
+        )
     , testPropertyWithSolver
         "MAP.inclusion failure: lhs key not included in rhs map"
         (do

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -22,6 +22,7 @@ module Test.Kore.Builtin.Map
     , test_keysList
     , test_inKeysElement
     , test_values
+    , test_inclusion
     , test_simplify
     , test_symbolic
     , test_isBuiltin
@@ -530,6 +531,72 @@ test_values =
             (===) expect      =<< evaluateT patConcreteValues
             (===) Pattern.top =<< evaluateT predicate
         )
+
+test_inclusion :: [TestTree]
+test_inclusion =
+    [testPropertyWithSolver
+        "MAP.inclusion success"
+        (do
+            patKey1 <- forAll genIntegerPattern
+            patKey2 <- forAll genIntegerPattern
+            Monad.when (patKey1 == patKey2) discard
+            patVal1 <- forAll genIntegerPattern
+            patVal2 <- forAll genIntegerPattern
+            let patMap1 = elementMap patKey1 patVal1
+                patMap2 = concatMap patMap1 (elementMap patKey2 patVal2)
+                patInclusion = inclusionMap patMap1 patMap2
+                predicate =
+                    mkImplies
+                        (mkNot (mkEquals_ patKey1 patKey2))
+                        (mkEquals_ (Test.Bool.asInternal True) patInclusion)
+            (===) (Test.Bool.asPattern True) =<< evaluateT patInclusion
+            (===) Pattern.top                =<< evaluateT predicate
+        )
+    , testPropertyWithSolver
+        "MAP.inclusion failure: lhs key not included in rhs map"
+        (do
+            patKey1 <- forAll genIntegerPattern
+            patKey2 <- forAll genIntegerPattern
+            Monad.when (patKey1 == patKey2) discard
+            patVal1 <- forAll genIntegerPattern
+            patVal2 <- forAll genIntegerPattern
+            let patMap1 = elementMap patKey1 patVal1
+                patMap2 = concatMap patMap1 (elementMap patKey2 patVal2)
+                patInclusion = inclusionMap patMap2 patMap1
+                predicate =
+                    mkImplies
+                        (mkNot (mkEquals_ patKey1 patKey2))
+                        (mkEquals_ (Test.Bool.asInternal False) patInclusion)
+            (===) (Test.Bool.asPattern False) =<< evaluateT patInclusion
+            (===) Pattern.top                 =<< evaluateT predicate
+        )
+    , testPropertyWithSolver
+        "MAP.inclusion failure: lhs key maps differently in rhs map"
+        (do
+            patKey1 <- forAll genIntegerPattern
+            patKey2 <- forAll genIntegerPattern
+            patVal1 <- forAll genIntegerPattern
+            patVal1' <- forAll genIntegerPattern
+            patVal2 <- forAll genIntegerPattern
+
+            Monad.when (patKey1 == patKey2) discard
+            Monad.when (patVal1 == patVal1') discard
+
+            let patMap1 = elementMap patKey1 patVal1
+                patMap2 = concatMap (elementMap patKey1 patVal1') (elementMap patKey2 patVal2)
+                patInclusion = inclusionMap patMap1 patMap2
+                predicate =
+                    mkImplies
+                        (mkNot (mkEquals_ patKey1 patKey2))
+                        (mkEquals_ (Test.Bool.asInternal False) patInclusion)
+            (===) (Test.Bool.asPattern False) =<< evaluateT patInclusion
+            (===) Pattern.top                 =<< evaluateT predicate
+        )
+    ]
+
+
+
+
 
 -- | Check that simplification is carried out on map elements.
 test_simplify :: TestTree


### PR DESCRIPTION
- Solves https://github.com/kframework/kore/issues/1678.
- I used `Map.isSubmapOf`, which takes `O(n + m)` time according to the docs. `O(n log m)` is also on option if this becomes an issue.
- I've added three unit tests, one positive and two negative (because of keys from the first map missing in the second and common keys mapping to different values, respectively).
- I noticed passing by that the documentation for `inKeys` seemed to be mistaken regarding argument order, so I fixed it. 

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
