### PR TITLE
Evaluate BOOL.and by unification

### DIFF
--- a/kore/src/Kore/Builtin/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool.hs
@@ -50,7 +50,6 @@ import qualified Text.Megaparsec.Char as Parsec
 import Kore.Attribute.Hook
     ( Hook (..)
     )
-import qualified Kore.Attribute.Symbol as Attribute.Symbol
 import Kore.Builtin.Bool.Bool
 import qualified Kore.Builtin.Builtin as Builtin
 import qualified Kore.Domain.Builtin as Domain
@@ -59,6 +58,7 @@ import Kore.Internal.Pattern
     ( Pattern
     )
 import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.Symbol
 import Kore.Internal.TermLike
 import Kore.Step.Simplification.Simplify
     ( TermSimplifier
@@ -210,9 +210,6 @@ termAndEquals unifyChildren a b =
 
     worker _ _ = empty
 
-getSymbolHook :: Symbol -> Maybe Text
-getSymbolHook = getHook . Attribute.Symbol.hook . symbolAttributes
-
 {- | Match a @BOOL.Bool@ builtin value.
  -}
 matchBool :: TermLike variable -> Maybe Bool
@@ -232,7 +229,7 @@ data BoolAnd term =
  -}
 matchBoolAnd :: TermLike variable -> Maybe (BoolAnd (TermLike variable))
 matchBoolAnd (App_ symbol [operand1, operand2]) = do
-    hook2 <- getSymbolHook symbol
+    hook2 <- (getHook . symbolHook) symbol
     Monad.guard (hook2 == andKey)
     return BoolAnd { symbol, operand1, operand2 }
 matchBoolAnd _ = Nothing

--- a/kore/src/Kore/Builtin/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool.hs
@@ -1,18 +1,7 @@
 {- |
-Module      : Kore.Builtin.Bool
-Description : Built-in Boolean sort
 Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
-Maintainer  : thomas.tuegel@runtimeverification.com
-Stability   : experimental
-Portability : portable
 
-This module is intended to be imported qualified, to avoid collision with other
-builtin modules.
-
-@
-    import qualified Kore.Builtin.Bool as Bool
-@
  -}
 module Kore.Builtin.Bool
     ( sort

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -19,6 +19,7 @@ module Kore.Internal.Condition
     , fromPattern
     , Conditional.fromPredicate
     , Conditional.fromSingleSubstitution
+    , Conditional.assign
     , Conditional.fromSubstitution
     , toPredicate
     , hasFreeVariable

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -14,6 +14,7 @@ module Kore.Internal.Conditional
     , fromPredicate
     , fromSubstitution
     , fromSingleSubstitution
+    , assign
     , andPredicate
     , splitTerm
     , isPredicate
@@ -77,6 +78,7 @@ import Kore.TopBottom
 import Kore.Unparser
 import Kore.Variables.UnifiedVariable
     ( MapVariables
+    , UnifiedVariable
     )
 import qualified SQL
 
@@ -380,6 +382,18 @@ fromSingleSubstitution
     => Assignment variable
     -> Conditional variable ()
 fromSingleSubstitution = from
+
+{- | A 'Conditional' assigning the 'UnifiedVariable' to the 'TermLike'.
+
+The result has a true 'Predicate'.
+
+ -}
+assign
+    :: InternalVariable variable
+    => UnifiedVariable variable
+    -> TermLike variable
+    -> Conditional variable ()
+assign uVar term = fromSingleSubstitution (Substitution.assign uVar term)
 
 {- | Combine the predicate with the conditions of the first argument.
  -}

--- a/kore/src/Kore/Internal/Symbol.hs
+++ b/kore/src/Kore/Internal/Symbol.hs
@@ -175,7 +175,8 @@ isMemo :: Symbol -> Bool
 isMemo = Attribute.isMemo . Attribute.memo . symbolAttributes
 
 noEvaluators :: Symbol -> Bool
-noEvaluators = Attribute.hasNoEvaluators . Attribute.noEvaluators . symbolAttributes
+noEvaluators =
+    Attribute.hasNoEvaluators . Attribute.noEvaluators . symbolAttributes
 
 symbolHook :: Symbol -> Attribute.Hook
 symbolHook = Attribute.hook . symbolAttributes

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -33,6 +33,7 @@ import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
+import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Endianness as Builtin.Endianness
 import qualified Kore.Builtin.List as Builtin.List
 import qualified Kore.Builtin.Map as Builtin.Map
@@ -216,6 +217,7 @@ andEqualsFunctions = fmap mapEqualsFunctions
     , (BothT,   \_ _ _ -> constructorSortInjectionAndEquals, "constructorSortInjectionAndEquals")
     , (BothT,   \_ _ _ -> constructorAndEqualsAssumesDifferentHeads, "constructorAndEqualsAssumesDifferentHeads")
     , (BothT,   \_ _ s -> overloadedConstructorSortInjectionAndEquals s, "overloadedConstructorSortInjectionAndEquals")
+    , (BothT,  \_ t _ -> Builtin.Bool.termAndEquals t, "Builtin.Bool.termAndEquals")
     , (BothT,   \_ _ _ -> Builtin.Endianness.unifyEquals, "Builtin.Endianness.unifyEquals")
     , (BothT,   \_ _ _ -> Builtin.Signedness.unifyEquals, "Builtin.Signedness.unifyEquals")
     , (BothT,   \_ _ s -> Builtin.Map.unifyEquals s, "Builtin.Map.unifyEquals")
@@ -609,10 +611,6 @@ domainValueAndEqualsAssumesDifferent
 domainValueAndEqualsAssumesDifferent
     first@(DV_ _ _)
     second@(DV_ _ _)
-  = lift $ cannotUnifyDomainValues first second
-domainValueAndEqualsAssumesDifferent
-    first@(Builtin_ (Domain.BuiltinBool _))
-    second@(Builtin_ (Domain.BuiltinBool _))
   = lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
     first@(Builtin_ (Domain.BuiltinInt _))

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -217,7 +217,7 @@ andEqualsFunctions = fmap mapEqualsFunctions
     , (BothT,   \_ _ _ -> constructorSortInjectionAndEquals, "constructorSortInjectionAndEquals")
     , (BothT,   \_ _ _ -> constructorAndEqualsAssumesDifferentHeads, "constructorAndEqualsAssumesDifferentHeads")
     , (BothT,   \_ _ s -> overloadedConstructorSortInjectionAndEquals s, "overloadedConstructorSortInjectionAndEquals")
-    , (BothT,  \_ t _ -> Builtin.Bool.termAndEquals t, "Builtin.Bool.termAndEquals")
+    , (BothT,   \_ _ s -> Builtin.Bool.termAndEquals s, "Builtin.Bool.termAndEquals")
     , (BothT,   \_ _ _ -> Builtin.Endianness.unifyEquals, "Builtin.Endianness.unifyEquals")
     , (BothT,   \_ _ _ -> Builtin.Signedness.unifyEquals, "Builtin.Signedness.unifyEquals")
     , (BothT,   \_ _ s -> Builtin.Map.unifyEquals s, "Builtin.Map.unifyEquals")

--- a/kore/test/Test/Kore/Builtin/Bool.hs
+++ b/kore/test/Test/Kore/Builtin/Bool.hs
@@ -8,8 +8,8 @@ module Test.Kore.Builtin.Bool
     , test_eq
     , test_not
     , test_implies
-    , test_simplification
     , hprop_unparse
+    , test_termAndEquals
     --
     , asPattern
     , asInternal
@@ -17,15 +17,28 @@ module Test.Kore.Builtin.Bool
 
 import Prelude.Kore
 
-import Hedgehog
+import Hedgehog hiding
+    ( test
+    )
 import qualified Hedgehog.Gen as Gen
 import Test.Tasty
 
+import Control.Error
+    ( runMaybeT
+    )
 import qualified Data.Text as Text
 
 import qualified Kore.Builtin.Bool as Bool
-import Kore.Internal.Pattern
+import qualified Kore.Internal.Condition as Condition
+import Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike
+import Kore.Step.Simplification.Data
+    ( runSimplifier
+    )
+import Kore.Unification.UnifierT
+    ( runUnifierT
+    )
+import Kore.Variables.UnifiedVariable
 import qualified SMT
 
 import Test.Kore.Builtin.Builtin
@@ -105,36 +118,76 @@ testUnary symb impl =
   where
     name = expectHook symb
 
-test_simplification :: TestTree
-test_simplification =
-    testGroup "simplification of operators with constant arguments"
-        [ testGroup "equality"
-            [ mkEquals_ _True  _False `becomes` bottom
-            , mkEquals_ _False _True  `becomes` bottom
-            , mkEquals_ _True  _True  `becomes` top
-            , mkEquals_ _False _False `becomes` top
-            ]
-        , testGroup "and"
-            [ mkAnd _True  _False `becomes` bottom
-            , mkAnd _False _True  `becomes` bottom
-            , mkAnd _True  _True  `becomes` asPattern True
-            , mkAnd _False _False `becomes` asPattern False
-            ]
-        ]
-      where
-        _True  = asInternal True
-        _False = asInternal False
-
-        becomes :: HasCallStack
-                => TermLike Variable
-                -> Pattern Variable
-                -> TestTree
-        becomes makerInput expected = testCase "" $ do
-            actual <-
-                SMT.runSMT SMT.defaultConfig mempty
-                $ SMT.withSolver
-                $ evaluate makerInput
-            assertEqual "" expected actual
-
 hprop_unparse :: Property
 hprop_unparse = hpropUnparse (asInternal <$> Gen.bool)
+
+test_termAndEquals :: [TestTree]
+test_termAndEquals =
+    [ testGroup "literals" $ do
+        (term1, value1) <- literals
+        (term2, value2) <- literals
+        let result
+              | value1 == value2 = [Just (Pattern.fromTermLike term1)]
+              | otherwise        = []
+        [test "" term1 term2 result]
+    ,
+        let term1 = _True
+            term2 = andBool (mkVar x) (mkVar y)
+            condition =
+                Condition.assign x _True
+                <> Condition.assign y _True
+            result = [Just (Pattern.withCondition _True condition)]
+        in
+            test "BOOL.and - true" term1 term2 result
+    ,
+        let term1 = _False
+            term2 = andBool (mkVar x) (mkVar y)
+            result = [Nothing]
+        in
+            test "BOOL.and - false" term1 term2 result
+    ]
+  where
+    _True  = asInternal True
+    _False = asInternal False
+    literals = [(_True, True), (_False, False)]
+    x = ElemVar (elemVarS "x" boolSort)
+    y = ElemVar (elemVarS "y" boolSort)
+
+    test
+        :: HasCallStack
+        => TestName
+        -> TermLike Variable
+        -> TermLike Variable
+        -> [Maybe (Pattern Variable)]
+        -> TestTree
+    test testName term1 term2 expected =
+        testCase testName $ do
+            actual <- unify term1 term2
+            assertEqual "" expected actual
+
+    unify term1 term2 =
+        run (Bool.termAndEquals termSimplifier term1 term2)
+        >>= expectRight
+
+    run =
+        SMT.runNoSMT mempty
+        . runSimplifier testEnv
+        . runUnifierT
+        . runMaybeT
+
+    expectRight (Right r) = return r
+    expectRight (Left  _) = assertFailure "Expected Right"
+
+    termSimplifier = \term1 term2 ->
+        runMaybeT (worker term1 term2 <|> worker term2 term1)
+        >>= maybe (fallback term1 term2) return
+      where
+        worker term1 term2
+          | ElemVar_ var <- term1 =
+            Pattern.assign (ElemVar var) term2
+            & return
+          | otherwise = empty
+        fallback term1 term2 =
+            mkAnd term1 term2
+            & Pattern.fromTermLike
+            & return

--- a/test/bmc/fail-3-bmc-spec.k.out.golden
+++ b/test/bmc/fail-3-bmc-spec.k.out.golden
@@ -14,7 +14,13 @@
   }
 #And
   {
-    0 <Int X andBool X <=Int 5
-  #Equals
     true
+  #Equals
+    0 <Int X
+  }
+#And
+  {
+    true
+  #Equals
+    X <=Int 5
   }

--- a/test/bmc/fail-4-bmc-spec.k.out.golden
+++ b/test/bmc/fail-4-bmc-spec.k.out.golden
@@ -8,13 +8,19 @@
   </T>
 #And
   {
-    5 <Int X andBool X <Int 8
+    X >Int 5
   #Equals
     true
   }
 #And
   {
-    X >Int 5
-  #Equals
     true
+  #Equals
+    5 <Int X
+  }
+#And
+  {
+    true
+  #Equals
+    X <Int 8
   }

--- a/test/regression-wasm-semantics-840390f/test-memory-concrete-type.sh.out.golden
+++ b/test/regression-wasm-semantics-840390f/test-memory-concrete-type.sh.out.golden
@@ -269,44 +269,57 @@
                     /* Created: Kore.Internal.Predicate.makeAndPredicate */
                     /* Sfa */
                     \and{SortGeneratedTopCell{}}(
+                        /* Created: Kore.Internal.Predicate.makeAndPredicate */
                         /* Sfa */
-                        \equals{SortBool{}, SortGeneratedTopCell{}}(
-                            /* Fl Fn D Sfa */
-                            Lbl'Unds'andBool'Unds'{}(
-                                /* Fl Fn D Sfa */
-                                Lbl'Unds'andBool'Unds'{}(
-                                    /* Fl Fn D Sfa */
-                                    Lbl'Unds-LT-Eqls'Int'Unds'{}(
+                        \and{SortGeneratedTopCell{}}(
+                            /* Created: Kore.Internal.Predicate.makeAndPredicate */
+                            /* Sfa */
+                            \and{SortGeneratedTopCell{}}(
+                                /* Created: Kore.Internal.Predicate.makeAndPredicate */
+                                /* Sfa */
+                                \and{SortGeneratedTopCell{}}(
+                                    /* Sfa */
+                                    \equals{SortBool{}, SortGeneratedTopCell{}}(
                                         /* Fl Fn D Sfa */
-                                        Lbl'UndsPlus'Int'Unds'{}(
-                                            /* Fl Fn D Sfa */ VarADDR:SortInt{},
-                                            /* Fl Fn D Sfa Cl */
-                                            /* builtin: */ \dv{SortInt{}}("8")
+                                        Lbl'Unds-LT-Eqls'Int'Unds'{}(
+                                            /* Fl Fn D Sfa */
+                                            Lbl'UndsPlus'Int'Unds'{}(
+                                                /* Fl Fn D Sfa */
+                                                VarADDR:SortInt{},
+                                                /* Fl Fn D Sfa Cl */
+                                                /* builtin: */
+                                                \dv{SortInt{}}("4")
+                                            ),
+                                            /* Fl Fn D Sfa */
+                                            Lbl'UndsStar'Int'Unds'{}(
+                                                /* Fl Fn D Sfa */
+                                                VarSIZE:SortInt{},
+                                                /* Fl Fn D Sfa Cl */
+                                                /* builtin: */
+                                                \dv{SortInt{}}("65536")
+                                            )
                                         ),
-                                        /* Fl Fn D Sfa */
-                                        Lbl'UndsStar'Int'Unds'{}(
-                                            /* Fl Fn D Sfa */ VarSIZE:SortInt{},
-                                            /* Fl Fn D Sfa Cl */
-                                            /* builtin: */
-                                            \dv{SortInt{}}("65536")
-                                        )
+                                        /* Fl Fn D Sfa Cl */
+                                        /* builtin: */ \dv{SortBool{}}("true")
                                     ),
-                                    /* Fl Fn D Sfa */
-                                    Lbl'Hash'isByteMap'LParUndsRParUnds'KWASM-LEMMAS'Unds'Bool'Unds'ByteMap{}(
+                                    /* Sfa */
+                                    \equals{SortBool{}, SortGeneratedTopCell{}}(
+                                        /* Fl Fn D Sfa Cl */
+                                        /* builtin: */ \dv{SortBool{}}("true"),
                                         /* Fl Fn D Sfa */
-                                        LblByteMap'-LT-PipeUndsPipe-GT-Unds'WASM-DATA'Unds'ByteMap'Unds'Map{}(
-                                            /* Fl Fn D Sfa */ VarBM0:SortMap{}
+                                        Lbl'Hash'isByteMap'LParUndsRParUnds'KWASM-LEMMAS'Unds'Bool'Unds'ByteMap{}(
+                                            /* Fl Fn D Sfa */
+                                            LblByteMap'-LT-PipeUndsPipe-GT-Unds'WASM-DATA'Unds'ByteMap'Unds'Map{}(
+                                                /* Fl Fn D Sfa */
+                                                VarBM0:SortMap{}
+                                            )
                                         )
                                     )
                                 ),
-                                /* Fl Fn D Sfa */
-                                Lbl'Unds'andBool'Unds'{}(
-                                    /* Fl Fn D Sfa */
-                                    Lbl'Unds-LT-Eqls'Int'Unds'{}(
-                                        /* Fl Fn D Sfa Cl */
-                                        /* builtin: */ \dv{SortInt{}}("0"),
-                                        /* Fl Fn D Sfa */ VarADDR:SortInt{}
-                                    ),
+                                /* Sfa */
+                                \equals{SortBool{}, SortGeneratedTopCell{}}(
+                                    /* Fl Fn D Sfa Cl */
+                                    /* builtin: */ \dv{SortBool{}}("true"),
                                     /* Fl Fn D Sfa */
                                     Lbl'Unds-LT-'Int'Unds'{}(
                                         /* Fl Fn D Sfa */ VarADDR:SortInt{},
@@ -316,28 +329,37 @@
                                     )
                                 )
                             ),
-                            /* Fl Fn D Sfa Cl */
-                            /* builtin: */ \dv{SortBool{}}("true")
+                            /* Sfa */
+                            \equals{SortBool{}, SortGeneratedTopCell{}}(
+                                /* Fl Fn D Sfa Cl */
+                                /* builtin: */ \dv{SortBool{}}("true"),
+                                /* Fl Fn D Sfa */
+                                Lbl'Unds-LT-Eqls'Int'Unds'{}(
+                                    /* Fl Fn D Sfa */
+                                    Lbl'UndsPlus'Int'Unds'{}(
+                                        /* Fl Fn D Sfa */ VarADDR:SortInt{},
+                                        /* Fl Fn D Sfa Cl */
+                                        /* builtin: */ \dv{SortInt{}}("8")
+                                    ),
+                                    /* Fl Fn D Sfa */
+                                    Lbl'UndsStar'Int'Unds'{}(
+                                        /* Fl Fn D Sfa */ VarSIZE:SortInt{},
+                                        /* Fl Fn D Sfa Cl */
+                                        /* builtin: */ \dv{SortInt{}}("65536")
+                                    )
+                                )
+                            )
                         ),
                         /* Sfa */
                         \equals{SortBool{}, SortGeneratedTopCell{}}(
+                            /* Fl Fn D Sfa Cl */
+                            /* builtin: */ \dv{SortBool{}}("true"),
                             /* Fl Fn D Sfa */
                             Lbl'Unds-LT-Eqls'Int'Unds'{}(
-                                /* Fl Fn D Sfa */
-                                Lbl'UndsPlus'Int'Unds'{}(
-                                    /* Fl Fn D Sfa */ VarADDR:SortInt{},
-                                    /* Fl Fn D Sfa Cl */
-                                    /* builtin: */ \dv{SortInt{}}("4")
-                                ),
-                                /* Fl Fn D Sfa */
-                                Lbl'UndsStar'Int'Unds'{}(
-                                    /* Fl Fn D Sfa */ VarSIZE:SortInt{},
-                                    /* Fl Fn D Sfa Cl */
-                                    /* builtin: */ \dv{SortInt{}}("65536")
-                                )
-                            ),
-                            /* Fl Fn D Sfa Cl */
-                            /* builtin: */ \dv{SortBool{}}("true")
+                                /* Fl Fn D Sfa Cl */
+                                /* builtin: */ \dv{SortInt{}}("0"),
+                                /* Fl Fn D Sfa */ VarADDR:SortInt{}
+                            )
                         )
                     ),
                     /* Sfa */

--- a/test/symbolic-ensures/1.strict.out.golden
+++ b/test/symbolic-ensures/1.strict.out.golden
@@ -3,7 +3,13 @@
   </k>
 #And
   {
-    ?X >=Int 1 andBool ?X <=Int 3
-  #Equals
     true
+  #Equals
+    ?X <=Int 3
+  }
+#And
+  {
+    true
+  #Equals
+    ?X >=Int 1
   }


### PR DESCRIPTION
This implements internally the rule

```
\equals(andBool(X, Y), true) => \and(\equals(X, true), \equals(Y, true))
```

See also: #1648

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
