### PR TITLE
kore/package.yaml: Disable flag release by default

### DIFF
--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -31,7 +31,7 @@ flags:
   release:
     description: Build a faster runtime, at the expense of a slower build.
     manual: true
-    default: true
+    default: false
 
 dependencies:
   - base >=4.7


### PR DESCRIPTION
The K Framework release job will still build with the flag enabled, but
developers building from source will get faster builds.

Fixes: #1527 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
