### PR TITLE
default.nix: Add profiling flag

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,5 @@
+{ profiling ? false }:
+
 let
   sources = import ./nix/sources.nix;
   haskell-nix = import sources."haskell.nix";
@@ -18,6 +20,18 @@ let
   project =
     pkgs.haskell-nix.stackProject {
       src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
+      modules = [
+        {
+          # package *
+          enableLibraryProfiling = true;
+          profilingDetail = "none";
+          # package kore
+          packages.kore = {
+            enableExecutableProfiling = profiling;
+            profilingDetail = "toplevel-functions";
+          };
+        }
+      ];
     };
   shell = import ./shell.nix { inherit default; };
   default =


### PR DESCRIPTION
The `profiling` flag builds profiled executables. For convenience, libraries are
now always built with profiling enabled.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
