### PR TITLE
shell.nix: Changed type of default.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ default ? import ./default.nix }:
+{ default ? import ./default.nix {} }:
 
 let
   inherit (default) project pkgs;


### PR DESCRIPTION
Fixes a bug introduced by #1707.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
