### PR TITLE
Begin to collect the scattered parts of equation application

### DIFF
--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -37,10 +37,6 @@ import qualified Data.Text.IO as Text
     ( putStrLn
     , readFile
     )
-import Data.Text.Prettyprint.Doc
-    ( Doc
-    , vsep
-    )
 import Data.Text.Prettyprint.Doc.Render.Text
     ( hPutDoc
     , putDoc
@@ -77,9 +73,6 @@ import System.IO
 
 import qualified Data.Limit as Limit
 import Kore.Attribute.Symbol as Attribute
-import Kore.Error
-    ( printError
-    )
 import Kore.Exec
 import Kore.IndexedModule.IndexedModule
     ( VerifiedModule
@@ -153,6 +146,11 @@ import Kore.Syntax.Definition
 import qualified Kore.Syntax.Definition as Definition.DoNotUse
 import Kore.Unparser
     ( unparse
+    )
+import Pretty
+    ( Doc
+    , Pretty (..)
+    , vsep
     )
 import SMT
     ( MonadSMT
@@ -712,7 +710,7 @@ mainParseSearchPattern indexedModule patternFileName = do
             Conditional
                 { term
                 , predicate =
-                    either (error . printError) id
+                    either (error . show . pretty) id
                         (makePredicate predicateTerm)
                 , substitution = mempty
                 }

--- a/kore/src/Kore/Equation.hs
+++ b/kore/src/Kore/Equation.hs
@@ -6,6 +6,8 @@ License     : NCSA
 
 module Kore.Equation
     ( module Kore.Equation.Equation
+    , fromSentenceAxiom
     ) where
 
 import Kore.Equation.Equation
+import Kore.Equation.Sentence

--- a/kore/src/Kore/Equation.hs
+++ b/kore/src/Kore/Equation.hs
@@ -1,0 +1,11 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Equation
+    ( module Kore.Equation.Equation
+    ) where
+
+import Kore.Equation.Equation

--- a/kore/src/Kore/Equation.hs
+++ b/kore/src/Kore/Equation.hs
@@ -7,7 +7,9 @@ License     : NCSA
 module Kore.Equation
     ( module Kore.Equation.Equation
     , fromSentenceAxiom
+    , extractEquations
     ) where
 
 import Kore.Equation.Equation
+import Kore.Equation.Registry
 import Kore.Equation.Sentence

--- a/kore/src/Kore/Equation.hs
+++ b/kore/src/Kore/Equation.hs
@@ -8,8 +8,10 @@ module Kore.Equation
     ( module Kore.Equation.Equation
     , fromSentenceAxiom
     , extractEquations
+    , simplifyExtractedEquations
     ) where
 
 import Kore.Equation.Equation
 import Kore.Equation.Registry
 import Kore.Equation.Sentence
+import Kore.Equation.Simplification

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -12,6 +12,7 @@ module Kore.Equation.Equation
     , checkInstantiation, InstantiationFailure (..)
     , isSimplificationRule
     , equationPriority
+    , matchEquation, MatchEquationError (..)
     ) where
 
 import Prelude.Kore
@@ -19,6 +20,7 @@ import Prelude.Kore
 import Control.DeepSeq
     ( NFData
     )
+import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Default as Default
 import Data.Map.Strict
     ( Map
@@ -30,13 +32,24 @@ import qualified GHC.Generics as GHC
 
 import Debug
 import qualified Kore.Attribute.Axiom as Attribute
+import Kore.Attribute.Axiom.Constructor
+    ( Constructor (..)
+    )
+import Kore.Attribute.Functional
+    ( Functional (..)
+    )
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables
     , HasFreeVariables (..)
     )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+import Kore.Attribute.Subsort
+    ( Subsorts (..)
+    )
 import Kore.Internal.Predicate
-    ( Predicate
+    ( NotPredicate
+    , Predicate
+    , makePredicate
     )
 import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.Symbol
@@ -48,6 +61,7 @@ import Kore.Internal.TermLike
     , SetVariable
     , TermLike
     , Variable
+    , termLikeSort
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Step.Step
@@ -238,13 +252,13 @@ an 'Equation'.
  -}
 data InstantiationFailure variable
     = NotConcrete (UnifiedVariable variable) (TermLike variable)
-    -- ^ The instantiation was rejected because a variable was instantiated with
-    -- a symbolic term where a concrete term was required.
+    -- ^ The variable was instantiated with a symbolic term where a concrete
+    -- term was required.
     | NotSymbolic (UnifiedVariable variable) (TermLike variable)
-    -- ^ The instantiation was rejected because a variable was instantiated with
-    -- a concrete term where a symbolic term was required.
+    -- ^ The variable was instantiated with a concrete term where a symbolic
+    -- term was required.
     | NotInstantiated (UnifiedVariable variable)
-    -- ^ The instantiation was rejected because a variable was not instantiated.
+    -- ^ The variable was not instantiated.
 
 checkInstantiation
     :: InternalVariable variable
@@ -284,3 +298,79 @@ isSimplificationRule Equation { attributes } =
 
 equationPriority :: Equation variable -> Integer
 equationPriority = Attribute.getPriorityOfAxiom . attributes
+
+data MatchEquationError variable
+    = NotEquation !(TermLike variable)
+    | RequiresError !(NotPredicate variable)
+    | EnsuresError !(NotPredicate variable)
+    | FunctionalAxiom
+    | ConstructorAxiom
+    | SubsortAxiom
+
+{- | Match a term encoding an 'QualifiedAxiomPattern'.
+
+@patternToAxiomPattern@ returns an error if the given 'TermLike' does
+not encode a normal rewrite or function axiom.
+-}
+matchEquation
+    :: forall variable
+    .  InternalVariable variable
+    => Attribute.Axiom Symbol variable
+    -> TermLike variable
+    -> Either (MatchEquationError variable) (Equation variable)
+matchEquation attributes termLike
+  | isFunctionalAxiom = Left FunctionalAxiom
+  | isConstructorAxiom = Left ConstructorAxiom
+  | isSubsortAxiom = Left SubsortAxiom
+  | TermLike.Forall_ _ _ child <- termLike = matchEquation attributes child
+  | otherwise = match termLike >>= removeRedundantEnsures
+  where
+    isFunctionalAxiom = (isDeclaredFunctional . Attribute.functional) attributes
+    isConstructorAxiom = (isConstructor . Attribute.constructor) attributes
+    isSubsortAxiom = (not . null . getSubsorts . Attribute.subsorts) attributes
+    match
+        (TermLike.Implies_ _
+            requires
+            (TermLike.And_ _
+                (TermLike.Equals_ _ _ left right)
+                ensures
+            )
+        )
+      = do
+        requires' <- makePredicate requires & Bifunctor.first RequiresError
+        ensures' <- makePredicate ensures & Bifunctor.first EnsuresError
+        pure Equation
+            { requires = requires'
+            , left
+            , right
+            , ensures = ensures'
+            , attributes
+            }
+
+    match (TermLike.Equals_ _ sort left right) =
+        pure Equation
+            { requires = Predicate.makeTruePredicate sort
+            , left
+            , right
+            , ensures = Predicate.makeTruePredicate sort
+            , attributes
+            }
+
+    match left@(TermLike.Ceil_ _ sort _) =
+        pure Equation
+            { requires = Predicate.makeTruePredicate sort
+            , left
+            , right = TermLike.mkTop sort
+            , ensures = Predicate.makeTruePredicate sort
+            , attributes
+            }
+
+    match termLike' = Left (NotEquation termLike')
+
+    -- If the ensures and requires are the same, then the ensures is redundant.
+    removeRedundantEnsures equation@Equation { requires, ensures }
+      | ensures == requires =
+        return equation { ensures = Predicate.makeTruePredicate sort }
+      | otherwise = return equation
+      where
+        sort = termLikeSort (Predicate.unwrapPredicate ensures)

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -7,6 +7,8 @@ License     : NCSA
 module Kore.Equation.Equation
     ( Equation (..)
     , mkEquation
+    , mapVariables
+    , refreshVariables
     ) where
 
 import Prelude.Kore
@@ -15,13 +17,17 @@ import Control.DeepSeq
     ( NFData
     )
 import qualified Data.Default as Default
+import qualified Data.Map.Strict as Map
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
 import Debug
 import qualified Kore.Attribute.Axiom as Attribute
-    ( Axiom
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables
+    , HasFreeVariables (..)
     )
+import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import Kore.Internal.Predicate
     ( Predicate
     )
@@ -30,14 +36,23 @@ import Kore.Internal.Symbol
     ( Symbol
     )
 import Kore.Internal.TermLike
-    ( InternalVariable
+    ( ElementVariable
+    , InternalVariable
+    , SetVariable
     , TermLike
     , Variable
     )
 import qualified Kore.Internal.TermLike as TermLike
+import Kore.Step.Step
+    ( Renaming
+    )
 import Kore.TopBottom
 import Kore.Unparser
     ( Unparse (..)
+    )
+import qualified Kore.Variables.Fresh as Fresh
+import Kore.Variables.UnifiedVariable
+    ( UnifiedVariable (..)
     )
 import Pretty
     ( Pretty (..)
@@ -141,3 +156,72 @@ instance
             )
       where
         Equation { left, requires, right, ensures } = equation
+
+instance
+    InternalVariable variable
+    => HasFreeVariables (Equation variable) variable
+  where
+    freeVariables rule@(Equation _ _ _ _ _) = case rule of
+        Equation { left, requires, right, ensures } ->
+            freeVariables left
+            <> freeVariables requires
+            <> freeVariables right
+            <> freeVariables ensures
+
+mapVariables
+    :: (Ord variable1, InternalVariable variable2)
+    => (ElementVariable variable1 -> ElementVariable variable2)
+    -> (SetVariable variable1 -> SetVariable variable2)
+    -> Equation variable1 -> Equation variable2
+mapVariables mapElemVar mapSetVar equation@(Equation _ _ _ _ _) =
+    equation
+        { requires = mapPredicateVariables requires
+        , left = mapTermLikeVariables left
+        , right = mapTermLikeVariables right
+        , ensures = mapPredicateVariables ensures
+        , attributes =
+            Attribute.mapAxiomVariables mapElemVar mapSetVar attributes
+        }
+  where
+    Equation { requires, left, right, ensures, attributes } = equation
+    mapTermLikeVariables = TermLike.mapVariables mapElemVar mapSetVar
+    mapPredicateVariables = Predicate.mapVariables mapElemVar mapSetVar
+
+refreshVariables
+    :: InternalVariable variable
+    => FreeVariables variable
+    -> Equation variable
+    -> (Renaming variable, Equation variable)
+refreshVariables
+    (FreeVariables.getFreeVariables -> avoid)
+    equation@(Equation _ _ _ _ _)
+  =
+    let rename = Fresh.refreshVariables avoid originalFreeVariables
+        mapElemVars elemVar =
+            case Map.lookup (ElemVar elemVar) rename of
+                Just (ElemVar elemVar') -> elemVar'
+                _ -> elemVar
+        mapSetVars setVar =
+            case Map.lookup (SetVar setVar) rename of
+                Just (SetVar setVar') -> setVar'
+                _ -> setVar
+        subst = TermLike.mkVar <$> rename
+        left' = TermLike.substitute subst left
+        requires' = Predicate.substitute subst requires
+        right' = TermLike.substitute subst right
+        ensures' = Predicate.substitute subst ensures
+        attributes' =
+            Attribute.mapAxiomVariables mapElemVars mapSetVars attributes
+        equation' =
+            equation
+                { left = left'
+                , requires = requires'
+                , right = right'
+                , ensures = ensures'
+                , attributes = attributes'
+                }
+    in (rename, equation')
+  where
+    Equation { left, requires, right, ensures, attributes } = equation
+    originalFreeVariables =
+        FreeVariables.getFreeVariables $ freeVariables equation

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -46,6 +46,7 @@ import Kore.Internal.TermLike
     ( ElementVariable
     , InternalVariable
     , SetVariable
+    , Sort
     , TermLike
     , Variable
     )
@@ -80,10 +81,11 @@ data Equation variable = Equation
 -- | Creates a basic, unconstrained, Equality pattern
 mkEquation
     :: InternalVariable variable
-    => TermLike variable
+    => Sort
+    -> TermLike variable
     -> TermLike variable
     -> Equation variable
-mkEquation left right =
+mkEquation sort left right =
     assert (TermLike.termLikeSort left == TermLike.termLikeSort right)
     Equation
         { left
@@ -92,8 +94,6 @@ mkEquation left right =
         , ensures = Predicate.makeTruePredicate sort
         , attributes = Default.def
         }
-  where
-    sort = TermLike.termLikeSort left
 
 instance NFData variable => NFData (Equation variable)
 

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -4,7 +4,7 @@ License     : NCSA
 
 -}
 
-module Kore.Equation.Types
+module Kore.Equation.Equation
     ( Equation (..)
     , mkEquation
     ) where

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -49,6 +49,7 @@ import Kore.Internal.TermLike
     , Sort
     , TermLike
     , Variable
+    , termLikeSort
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Step.Step
@@ -151,17 +152,20 @@ instance
       -- unconditional equation
       | isTop requires
       , isTop ensures
-      = TermLike.mkEquals_ left right
+      = TermLike.mkEquals sort left right
 
       -- conditional equation
       | otherwise =
         TermLike.mkImplies
-            (from @(Predicate variable) requires)
+            requires'
             (TermLike.mkAnd
-                (TermLike.mkEquals_ left right)
-                (from @(Predicate variable) ensures)
+                (TermLike.mkEquals sort left right)
+                ensures'
             )
       where
+        requires' = from @(Predicate variable) requires
+        ensures' = from @(Predicate variable) ensures
+        sort = termLikeSort requires'
         Equation { left, requires, right, ensures } = equation
 
 instance

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -10,6 +10,8 @@ module Kore.Equation.Equation
     , mapVariables
     , refreshVariables
     , checkInstantiation, InstantiationFailure (..)
+    , isSimplificationRule
+    , equationPriority
     ) where
 
 import Prelude.Kore
@@ -272,3 +274,13 @@ checkInstantiation rule substitutionMap =
               | otherwise -> Nothing
     notConcretes = mapMaybe checkConcrete (Set.toList concretes)
     notSymbolics = mapMaybe checkSymbolic (Set.toList symbolics)
+
+isSimplificationRule :: Equation variable -> Bool
+isSimplificationRule Equation { attributes } =
+    isSimplification
+  where
+    Attribute.Simplification { isSimplification } =
+        Attribute.simplification attributes
+
+equationPriority :: Equation variable -> Integer
+equationPriority = Attribute.getPriorityOfAxiom . attributes

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -12,7 +12,6 @@ module Kore.Equation.Equation
     , checkInstantiation, InstantiationFailure (..)
     , isSimplificationRule
     , equationPriority
-    , matchEquation, MatchEquationError (..)
     ) where
 
 import Prelude.Kore
@@ -20,7 +19,6 @@ import Prelude.Kore
 import Control.DeepSeq
     ( NFData
     )
-import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Default as Default
 import Data.Map.Strict
     ( Map
@@ -32,24 +30,13 @@ import qualified GHC.Generics as GHC
 
 import Debug
 import qualified Kore.Attribute.Axiom as Attribute
-import Kore.Attribute.Axiom.Constructor
-    ( Constructor (..)
-    )
-import Kore.Attribute.Functional
-    ( Functional (..)
-    )
 import Kore.Attribute.Pattern.FreeVariables
     ( FreeVariables
     , HasFreeVariables (..)
     )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import Kore.Attribute.Subsort
-    ( Subsorts (..)
-    )
 import Kore.Internal.Predicate
-    ( NotPredicate
-    , Predicate
-    , makePredicate
+    ( Predicate
     )
 import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.Symbol
@@ -61,7 +48,6 @@ import Kore.Internal.TermLike
     , SetVariable
     , TermLike
     , Variable
-    , termLikeSort
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Step.Step
@@ -298,79 +284,3 @@ isSimplificationRule Equation { attributes } =
 
 equationPriority :: Equation variable -> Integer
 equationPriority = Attribute.getPriorityOfAxiom . attributes
-
-data MatchEquationError variable
-    = NotEquation !(TermLike variable)
-    | RequiresError !(NotPredicate variable)
-    | EnsuresError !(NotPredicate variable)
-    | FunctionalAxiom
-    | ConstructorAxiom
-    | SubsortAxiom
-
-{- | Match a term encoding an 'QualifiedAxiomPattern'.
-
-@patternToAxiomPattern@ returns an error if the given 'TermLike' does
-not encode a normal rewrite or function axiom.
--}
-matchEquation
-    :: forall variable
-    .  InternalVariable variable
-    => Attribute.Axiom Symbol variable
-    -> TermLike variable
-    -> Either (MatchEquationError variable) (Equation variable)
-matchEquation attributes termLike
-  | isFunctionalAxiom = Left FunctionalAxiom
-  | isConstructorAxiom = Left ConstructorAxiom
-  | isSubsortAxiom = Left SubsortAxiom
-  | TermLike.Forall_ _ _ child <- termLike = matchEquation attributes child
-  | otherwise = match termLike >>= removeRedundantEnsures
-  where
-    isFunctionalAxiom = (isDeclaredFunctional . Attribute.functional) attributes
-    isConstructorAxiom = (isConstructor . Attribute.constructor) attributes
-    isSubsortAxiom = (not . null . getSubsorts . Attribute.subsorts) attributes
-    match
-        (TermLike.Implies_ _
-            requires
-            (TermLike.And_ _
-                (TermLike.Equals_ _ _ left right)
-                ensures
-            )
-        )
-      = do
-        requires' <- makePredicate requires & Bifunctor.first RequiresError
-        ensures' <- makePredicate ensures & Bifunctor.first EnsuresError
-        pure Equation
-            { requires = requires'
-            , left
-            , right
-            , ensures = ensures'
-            , attributes
-            }
-
-    match (TermLike.Equals_ _ sort left right) =
-        pure Equation
-            { requires = Predicate.makeTruePredicate sort
-            , left
-            , right
-            , ensures = Predicate.makeTruePredicate sort
-            , attributes
-            }
-
-    match left@(TermLike.Ceil_ _ sort _) =
-        pure Equation
-            { requires = Predicate.makeTruePredicate sort
-            , left
-            , right = TermLike.mkTop sort
-            , ensures = Predicate.makeTruePredicate sort
-            , attributes
-            }
-
-    match termLike' = Left (NotEquation termLike')
-
-    -- If the ensures and requires are the same, then the ensures is redundant.
-    removeRedundantEnsures equation@Equation { requires, ensures }
-      | ensures == requires =
-        return equation { ensures = Predicate.makeTruePredicate sort }
-      | otherwise = return equation
-      where
-        sort = termLikeSort (Predicate.unwrapPredicate ensures)

--- a/kore/src/Kore/Equation/Sentence.hs
+++ b/kore/src/Kore/Equation/Sentence.hs
@@ -12,7 +12,10 @@ module Kore.Equation.Sentence
 import Prelude.Kore
 
 import qualified Data.Bifunctor as Bifunctor
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 
+import Debug
 import qualified Kore.Attribute.Axiom as Attribute
 import Kore.Attribute.Axiom.Constructor
     ( Constructor (..)
@@ -55,6 +58,13 @@ data MatchEquationError variable
     | FunctionalAxiom
     | ConstructorAxiom
     | SubsortAxiom
+    deriving (GHC.Generic)
+
+instance SOP.Generic (MatchEquationError variable)
+
+instance SOP.HasDatatypeInfo (MatchEquationError variable)
+
+instance Debug variable => Debug (MatchEquationError variable)
 
 {- | Match a term encoding an 'QualifiedAxiomPattern'.
 

--- a/kore/src/Kore/Equation/Sentence.hs
+++ b/kore/src/Kore/Equation/Sentence.hs
@@ -1,0 +1,125 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Equation.Sentence
+    ( fromSentenceAxiom
+    , matchEquation, MatchEquationError (..)
+    ) where
+
+import Prelude.Kore
+
+import qualified Data.Bifunctor as Bifunctor
+
+import qualified Kore.Attribute.Axiom as Attribute
+import Kore.Attribute.Axiom.Constructor
+    ( Constructor (..)
+    )
+import Kore.Attribute.Functional
+    ( Functional (..)
+    )
+import Kore.Attribute.Subsort
+    ( Subsorts (..)
+    )
+import Kore.Equation.Equation
+import Kore.Internal.Predicate
+    ( NotPredicate
+    , makePredicate
+    )
+import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , Symbol
+    , TermLike
+    , Variable
+    , termLikeSort
+    )
+import qualified Kore.Internal.TermLike as TermLike
+import Kore.Syntax.Sentence
+    ( SentenceAxiom (..)
+    )
+import qualified Kore.Verified as Verified
+
+fromSentenceAxiom
+    :: (Attribute.Axiom Symbol Variable, Verified.SentenceAxiom)
+    -> Either (MatchEquationError Variable) (Equation Variable)
+fromSentenceAxiom (attributes, SentenceAxiom { sentenceAxiomPattern }) =
+    matchEquation attributes sentenceAxiomPattern
+
+data MatchEquationError variable
+    = NotEquation !(TermLike variable)
+    | RequiresError !(NotPredicate variable)
+    | EnsuresError !(NotPredicate variable)
+    | FunctionalAxiom
+    | ConstructorAxiom
+    | SubsortAxiom
+
+{- | Match a term encoding an 'QualifiedAxiomPattern'.
+
+@patternToAxiomPattern@ returns an error if the given 'TermLike' does
+not encode a normal rewrite or function axiom.
+-}
+matchEquation
+    :: forall variable
+    .  InternalVariable variable
+    => Attribute.Axiom Symbol variable
+    -> TermLike variable
+    -> Either (MatchEquationError variable) (Equation variable)
+matchEquation attributes termLike
+  | isFunctionalAxiom = Left FunctionalAxiom
+  | isConstructorAxiom = Left ConstructorAxiom
+  | isSubsortAxiom = Left SubsortAxiom
+  | TermLike.Forall_ _ _ child <- termLike = matchEquation attributes child
+  | otherwise = match termLike >>= removeRedundantEnsures
+  where
+    isFunctionalAxiom = (isDeclaredFunctional . Attribute.functional) attributes
+    isConstructorAxiom = (isConstructor . Attribute.constructor) attributes
+    isSubsortAxiom = (not . null . getSubsorts . Attribute.subsorts) attributes
+    match
+        (TermLike.Implies_ _
+            requires
+            (TermLike.And_ _
+                (TermLike.Equals_ _ _ left right)
+                ensures
+            )
+        )
+      = do
+        requires' <- makePredicate requires & Bifunctor.first RequiresError
+        ensures' <- makePredicate ensures & Bifunctor.first EnsuresError
+        pure Equation
+            { requires = requires'
+            , left
+            , right
+            , ensures = ensures'
+            , attributes
+            }
+
+    match (TermLike.Equals_ _ sort left right) =
+        pure Equation
+            { requires = Predicate.makeTruePredicate sort
+            , left
+            , right
+            , ensures = Predicate.makeTruePredicate sort
+            , attributes
+            }
+
+    match left@(TermLike.Ceil_ _ sort _) =
+        pure Equation
+            { requires = Predicate.makeTruePredicate sort
+            , left
+            , right = TermLike.mkTop sort
+            , ensures = Predicate.makeTruePredicate sort
+            , attributes
+            }
+
+    match termLike' = Left (NotEquation termLike')
+
+    -- If the ensures and requires are the same, then the ensures is redundant.
+    removeRedundantEnsures equation@Equation { requires, ensures }
+      | ensures == requires =
+        return equation { ensures = Predicate.makeTruePredicate sort }
+      | otherwise = return equation
+      where
+        sort = termLikeSort (Predicate.unwrapPredicate ensures)

--- a/kore/src/Kore/Equation/Simplification.hs
+++ b/kore/src/Kore/Equation/Simplification.hs
@@ -1,0 +1,107 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Equation.Simplification
+    ( simplifyEquation
+    , simplifyExtractedEquations
+    ) where
+
+import Prelude.Kore
+
+import Control.Error
+    ( maybeT
+    )
+import qualified Control.Monad as Monad
+import Data.Map.Strict
+    ( Map
+    )
+
+import Kore.Equation.Equation
+import Kore.Internal.Conditional
+    ( Conditional (..)
+    )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+import qualified Kore.Internal.Pattern as Pattern
+import qualified Kore.Internal.Predicate as Predicate
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( topTODO
+    )
+import qualified Kore.Internal.Substitution as Substitution
+import Kore.Internal.TermLike
+    ( TermLike
+    )
+import qualified Kore.Internal.TermLike as TermLike
+import qualified Kore.Step.Simplification.Pattern as Pattern
+import qualified Kore.Step.Simplification.Simplifier as Simplifier
+import Kore.Step.Simplification.Simplify
+    ( InternalVariable
+    , MonadSimplify
+    )
+import qualified Kore.Step.Simplification.Simplify as Simplifier
+import Kore.TopBottom
+
+{- | Simplify a 'Map' of 'EqualityRule's using only Matching Logic rules.
+
+See also: 'Kore.Equation.Registry.extractEquations'
+
+ -}
+simplifyExtractedEquations
+    :: (InternalVariable variable, MonadSimplify simplifier)
+    => Map identifier [Equation variable]
+    -> simplifier (Map identifier [Equation variable])
+simplifyExtractedEquations =
+    (traverse . traverse) simplifyEquation
+
+{- | Simplify an 'Equation' using only Matching Logic rules.
+
+The original rule is returned unless the simplification result matches certain
+narrowly-defined criteria.
+
+ -}
+simplifyEquation
+    :: (InternalVariable variable, MonadSimplify simplifier)
+    => Equation variable
+    -> simplifier (Equation variable)
+simplifyEquation equation@(Equation _ _ _ _ _) =
+    do
+        let Equation { requires, left, right, ensures, attributes } = equation
+        simplified <- simplifyTermLike left >>= expectSingleResult
+        let Conditional { term, predicate, substitution } = simplified
+        Monad.guard (isTop predicate)
+        let subst = Substitution.toMap substitution
+            left' = TermLike.substitute subst term
+            requires' = TermLike.substitute subst <$> requires
+            right' = TermLike.substitute subst right
+            ensures' = TermLike.substitute subst <$> ensures
+        return Equation
+            { left = TermLike.forgetSimplified left'
+            , requires = Predicate.forgetSimplified requires'
+            , right = TermLike.forgetSimplified right'
+            , ensures = Predicate.forgetSimplified ensures'
+            , attributes = attributes
+            }
+    -- Unable to simplify the given equation, so we return the original equation
+    -- in the hope that we can do something with it later.
+    & fromMaybeT (return equation)
+  where
+    fromMaybeT = flip maybeT return
+    expectSingleResult results =
+        case OrPattern.toPatterns results of
+            [result] -> return result
+            _        -> empty
+
+-- | Simplify a 'TermLike' using only matching logic rules.
+simplifyTermLike
+    :: (InternalVariable variable, MonadSimplify simplifier)
+    => TermLike variable
+    -> simplifier (OrPattern variable)
+simplifyTermLike termLike =
+    Simplifier.localSimplifierTermLike (const Simplifier.create)
+    $ Simplifier.localSimplifierAxioms (const mempty)
+    $ Pattern.simplify SideCondition.topTODO (Pattern.fromTermLike termLike)

--- a/kore/src/Kore/Equation/Types.hs
+++ b/kore/src/Kore/Equation/Types.hs
@@ -6,6 +6,7 @@ License     : NCSA
 
 module Kore.Equation.Types
     ( Equation (..)
+    , mkEquation
     ) where
 
 import Prelude.Kore
@@ -13,6 +14,7 @@ import Prelude.Kore
 import Control.DeepSeq
     ( NFData
     )
+import qualified Data.Default as Default
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
@@ -23,11 +25,13 @@ import qualified Kore.Attribute.Axiom as Attribute
 import Kore.Internal.Predicate
     ( Predicate
     )
+import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.Symbol
     ( Symbol
     )
 import Kore.Internal.TermLike
     ( TermLike
+    , termLikeSort
     )
 import Kore.Internal.Variable
 import Kore.TopBottom
@@ -89,3 +93,21 @@ instance SQL.Table (Equation Variable)
 instance SQL.Column (Equation Variable) where
     defineColumn = SQL.defineForeignKeyColumn
     toColumn = SQL.toForeignKeyColumn
+
+-- | Creates a basic, unconstrained, Equality pattern
+mkEquation
+    :: InternalVariable variable
+    => TermLike variable
+    -> TermLike variable
+    -> Equation variable
+mkEquation left right =
+    assert (termLikeSort left == termLikeSort right)
+    Equation
+        { left
+        , requires = Predicate.makeTruePredicate sort
+        , right
+        , ensures = Predicate.makeTruePredicate sort
+        , attributes = Default.def
+        }
+  where
+    sort = termLikeSort left

--- a/kore/src/Kore/Equation/Types.hs
+++ b/kore/src/Kore/Equation/Types.hs
@@ -1,0 +1,91 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Equation.Types
+    ( Equation (..)
+    ) where
+
+import Prelude.Kore
+
+import Control.DeepSeq
+    ( NFData
+    )
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Debug
+import qualified Kore.Attribute.Axiom as Attribute
+    ( Axiom
+    )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
+import Kore.Internal.Symbol
+    ( Symbol
+    )
+import Kore.Internal.TermLike
+    ( TermLike
+    )
+import Kore.Internal.Variable
+import Kore.TopBottom
+import Kore.Unparser
+    ( Unparse (..)
+    )
+import Pretty
+    ( Pretty (..)
+    )
+import qualified Pretty
+import qualified SQL
+
+data Equation variable = Equation
+    { requires :: !(Predicate variable)
+    , left  :: !(TermLike variable)
+    , right :: !(TermLike variable)
+    , ensures :: !(Predicate variable)
+    , attributes :: !(Attribute.Axiom Symbol variable)
+    }
+    deriving (Eq, Ord, Show)
+    deriving (GHC.Generic)
+
+instance NFData variable => NFData (Equation variable)
+
+instance SOP.Generic (Equation variable)
+
+instance SOP.HasDatatypeInfo (Equation variable)
+
+instance Debug variable => Debug (Equation variable)
+
+instance (Debug variable, Diff variable) => Diff (Equation variable)
+
+instance InternalVariable variable => Pretty (Equation variable) where
+    pretty equation@(Equation _ _ _ _ _) =
+        Pretty.vsep
+            [ "requires:"
+            , Pretty.indent 4 (unparse requires)
+            , "left:"
+            , Pretty.indent 4 (unparse left)
+            , "right:"
+            , Pretty.indent 4 (unparse right)
+            , "ensures:"
+            , Pretty.indent 4 (unparse ensures)
+            ]
+      where
+        Equation
+            { requires
+            , left
+            , right
+            , ensures
+            } = equation
+
+instance TopBottom (Equation variable) where
+    isTop _ = False
+    isBottom _ = False
+
+instance SQL.Table (Equation Variable)
+
+instance SQL.Column (Equation Variable) where
+    defineColumn = SQL.defineForeignKeyColumn
+    toColumn = SQL.toForeignKeyColumn

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -574,7 +574,7 @@ instance InternalVariable variable => Pretty (NotPredicate variable) where
     pretty (NotPredicate termLikeF) =
         Pretty.vsep
         [ "Expected a predicate, but found:"
-        , (Pretty.indent 4) (unparse termLikeF)
+        , Pretty.indent 4 (unparse termLikeF)
         ]
 
 makePredicate

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -13,7 +13,7 @@ module Kore.Internal.Predicate
     , freshVariable
     , isFalse
     , depth
-    , makePredicate
+    , makePredicate, NotPredicate (..)
     , isPredicate
     , makeAndPredicate
     , makeMultipleAndPredicate
@@ -98,10 +98,6 @@ import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Pattern as Attribute.Pattern.DoNotUse
 import Kore.Attribute.Pattern.FreeVariables
 import Kore.Debug
-import Kore.Error
-    ( Error
-    , koreFail
-    )
 import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
     )
@@ -131,6 +127,10 @@ import Kore.Variables.Fresh
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
+import Pretty
+    ( Pretty (..)
+    )
+import qualified Pretty
 import qualified SQL
 
 {-| 'GenericPredicate' is a wrapper for predicates used for type safety.
@@ -560,24 +560,41 @@ instance Semigroup HasChanged where
 instance Monoid HasChanged where
     mempty = NotChanged
 
+newtype NotPredicate variable
+    = NotPredicate (TermLikeF variable (Predicate variable))
+    deriving (GHC.Generic)
+
+instance SOP.Generic (NotPredicate variable)
+
+instance SOP.HasDatatypeInfo (NotPredicate variable)
+
+instance Debug variable => Debug (NotPredicate variable)
+
+instance InternalVariable variable => Pretty (NotPredicate variable) where
+    pretty (NotPredicate termLikeF) =
+        Pretty.vsep
+        [ "Expected a predicate, but found:"
+        , (Pretty.indent 4) (unparse termLikeF)
+        ]
+
 makePredicate
-    :: forall variable e
+    :: forall variable
     .  InternalVariable variable
     => TermLike variable
-    -> Either (Error e) (Predicate variable)
+    -> Either (NotPredicate variable) (Predicate variable)
 makePredicate t = fst <$> makePredicateWorker t
   where
     makePredicateWorker
         :: TermLike variable
-        -> Either (Error e) (Predicate variable, HasChanged)
+        -> Either (NotPredicate variable) (Predicate variable, HasChanged)
     makePredicateWorker =
         Recursive.elgot makePredicateBottomUp makePredicateTopDown
 
     makePredicateBottomUp
         :: Base
             (TermLike variable)
-            (Either (Error e) (Predicate variable, HasChanged))
-        -> Either (Error e) (Predicate variable, HasChanged)
+            (Either (NotPredicate variable) (Predicate variable, HasChanged))
+        -> Either (NotPredicate variable) (Predicate variable, HasChanged)
     makePredicateBottomUp termE = do
         termWithChanged <- sequence termE
         let dropChanged
@@ -607,8 +624,7 @@ makePredicate t = fst <$> makePredicateWorker t
                 makeExistsPredicate (existsVariable p) (existsChild p)
             ForallF p -> return $
                 makeForallPredicate (forallVariable p) (forallChild p)
-            p -> koreFail
-                ("Cannot translate to predicate: " ++ show p)
+            p -> Left (NotPredicate p)
         return
             (keepSimplifiedAndUpdateChanged
                 childChanged
@@ -619,7 +635,7 @@ makePredicate t = fst <$> makePredicateWorker t
     makePredicateTopDown
         :: TermLike variable
         -> Either
-            (Either (Error e) (Predicate variable, HasChanged))
+            (Either (NotPredicate variable) (Predicate variable, HasChanged))
             (Base (TermLike variable) (TermLike variable))
     makePredicateTopDown (Recursive.project -> projected@(attrs :< pat)) =
         case pat of

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -182,6 +182,10 @@ instance InternalVariable variable => SQL.Column (Predicate variable) where
     defineColumn _ = SQL.defineColumn (SQL.Proxy @(TermLike variable))
     toColumn (GenericPredicate termLike) = SQL.toColumn termLike
 
+instance From (Predicate variable) (TermLike variable) where
+    from = unwrapPredicate
+    {-# INLINE from #-}
+
 {- 'compactPredicatePredicate' removes one level of 'GenericPredicate' which
 sometimes occurs when, say, using Predicates as Traversable.
 -}

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -9,7 +9,7 @@ Portability : portable
 -}
 module Kore.Step.Axiom.Registry
     ( extractEqualityAxioms
-    , axiomPatternsToEvaluators
+    , mkEvaluatorRegistry
     , partitionEquations
     , PartitionedEquations (..)
     ) where
@@ -169,10 +169,10 @@ equalitiesToEvaluators
             then Nothing
             else Just . definitionEvaluation $ from <$> functionRules
 
-axiomPatternsToEvaluators
-    :: Map.Map AxiomIdentifier [Equation Variable]
-    -> Map.Map AxiomIdentifier BuiltinAndAxiomSimplifier
-axiomPatternsToEvaluators =
+mkEvaluatorRegistry
+    :: Map AxiomIdentifier [Equation Variable]
+    -> Map AxiomIdentifier BuiltinAndAxiomSimplifier
+mkEvaluatorRegistry =
     mapMaybe (equalitiesToEvaluators . partitionEquations)
 
 {- | Should we ignore the 'EqualityRule' for evaluation or simplification?

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -10,7 +10,7 @@ Portability : portable
 module Kore.Step.Axiom.Registry
     ( extractEqualityAxioms
     , axiomPatternsToEvaluators
-    , processEqualityRules
+    , partitionEquations
     , PartitionedEquations (..)
     ) where
 
@@ -123,10 +123,10 @@ data PartitionedEquations =
 -- | Filters and partitions a list of 'EqualityRule's to
 -- simplification rules and function rules. The function rules
 -- are also sorted in order of priority.
-processEqualityRules
+partitionEquations
     :: [Equation Variable]
     -> PartitionedEquations
-processEqualityRules equations =
+partitionEquations equations =
     PartitionedEquations
         { functionRules
         , simplificationRules
@@ -173,7 +173,7 @@ axiomPatternsToEvaluators
     :: Map.Map AxiomIdentifier [Equation Variable]
     -> Map.Map AxiomIdentifier BuiltinAndAxiomSimplifier
 axiomPatternsToEvaluators =
-    mapMaybe (equalitiesToEvaluators . processEqualityRules)
+    mapMaybe (equalitiesToEvaluators . partitionEquations)
 
 {- | Should we ignore the 'EqualityRule' for evaluation or simplification?
 

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -76,16 +76,16 @@ import qualified Kore.Verified as Verified
  -}
 extractEqualityAxioms
     :: VerifiedModule StepperAttributes
-    -> Map AxiomIdentifier [EqualityRule Variable]
+    -> Map AxiomIdentifier [Equation Variable]
 extractEqualityAxioms =
     Foldable.foldl' extractModuleAxioms Map.empty
     . indexedModulesInScope
   where
     -- | Update the map of function axioms with all the axioms in one module.
     extractModuleAxioms
-        :: Map AxiomIdentifier [EqualityRule Variable]
+        :: Map AxiomIdentifier [Equation Variable]
         -> VerifiedModule StepperAttributes
-        -> Map AxiomIdentifier [EqualityRule Variable]
+        -> Map AxiomIdentifier [Equation Variable]
     extractModuleAxioms axioms imod =
         Foldable.foldl' extractSentenceAxiom axioms sentences
       where
@@ -95,9 +95,9 @@ extractEqualityAxioms =
     -- axioms with it. The map is returned unmodified in case the sentence is
     -- not a function axiom.
     extractSentenceAxiom
-        :: Map AxiomIdentifier [EqualityRule Variable]
+        :: Map AxiomIdentifier [Equation Variable]
         -> (Attribute.Axiom Symbol Variable, Verified.SentenceAxiom)
-        -> Map AxiomIdentifier [EqualityRule Variable]
+        -> Map AxiomIdentifier [Equation Variable]
     extractSentenceAxiom axioms sentence =
         let
             namedAxiom = axiomToIdAxiomPatternPair sentence
@@ -106,19 +106,19 @@ extractEqualityAxioms =
 
     -- | Update the map of function axioms by inserting the axiom at the key.
     insertAxiom
-        :: Map AxiomIdentifier [EqualityRule Variable]
-        -> (AxiomIdentifier, EqualityRule Variable)
-        -> Map AxiomIdentifier [EqualityRule Variable]
+        :: Map AxiomIdentifier [Equation Variable]
+        -> (AxiomIdentifier, Equation Variable)
+        -> Map AxiomIdentifier [Equation Variable]
     insertAxiom axioms (name, patt) =
         Map.alter (Just . (patt :) . fromMaybe []) name axioms
 
 axiomToIdAxiomPatternPair
     :: (Attribute.Axiom Symbol Variable, SentenceAxiom (TermLike Variable))
-    -> Maybe (AxiomIdentifier, EqualityRule Variable)
+    -> Maybe (AxiomIdentifier, Equation Variable)
 axiomToIdAxiomPatternPair axiom = do
     equation@Equation { left } <- hush $ Equation.fromSentenceAxiom axiom
     identifier <- AxiomIdentifier.matchAxiomIdentifier left
-    pure (identifier, from @(Equation Variable) equation)
+    pure (identifier, equation)
 
 data PartitionedEqualityRules =
     PartitionedEqualityRules

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -11,7 +11,7 @@ module Kore.Step.Axiom.Registry
     ( extractEqualityAxioms
     , axiomPatternsToEvaluators
     , processEqualityRules
-    , PartitionedEqualityRules (..)
+    , PartitionedEquations (..)
     ) where
 
 import Prelude.Kore
@@ -114,8 +114,8 @@ axiomToIdAxiomPatternPair axiom = do
     identifier <- AxiomIdentifier.matchAxiomIdentifier left
     pure (identifier, equation)
 
-data PartitionedEqualityRules =
-    PartitionedEqualityRules
+data PartitionedEquations =
+    PartitionedEquations
         { functionRules       :: ![Equation Variable]
         , simplificationRules :: ![Equation Variable]
         }
@@ -125,9 +125,9 @@ data PartitionedEqualityRules =
 -- are also sorted in order of priority.
 processEqualityRules
     :: [Equation Variable]
-    -> PartitionedEqualityRules
+    -> PartitionedEquations
 processEqualityRules equations =
-    PartitionedEqualityRules
+    PartitionedEquations
         { functionRules
         , simplificationRules
         }
@@ -144,10 +144,10 @@ processEqualityRules equations =
 -- | Converts a collection of processed 'EqualityRule's to one of
 -- 'BuiltinAndAxiomSimplifier's
 equalitiesToEvaluators
-    :: PartitionedEqualityRules
+    :: PartitionedEquations
     -> Maybe BuiltinAndAxiomSimplifier
 equalitiesToEvaluators
-    PartitionedEqualityRules { functionRules, simplificationRules }
+    PartitionedEquations { functionRules, simplificationRules }
   =
     case (simplificationEvaluator, definitionEvaluator) of
         (Nothing, Nothing) -> Nothing

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -1,51 +1,25 @@
-{-|
-Module      : Kore.Step.Axiom.Registry
-Description : Creates a registry of axiom/builtin-based evaluators.
+{- |
 Copyright   : (c) Runtime Verification, 2018
 License     : NCSA
-Maintainer  : virgil.serbanuta@runtimeverification.com
-Stability   : experimental
-Portability : portable
+
 -}
+
 module Kore.Step.Axiom.Registry
-    ( extractEquations
-    , mkEvaluatorRegistry
-    , partitionEquations
-    , PartitionedEquations (..)
+    ( mkEvaluatorRegistry
+    , extractEquations
     ) where
 
 import Prelude.Kore
 
-import Control.Error
-    ( hush
-    )
-import qualified Data.Foldable as Foldable
-import Data.List
-    ( partition
-    , sortOn
-    )
 import Data.Map.Strict
     ( Map
     )
-import qualified Data.Map.Strict as Map
 
-import Kore.Attribute.Axiom
-    ( Assoc (Assoc)
-    , Comm (Comm)
-    , Idem (Idem)
-    , Unit (Unit)
-    )
-import qualified Kore.Attribute.Axiom as Attribute
-import Kore.Attribute.Overload
-import qualified Kore.Attribute.Pattern as Pattern
-import Kore.Attribute.Symbol
-    ( StepperAttributes
-    )
 import Kore.Equation
     ( Equation (..)
     )
-import qualified Kore.Equation as Equation
-import Kore.IndexedModule.IndexedModule
+-- TODO (thomas.tuegel): Remove private import
+import Kore.Equation.Registry
 import Kore.Internal.TermLike
 import Kore.Step.Axiom.EvaluationStrategy
     ( definitionEvaluation
@@ -56,96 +30,16 @@ import Kore.Step.Axiom.EvaluationStrategy
 import Kore.Step.Axiom.Identifier
     ( AxiomIdentifier
     )
-import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import Kore.Step.Simplification.Simplify
     ( BuiltinAndAxiomSimplifier (..)
     )
-import Kore.Syntax.Sentence
-    ( SentenceAxiom (..)
-    )
-import qualified Kore.Verified as Verified
-
-{- | Create a mapping from symbol identifiers to their defining axioms.
-
- -}
-extractEquations
-    :: VerifiedModule StepperAttributes
-    -> Map AxiomIdentifier [Equation Variable]
-extractEquations =
-    Foldable.foldl' moduleWorker Map.empty
-    . indexedModulesInScope
-  where
-    -- | Update the map of function axioms with all the axioms in one module.
-    moduleWorker
-        :: Map AxiomIdentifier [Equation Variable]
-        -> VerifiedModule StepperAttributes
-        -> Map AxiomIdentifier [Equation Variable]
-    moduleWorker axioms imod =
-        Foldable.foldl' sentenceWorker axioms sentences
-      where
-        sentences = indexedModuleAxioms imod
-
-    -- | Extract an axiom from one sentence and update the map of function
-    -- axioms with it. The map is returned unmodified in case the sentence is
-    -- not a function axiom.
-    sentenceWorker
-        :: Map AxiomIdentifier [Equation Variable]
-        -> (Attribute.Axiom Symbol Variable, Verified.SentenceAxiom)
-        -> Map AxiomIdentifier [Equation Variable]
-    sentenceWorker axioms sentence =
-        Foldable.foldl' insertAxiom axioms (identifyEquation sentence)
-
-    -- | Update the map of function axioms by inserting the axiom at the key.
-    insertAxiom
-        :: Map AxiomIdentifier [Equation Variable]
-        -> (AxiomIdentifier, Equation Variable)
-        -> Map AxiomIdentifier [Equation Variable]
-    insertAxiom axioms (name, patt) =
-        Map.alter (Just . (patt :) . fromMaybe []) name axioms
-
-identifyEquation
-    :: (Attribute.Axiom Symbol Variable, SentenceAxiom (TermLike Variable))
-    -> Maybe (AxiomIdentifier, Equation Variable)
-identifyEquation axiom = do
-    equation@Equation { left } <- hush $ Equation.fromSentenceAxiom axiom
-    identifier <- AxiomIdentifier.matchAxiomIdentifier left
-    pure (identifier, equation)
-
-data PartitionedEquations =
-    PartitionedEquations
-        { functionRules       :: ![Equation Variable]
-        , simplificationRules :: ![Equation Variable]
-        }
-
--- | Filters and partitions a list of 'EqualityRule's to
--- simplification rules and function rules. The function rules
--- are also sorted in order of priority.
-partitionEquations
-    :: [Equation Variable]
-    -> PartitionedEquations
-partitionEquations equations =
-    PartitionedEquations
-        { functionRules
-        , simplificationRules
-        }
-  where
-    equations' =
-        equations
-        & filter (not . ignoreEquation)
-    (simplificationRules, unProcessedFunctionRules) =
-        partition Equation.isSimplificationRule
-        . sortOn Equation.equationPriority
-        $ equations'
-    functionRules = filter (not . ignoreDefinition) unProcessedFunctionRules
 
 -- | Converts a collection of processed 'EqualityRule's to one of
 -- 'BuiltinAndAxiomSimplifier's
-equalitiesToEvaluators
+mkEvaluator
     :: PartitionedEquations
     -> Maybe BuiltinAndAxiomSimplifier
-equalitiesToEvaluators
-    PartitionedEquations { functionRules, simplificationRules }
-  =
+mkEvaluator PartitionedEquations { functionRules, simplificationRules } =
     case (simplificationEvaluator, definitionEvaluator) of
         (Nothing, Nothing) -> Nothing
         (Just evaluator, Nothing) -> Just evaluator
@@ -170,37 +64,4 @@ mkEvaluatorRegistry
     :: Map AxiomIdentifier [Equation Variable]
     -> Map AxiomIdentifier BuiltinAndAxiomSimplifier
 mkEvaluatorRegistry =
-    mapMaybe (equalitiesToEvaluators . partitionEquations)
-
-{- | Should we ignore the 'EqualityRule' for evaluation or simplification?
-
-@ignoreEqualityRule@ returns 'True' if the 'EqualityRule' should not be used in
-evaluation or simplification, such as if it is an associativity or commutativity
-axiom.
-
- -}
-ignoreEquation :: Equation Variable -> Bool
-ignoreEquation Equation { attributes }
-  | isAssoc = True
-  | isComm = True
-  -- TODO (thomas.tuegel): Add unification cases for builtin units and enable
-  -- extraction of their axioms.
-  | isUnit = True
-  | isIdem = True
-  | Just _ <- getOverload = False
-  | otherwise = False
-  where
-    Assoc { isAssoc } = Attribute.assoc attributes
-    Comm { isComm } = Attribute.comm attributes
-    Unit { isUnit } = Attribute.unit attributes
-    Idem { isIdem } = Attribute.idem attributes
-    Overload { getOverload } = Attribute.overload attributes
-
-{- | Should we ignore the 'EqualityRule' for evaluating function definitions?
- -}
-ignoreDefinition :: Equation Variable -> Bool
-ignoreDefinition Equation { left } =
-    assert isLeftFunctionLike False
-  where
-    isLeftFunctionLike =
-        (Pattern.isFunction . Pattern.function) (extractAttributes left)
+    mapMaybe (mkEvaluator . partitionEquations)

--- a/kore/src/Kore/Step/Axiom/Registry.hs
+++ b/kore/src/Kore/Step/Axiom/Registry.hs
@@ -130,14 +130,18 @@ data PartitionedEqualityRules =
 -- simplification rules and function rules. The function rules
 -- are also sorted in order of priority.
 processEqualityRules
-    :: [EqualityRule Variable]
+    :: [Equation Variable]
     -> PartitionedEqualityRules
-processEqualityRules (filter (not . ignoreEqualityRule) -> equalities) =
+processEqualityRules equations =
     PartitionedEqualityRules
         { functionRules
         , simplificationRules
         }
   where
+    equalities =
+        equations
+        & map from
+        & filter (not . ignoreEqualityRule)
     (simplificationRules, unProcessedFunctionRules) =
         partition isSimplificationRule
         . sortOn getPriorityOfRule
@@ -172,7 +176,7 @@ equalitiesToEvaluators
             else Just $ definitionEvaluation functionRules
 
 axiomPatternsToEvaluators
-    :: Map.Map AxiomIdentifier [EqualityRule Variable]
+    :: Map.Map AxiomIdentifier [Equation Variable]
     -> Map.Map AxiomIdentifier BuiltinAndAxiomSimplifier
 axiomPatternsToEvaluators =
     mapMaybe (equalitiesToEvaluators . processEqualityRules)

--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -348,8 +348,8 @@ promoteSubTermsToTop predicate =
                 [ "Replacing"
                 , (Pretty.indent 4 . Pretty.vsep) (unparse <$> HashMap.keys replacements)
                 , "in"
-                , (Pretty.indent 4) (unparse original)
-                , (Pretty.indent 4) (Pretty.pretty err)
+                , Pretty.indent 4 (unparse original)
+                , Pretty.indent 4 (Pretty.pretty err)
                 ]
             Right p -> p
 

--- a/kore/src/Kore/Step/Simplification/And.hs
+++ b/kore/src/Kore/Step/Simplification/And.hs
@@ -66,9 +66,6 @@ import Changed
 import Kore.Attribute.Synthetic
     ( synthesize
     )
-import Kore.Error
-    ( printError
-    )
 import Kore.Internal.Conditional
     ( Conditional (..)
     )
@@ -129,11 +126,12 @@ import Kore.Unification.Unify
     ( MonadUnify
     )
 import Kore.Unparser
-    ( unparseToString
+    ( unparse
     )
 import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (ElemVar, SetVar)
     )
+import qualified Pretty
 
 {-|'simplify' simplifies an 'And' of 'OrPattern'.
 
@@ -345,13 +343,13 @@ promoteSubTermsToTop predicate =
         case makePredicate result of
             -- TODO (ttuegel): https://github.com/kframework/kore/issues/1442
             -- should make it impossible to have an error here.
-            Left err -> error $ unlines
+            Left err ->
+                (error . show . Pretty.vsep)
                 [ "Replacing"
-                , unlines $ map unparseToString $ HashMap.keys replacements
+                , (Pretty.indent 4 . Pretty.vsep) (unparse <$> HashMap.keys replacements)
                 , "in"
-                , unparseToString original
-                , "did not produce a predicate!"
-                , printError err
+                , (Pretty.indent 4) (unparse original)
+                , (Pretty.indent 4) (Pretty.pretty err)
                 ]
             Right p -> p
 

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -46,11 +46,17 @@ import Kore.IndexedModule.MetadataTools
 import qualified Kore.IndexedModule.MetadataToolsBuilder as MetadataTools
 import qualified Kore.IndexedModule.OverloadGraph as OverloadGraph
 import qualified Kore.IndexedModule.SortGraph as SortGraph
+import Kore.Internal.Variable
+    ( Variable
+    )
 import Kore.Profiler.Data
     ( MonadProfiler (profile)
     )
 import qualified Kore.Step.Axiom.EvaluationStrategy as Axiom.EvaluationStrategy
 import qualified Kore.Step.Axiom.Registry as Axiom.Registry
+import Kore.Step.EqualityPattern
+    ( EqualityRule
+    )
 import qualified Kore.Step.Function.Memo as Memo
 import qualified Kore.Step.Simplification.Condition as Condition
 import Kore.Step.Simplification.InjSimplifier
@@ -218,6 +224,7 @@ evalSimplifier verifiedModule simplifier = do
     initialize = do
         let equalityAxioms =
                 Axiom.Registry.extractEqualityAxioms verifiedModule'
+                & (fmap . map) (from @_ @(EqualityRule Variable))
         functionAxioms <- Rule.simplifyFunctionAxioms equalityAxioms
         let
             builtinEvaluators, userEvaluators, simplifierAxioms

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -36,6 +36,7 @@ import qualified Kore.Attribute.Symbol as Attribute
     ( Symbol
     )
 import qualified Kore.Builtin as Builtin
+import qualified Kore.Equation as Equation
 import Kore.IndexedModule.IndexedModule
     ( VerifiedModule
     )
@@ -53,7 +54,9 @@ import Kore.Profiler.Data
     ( MonadProfiler (profile)
     )
 import qualified Kore.Step.Axiom.EvaluationStrategy as Axiom.EvaluationStrategy
-import qualified Kore.Step.Axiom.Registry as Axiom.Registry
+import Kore.Step.Axiom.Registry
+    ( mkEvaluatorRegistry
+    )
 import Kore.Step.EqualityPattern
     ( EqualityRule
     )
@@ -223,7 +226,7 @@ evalSimplifier verifiedModule simplifier = do
     initialize :: SimplifierT smt (Env (SimplifierT smt))
     initialize = do
         let equalityAxioms =
-                Axiom.Registry.extractEquations verifiedModule'
+                Equation.extractEquations verifiedModule'
                 & (fmap . map) (from @_ @(EqualityRule Variable))
         functionAxioms <- Rule.simplifyFunctionAxioms equalityAxioms
         let
@@ -233,7 +236,7 @@ evalSimplifier verifiedModule simplifier = do
                 Axiom.EvaluationStrategy.builtinEvaluation
                 <$> Builtin.koreEvaluators verifiedModule'
             userEvaluators =
-                Axiom.Registry.mkEvaluatorRegistry
+                mkEvaluatorRegistry
                 $ (fmap . map) from functionAxioms
             simplifierAxioms =
                 Map.unionWith

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -223,7 +223,7 @@ evalSimplifier verifiedModule simplifier = do
     initialize :: SimplifierT smt (Env (SimplifierT smt))
     initialize = do
         let equalityAxioms =
-                Axiom.Registry.extractEqualityAxioms verifiedModule'
+                Axiom.Registry.extractEquations verifiedModule'
                 & (fmap . map) (from @_ @(EqualityRule Variable))
         functionAxioms <- Rule.simplifyFunctionAxioms equalityAxioms
         let

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -233,7 +233,8 @@ evalSimplifier verifiedModule simplifier = do
                 Axiom.EvaluationStrategy.builtinEvaluation
                 <$> Builtin.koreEvaluators verifiedModule'
             userEvaluators =
-                Axiom.Registry.axiomPatternsToEvaluators functionAxioms
+                Axiom.Registry.axiomPatternsToEvaluators
+                $ (fmap . map) from functionAxioms
             simplifierAxioms =
                 Map.unionWith
                     Axiom.EvaluationStrategy.simplifierWithFallback

--- a/kore/src/Kore/Step/Simplification/Data.hs
+++ b/kore/src/Kore/Step/Simplification/Data.hs
@@ -233,7 +233,7 @@ evalSimplifier verifiedModule simplifier = do
                 Axiom.EvaluationStrategy.builtinEvaluation
                 <$> Builtin.koreEvaluators verifiedModule'
             userEvaluators =
-                Axiom.Registry.axiomPatternsToEvaluators
+                Axiom.Registry.mkEvaluatorRegistry
                 $ (fmap . map) from functionAxioms
             simplifierAxioms =
                 Map.unionWith

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -353,7 +353,9 @@ simplifyInternal term sideCondition = do
                         resultTerm
                     )
                 )
-          | isTop resultTerm && Right resultPredicate == termAsPredicate
+          | isTop resultTerm
+          , Right condition <- termAsPredicate
+          , resultPredicate == condition
           = return
                 $ OrPattern.fromPattern
                 $ Pattern.fromCondition

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -9,6 +9,7 @@ module Kore.Step.Step
     ( UnifiedRule
     , Result
     , Results
+    , Renaming
     , UnifyingRule (..)
     , InstantiationFailure (..)
     , unifyRules

--- a/kore/src/Kore/Strategies/Goal.hs
+++ b/kore/src/Kore/Strategies/Goal.hs
@@ -575,7 +575,7 @@ data TransitionRuleTemplate monad goal =
 logTransitionRule
     :: forall m goal
     .  MonadSimplify m
-    => goal ~ (ReachabilityRule Variable)
+    => goal ~ ReachabilityRule Variable
     =>  (  Prim goal
         -> ProofState goal goal
         -> Strategy.TransitionT (Rule goal) m (ProofState goal goal)

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -1,0 +1,12 @@
+module Test.Expect
+    ( expectRight
+    ) where
+
+import Prelude.Kore
+
+import Debug
+
+import Test.Tasty.HUnit.Ext
+
+expectRight :: Debug left => Either left right -> IO right
+expectRight = either (assertFailure . show . debug) return

--- a/kore/test/Test/Kore/Attribute/Overload.hs
+++ b/kore/test/Test/Kore/Attribute/Overload.hs
@@ -131,7 +131,7 @@ test_dont_ignore =
                 assertFailure "Should not ignore overloaded production axiom"
             Just _ -> return ()
   where
-    evaluators = axiomPatternsToEvaluators $ extractEqualityAxioms indexedModule
+    evaluators = mkEvaluatorRegistry $ extractEqualityAxioms indexedModule
     verifiedModules =
         assertRight
         $ verifyAndIndexDefinition Builtin.koreVerifiers testDefinition

--- a/kore/test/Test/Kore/Attribute/Overload.hs
+++ b/kore/test/Test/Kore/Attribute/Overload.hs
@@ -131,10 +131,7 @@ test_dont_ignore =
                 assertFailure "Should not ignore overloaded production axiom"
             Just _ -> return ()
   where
-    evaluators =
-        axiomPatternsToEvaluators
-        $ (fmap . map) from
-        $ extractEqualityAxioms indexedModule
+    evaluators = axiomPatternsToEvaluators $ extractEqualityAxioms indexedModule
     verifiedModules =
         assertRight
         $ verifyAndIndexDefinition Builtin.koreVerifiers testDefinition

--- a/kore/test/Test/Kore/Attribute/Overload.hs
+++ b/kore/test/Test/Kore/Attribute/Overload.hs
@@ -131,7 +131,7 @@ test_dont_ignore =
                 assertFailure "Should not ignore overloaded production axiom"
             Just _ -> return ()
   where
-    evaluators = mkEvaluatorRegistry $ extractEqualityAxioms indexedModule
+    evaluators = mkEvaluatorRegistry $ extractEquations indexedModule
     verifiedModules =
         assertRight
         $ verifyAndIndexDefinition Builtin.koreVerifiers testDefinition

--- a/kore/test/Test/Kore/Attribute/Overload.hs
+++ b/kore/test/Test/Kore/Attribute/Overload.hs
@@ -132,7 +132,9 @@ test_dont_ignore =
             Just _ -> return ()
   where
     evaluators =
-        axiomPatternsToEvaluators $ extractEqualityAxioms indexedModule
+        axiomPatternsToEvaluators
+        $ (fmap . map) from
+        $ extractEqualityAxioms indexedModule
     verifiedModules =
         assertRight
         $ verifyAndIndexDefinition Builtin.koreVerifiers testDefinition

--- a/kore/test/Test/Kore/Equation/Sentence.hs
+++ b/kore/test/Test/Kore/Equation/Sentence.hs
@@ -1,0 +1,56 @@
+module Test.Kore.Equation.Sentence
+    ( test_fromSentenceAxiom
+    ) where
+
+import Prelude.Kore
+
+import Test.Tasty
+
+import Data.Default
+    ( def
+    )
+
+import Kore.Equation
+import Kore.Internal.TermLike
+import qualified Kore.Verified as Verified
+
+import Test.Expect
+import Test.Kore
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Tasty.HUnit.Ext
+
+test_fromSentenceAxiom :: [TestTree]
+test_fromSentenceAxiom =
+    [ testCase "\\ceil(I1:AInt <= I2:AInt)" $ do
+        let term = Mock.tdivInt varI1 varI2
+            sortR = mkSortVariable (testId "R")
+        actual <- expectRight $ fromSentenceAxiom (def, mkCeilEquation term)
+        let expect = mkEquation (mkCeil sortR term) (mkTop sortR)
+        assertEqual "" expect actual
+    ]
+
+varI1, varI2 :: TermLike Variable
+varI1 =
+    mkElemVar $ ElementVariable Variable
+        { variableName = testId "VarI1"
+        , variableCounter = mempty
+        , variableSort = Mock.intSort
+        }
+
+varI2 =
+    mkElemVar $ ElementVariable Variable
+        { variableName = testId "VarI2"
+        , variableCounter = mempty
+        , variableSort = Mock.intSort
+        }
+
+{- | Construct a 'SentenceAxiom' corresponding to a 'Ceil' axiom.
+
+ -}
+mkCeilEquation
+    :: TermLike Variable  -- ^ the child of 'Ceil'
+    -> Verified.SentenceAxiom
+mkCeilEquation child = mkAxiom [sortVariableR] $ mkCeil sortR child
+  where
+    sortVariableR = SortVariable "R"
+    sortR = SortVariableSort sortVariableR

--- a/kore/test/Test/Kore/Equation/Sentence.hs
+++ b/kore/test/Test/Kore/Equation/Sentence.hs
@@ -26,14 +26,14 @@ test_fromSentenceAxiom =
     [ testCase "⌈I1 / I2⌉" $ do
         let term = Mock.tdivInt varI1 varI2
             original = mkAxiom [sortVariableR] $ mkCeil sortR term
-            expect = mkEquation (mkCeil sortR term) (mkTop sortR)
+            expect = mkEquation sortR (mkCeil sortR term) (mkTop sortR)
         actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
     , testCase "I1 < I2 = I2 >= I1" $ do
         let left = Mock.lessInt varI1 varI2
             right = Mock.greaterEqInt varI2 varI1
             original = mkAxiom [sortVariableR] $ mkEquals sortR left right
-            expect = mkEquation left right
+            expect = mkEquation sortR left right
         actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
     , testCase "⌈f(x))⌉ → f(x) = g(x) ∧ ⌈h(x)⌉" $ do
@@ -45,7 +45,7 @@ test_fromSentenceAxiom =
                 mkAxiom [sortVariableR]
                 $ mkImplies requires
                 $ mkAnd (mkEquals sortR left right) ensures
-            expect = (mkEquation left right)
+            expect = (mkEquation sortR left right)
                 { requires = wrapPredicate requires
                 , ensures = wrapPredicate ensures
                 }

--- a/kore/test/Test/Kore/Equation/Sentence.hs
+++ b/kore/test/Test/Kore/Equation/Sentence.hs
@@ -20,10 +20,17 @@ import Test.Tasty.HUnit.Ext
 
 test_fromSentenceAxiom :: [TestTree]
 test_fromSentenceAxiom =
-    [ testCase "\\ceil(tdivInt(I1:AInt, I2:AInt))" $ do
+    [ testCase "\\ceil(I1 / I2)" $ do
         let term = Mock.tdivInt varI1 varI2
             original = mkAxiom [sortVariableR] $ mkCeil sortR term
             expect = mkEquation (mkCeil sortR term) (mkTop sortR)
+        actual <- expectRight $ fromSentenceAxiom (def, original)
+        assertEqual "" expect actual
+    , testCase "\\equals(I1 < I2, I2 >= I1)" $ do
+        let left = Mock.lessInt varI1 varI2
+            right = Mock.greaterEqInt varI2 varI1
+            original = mkAxiom [sortVariableR] $ mkEquals sortR left right
+            expect = mkEquation left right
         actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
     ]

--- a/kore/test/Test/Kore/Equation/Sentence.hs
+++ b/kore/test/Test/Kore/Equation/Sentence.hs
@@ -11,6 +11,9 @@ import Data.Default
     )
 
 import Kore.Equation
+import Kore.Internal.Predicate
+    ( wrapPredicate
+    )
 import Kore.Internal.TermLike
 
 import Test.Expect
@@ -20,17 +23,32 @@ import Test.Tasty.HUnit.Ext
 
 test_fromSentenceAxiom :: [TestTree]
 test_fromSentenceAxiom =
-    [ testCase "\\ceil(I1 / I2)" $ do
+    [ testCase "⌈I1 / I2⌉" $ do
         let term = Mock.tdivInt varI1 varI2
             original = mkAxiom [sortVariableR] $ mkCeil sortR term
             expect = mkEquation (mkCeil sortR term) (mkTop sortR)
         actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
-    , testCase "\\equals(I1 < I2, I2 >= I1)" $ do
+    , testCase "I1 < I2 = I2 >= I1" $ do
         let left = Mock.lessInt varI1 varI2
             right = Mock.greaterEqInt varI2 varI1
             original = mkAxiom [sortVariableR] $ mkEquals sortR left right
             expect = mkEquation left right
+        actual <- expectRight $ fromSentenceAxiom (def, original)
+        assertEqual "" expect actual
+    , testCase "⌈f(x))⌉ → f(x) = g(x) ∧ ⌈h(x)⌉" $ do
+        let requires = mkCeil sortR (Mock.f Mock.a)
+            ensures = mkCeil sortR (Mock.h Mock.b)
+            left = Mock.f (mkElemVar Mock.x)
+            right = Mock.g (mkElemVar Mock.x)
+            original =
+                mkAxiom [sortVariableR]
+                $ mkImplies requires
+                $ mkAnd (mkEquals sortR left right) ensures
+            expect = (mkEquation left right)
+                { requires = wrapPredicate requires
+                , ensures = wrapPredicate ensures
+                }
         actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
     ]

--- a/kore/test/Test/Kore/Equation/Sentence.hs
+++ b/kore/test/Test/Kore/Equation/Sentence.hs
@@ -12,7 +12,6 @@ import Data.Default
 
 import Kore.Equation
 import Kore.Internal.TermLike
-import qualified Kore.Verified as Verified
 
 import Test.Expect
 import Test.Kore
@@ -21,13 +20,16 @@ import Test.Tasty.HUnit.Ext
 
 test_fromSentenceAxiom :: [TestTree]
 test_fromSentenceAxiom =
-    [ testCase "\\ceil(I1:AInt <= I2:AInt)" $ do
+    [ testCase "\\ceil(tdivInt(I1:AInt, I2:AInt))" $ do
         let term = Mock.tdivInt varI1 varI2
-            sortR = mkSortVariable (testId "R")
-        actual <- expectRight $ fromSentenceAxiom (def, mkCeilEquation term)
-        let expect = mkEquation (mkCeil sortR term) (mkTop sortR)
+            original = mkAxiom [sortVariableR] $ mkCeil sortR term
+            expect = mkEquation (mkCeil sortR term) (mkTop sortR)
+        actual <- expectRight $ fromSentenceAxiom (def, original)
         assertEqual "" expect actual
     ]
+  where
+    sortVariableR = SortVariable (testId "R")
+    sortR = SortVariableSort sortVariableR
 
 varI1, varI2 :: TermLike Variable
 varI1 =
@@ -43,14 +45,3 @@ varI2 =
         , variableCounter = mempty
         , variableSort = Mock.intSort
         }
-
-{- | Construct a 'SentenceAxiom' corresponding to a 'Ceil' axiom.
-
- -}
-mkCeilEquation
-    :: TermLike Variable  -- ^ the child of 'Ceil'
-    -> Verified.SentenceAxiom
-mkCeilEquation child = mkAxiom [sortVariableR] $ mkCeil sortR child
-  where
-    sortVariableR = SortVariable "R"
-    sortR = SortVariableSort sortVariableR

--- a/kore/test/Test/Kore/Internal/Predicate.hs
+++ b/kore/test/Test/Kore/Internal/Predicate.hs
@@ -383,6 +383,9 @@ test_predicate =
 
 data Simplified = IsSimplified | NotSimplified
 
+expectRight :: Debug left => Either left right -> IO right
+expectRight = either (assertFailure . show . debug) return
+
 makesPredicate
     :: HasCallStack
     => (TermLike Variable, Simplified)
@@ -392,24 +395,22 @@ makesPredicate
     (term, termSimplification)
     (predicate, predicateSimplification)
   = do
-    let eitherPredicate = makePredicate term
-    assertEqual "Predicate equality" (Right predicate) eitherPredicate
+    actual <- expectRight (makePredicate term)
+    assertEqual "Predicate equality" predicate actual
     assertEqual "Term simplification"
         (toBool termSimplification)
         (TermLike.isSimplified sideRepresentation term)
     assertEqual "Predicate simplification"
-        (Right (toBool predicateSimplification))
-        (Predicate.isSimplified sideRepresentation <$> eitherPredicate)
+        (toBool predicateSimplification)
+        (Predicate.isSimplified sideRepresentation actual)
   where
     toBool IsSimplified = True
     toBool NotSimplified = False
 
 makePredicateYieldsWrapPredicate :: String -> TermLike Variable -> IO ()
-makePredicateYieldsWrapPredicate msg p =
-    assertEqual msg
-        (Right (wrapPredicate p))
-        (makePredicate p)
-
+makePredicateYieldsWrapPredicate msg p = do
+    p' <- expectRight (makePredicate p)
+    assertEqual msg (wrapPredicate p) p'
 
 pr1 :: Predicate Variable
 pr1 =

--- a/kore/test/Test/Kore/Internal/Predicate.hs
+++ b/kore/test/Test/Kore/Internal/Predicate.hs
@@ -29,6 +29,7 @@ import Kore.Variables.UnifiedVariable
     ( UnifiedVariable (..)
     )
 
+import Test.Expect
 import Test.Kore
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
@@ -382,9 +383,6 @@ test_predicate =
     ]
 
 data Simplified = IsSimplified | NotSimplified
-
-expectRight :: Debug left => Either left right -> IO right
-expectRight = either (assertFailure . show . debug) return
 
 makesPredicate
     :: HasCallStack

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -31,6 +31,7 @@ import Kore.Attribute.Simplification
     )
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
+import qualified Kore.Equation as Equation
 import Kore.Error
     ( printError
     )
@@ -54,9 +55,6 @@ import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
     ( AxiomIdentifier (..)
     )
 import Kore.Step.Axiom.Registry
-import Kore.Step.EqualityPattern
-    ( getPriorityOfRule
-    )
 import Kore.Step.Rule
     ( extractRewriteAxioms
     )
@@ -477,7 +475,7 @@ test_functionRegistry =
                 Just PartitionedEqualityRules { functionRules } ->
                     assertEqual ""
                         [1, 2, 3, defaultPriority, owisePriority]
-                        (fmap getPriorityOfRule functionRules)
+                        (fmap Equation.equationPriority functionRules)
                 _ -> assertFailure "Should find function rules for f"
             )
         )
@@ -488,7 +486,7 @@ test_functionRegistry =
                 Just PartitionedEqualityRules { simplificationRules } ->
                     assertEqual ""
                         [1, 2, 3]
-                        (fmap getPriorityOfRule simplificationRules)
+                        (fmap Equation.equationPriority simplificationRules)
                 _ -> assertFailure "Should find simplification rules for p"
             )
         )

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -69,8 +69,8 @@ import Test.Kore.ASTVerifier.DefinitionVerifier
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 
-type PartitionedEqualityRulesMap =
-    Map.Map AxiomIdentifier.AxiomIdentifier PartitionedEqualityRules
+type PartitionedEquationsMap =
+    Map.Map AxiomIdentifier.AxiomIdentifier PartitionedEquations
 
 updateAttributes :: Attributes -> Sentence patternType -> Sentence patternType
 updateAttributes attrs = updateAttrs
@@ -396,7 +396,7 @@ testEvaluators :: BuiltinAndAxiomSimplifierMap
 testEvaluators =
     axiomPatternsToEvaluators $ extractEqualityAxioms testIndexedModule
 
-testProcessedAxiomPatterns :: PartitionedEqualityRulesMap
+testProcessedAxiomPatterns :: PartitionedEquationsMap
 testProcessedAxiomPatterns =
     processEqualityRules <$> extractEqualityAxioms testIndexedModule
 
@@ -472,7 +472,7 @@ test_functionRegistry =
         (let axiomId = AxiomIdentifier.Application (testId "f")
           in
            (case Map.lookup axiomId testProcessedAxiomPatterns of
-                Just PartitionedEqualityRules { functionRules } ->
+                Just PartitionedEquations { functionRules } ->
                     assertEqual ""
                         [1, 2, 3, defaultPriority, owisePriority]
                         (fmap Equation.equationPriority functionRules)
@@ -483,7 +483,7 @@ test_functionRegistry =
         (let axiomId = AxiomIdentifier.Application (testId "p")
           in
            (case Map.lookup axiomId testProcessedAxiomPatterns of
-                Just PartitionedEqualityRules { simplificationRules } ->
+                Just PartitionedEquations { simplificationRules } ->
                     assertEqual ""
                         [1, 2, 3]
                         (fmap Equation.equationPriority simplificationRules)

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -55,8 +55,7 @@ import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
     )
 import Kore.Step.Axiom.Registry
 import Kore.Step.EqualityPattern
-    ( EqualityRule
-    , getPriorityOfRule
+    ( getPriorityOfRule
     )
 import Kore.Step.Rule
     ( extractRewriteAxioms
@@ -397,15 +396,11 @@ testIndexedModule =
 
 testEvaluators :: BuiltinAndAxiomSimplifierMap
 testEvaluators =
-    axiomPatternsToEvaluators
-    $ (fmap . map) (from @_ @(EqualityRule Variable))
-    $ extractEqualityAxioms testIndexedModule
+    axiomPatternsToEvaluators $ extractEqualityAxioms testIndexedModule
 
 testProcessedAxiomPatterns :: PartitionedEqualityRulesMap
 testProcessedAxiomPatterns =
-    processEqualityRules
-    . map (from @_ @(EqualityRule Variable))
-    <$> extractEqualityAxioms testIndexedModule
+    processEqualityRules <$> extractEqualityAxioms testIndexedModule
 
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -398,7 +398,7 @@ testEvaluators =
 
 testProcessedAxiomPatterns :: PartitionedEquationsMap
 testProcessedAxiomPatterns =
-    processEqualityRules <$> extractEqualityAxioms testIndexedModule
+    partitionEquations <$> extractEqualityAxioms testIndexedModule
 
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -394,11 +394,11 @@ testIndexedModule =
 
 testEvaluators :: BuiltinAndAxiomSimplifierMap
 testEvaluators =
-    mkEvaluatorRegistry $ extractEqualityAxioms testIndexedModule
+    mkEvaluatorRegistry $ extractEquations testIndexedModule
 
 testProcessedAxiomPatterns :: PartitionedEquationsMap
 testProcessedAxiomPatterns =
-    partitionEquations <$> extractEqualityAxioms testIndexedModule
+    partitionEquations <$> extractEquations testIndexedModule
 
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -32,6 +32,7 @@ import Kore.Attribute.Simplification
 import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin as Builtin
 import qualified Kore.Equation as Equation
+import Kore.Equation.Registry
 import Kore.Error
     ( printError
     )

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -394,7 +394,7 @@ testIndexedModule =
 
 testEvaluators :: BuiltinAndAxiomSimplifierMap
 testEvaluators =
-    axiomPatternsToEvaluators $ extractEqualityAxioms testIndexedModule
+    mkEvaluatorRegistry $ extractEqualityAxioms testIndexedModule
 
 testProcessedAxiomPatterns :: PartitionedEquationsMap
 testProcessedAxiomPatterns =

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -55,7 +55,8 @@ import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
     )
 import Kore.Step.Axiom.Registry
 import Kore.Step.EqualityPattern
-    ( getPriorityOfRule
+    ( EqualityRule
+    , getPriorityOfRule
     )
 import Kore.Step.Rule
     ( extractRewriteAxioms
@@ -396,11 +397,15 @@ testIndexedModule =
 
 testEvaluators :: BuiltinAndAxiomSimplifierMap
 testEvaluators =
-    axiomPatternsToEvaluators $ extractEqualityAxioms testIndexedModule
+    axiomPatternsToEvaluators
+    $ (fmap . map) (from @_ @(EqualityRule Variable))
+    $ extractEqualityAxioms testIndexedModule
 
 testProcessedAxiomPatterns :: PartitionedEqualityRulesMap
 testProcessedAxiomPatterns =
-    processEqualityRules <$> extractEqualityAxioms testIndexedModule
+    processEqualityRules
+    . map (from @_ @(EqualityRule Variable))
+    <$> extractEqualityAxioms testIndexedModule
 
 testMetadataTools :: SmtMetadataTools Attribute.Symbol
 testMetadataTools = MetadataTools.build testIndexedModule

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -35,7 +35,6 @@ import Kore.Internal.ApplicationSorts
     )
 import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.TermLike
-import Kore.Step.EqualityPattern
 import Kore.Step.Rule
 import Kore.Step.RulePattern
 import Kore.Syntax.Definition hiding
@@ -135,15 +134,6 @@ axiomPatternsUnitTests =
                     . map fromSentenceAxiom . indexedModuleAxioms
                     $ extractIndexedModule "TEST" indexedDefinition
                     )
-        , testCase "\\ceil(I1:AInt <= I2:AInt)" $ do
-            let term = applyLeqAInt varI1 varI2
-                sortR = mkSortVariable (testId "R")
-            assertEqual ""
-                (Right $ FunctionAxiomPattern $ EqualityRule $ equalityPattern
-                    (mkCeil sortR term)
-                    (mkTop sortR)
-                )
-                (fromSentence . (,) def $ mkCeilAxiom term)
         , testCase "(I1:AInt => I2:AInt)::KItem"
             $ assertErrorIO
                 (assertSubstring "" "Unsupported pattern type in axiom")

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -272,30 +272,6 @@ test_patternToAxiomPatternAndBack =
                         (Right initialPattern)
                         (perhapsFinalPattern def initialPattern)
         ,
-            let initialPattern = mkImplies
-                    (Predicate.unwrapPredicate requiresP)
-                    (mkAnd (mkEquals_ leftP rightP) mkTop_)
-            in
-                testCase "Function axioms: general" $
-                    assertEqual ""
-                        (Right initialPattern)
-                        (perhapsFinalPattern def initialPattern)
-        ,
-            let initialPattern = mkEquals_ leftP rightP
-            in
-                testCase "Function axioms: trivial pre- and post-conditions" $
-                    assertEqual ""
-                        (Right initialPattern)
-                        (perhapsFinalPattern def initialPattern)
-        ,
-            let initialPattern = mkCeil (termLikeSort (mkElemVar Mock.x))
-                                    $ mkElemVar Mock.x
-            in
-                testCase "Definedness axioms" $
-                    assertEqual ""
-                        (Right initialPattern)
-                        (perhapsFinalPattern def initialPattern)
-        ,
             let op = aPG $ termLikeSort leftP
                 initialPattern = mkImplies
                     leftP

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -1189,21 +1189,21 @@ test_equalsTermsSimplification =
                                 (mkCeil sortVar Mock.cf)
                                 (mkOr
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.f (mkElemVar Mock.y))
                                             Mock.a
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.y)
                                             Mock.a
                                         )
                                     )
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.f (mkElemVar Mock.y))
                                             Mock.b
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.y)
                                             Mock.b
                                         )
@@ -1283,21 +1283,21 @@ test_equalsTermsSimplification =
                                 (mkCeil sortVar Mock.cf)
                                 (mkOr
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.f (mkElemVar Mock.y))
                                             Mock.a
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.y)
                                             Mock.a
                                         )
                                     )
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.f (mkElemVar Mock.y))
                                             Mock.b
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.y)
                                             Mock.b
                                         )
@@ -1316,21 +1316,21 @@ test_equalsTermsSimplification =
                                 (mkCeil sortVar Mock.cg)
                                 (mkOr
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.g (mkElemVar Mock.z))
                                             Mock.a
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.z)
                                             Mock.a
                                         )
                                     )
                                     (mkAnd
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (Mock.g (mkElemVar Mock.z))
                                             Mock.b
                                         )
-                                        (mkEquals_
+                                        (mkEquals sortVar
                                             (mkElemVar Mock.z)
                                             Mock.b
                                         )

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -61,7 +61,7 @@ import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike as TermLike
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import Kore.Step.Axiom.Registry
-    ( axiomPatternsToEvaluators
+    ( mkEvaluatorRegistry
     )
 import Kore.Step.Simplification.And
     ( termAnd
@@ -1180,7 +1180,7 @@ test_equalsTermsSimplification =
                     }
                 ]
             sortVar = SortVariableSort (SortVariable (testId "S"))
-            simplifiers = axiomPatternsToEvaluators $ Map.fromList
+            simplifiers = mkEvaluatorRegistry $ Map.fromList
                 [   (   AxiomIdentifier.Ceil
                             (AxiomIdentifier.Application Mock.cfId)
                     ,   [
@@ -1275,7 +1275,7 @@ test_equalsTermsSimplification =
                     }
                 ]
             sortVar = SortVariableSort (SortVariable (testId "S"))
-            simplifiers = axiomPatternsToEvaluators $ Map.fromList
+            simplifiers = mkEvaluatorRegistry $ Map.fromList
                 [   (   AxiomIdentifier.Ceil
                             (AxiomIdentifier.Application Mock.cfId)
                     ,   [

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -29,6 +29,10 @@ import Kore.Attribute.Simplification
     )
 import qualified Kore.Builtin.AssociativeCommutative as Ac
 import qualified Kore.Domain.Builtin as Domain
+import Kore.Equation
+    ( Equation (..)
+    , mkEquation
+    )
 import Kore.Internal.Condition as Condition
 import qualified Kore.Internal.Conditional as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
@@ -58,11 +62,6 @@ import Kore.Internal.TermLike as TermLike
 import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import Kore.Step.Axiom.Registry
     ( axiomPatternsToEvaluators
-    )
-import Kore.Step.EqualityPattern
-    ( EqualityPattern (..)
-    , EqualityRule (EqualityRule)
-    , equalityPattern
     )
 import Kore.Step.Simplification.And
     ( termAnd
@@ -1184,8 +1183,9 @@ test_equalsTermsSimplification =
             simplifiers = axiomPatternsToEvaluators $ Map.fromList
                 [   (   AxiomIdentifier.Ceil
                             (AxiomIdentifier.Application Mock.cfId)
-                    ,   [ EqualityRule
-                            (equalityPattern
+                    ,   [
+                            (mkEquation
+                                sortVar
                                 (mkCeil sortVar Mock.cf)
                                 (mkOr
                                     (mkAnd
@@ -1210,7 +1210,7 @@ test_equalsTermsSimplification =
                                     )
                                 )
                             )
-                            {attributes = def
+                            { attributes = def
                                 {Attribute.simplification = Simplification True}
                             }
                         ]
@@ -1278,8 +1278,8 @@ test_equalsTermsSimplification =
             simplifiers = axiomPatternsToEvaluators $ Map.fromList
                 [   (   AxiomIdentifier.Ceil
                             (AxiomIdentifier.Application Mock.cfId)
-                    ,   [ EqualityRule
-                            (equalityPattern
+                    ,   [
+                            (mkEquation sortVar
                                 (mkCeil sortVar Mock.cf)
                                 (mkOr
                                     (mkAnd
@@ -1311,8 +1311,8 @@ test_equalsTermsSimplification =
                     )
                 ,   (   AxiomIdentifier.Ceil
                             (AxiomIdentifier.Application Mock.cgId)
-                    ,   [ EqualityRule
-                            (equalityPattern
+                    ,   [
+                            (mkEquation sortVar
                                 (mkCeil sortVar Mock.cg)
                                 (mkOr
                                     (mkAnd

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -218,7 +218,7 @@ test_simplificationIntegration =
                     (Map.fromList
                         [   ( AxiomIdentifier.Application
                                 Mock.function20MapTestId
-                            ,   [ EqualityRule $ equalityPattern
+                            ,   [ from . EqualityRule $ equalityPattern
                                     (Mock.function20MapTest
                                         (Mock.concatMap
                                             (Mock.elementMap
@@ -255,7 +255,7 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
-                          , [ axiom
+                          , [ from $ axiom
                                 (Mock.functionalConstr10 (mkElemVar Mock.x))
                                 (Mock.g Mock.a)
                                 requirement
@@ -299,14 +299,14 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.fIntId
-                            ,   [ EqualityRule $ equalityPattern
+                            ,   [ from . EqualityRule $ equalityPattern
                                     (Mock.fInt (mkElemVar Mock.xInt))
                                     (mkElemVar Mock.xInt)
                                 ]
                             )
                         ,   (AxiomIdentifier.Ceil
                                 (AxiomIdentifier.Application Mock.tdivIntId)
-                            ,   [ EqualityRule $ simplificationRulePattern
+                            ,   [ from . EqualityRule $ simplificationRulePattern
                                     (mkCeil testSortVariable
                                         $ Mock.tdivInt
                                             (mkElemVar Mock.xInt)
@@ -348,11 +348,11 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.functional10Id
-                            ,   [ EqualityRule $ conditionalEqualityPattern
+                            ,   [ from . EqualityRule $ conditionalEqualityPattern
                                     (Mock.functional10 (mkElemVar Mock.x))
                                     (makeEqualsPredicate_ Mock.cf Mock.a)
                                     (mkElemVar Mock.x)
-                                , EqualityRule $ conditionalEqualityPattern
+                                , from . EqualityRule $ conditionalEqualityPattern
                                     (Mock.functional10 (mkElemVar Mock.x))
                                     (makeNotPredicate
                                         (makeEqualsPredicate_ Mock.cf Mock.a)
@@ -379,14 +379,14 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.fIntId
-                            ,   [ EqualityRule $ equalityPattern
+                            ,   [ from . EqualityRule $ equalityPattern
                                     (Mock.fInt (mkElemVar Mock.xInt))
                                     (mkElemVar Mock.xInt)
                                 ]
                             )
                         ,   (AxiomIdentifier.Ceil
                                 (AxiomIdentifier.Application Mock.tdivIntId)
-                            ,   [ EqualityRule
+                            ,   [ from . EqualityRule
                                   $ conditionalSimplificationRulePattern
                                     (mkCeil testSortVariable
                                         $ Mock.tdivInt
@@ -470,7 +470,7 @@ test_simplificationIntegration =
             evaluateWithAxioms
                 (axiomPatternsToEvaluators $ Map.fromList
                     [   ( AxiomIdentifier.Application Mock.cfId
-                        ,   [ EqualityRule $ equalityPattern
+                        ,   [ from . EqualityRule $ equalityPattern
                                 Mock.cf
                                 (Mock.f (mkElemVar Mock.x))
                             ]
@@ -502,7 +502,7 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
-                          , [ axiom
+                          , [ from $ axiom
                                 (Mock.functionalConstr10 (mkElemVar Mock.x))
                                 (Mock.g Mock.a)
                                 requirement
@@ -536,7 +536,7 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
-                          , [ axiom
+                          , [ from $ axiom
                                 (Mock.functionalConstr10 (mkElemVar Mock.x))
                                 (Mock.g Mock.a)
                                 requirement
@@ -569,7 +569,7 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
-                          , [ axiom
+                          , [ from $ axiom
                                 (Mock.functionalConstr10 (mkElemVar Mock.x))
                                 (Mock.g Mock.a)
                                 requirement
@@ -602,7 +602,7 @@ test_simplificationIntegration =
                 ( axiomPatternsToEvaluators
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
-                          , [ axiom
+                          , [ from $ axiom
                                 (Mock.functionalConstr10 (mkElemVar Mock.x))
                                 (Mock.g Mock.a)
                                 requirement

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -67,7 +67,7 @@ import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
     ( AxiomIdentifier (..)
     )
 import Kore.Step.Axiom.Registry
-    ( axiomPatternsToEvaluators
+    ( mkEvaluatorRegistry
     )
 import Kore.Step.EqualityPattern
     ( EqualityPattern (..)
@@ -214,7 +214,7 @@ test_simplificationIntegration =
             expect = OrPattern.fromPattern initial
         actual <-
             evaluateWithAxioms
-                (axiomPatternsToEvaluators
+                (mkEvaluatorRegistry
                     (Map.fromList
                         [   ( AxiomIdentifier.Application
                                 Mock.function20MapTestId
@@ -252,7 +252,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
                           , [ from $ axiom
@@ -296,7 +296,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.fIntId
                             ,   [ from . EqualityRule $ equalityPattern
@@ -345,7 +345,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.functional10Id
                             ,   [ from . EqualityRule $ conditionalEqualityPattern
@@ -376,7 +376,7 @@ test_simplificationIntegration =
         assertErrorIO
             (assertSubstring "" "doesn't imply rule condition")
             (evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [   (AxiomIdentifier.Application Mock.fIntId
                             ,   [ from . EqualityRule $ equalityPattern
@@ -468,7 +468,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                (axiomPatternsToEvaluators $ Map.fromList
+                (mkEvaluatorRegistry $ Map.fromList
                     [   ( AxiomIdentifier.Application Mock.cfId
                         ,   [ from . EqualityRule $ equalityPattern
                                 Mock.cf
@@ -499,7 +499,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
                           , [ from $ axiom
@@ -533,7 +533,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
                           , [ from $ axiom
@@ -566,7 +566,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
                           , [ from $ axiom
@@ -599,7 +599,7 @@ test_simplificationIntegration =
                 ]
         actual <-
             evaluateWithAxioms
-                ( axiomPatternsToEvaluators
+                ( mkEvaluatorRegistry
                     ( Map.fromList
                         [ (AxiomIdentifier.Application Mock.functionalConstr10Id
                           , [ from $ axiom


### PR DESCRIPTION
The parts of the backend related to applying equations are scattered through several parts of the code. Here, I begin to collect them under `Kore.Equation`.

See also: #1560 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
