### PR TITLE
Kore.Equation.Application

### DIFF
--- a/kore/src/Debug.hs
+++ b/kore/src/Debug.hs
@@ -170,6 +170,9 @@ class Debug a where
         -> Doc ann
     debugPrec = debugPrecGeneric
 
+    debugPrecBrief :: a -> Int -> Doc ann
+    debugPrecBrief = debugPrec
+
 debugPrecGeneric
     :: forall a ann
     .  (Generic a, HasDatatypeInfo a, All2 Debug (Code a))
@@ -247,7 +250,7 @@ debugSOP
     => SOP I xss
     -> SOP (K (Int -> Doc ann)) xss
 debugSOP (SOP sop) =
-    SOP $ SOP.hcmap pAllDebug (SOP.hcmap pDebug (SOP.mapIK debugPrec)) sop
+    SOP $ SOP.hcmap pAllDebug (SOP.hcmap pDebug (SOP.mapIK debugPrecBrief)) sop
   where
     pDebug = Proxy :: Proxy Debug
     pAllDebug = Proxy :: Proxy (All Debug)

--- a/kore/src/Debug.hs
+++ b/kore/src/Debug.hs
@@ -39,6 +39,9 @@ import Data.Hashable
     , unhashed
     )
 import Data.Int
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
 import Data.Map.Strict
     ( Map
     )
@@ -254,6 +257,8 @@ instance Debug a => Debug [a] where
         Pretty.group
         . encloseSep Pretty.lbracket Pretty.rbracket Pretty.comma
         $ map debug as
+
+instance Debug a => Debug (NonEmpty a)
 
 instance {-# OVERLAPS #-} Debug String where
     debugPrec a = \p -> Pretty.pretty (showsPrec p a "")
@@ -528,6 +533,8 @@ instance Diff Bool where
     diffPrec = diffPrecEq
 
 instance (Debug a, Diff a) => Diff [a]
+
+instance (Debug a, Diff a) => Diff (NonEmpty a)
 
 instance {-# OVERLAPS #-} Diff String where
     diffPrec = diffPrecEq

--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -97,7 +97,8 @@ instance SOP.Generic (Pattern variable)
 
 instance SOP.HasDatatypeInfo (Pattern variable)
 
-instance Debug variable => Debug (Pattern variable)
+instance Debug variable => Debug (Pattern variable) where
+    debugPrecBrief _ _ = "_"
 
 instance (Debug variable, Diff variable) => Diff (Pattern variable)
 

--- a/kore/src/Kore/Attribute/Symbol.hs
+++ b/kore/src/Kore/Attribute/Symbol.hs
@@ -131,7 +131,8 @@ instance SOP.Generic Symbol
 
 instance SOP.HasDatatypeInfo Symbol
 
-instance Debug Symbol
+instance Debug Symbol where
+    debugPrecBrief _ _ = "_"
 
 instance Diff Symbol
 

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -181,11 +181,11 @@ applyMatchResult equation matchResult@(predicate, substitution) =
     Equation { attributes } = equation
     concretes =
         attributes
-        & Attribute.unConcrete . Attribute.concrete
+        & Attribute.concrete & Attribute.unConcrete
         & FreeVariables.getFreeVariables
     symbolics =
         attributes
-        & Attribute.unSymbolic . Attribute.symbolic
+        & Attribute.symbolic & Attribute.unSymbolic
         & FreeVariables.getFreeVariables
     checkConcrete var =
         case Map.lookup var substitution of

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -146,6 +146,16 @@ applyEquation sideCondition termLike equation = runExceptT $ do
   where
     match term1 term2 = MaybeT $ matchIncremental term1 term2
 
+{- | Use a 'MatchResult' to instantiate an 'Equation'.
+
+The 'MatchResult' must cover all the free variables of the 'Equation'; this
+condition is not checked, but enforced by the matcher. The result is the
+'Equation' and any 'Predicate' assembled during matching, both instantiated by
+the 'MatchResult'.
+
+Throws 'InstantiationErrors' if there is a problem with the 'MatchResult'.
+
+ -}
 applyMatchResult
     :: forall monad variable
     .   Monad monad
@@ -193,13 +203,19 @@ applyMatchResult equation matchResult@(predicate, substitution) =
     notConcretes = mapMaybe checkConcrete (Set.toList concretes)
     notSymbolics = mapMaybe checkSymbolic (Set.toList symbolics)
 
+{- | Check that the requires from matching and the 'Equation' hold.
+
+Throws 'RequiresNotMet' if the 'Predicate's do not hold under the
+'SideCondition'.
+
+ -}
 checkRequires
     :: forall simplifier variable
     .  MonadSimplify simplifier
     => InternalVariable variable
     => SideCondition (Target variable)
-    -> Predicate variable
-    -> Predicate variable
+    -> Predicate variable  -- ^ requires from matching
+    -> Predicate variable  -- ^ requires from 'Equation'
     -> ExceptT (ApplyEquationError variable) simplifier ()
 checkRequires sideCondition predicate requires =
     do

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -92,6 +92,8 @@ instance SOP.HasDatatypeInfo (ApplyEquationError variable)
 
 instance Debug variable => Debug (ApplyEquationError variable)
 
+instance (Debug variable, Diff variable) => Diff (ApplyEquationError variable)
+
 {- | @InstantiationError@ represents a reason to reject the instantiation of
 an 'Equation'.
  -}
@@ -111,6 +113,8 @@ instance SOP.Generic (InstantiationError variable)
 instance SOP.HasDatatypeInfo (InstantiationError variable)
 
 instance Debug variable => Debug (InstantiationError variable)
+
+instance (Debug variable, Diff variable) => Diff (InstantiationError variable)
 
 applyEquation
     :: forall simplifier variable

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -1,0 +1,199 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Equation.Application
+    ( applyEquation
+    , ApplyEquationResult
+    , ApplyEquationError (..)
+    , InstantiationError (..)
+    ) where
+
+import Prelude.Kore
+
+import Control.Error
+    ( ExceptT
+    , MaybeT (..)
+    , noteT
+    , runExceptT
+    , throwE
+    )
+import Control.Monad
+    ( (>=>)
+    )
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+import qualified Kore.Attribute.Axiom as Attribute
+import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+import Kore.Equation.Equation
+    ( Equation (..)
+    )
+import qualified Kore.Equation.Equation as Equation
+import Kore.Internal.Condition
+    ( Condition
+    )
+import qualified Kore.Internal.Condition as Condition
+import qualified Kore.Internal.OrCondition as OrCondition
+import Kore.Internal.Pattern
+    ( Pattern
+    )
+import qualified Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate
+    ( Predicate
+    , makeAndPredicate
+    , makeNotPredicate
+    )
+import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , TermLike
+    )
+import qualified Kore.Internal.TermLike as TermLike
+import Kore.Step.Axiom.Matcher
+    ( MatchResult
+    , matchIncremental
+    )
+import qualified Kore.Step.Simplification.Data as Simplifier
+import Kore.Step.Simplification.Simplify
+    ( MonadSimplify
+    )
+import qualified Kore.Step.SMT.Evaluator as SMT
+import Kore.TopBottom
+import Kore.Variables.UnifiedVariable
+    ( UnifiedVariable
+    )
+
+type ApplyEquationResult variable =
+    Either (ApplyEquationError variable) (Pattern variable)
+
+data ApplyEquationError variable
+    = NotMatched !(TermLike variable) !(Equation variable)
+    | InstantiationErrors
+        !(MatchResult variable)
+        !(NonEmpty (InstantiationError variable))
+    | RequiresNotMet !(Predicate variable) !(Predicate variable)
+
+{- | @InstantiationError@ represents a reason to reject the instantiation of
+an 'Equation'.
+ -}
+data InstantiationError variable
+    = NotConcrete (UnifiedVariable variable) (TermLike variable)
+    -- ^ The variable was instantiated with a symbolic term where a concrete
+    -- term was required.
+    | NotSymbolic (UnifiedVariable variable) (TermLike variable)
+    -- ^ The variable was instantiated with a concrete term where a symbolic
+    -- term was required.
+    | NotInstantiated (UnifiedVariable variable)
+    -- ^ The variable was not instantiated.
+
+applyEquation
+    :: forall simplifier variable
+    .  MonadSimplify simplifier
+    => InternalVariable variable
+    => SideCondition variable
+    -> TermLike variable
+    -> Equation variable
+    -> simplifier (ApplyEquationResult variable)
+applyEquation sideCondition termLike equation = runExceptT $ do
+    let Equation { left } = equation
+    matchResult <- match left termLike & noteT notMatched
+    (equation', predicate) <- applyMatchResult equation matchResult
+    let Equation { requires } = equation'
+    checkRequires sideCondition predicate requires
+    let Equation { right, ensures } = equation'
+    return $ Pattern.withCondition right $ from @(Predicate _) ensures
+  where
+    match term1 term2 = MaybeT $ matchIncremental term1 term2
+    notMatched = NotMatched termLike equation
+
+applyMatchResult
+    :: forall monad variable
+    .   Monad monad
+    =>  InternalVariable variable
+    =>  Equation variable
+    ->  MatchResult variable
+    ->  ExceptT (ApplyEquationError variable) monad
+            (Equation variable, Predicate variable)
+applyMatchResult equation matchResult@(predicate, substitution) =
+    case errors of
+        x : xs -> throwE $ InstantiationErrors matchResult (x :| xs)
+        _      -> return (equation', predicate')
+  where
+    errors = notConcretes <> notSymbolics
+
+    predicate' = Predicate.substitute substitution predicate
+    equation' = Equation.substitute substitution equation
+
+    Equation { attributes } = equation
+    concretes =
+        attributes
+        & Attribute.unConcrete . Attribute.concrete
+        & FreeVariables.getFreeVariables
+    symbolics =
+        attributes
+        & Attribute.unSymbolic . Attribute.symbolic
+        & FreeVariables.getFreeVariables
+    checkConcrete var =
+        case Map.lookup var substitution of
+            Nothing -> Just (NotInstantiated var)
+            Just termLike
+              | TermLike.isConstructorLike termLike -> Nothing
+              | otherwise -> Just (NotConcrete var termLike)
+    checkSymbolic var =
+        case Map.lookup var substitution of
+            Nothing -> Just (NotInstantiated var)
+            Just termLike
+              | TermLike.isConstructorLike termLike ->
+                Just (NotSymbolic var termLike)
+              | otherwise -> Nothing
+    notConcretes = mapMaybe checkConcrete (Set.toList concretes)
+    notSymbolics = mapMaybe checkSymbolic (Set.toList symbolics)
+
+checkRequires
+    :: forall simplifier variable
+    .  MonadSimplify simplifier
+    => InternalVariable variable
+    => SideCondition variable
+    -> Predicate variable
+    -> Predicate variable
+    -> ExceptT (ApplyEquationError variable) simplifier ()
+checkRequires sideCondition predicate requires =
+    do
+        let requires' = makeAndPredicate predicate requires
+            -- The condition to refute:
+            condition :: Condition variable
+            condition = from @(Predicate _) (makeNotPredicate requires')
+        return condition
+            -- First try to refute 'condition' without user-defined axioms:
+            >>= withoutAxioms . simplifyCondition
+            -- Next try to refute 'condition' including user-defined axioms:
+            >>= withAxioms . simplifyCondition
+            -- Finally, try to refute the simplified 'condition' using the
+            -- external solver:
+            >>= SMT.filterBranch
+    -- Collect the simplified results. If they are \bottom, then \and(predicate,
+    -- requires) is valid; otherwise, the required pre-conditions are not met
+    -- and the rule will not be applied.
+    & (OrCondition.gather >=> assertBottom)
+  where
+    simplifyCondition = Simplifier.simplifyCondition sideCondition
+
+    assertBottom orCondition
+      | isBottom orCondition = done
+      | otherwise            = requiresNotMet
+    done = return ()
+    requiresNotMet = throwE (RequiresNotMet predicate requires)
+
+    withoutAxioms =
+        fmap Condition.forgetSimplified
+        . Simplifier.localSimplifierAxioms (const mempty)
+    withAxioms = id

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -200,13 +200,16 @@ checkRequires sideCondition predicate requires =
             >>= withAxioms . simplifyCondition
             -- Finally, try to refute the simplified 'condition' using the
             -- external solver:
-            >>= SMT.filterBranch
+            >>= SMT.filterBranch . andSideCondition
     -- Collect the simplified results. If they are \bottom, then \and(predicate,
     -- requires) is valid; otherwise, the required pre-conditions are not met
     -- and the rule will not be applied.
     & (OrCondition.gather >=> assertBottom)
   where
     simplifyCondition = Simplifier.simplifyCondition sideCondition
+
+    andSideCondition condition =
+        from @(SideCondition _) sideCondition <> condition
 
     assertBottom orCondition
       | isBottom orCondition = done

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -33,6 +33,9 @@ import qualified GHC.Generics as GHC
 
 import Debug
 import qualified Kore.Attribute.Axiom as Attribute
+import Kore.Attribute.Pattern.FreeVariables
+    ( HasFreeVariables (..)
+    )
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import Kore.Equation.Equation
     ( Equation (..)
@@ -125,7 +128,11 @@ applyEquation
     -> Equation variable
     -> simplifier (ApplyEquationResult variable)
 applyEquation sideCondition termLike equation = runExceptT $ do
-    let Equation { left } = equation
+    let configFreeVariables =
+            freeVariables sideCondition <> freeVariables termLike
+        (_, equationRenamed) =
+            Equation.refreshVariables configFreeVariables equation
+    let Equation { left } = equationRenamed
     matchResult <- match left termLike & noteT notMatched
     (equation', predicate) <- applyMatchResult equation matchResult
     let Equation { requires } = equation'

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -28,7 +28,10 @@ import Data.List.NonEmpty
     )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 
+import Debug
 import qualified Kore.Attribute.Axiom as Attribute
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import Kore.Equation.Equation
@@ -81,6 +84,13 @@ data ApplyEquationError variable
         !(MatchResult variable)
         !(NonEmpty (InstantiationError variable))
     | RequiresNotMet !(Predicate variable) !(Predicate variable)
+    deriving (GHC.Generic)
+
+instance SOP.Generic (ApplyEquationError variable)
+
+instance SOP.HasDatatypeInfo (ApplyEquationError variable)
+
+instance Debug variable => Debug (ApplyEquationError variable)
 
 {- | @InstantiationError@ represents a reason to reject the instantiation of
 an 'Equation'.
@@ -94,6 +104,13 @@ data InstantiationError variable
     -- term was required.
     | NotInstantiated (UnifiedVariable variable)
     -- ^ The variable was not instantiated.
+    deriving (GHC.Generic)
+
+instance SOP.Generic (InstantiationError variable)
+
+instance SOP.HasDatatypeInfo (InstantiationError variable)
+
+instance Debug variable => Debug (InstantiationError variable)
 
 applyEquation
     :: forall simplifier variable

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -12,6 +12,7 @@ module Kore.Equation.Equation
     , checkInstantiation, InstantiationFailure (..)
     , isSimplificationRule
     , equationPriority
+    , substitute
     ) where
 
 import Prelude.Kore
@@ -288,3 +289,19 @@ isSimplificationRule Equation { attributes } =
 
 equationPriority :: Equation variable -> Integer
 equationPriority = Attribute.getPriorityOfAxiom . attributes
+
+substitute
+    :: InternalVariable variable
+    => Map (UnifiedVariable variable) (TermLike variable)
+    -> Equation variable
+    -> Equation variable
+substitute assignments equation =
+    Equation
+        { requires = Predicate.substitute assignments requires
+        , left = TermLike.substitute assignments left
+        , right = TermLike.substitute assignments right
+        , ensures = Predicate.substitute assignments ensures
+        , attributes
+        }
+  where
+    Equation { requires, left, right, ensures, attributes } = equation

--- a/kore/src/Kore/Equation/Equation.hs
+++ b/kore/src/Kore/Equation/Equation.hs
@@ -80,7 +80,8 @@ data Equation variable = Equation
 
 -- | Creates a basic, unconstrained, Equality pattern
 mkEquation
-    :: InternalVariable variable
+    :: HasCallStack
+    => InternalVariable variable
     => Sort
     -> TermLike variable
     -> TermLike variable

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -14,6 +14,7 @@ module Kore.Internal.Condition
     , eraseConditionalTerm
     , top
     , bottom
+    , bottomOf
     , topCondition
     , bottomCondition
     , fromPattern
@@ -107,6 +108,14 @@ bottom =
     Conditional
         { term = ()
         , predicate = Predicate.makeFalsePredicate_
+        , substitution = mempty
+        }
+
+bottomOf :: InternalVariable variable => Sort -> Condition variable
+bottomOf sort =
+    Conditional
+        { term = ()
+        , predicate = Predicate.makeFalsePredicate sort
         , substitution = mempty
         }
 

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -14,6 +14,7 @@ module Kore.Internal.Condition
     , eraseConditionalTerm
     , top
     , bottom
+    , topOf
     , bottomOf
     , topCondition
     , bottomCondition
@@ -108,6 +109,14 @@ bottom =
     Conditional
         { term = ()
         , predicate = Predicate.makeFalsePredicate_
+        , substitution = mempty
+        }
+
+topOf :: InternalVariable variable => Sort -> Condition variable
+topOf sort =
+    Conditional
+        { term = ()
+        , predicate = Predicate.makeTruePredicate sort
         , substitution = mempty
         }
 

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -202,7 +202,7 @@ bottomOf :: InternalVariable variable => Sort -> Pattern variable
 bottomOf resultSort =
     Conditional
         { term      = mkBottom resultSort
-        , predicate = Predicate.makeFalsePredicate_
+        , predicate = Predicate.makeFalsePredicate resultSort
         , substitution = mempty
         }
 

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -240,7 +240,7 @@ fromTermLike
     => TermLike variable
     -> Pattern variable
 fromTermLike term
-  | isBottom term = bottom
+  | isBottom term = bottomOf (termLikeSort term)
   | otherwise =
     Conditional
         { term
@@ -261,8 +261,8 @@ withCondition
         , predicate
         , substitution
         }
-  = syncSort
-    Conditional { term, predicate, substitution }
+  =
+    syncSort Conditional { term, predicate, substitution }
 
 withConditionUnsorted
     :: TermLike variable

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -134,6 +134,10 @@ instance
             , assumedTrue
             }
 
+instance From (SideCondition variable) (Condition variable) where
+    from = assumedTrue
+    {-# INLINE from #-}
+
 top :: InternalVariable variable => SideCondition variable
 top = fromCondition Condition.top
 

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -10,6 +10,7 @@ Portability : portable
 -}
 module Kore.Step.Axiom.Matcher
     ( MatchingVariable
+    , MatchResult
     , matchIncremental
     ) where
 

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -163,9 +163,9 @@ pair, it is deferred until we have more information.
 
  -}
 matchOne
-    :: (MatchingVariable variable, MonadSimplify unifier)
+    :: (MatchingVariable variable, MonadSimplify simplifier)
     => Pair (TermLike variable)
-    -> MatcherT variable unifier ()
+    -> MatcherT variable simplifier ()
 matchOne pair =
     (   matchVariable    pair
     <|> matchEqualHeads  pair
@@ -187,15 +187,15 @@ deferred constraints, then matching fails.
 
  -}
 matchIncremental
-    :: forall variable unifier
-    .  (MatchingVariable variable, MonadSimplify unifier)
+    :: forall variable simplifier
+    .  (MatchingVariable variable, MonadSimplify simplifier)
     => TermLike variable
     -> TermLike variable
-    -> unifier (Maybe (MatchResult variable))
+    -> simplifier (Maybe (MatchResult variable))
 matchIncremental termLike1 termLike2 =
     Monad.State.evalStateT matcher initial
   where
-    matcher :: MatcherT variable unifier (Maybe (MatchResult variable))
+    matcher :: MatcherT variable simplifier (Maybe (MatchResult variable))
     matcher = pop >>= maybe done (\pair -> matchOne pair >> matcher)
 
     initial =
@@ -212,7 +212,7 @@ matchIncremental termLike1 termLike2 =
     free2 = (getFreeVariables . freeVariables) termLike2
 
     -- | Check that matching is finished and construct the result.
-    done :: MatcherT variable unifier (Maybe (MatchResult variable))
+    done :: MatcherT variable simplifier (Maybe (MatchResult variable))
     done = do
         MatcherState { queued, deferred } <- Monad.State.get
         let isDone = null queued && null deferred
@@ -220,7 +220,7 @@ matchIncremental termLike1 termLike2 =
             then Just <$> assembleResult
             else return Nothing
 
-    assembleResult :: MatcherT variable unifier (MatchResult variable)
+    assembleResult :: MatcherT variable simplifier (MatchResult variable)
     assembleResult = do
         final <- Monad.State.get
         let MatcherState { predicate, substitution } = final
@@ -229,9 +229,9 @@ matchIncremental termLike1 termLike2 =
 
 matchEqualHeads
     :: Ord variable
-    => Monad unifier
+    => Monad simplifier
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 -- Terminal patterns
 matchEqualHeads (Pair (StringLiteral_ string1) (StringLiteral_ string2)) =
     Monad.guard (string1 == string2)
@@ -267,26 +267,26 @@ matchEqualHeads (Pair (Equals_ _ _ term11 term12) (Equals_ _ _ term21 term22)) =
 matchEqualHeads _ = empty
 
 matchExists
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchExists (Pair (Exists_ _ variable1 term1) (Exists_ _ variable2 term2)) =
     matchBinder (Binder variable1 term1) (Binder variable2 term2)
 matchExists _ = empty
 
 matchForall
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchForall (Pair (Forall_ _ variable1 term1) (Forall_ _ variable2 term2)) =
     matchBinder (Binder variable1 term1) (Binder variable2 term2)
 matchForall _ = empty
 
 matchBinder
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Binder (ElementVariable variable) (TermLike variable)
     -> Binder (ElementVariable variable) (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchBinder (Binder variable1 term1) (Binder variable2 term2) = do
     Monad.guard (variableSort1 == variableSort2)
     -- Lift the bound variable to the top level.
@@ -308,9 +308,9 @@ matchBinder (Binder variable1 term1) (Binder variable2 term2) = do
     variableSort2 = elementVariableSort variable2
 
 matchVariable
-    :: (MatchingVariable variable, MonadSimplify unifier)
+    :: (MatchingVariable variable, MonadSimplify simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchVariable (Pair (Var_ variable1) (Var_ variable2))
   | variable1 == variable2 = return ()
 matchVariable (Pair (ElemVar_ variable1) term2) = do
@@ -324,18 +324,18 @@ matchVariable _ = empty
 
 matchApplication
     :: Ord variable
-    => Monad unifier
+    => Monad simplifier
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchApplication (Pair (App_ symbol1 children1) (App_ symbol2 children2)) = do
     Monad.guard (symbol1 == symbol2)
     Foldable.traverse_ push (zipWith Pair children1 children2)
 matchApplication _ = empty
 
 matchBuiltinList
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchBuiltinList (Pair (BuiltinList_ list1) (BuiltinList_ list2)) = do
     (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
     Monad.guard (null tail2)
@@ -345,10 +345,10 @@ matchBuiltinList (Pair (App_ symbol1 children1) (BuiltinList_ list2))
 matchBuiltinList _ = empty
 
 matchBuiltinListConcat
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => [TermLike variable]
     -> Builtin.InternalList (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 
 matchBuiltinListConcat [BuiltinList_ list1, frame1] list2 = do
     (aligned, tail2) <- leftAlignLists list1 list2 & Error.hoistMaybe
@@ -363,9 +363,9 @@ matchBuiltinListConcat [frame1, BuiltinList_ list1] list2 = do
 matchBuiltinListConcat _ _ = empty
 
 matchBuiltinSet
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchBuiltinSet (Pair (BuiltinSet_ set1) (BuiltinSet_ set2)) =
     matchNormalizedAc pushSetElement pushSetValue wrapTermLike normalized1 normalized2
   where
@@ -380,9 +380,9 @@ matchBuiltinSet (Pair (BuiltinSet_ set1) (BuiltinSet_ set2)) =
 matchBuiltinSet _ = empty
 
 matchBuiltinMap
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchBuiltinMap (Pair (BuiltinMap_ map1) (BuiltinMap_ map2)) =
     matchNormalizedAc pushMapElement pushMapValue wrapTermLike normalized1 normalized2
   where
@@ -401,18 +401,18 @@ matchBuiltinMap (Pair (BuiltinMap_ map1) (BuiltinMap_ map2)) =
 matchBuiltinMap _ = empty
 
 matchInj
-    :: (MatchingVariable variable, MonadSimplify unifier)
+    :: (MatchingVariable variable, MonadSimplify simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchInj (Pair (Inj_ inj1) (Inj_ inj2)) = do
     InjSimplifier { unifyInj } <- Simplifier.askInjSimplifier
     unifyInj inj1 inj2 & either (const empty) (push . injChild)
 matchInj _ = empty
 
 matchOverload
-    :: (MatchingVariable variable, MonadSimplify unifier)
+    :: (MatchingVariable variable, MonadSimplify simplifier)
     => Pair (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 matchOverload termPair = Error.hushT (unifyOverloading termPair) >>= push
 
 -- * Implementation
@@ -441,7 +441,7 @@ data MatcherState variable =
         }
     deriving (GHC.Generic)
 
-type MatcherT variable unifier = StateT (MatcherState variable) unifier
+type MatcherT variable simplifier = StateT (MatcherState variable) simplifier
 
 {- | Pop the next constraint from the matching queue.
  -}
@@ -488,11 +488,11 @@ matching solution (so that it is always normalized). @substitute@ ensures that:
 
  -}
 substitute
-    :: forall unifier variable
-    .  (MatchingVariable variable, MonadSimplify unifier)
+    :: forall simplifier variable
+    .  (MatchingVariable variable, MonadSimplify simplifier)
     => ElementVariable variable
     -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 substitute eVariable termLike = do
     -- Ensure that the variable does not occur free in the TermLike.
     occursCheck variable termLike
@@ -528,13 +528,13 @@ substitute eVariable termLike = do
 
     substitute2
         :: Constraint variable
-        -> MaybeT (MatcherT variable unifier) (Constraint variable)
+        -> MaybeT (MatcherT variable simplifier) (Constraint variable)
     substitute2 (Constraint pair) =
         Constraint <$> traverse substitute1 pair
 
     substitute1
         :: TermLike variable
-        -> MaybeT (MatcherT variable unifier) (TermLike variable)
+        -> MaybeT (MatcherT variable simplifier) (TermLike variable)
     substitute1 termLike' = do
         injSimplifier <- Simplifier.askInjSimplifier
         termLike'
@@ -553,11 +553,11 @@ the variable does not occur on the right-hand side of the substitution.
 
  -}
 setSubstitute
-    :: forall variable unifier
-    .  (MatchingVariable variable, MonadSimplify unifier)
+    :: forall variable simplifier
+    .  (MatchingVariable variable, MonadSimplify simplifier)
     => SetVariable variable
     -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 setSubstitute sVariable termLike = do
     -- Ensure that the variable does not occur free in the TermLike.
     occursCheck variable termLike
@@ -605,10 +605,10 @@ substituteTermLike
 substituteTermLike subst = Builtin.renormalize . TermLike.substitute subst
 
 occursCheck
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => UnifiedVariable variable
     -> TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 occursCheck variable termLike =
     (Monad.guard . not) (hasFreeVariable variable termLike)
 
@@ -631,9 +631,9 @@ do not attempt to match on them.
 
  -}
 targetCheck
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => UnifiedVariable variable
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 targetCheck variable = do
     MatcherState { targets } <- Monad.State.get
     Monad.guard (Set.member variable targets)
@@ -645,9 +645,9 @@ escape.
 
  -}
 escapeCheck
-    :: (MatchingVariable variable, Monad unifier)
+    :: (MatchingVariable variable, Monad simplifier)
     => TermLike variable
-    -> MaybeT (MatcherT variable unifier) ()
+    -> MaybeT (MatcherT variable simplifier) ()
 escapeCheck termLike = do
     let free = getFreeVariables (freeVariables termLike)
     MatcherState { bound } <- Monad.State.get
@@ -720,22 +720,29 @@ rightAlignLists internal1 internal2
     list12 = Seq.zipWith Pair list1 tail2
     (head2, tail2) = Seq.splitAt (length list2 - length list1) list2
 
-type Push variable unifier a = Pair a -> MatcherT variable unifier ()
+type Push variable simplifier a = Pair a -> MatcherT variable simplifier ()
+
+type Element normalized variable =
+    Builtin.Element normalized (TermLike variable)
+
+type Value normalized variable =
+    Builtin.Value normalized (TermLike variable)
+
+type NormalizedAc normalized variable =
+    Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
 
 matchNormalizedAc
-    :: forall normalized unifier variable
+    :: forall normalized simplifier variable
     .   ( Builtin.AcWrapper normalized
         , MatchingVariable variable
-        , Monad unifier
+        , Monad simplifier
         )
-    =>  Push variable unifier (Builtin.Element normalized (TermLike variable))
-    ->  Push variable unifier (Builtin.Value normalized (TermLike variable))
-    ->  (Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-        -> TermLike variable
-        )
-    -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-    -> Builtin.NormalizedAc normalized (TermLike Concrete) (TermLike variable)
-    -> MaybeT (MatcherT variable unifier) ()
+    =>  Push variable simplifier (Element normalized variable)
+    ->  Push variable simplifier (Value normalized variable)
+    ->  (NormalizedAc normalized variable -> TermLike variable)
+    ->  NormalizedAc normalized variable
+    ->  NormalizedAc normalized variable
+    ->  MaybeT (MatcherT variable simplifier) ()
 matchNormalizedAc pushElement pushValue wrapTermLike normalized1 normalized2
     | [] <- excessAbstract1
     = do

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -9,8 +9,8 @@ import Debug
 
 import Test.Tasty.HUnit.Ext
 
-expectRight :: Debug left => Either left right -> IO right
+expectRight :: HasCallStack => Debug left => Either left right -> IO right
 expectRight = either (assertFailure . show . debug) return
 
-expectLeft :: Debug right => Either left right -> IO left
+expectLeft :: HasCallStack => Debug right => Either left right -> IO left
 expectLeft = either return (assertFailure . show . debug)

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -1,5 +1,6 @@
 module Test.Expect
     ( expectRight
+    , expectLeft
     ) where
 
 import Prelude.Kore
@@ -10,3 +11,6 @@ import Test.Tasty.HUnit.Ext
 
 expectRight :: Debug left => Either left right -> IO right
 expectRight = either (assertFailure . show . debug) return
+
+expectLeft :: Debug right => Either left right -> IO left
+expectLeft = either return (assertFailure . show . debug)

--- a/kore/test/Test/Kore/Equation/Application.hs
+++ b/kore/test/Test/Kore/Equation/Application.hs
@@ -1,0 +1,296 @@
+module Test.Kore.Equation.Application
+    ( test_applyEquation
+    ) where
+
+import Prelude.Kore
+
+import Test.Tasty
+
+import Kore.Equation.Application hiding
+    ( applyEquation
+    )
+import qualified Kore.Equation.Application as Equation
+import Kore.Equation.Equation
+import qualified Kore.Internal.Condition as Condition
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate as Predicate
+    ( makeEqualsPredicate
+    , makeEqualsPredicate_
+    , makeFalsePredicate
+    , makeTruePredicate_
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+import Kore.Internal.TermLike
+
+import Test.Expect
+import Test.Kore
+    ( testId
+    )
+import qualified Test.Kore.Step.MockSymbols as Mock
+import Test.Kore.Step.Simplification
+import Test.Tasty.HUnit.Ext
+
+applyEquation
+    :: SideCondition Variable
+    -> TermLike Variable
+    -> Equation Variable
+    -> IO (ApplyEquationResult Variable)
+applyEquation sideCondition termLike equation =
+    Equation.applyEquation sideCondition termLike equation
+    & runSimplifier Mock.env
+
+test_applyEquation :: [TestTree]
+test_applyEquation =
+    [ testCase "apply identity axiom" $ do
+        let expect = Pattern.fromTermLike initial
+            initial = mkElemVar Mock.x
+        applyEquation SideCondition.top initial equationId
+            >>= expectRight >>= assertEqual "" expect
+
+    , testCase "apply identity without renaming" $ do
+        let expect = Pattern.fromTermLike initial
+            initial = mkElemVar Mock.y
+        applyEquation SideCondition.top initial equationId
+            >>= expectRight >>= assertEqual "" expect
+
+    , testCase "substitute variable with itself" $ do
+        let expect = Pattern.fromTermLike (mkElemVar Mock.x)
+            initial = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x)
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectRight >>= assertEqual "" expect
+
+    , testCase "merge configuration patterns" $ do
+        let expect = NotMatched initial equationSigmaId
+            initial =
+                Mock.sigma (mkElemVar Mock.x)
+                $ Mock.functionalConstr10 (mkElemVar Mock.y)
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    , testCase "substitution with symbol matching" $ do
+        let expect = NotMatched initial equationSigmaId
+            fy = Mock.functionalConstr10 (mkElemVar Mock.y)
+            fz = Mock.functionalConstr10 (mkElemVar Mock.z)
+            initial = Mock.sigma fy fz
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    , testCase "merge multiple variables" $ do
+        let expect = NotMatched initial equationSigmaXXYY
+            xy = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y)
+            yx = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.x)
+            initial = Mock.sigma xy yx
+        applyEquation SideCondition.top initial equationSigmaXXYY
+            >>= expectLeft >>= assertEqual "" expect
+
+    , testCase "symbol clash" $ do
+        let expect = NotMatched initial equationSigmaId
+            fx = Mock.functionalConstr10 (mkElemVar Mock.x)
+            gy = Mock.functionalConstr11 (mkElemVar Mock.y)
+            initial = Mock.sigma fx gy
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    , testCase "impossible substitution" $ do
+        let expect = NotMatched initial equationSigmaXXYY
+            xfy =
+                Mock.sigma
+                    (mkElemVar Mock.x)
+                    (Mock.functionalConstr10 (mkElemVar Mock.y))
+            xy = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y)
+            initial = Mock.sigma xfy xy
+        applyEquation SideCondition.top initial equationSigmaXXYY
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- sigma(x, x) -> x
+    -- vs
+    -- sigma(a, h(b)) with substitution b=a
+    , testCase "circular dependency error" $ do
+        let expect = NotMatched initial equationSigmaId
+            fx = Mock.functional10 (mkElemVar Mock.x)
+            initial = Mock.sigma (mkElemVar Mock.x) fx
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- sigma(x, x) -> x
+    -- vs
+    -- sigma(a, i(b)) with substitution b=a
+    , testCase "non-function substitution error" $ do
+        let expect = NotMatched initial equationSigmaId
+            initial =
+                Mock.sigma (mkElemVar Mock.x) (Mock.plain10 (mkElemVar Mock.y))
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- sigma(x, x) -> x
+    -- vs
+    -- sigma(sigma(a, a), sigma(sigma(b, c), sigma(b, b)))
+    , testCase "unify all children" $ do
+        let expect = NotMatched initial equationSigmaId
+            xx = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x)
+            yy = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.y)
+            yz = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.z)
+            initial = Mock.sigma xx (Mock.sigma yz yy)
+        applyEquation SideCondition.top initial equationSigmaId
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- sigma(sigma(x, x), y) => sigma(x, y)
+    -- vs
+    -- sigma(sigma(a, f(b)), a)
+    -- Expected: sigma(f(b), f(b)) and a=f(b)
+    , testCase "normalize substitution" $ do
+        let
+            fb = Mock.functional10 (mkElemVar Mock.y)
+            expect = NotMatched initial equationSigmaXXY
+            initial =
+                Mock.sigma (Mock.sigma (mkElemVar Mock.x) fb) (mkElemVar Mock.x)
+        applyEquation SideCondition.top initial equationSigmaXXY
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- sigma(sigma(x, x), y) => sigma(x, y)
+    -- vs
+    -- sigma(sigma(a, f(b)), a) and a=f(c)
+    -- Expected: sigma(f(b), f(b)) and a=f(b), b=c
+    , testCase "merge substitution with initial" $ do
+        let
+            fy = Mock.functionalConstr10 (mkElemVar Mock.y)
+            fz = Mock.functionalConstr10 (mkElemVar Mock.z)
+            expect = NotMatched initial equationSigmaXXY
+            initial = Mock.sigma (Mock.sigma fz fy) fz
+        applyEquation SideCondition.top initial equationSigmaXXY
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- "sl1" => x
+    -- vs
+    -- "sl2"
+    -- Expected: bottom
+    , testCase "unmatched strings" $ do
+        let expect = NotMatched initial equation
+            initial = Mock.builtinString "Hello, world!"
+            equation =
+                mkEquation sortR
+                    (Mock.builtinString "Good-bye, world!")
+                    (mkElemVar Mock.xString)
+        applyEquation SideCondition.top initial equation
+            >>= expectLeft >>= assertEqual "" expect
+
+    -- x => x ensures g(x)=f(x)
+    -- vs
+    -- y
+    -- Expected: y and g(y)=f(y)
+    , testCase "conjoin rule ensures" $ do
+        let
+            ensures =
+                makeEqualsPredicate_
+                    (Mock.functional11 (mkElemVar Mock.x))
+                    (Mock.functional10 (mkElemVar Mock.x))
+            expect =
+                Pattern.withCondition initial
+                $ Condition.fromPredicate
+                $ makeEqualsPredicate Mock.testSort
+                    (Mock.functional11 (mkElemVar Mock.y))
+                    (Mock.functional10 (mkElemVar Mock.y))
+            initial = mkElemVar Mock.y
+            equation = equationId { ensures }
+        applyEquation SideCondition.top initial equation
+            >>= expectRight >>= assertEqual "" expect
+
+    -- x => x requires g(x)=f(x)
+    -- vs
+    -- a
+    -- Expected: y1 and g(a)=f(a)
+    , testCase "equation requirement" $ do
+        let
+            requires =
+                makeEqualsPredicate sortR
+                    (Mock.functional11 (mkElemVar Mock.x))
+                    (Mock.functional10 (mkElemVar Mock.x))
+            equation = equationId { requires }
+            initial = Mock.a
+        let requires1 =
+                makeEqualsPredicate sortR
+                    (Mock.functional11 Mock.a)
+                    (Mock.functional10 Mock.a)
+            expect1 = RequiresNotMet makeTruePredicate_ requires1
+        applyEquation SideCondition.top initial equation
+            >>= expectLeft >>= assertEqual "" expect1
+        let requires2 =
+                makeEqualsPredicate sortR
+                    (Mock.functional11 Mock.a)
+                    (Mock.functional10 Mock.a)
+            sideCondition2 =
+                SideCondition.fromCondition . Condition.fromPredicate
+                $ requires2
+            expect2 = Pattern.fromTermLike initial
+        applyEquation sideCondition2 initial equation
+            >>= expectRight >>= assertEqual "" expect2
+
+    , testCase "rule a => \\bottom" $ do
+        let expect =
+                Pattern.withCondition (mkBottom Mock.testSort)
+                $ Condition.topOf Mock.testSort
+            initial = Mock.a
+        applyEquation SideCondition.top initial equationBottom
+            >>= expectRight >>= assertEqual "" expect
+
+    , testCase "rule a => b ensures \\bottom" $ do
+        let expect =
+                Pattern.withCondition Mock.b
+                $ Condition.bottomOf Mock.testSort
+            initial = Mock.a
+        applyEquation SideCondition.top initial equationEnsuresBottom
+            >>= expectRight >>= assertEqual "" expect
+
+    , testCase "rule a => b requires \\bottom" $ do
+        let expect =
+                RequiresNotMet
+                    makeTruePredicate_
+                    (makeFalsePredicate sortR)
+            initial = Mock.a
+        applyEquation SideCondition.top initial equationRequiresBottom
+            >>= expectLeft >>= assertEqual "" expect
+
+    , testCase "rule a => \\bottom does not apply to c" $ do
+        let expect = NotMatched initial equationRequiresBottom
+            initial = Mock.c
+        applyEquation SideCondition.top initial equationRequiresBottom
+            >>= expectLeft >>= assertEqual "" expect
+    ]
+  where
+    sortR = mkSortVariable (testId "R")
+    equationId = mkEquation sortR (mkElemVar Mock.x) (mkElemVar Mock.x)
+
+    equationSigmaId =
+        mkEquation sortR
+            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
+            (mkElemVar Mock.x)
+
+    equationSigmaXXYY =
+        mkEquation sortR
+            (Mock.sigma
+                (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
+                (Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.y))
+            )
+            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y))
+
+    equationSigmaXXY =
+        mkEquation sortR
+            (Mock.sigma
+                    (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
+                    (mkElemVar Mock.y)
+            )
+            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y))
+
+    equationRequiresBottom =
+        (mkEquation sortR Mock.a Mock.b)
+            { requires = makeFalsePredicate sortR }
+
+    equationEnsuresBottom =
+        (mkEquation sortR Mock.a Mock.b)
+            { ensures = makeFalsePredicate sortR }
+
+    equationBottom =
+        mkEquation sortR Mock.a (mkBottom Mock.testSort)


### PR DESCRIPTION
This pull request adds the module `Kore.Equation.Application` for applying equations. I have not yet replaced `Kore.Step.EquationalStep` throughout the code, but it does have dedicated unit tests in `Test.Kore.Equation.Application`. This is a rewrite of `EquationalStep` that avoids the external solver whenever possible. I also found several latent bugs in the former implementation.

There is an unrelated change included: the `Debug` class gets a `debugPrecBrief` method to avoid the verbosity of printing all pattern and symbol attributes.

Fixes #1561 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
