### PR TITLE
Port tests from evaluateAxioms to applyEquation

### DIFF
--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -9,6 +9,7 @@ License     : NCSA
 module Kore.Internal.SideCondition
     ( SideCondition  -- Constructor not exported on purpose
     , fromCondition
+    , fromPredicate
     , andCondition
     , assumeTrueCondition
     , assumeTruePredicate
@@ -193,6 +194,10 @@ mapVariables mapElemVar mapSetVar condition@(SideCondition _ _) =
 fromCondition
     :: InternalVariable variable => Condition variable -> SideCondition variable
 fromCondition = from
+
+fromPredicate
+    :: InternalVariable variable => Predicate variable -> SideCondition variable
+fromPredicate = fromCondition . from
 
 toRepresentationCondition
     :: InternalVariable variable

--- a/kore/test/Test/Kore/Equation/Application.hs
+++ b/kore/test/Test/Kore/Equation/Application.hs
@@ -6,6 +6,23 @@ import Prelude.Kore
 
 import Test.Tasty
 
+import qualified Control.Lens as Lens
+import Control.Monad
+    ( (>=>)
+    )
+import Data.Generics.Product
+    ( field
+    )
+import Data.Text
+    ( Text
+    )
+
+import Kore.Attribute.Axiom.Concrete
+    ( Concrete (..)
+    )
+import Kore.Attribute.Axiom.Symbolic
+    ( Symbolic (..)
+    )
 import Kore.Equation.Application hiding
     ( applyEquation
     )
@@ -13,10 +30,17 @@ import qualified Kore.Equation.Application as Equation
 import Kore.Equation.Equation
 import qualified Kore.Internal.Condition as Condition
 import Kore.Internal.Pattern as Pattern
+import Kore.Internal.Predicate
+    ( Predicate
+    )
 import Kore.Internal.Predicate as Predicate
-    ( makeEqualsPredicate
+    ( makeAndPredicate
+    , makeEqualsPredicate
     , makeEqualsPredicate_
     , makeFalsePredicate
+    , makeNotPredicate
+    , makeOrPredicate
+    , makeTruePredicate
     , makeTruePredicate_
     )
 import Kore.Internal.SideCondition
@@ -65,133 +89,97 @@ assertNotMatched result =
         , Pretty.indent 4 (debug result)
         ]
 
+assertInstantiationErrors :: ApplyEquationError Variable -> Assertion
+assertInstantiationErrors (InstantiationErrors _ _) = return ()
+assertInstantiationErrors result =
+    (assertFailure . show . Pretty.vsep)
+        [ "Expected (InstantiationErrors _ _), but found:"
+        , Pretty.indent 4 (debug result)
+        ]
+
+assertRequiresNotMet :: ApplyEquationError Variable -> Assertion
+assertRequiresNotMet (RequiresNotMet _ _) = return ()
+assertRequiresNotMet result =
+    (assertFailure . show . Pretty.vsep)
+        [ "Expected (RequiresNotMet _ _), but found:"
+        , Pretty.indent 4 (debug result)
+        ]
+
 test_applyEquation :: [TestTree]
 test_applyEquation =
-    [ testCase "apply identity axiom" $ do
-        let expect = Pattern.fromTermLike initial
-            initial = mkElemVar Mock.x
-        applyEquation SideCondition.top initial equationId
-            >>= expectRight >>= assertEqual "" expect
+    [ applies "applies identity axiom"
+        (axiom_ x x)
+        SideCondition.top
+        x
+        (Pattern.fromTermLike x)
 
-    , testCase "apply identity without renaming" $ do
-        let expect = Pattern.fromTermLike initial
-            initial = mkElemVar Mock.y
-        applyEquation SideCondition.top initial equationId
-            >>= expectRight >>= assertEqual "" expect
+    , applies "applies identity without renaming"
+        (axiom_ x x)
+        SideCondition.top
+        y
+        (Pattern.fromTermLike y)
 
-    , testCase "substitute variable with itself" $ do
-        let expect = Pattern.fromTermLike (mkElemVar Mock.x)
-            initial = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x)
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectRight >>= assertEqual "" expect
+    , applies "Σ(X, X) => X applies to Σ(f(X), f(X))"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma (f x) (f x))
+        (Pattern.fromTermLike $ f x)
 
-    , testCase "merge configuration patterns" $ do
-        let initial =
-                Mock.sigma (mkElemVar Mock.x)
-                $ Mock.functionalConstr10 (mkElemVar Mock.y)
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "merge configuration patterns"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma x (f x))
 
-    , testCase "substitution with symbol matching" $ do
-        let fy = Mock.functionalConstr10 (mkElemVar Mock.y)
-            fz = Mock.functionalConstr10 (mkElemVar Mock.z)
-            initial = Mock.sigma fy fz
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "substitution with symbol matching"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma (f y) (f z))
 
-    , testCase "merge multiple variables" $ do
-        let xy = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y)
-            yx = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.x)
-            initial = Mock.sigma xy yx
-        applyEquation SideCondition.top initial equationSigmaXXYY
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "merge multiple variables"
+        (axiom_ (sigma (sigma x x) (sigma y y)) (sigma x y))
+        SideCondition.top
+        (sigma (sigma x y) (sigma y x))
 
-    , testCase "symbol clash" $ do
-        let fx = Mock.functionalConstr10 (mkElemVar Mock.x)
-            gy = Mock.functionalConstr11 (mkElemVar Mock.y)
-            initial = Mock.sigma fx gy
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "symbol clash"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma (f x) (g x))
 
-    , testCase "impossible substitution" $ do
-        let xfy =
-                Mock.sigma
-                    (mkElemVar Mock.x)
-                    (Mock.functionalConstr10 (mkElemVar Mock.y))
-            xy = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y)
-            initial = Mock.sigma xfy xy
-        applyEquation SideCondition.top initial equationSigmaXXYY
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "impossible substitution"
+        (axiom_ (sigma (sigma x x) (sigma y y)) (sigma x y))
+        SideCondition.top
+        (sigma (sigma x (f y)) (sigma x y))
 
-    -- sigma(x, x) -> x
-    -- vs
-    -- sigma(a, h(b)) with substitution b=a
-    , testCase "circular dependency error" $ do
-        let fx = Mock.functional10 (mkElemVar Mock.x)
-            initial = Mock.sigma (mkElemVar Mock.x) fx
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "circular dependency error"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma x (f x))
 
-    -- sigma(x, x) -> x
-    -- vs
-    -- sigma(a, i(b)) with substitution b=a
-    , testCase "non-function substitution error" $ do
-        let initial =
-                Mock.sigma (mkElemVar Mock.x) (Mock.plain10 (mkElemVar Mock.y))
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "non-function substitution error"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma x (f y))
 
-    -- sigma(x, x) -> x
-    -- vs
-    -- sigma(sigma(a, a), sigma(sigma(b, c), sigma(b, b)))
-    , testCase "unify all children" $ do
-        let xx = Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x)
-            yy = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.y)
-            yz = Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.z)
-            initial = Mock.sigma xx (Mock.sigma yz yy)
-        applyEquation SideCondition.top initial equationSigmaId
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "unify all children"
+        (axiom_ (sigma x x) x)
+        SideCondition.top
+        (sigma (sigma x x) (sigma (sigma y z) (sigma y y)))
 
-    -- sigma(sigma(x, x), y) => sigma(x, y)
-    -- vs
-    -- sigma(sigma(a, f(b)), a)
-    -- Expected: sigma(f(b), f(b)) and a=f(b)
-    , testCase "normalize substitution" $ do
-        let fb = Mock.functional10 (mkElemVar Mock.y)
-            initial =
-                Mock.sigma (Mock.sigma (mkElemVar Mock.x) fb) (mkElemVar Mock.x)
-        applyEquation SideCondition.top initial equationSigmaXXY
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "normalize substitution"
+        (axiom_ (sigma (sigma x x) y) (sigma x y))
+        SideCondition.top
+        (sigma (sigma x (f b)) x)
 
-    -- sigma(sigma(x, x), y) => sigma(x, y)
-    -- vs
-    -- sigma(sigma(a, f(b)), a) and a=f(c)
-    -- Expected: sigma(f(b), f(b)) and a=f(b), b=c
-    , testCase "merge substitution with initial" $ do
-        let
-            fy = Mock.functionalConstr10 (mkElemVar Mock.y)
-            fz = Mock.functionalConstr10 (mkElemVar Mock.z)
-            initial = Mock.sigma (Mock.sigma fz fy) fz
-        applyEquation SideCondition.top initial equationSigmaXXY
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "merge substitution with initial"
+        (axiom_ (sigma (sigma x x) y) (sigma x y))
+        SideCondition.top
+        (sigma (sigma (f z) (f y)) (f z))
 
-    -- "sl1" => x
-    -- vs
-    -- "sl2"
-    -- Expected: bottom
-    , testCase "unmatched strings" $ do
-        let initial = Mock.builtinString "Hello, world!"
-            equation =
-                mkEquation sortR
-                    (Mock.builtinString "Good-bye, world!")
-                    (mkElemVar Mock.xString)
-        applyEquation SideCondition.top initial equation
-            >>= expectLeft >>= assertNotMatched
+    , notMatched "unmatched strings"
+        (axiom_ (string "Good-bye, world!") xString)
+        SideCondition.top
+        (string "Hello, world!")
 
-    -- x => x ensures g(x)=f(x)
-    -- vs
-    -- y
-    -- Expected: y and g(y)=f(y)
     , testCase "conjoin rule ensures" $ do
         let
             ensures =
@@ -209,10 +197,6 @@ test_applyEquation =
         applyEquation SideCondition.top initial equation
             >>= expectRight >>= assertEqual "" expect
 
-    -- x => x requires g(x)=f(x)
-    -- vs
-    -- a
-    -- Expected: y1 and g(a)=f(a)
     , testCase "equation requirement" $ do
         let
             requires =
@@ -268,39 +252,224 @@ test_applyEquation =
         let initial = Mock.c
         applyEquation SideCondition.top initial equationRequiresBottom
             >>= expectLeft >>= assertNotMatched
+    , applies "F(x) => G(x) applies to F(x)"
+        (axiom_ (f x) (g x))
+        SideCondition.top
+        (f x)
+        (Pattern.fromTermLike $ g x)
+    , applies "F(x) => G(x) [symbolic(x)] applies to F(x)"
+        (axiom_ (f x) (g x) & symbolic [x])
+        SideCondition.top
+        (f x)
+        (Pattern.fromTermLike $ g x)
+    , notInstantiated "F(x) => G(x) [concrete(x)] doesn't apply to F(x)"
+        (axiom_ (f x) (g x) & concrete [x])
+        SideCondition.top
+        (f x)
+    , notInstantiated "F(x) => G(x) [concrete] doesn't apply to f(cf)"
+        (axiom_ (f x) (g x) & concrete [x])
+        SideCondition.top
+        (f cf)
+    , notMatched "F(x) => G(x) doesn't apply to F(top)"
+        (axiom_ (f x) (g x))
+        SideCondition.top
+        (f mkTop_)
+    , applies "F(x) => G(x) [concrete] applies to F(a)"
+        (axiom_ (f x) (g x) & concrete [x])
+        SideCondition.top
+        (f a)
+        (Pattern.fromTermLike $ g a)
+    , applies
+        "Σ(X, Y) => A [symbolic(x), concrete(Y)]"
+        (axiom_ (sigma x y) a & symbolic [x] & concrete [y])
+        SideCondition.top
+        (sigma x a)
+        (Pattern.fromTermLike a)
+    , notInstantiated
+        "Σ(X, Y) => A [symbolic(x), concrete(Y)]"
+        (axiom_ (sigma x y) a & symbolic [x] & concrete [y])
+        SideCondition.top
+        (sigma a a)
+    , notInstantiated
+        "Σ(X, Y) => A [symbolic(x), concrete(Y)]"
+        (axiom_ (sigma x y) a & symbolic [x] & concrete [y])
+        SideCondition.top
+        (sigma x x)
+    , requiresNotMet "F(x) => G(x) requires \\bottom doesn't apply to F(x)"
+        (axiom (f x) (g x) (makeFalsePredicate sortR))
+        SideCondition.top
+        (f x)
+    , notMatched "Σ(X, X) => G(X) doesn't apply to Σ(Y, Z) -- no narrowing"
+        (axiom_ (sigma x x) (g x))
+        SideCondition.top
+        (sigma y z)
+    , requiresNotMet
+        -- using SMT
+        "Σ(X, Y) => A requires (X > 0 and not Y > 0) doesn't apply to Σ(Z, Z)"
+        (axiom (sigma x y) a (positive x `andNot` positive y))
+        SideCondition.top
+        (sigma z z)
+    , applies
+        -- using SMT
+        "Σ(X, Y) => A requires (X > 0 or not Y > 0) applies to Σ(Z, Z)"
+        (axiom (sigma x y) a (positive x `orNot` positive y))
+        (SideCondition.fromPredicate $ positive a)
+        (sigma a a)
+        -- SMT not used to simplify trivial constraints
+        (Pattern.fromTermLike a)
+    , requiresNotMet
+        -- using SMT
+        "f(X) => A requires (X > 0) doesn't apply to f(Z) and (not (Z > 0))"
+        (axiom (f x) a (positive x))
+        (SideCondition.fromPredicate $ makeNotPredicate (positive z))
+        (f z)
+    , applies
+        -- using SMT
+        "f(X) => A requires (X > 0) applies to f(Z) and (Z > 0)"
+        (axiom (f x) a (positive x))
+        (SideCondition.fromPredicate $ positive z)
+        (f z)
+        (Pattern.fromTermLike a)
     ]
-  where
-    sortR = mkSortVariable (testId "R")
-    equationId = mkEquation sortR (mkElemVar Mock.x) (mkElemVar Mock.x)
 
-    equationSigmaId =
-        mkEquation sortR
-            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
-            (mkElemVar Mock.x)
+-- * Test data
 
-    equationSigmaXXYY =
-        mkEquation sortR
-            (Mock.sigma
-                (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
-                (Mock.sigma (mkElemVar Mock.y) (mkElemVar Mock.y))
-            )
-            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y))
+equationId :: Equation Variable
+equationId = mkEquation sortR (mkElemVar Mock.x) (mkElemVar Mock.x)
 
-    equationSigmaXXY =
-        mkEquation sortR
-            (Mock.sigma
-                    (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.x))
-                    (mkElemVar Mock.y)
-            )
-            (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.y))
+equationRequiresBottom :: Equation Variable
+equationRequiresBottom =
+    (mkEquation sortR Mock.a Mock.b)
+        { requires = makeFalsePredicate sortR }
 
-    equationRequiresBottom =
-        (mkEquation sortR Mock.a Mock.b)
-            { requires = makeFalsePredicate sortR }
+equationEnsuresBottom :: Equation Variable
+equationEnsuresBottom =
+    (mkEquation sortR Mock.a Mock.b)
+        { ensures = makeFalsePredicate sortR }
 
-    equationEnsuresBottom =
-        (mkEquation sortR Mock.a Mock.b)
-            { ensures = makeFalsePredicate sortR }
+equationBottom :: Equation Variable
+equationBottom =
+    mkEquation sortR Mock.a (mkBottom Mock.testSort)
 
-    equationBottom =
-        mkEquation sortR Mock.a (mkBottom Mock.testSort)
+sortR :: Sort
+sortR = mkSortVariable (testId "R")
+
+f, g :: TermLike Variable -> TermLike Variable
+f = Mock.functionalConstr10
+g = Mock.functionalConstr11
+
+cf :: TermLike Variable
+cf = Mock.cf
+
+sigma :: TermLike Variable -> TermLike Variable -> TermLike Variable
+sigma = Mock.functionalConstr20
+
+string :: Text -> TermLike Variable
+string = Mock.builtinString
+
+x, xString, y, z :: TermLike Variable
+x = mkElemVar Mock.x
+xString = mkElemVar Mock.xString
+y = mkElemVar Mock.y
+z = mkElemVar Mock.z
+
+a, b :: TermLike Variable
+a = Mock.a
+b = Mock.b
+
+positive :: TermLike Variable -> Predicate Variable
+positive u =
+    makeEqualsPredicate Mock.testSort
+        (Mock.lessInt
+            (Mock.fTestInt u)  -- wrap the given term for sort agreement
+            (Mock.builtinInt 0)
+        )
+        (Mock.builtinBool False)
+
+andNot, orNot
+    :: Predicate Variable
+    -> Predicate Variable
+    -> Predicate Variable
+andNot p1 p2 = makeAndPredicate p1 (makeNotPredicate p2)
+orNot p1 p2 = makeOrPredicate p1 (makeNotPredicate p2)
+
+-- * Helpers
+
+axiom
+    :: TermLike Variable
+    -> TermLike Variable
+    -> Predicate Variable
+    -> Equation Variable
+axiom left right requires =
+    (mkEquation sortR left right) { requires }
+
+axiom_
+    :: TermLike Variable
+    -> TermLike Variable
+    -> Equation Variable
+axiom_ left right = axiom left right (makeTruePredicate sortR)
+
+concrete :: [TermLike Variable] -> Equation Variable -> Equation Variable
+concrete vars =
+    Lens.set
+        (field @"attributes" . field @"concrete")
+        (Concrete $ foldMap freeVariables vars)
+
+symbolic :: [TermLike Variable] -> Equation Variable -> Equation Variable
+symbolic vars =
+    Lens.set
+        (field @"attributes" . field @"symbolic")
+        (Symbolic $ foldMap freeVariables vars)
+
+-- * Test cases
+
+withApplyEquationResult
+    :: (ApplyEquationResult Variable -> Assertion)
+    -> TestName
+    -> Equation Variable
+    -> SideCondition Variable
+    -> TermLike Variable
+    -> TestTree
+withApplyEquationResult check testName equation sideCondition initial =
+    testCase testName (applyEquation sideCondition initial equation >>= check)
+
+applies
+    :: TestName
+    -> Equation Variable
+    -> SideCondition Variable
+    -> TermLike Variable
+    -> Pattern Variable
+    -> TestTree
+applies testName equation sideCondition initial expect =
+    withApplyEquationResult
+        (expectRight >=> assertEqual "" expect)
+        testName
+        equation
+        sideCondition
+        initial
+
+notMatched
+    :: TestName
+    -> Equation Variable
+    -> SideCondition Variable
+    -> TermLike Variable
+    -> TestTree
+notMatched = withApplyEquationResult (expectLeft >=> assertNotMatched)
+
+notInstantiated
+    :: TestName
+    -> Equation Variable
+    -> SideCondition Variable
+    -> TermLike Variable
+    -> TestTree
+notInstantiated =
+    withApplyEquationResult (expectLeft >=> assertInstantiationErrors)
+
+requiresNotMet
+    :: TestName
+    -> Equation Variable
+    -> SideCondition Variable
+    -> TermLike Variable
+    -> TestTree
+requiresNotMet =
+    withApplyEquationResult (expectLeft >=> assertRequiresNotMet)


### PR DESCRIPTION
This pull request duplicates some tests from `Test.Kore.Step.Axiom.Evaluate` into `Test.Kore.Equation.Application` in preparation to remove the former.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
