### PR TITLE
Send side conditions to the solver

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -55,6 +55,10 @@
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
 
+# This warning should apply to Control.Exception.evaluate, but is mistakenly
+# applied to Kore.Step.SMT.Evaluator.evaluate.
+- ignore: {name: "Redundant evaluate"}
+
 # Corporate style
 - ignore: {name: "Use tuple-section"}
 - ignore: {name: "Use record patterns"}

--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ let
           profilingDetail = "none";
           # package kore
           packages.kore = {
+            enableLibraryProfiling = profiling;
             enableExecutableProfiling = profiling;
             profilingDetail = "toplevel-functions";
           };

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -10,7 +10,7 @@ module Kore.Internal.Predicate
     , pattern PredicateFalse
     , pattern PredicateTrue
     , compactPredicatePredicate
-    , freshVariable
+    , externalizeFreshVariables
     , isFalse
     , depth
     , makePredicate, NotPredicate (..)
@@ -103,6 +103,7 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     )
 import Kore.Internal.TermLike hiding
     ( depth
+    , externalizeFreshVariables
     , hasFreeVariable
     , isSimplified
     , mapVariables
@@ -829,15 +830,18 @@ substitute
 substitute subst (GenericPredicate termLike) =
     GenericPredicate (TermLike.substitute subst termLike)
 
-{- | Externalize the variables
+{- | Transform arbitrary 'InternalVariable's into external 'Variable's.
+
+@externalizeFreshVariables@ ensures that bound variables are renamed to avoid
+capturing the resulting 'Variable's.
 
 -}
-freshVariable
+externalizeFreshVariables
     :: InternalVariable variable
     => Predicate variable
     -> Predicate Variable
-freshVariable predicate =
-    externalizeFreshVariables
+externalizeFreshVariables predicate =
+    TermLike.externalizeFreshVariables
     . TermLike.mapVariables (fmap toVariable) (fmap toVariable)
     <$> predicate
 

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -139,6 +139,13 @@ instance From (SideCondition variable) (Condition variable) where
     from = assumedTrue
     {-# INLINE from #-}
 
+instance
+    InternalVariable variable
+    => From (SideCondition variable) (Predicate variable)
+  where
+    from = from @(Condition variable) . from @(SideCondition variable)
+    {-# INLINE from #-}
+
 top :: InternalVariable variable => SideCondition variable
 top = fromCondition Condition.top
 

--- a/kore/src/Kore/Log/DebugEvaluateCondition.hs
+++ b/kore/src/Kore/Log/DebugEvaluateCondition.hs
@@ -6,7 +6,7 @@ License     : NCSA
 
 module Kore.Log.DebugEvaluateCondition
     ( DebugEvaluateCondition (..)
-    , debugEvaluateCondition
+    , whileDebugEvaluateCondition
     ) where
 
 import Prelude.Kore
@@ -49,13 +49,15 @@ instance Pretty DebugEvaluateCondition where
 
 instance Entry DebugEvaluateCondition where
     entrySeverity _ = Debug
+    shortDoc _ = Just "while evaluating predicate"
 
 instance SQL.Table DebugEvaluateCondition
 
-debugEvaluateCondition
+whileDebugEvaluateCondition
     :: MonadLog log
     => InternalVariable variable
     => NonEmpty (Predicate variable)
-    -> log ()
-debugEvaluateCondition =
-    logEntry . DebugEvaluateCondition . fmap Predicate.externalizeFreshVariables
+    -> log a
+    -> log a
+whileDebugEvaluateCondition =
+    logWhile . DebugEvaluateCondition . fmap Predicate.externalizeFreshVariables

--- a/kore/src/Kore/Log/DebugEvaluateCondition.hs
+++ b/kore/src/Kore/Log/DebugEvaluateCondition.hs
@@ -11,8 +11,8 @@ module Kore.Log.DebugEvaluateCondition
 
 import Prelude.Kore
 
-import Data.Text.Prettyprint.Doc
-    ( Pretty (..)
+import Data.List.NonEmpty
+    ( NonEmpty (..)
     )
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
@@ -24,10 +24,14 @@ import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.TermLike
 import Kore.Unparser
 import Log
+import Pretty
+    ( Pretty (..)
+    )
+import qualified Pretty
 import qualified SQL
 
 newtype DebugEvaluateCondition =
-    DebugEvaluateCondition { getCondition :: Predicate Variable }
+    DebugEvaluateCondition { getPredicates :: NonEmpty (Predicate Variable) }
     deriving (GHC.Generic)
 
 instance SOP.Generic DebugEvaluateCondition
@@ -35,7 +39,13 @@ instance SOP.Generic DebugEvaluateCondition
 instance SOP.HasDatatypeInfo DebugEvaluateCondition
 
 instance Pretty DebugEvaluateCondition where
-    pretty = pretty . unparseToString . getCondition
+    pretty (DebugEvaluateCondition (predicate :| sideConditions)) =
+        (Pretty.vsep . concat)
+        [ [ "evaluating predicate:" , Pretty.indent 4 (unparse predicate) ]
+        , do
+            sideCondition <- sideConditions
+            [ "with side condition:", Pretty.indent 4 (unparse sideCondition) ]
+        ]
 
 instance Entry DebugEvaluateCondition where
     entrySeverity _ = Debug
@@ -45,8 +55,7 @@ instance SQL.Table DebugEvaluateCondition
 debugEvaluateCondition
     :: MonadLog log
     => InternalVariable variable
-    => Predicate variable -> log ()
-debugEvaluateCondition predicate =
-    logEntry
-    $ DebugEvaluateCondition
-    $ Predicate.externalizeFreshVariables predicate
+    => NonEmpty (Predicate variable)
+    -> log ()
+debugEvaluateCondition =
+    logEntry . DebugEvaluateCondition . fmap Predicate.externalizeFreshVariables

--- a/kore/src/Kore/Log/DebugEvaluateCondition.hs
+++ b/kore/src/Kore/Log/DebugEvaluateCondition.hs
@@ -19,8 +19,8 @@ import qualified GHC.Generics as GHC
 
 import Kore.Internal.Predicate
     ( Predicate
-    , freshVariable
     )
+import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.TermLike
 import Kore.Unparser
 import Log
@@ -47,4 +47,6 @@ debugEvaluateCondition
     => InternalVariable variable
     => Predicate variable -> log ()
 debugEvaluateCondition predicate =
-    logEntry $ DebugEvaluateCondition $ freshVariable predicate
+    logEntry
+    $ DebugEvaluateCondition
+    $ Predicate.externalizeFreshVariables predicate

--- a/kore/src/Kore/Log/Registry.hs
+++ b/kore/src/Kore/Log/Registry.hs
@@ -85,6 +85,9 @@ import Kore.Log.InfoReachability
 import Kore.Log.WarnBottomHook
     ( WarnBottomHook
     )
+import Kore.Log.WarnDecidePredicateUnknown
+    ( WarnDecidePredicateUnknown
+    )
 import Kore.Log.WarnFunctionWithoutEvaluators
     ( WarnFunctionWithoutEvaluators
     )
@@ -115,6 +118,7 @@ registry =
                 , register debugProofStateType
                 , register debugAppliedRewriteRulesType
                 , register warnBottomHookType
+                , register warnDecidePredicateUnknownType
                 , register warnFunctionWithoutEvaluatorsType
                 , register debugSkipSimplificationType
                 , register logDebugEvaluateConditionType
@@ -155,6 +159,7 @@ debugAppliedRuleType
   , debugProofStateType
   , debugAppliedRewriteRulesType
   , warnBottomHookType
+  , warnDecidePredicateUnknownType
   , warnFunctionWithoutEvaluatorsType
   , debugSkipSimplificationType
   , logDebugEvaluateConditionType
@@ -179,6 +184,8 @@ debugAppliedRewriteRulesType =
     someTypeRep (Proxy :: Proxy DebugAppliedRewriteRules)
 warnBottomHookType =
     someTypeRep (Proxy :: Proxy WarnBottomHook)
+warnDecidePredicateUnknownType =
+    someTypeRep (Proxy :: Proxy WarnDecidePredicateUnknown)
 warnFunctionWithoutEvaluatorsType =
     someTypeRep (Proxy :: Proxy WarnFunctionWithoutEvaluators)
 debugSkipSimplificationType =

--- a/kore/src/Kore/Log/WarnDecidePredicateUnknown.hs
+++ b/kore/src/Kore/Log/WarnDecidePredicateUnknown.hs
@@ -1,0 +1,67 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+
+-}
+
+module Kore.Log.WarnDecidePredicateUnknown
+    ( WarnDecidePredicateUnknown (..)
+    , warnDecidePredicateUnknown
+    ) where
+
+import Prelude.Kore
+
+import Kore.Internal.Predicate
+    ( Predicate
+    )
+import qualified Kore.Internal.Predicate as Predicate
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+import Kore.Internal.Variable
+import Kore.Unparser
+import Log
+import Pretty
+    ( Pretty (..)
+    )
+import qualified Pretty
+
+data WarnDecidePredicateUnknown =
+    WarnDecidePredicateUnknown
+        { sideCondition :: !(Maybe (SideCondition Variable))
+        , predicate :: !(Predicate Variable)
+        }
+
+instance Pretty WarnDecidePredicateUnknown where
+    pretty WarnDecidePredicateUnknown { sideCondition, predicate } =
+        Pretty.vsep
+        [ "Failed to decide predicate:"
+        , Pretty.indent 4 (unparse predicate)
+        , "under side condition:"
+        , Pretty.indent 4 $ unparse $ fromMaybe SideCondition.top sideCondition
+        ]
+
+instance Entry WarnDecidePredicateUnknown where
+    entrySeverity _ = Warning
+
+warnDecidePredicateUnknown
+    :: MonadLog log
+    => InternalVariable variable
+    => Maybe (SideCondition variable)
+    -> Predicate variable
+    -> log ()
+warnDecidePredicateUnknown sideCondition' predicate' =
+    logEntry WarnDecidePredicateUnknown
+        { sideCondition
+        , predicate
+        }
+  where
+    predicate =
+        Predicate.mapVariables
+            (fmap toVariable)
+            (fmap toVariable)
+            predicate'
+    sideCondition =
+        flip fmap sideCondition'
+        $ SideCondition.mapVariables (fmap toVariable) (fmap toVariable)

--- a/kore/src/Kore/Log/WarnDecidePredicateUnknown.hs
+++ b/kore/src/Kore/Log/WarnDecidePredicateUnknown.hs
@@ -27,19 +27,21 @@ import Pretty
     )
 import qualified Pretty
 
-data WarnDecidePredicateUnknown =
+newtype WarnDecidePredicateUnknown =
     WarnDecidePredicateUnknown
-        { predicates :: !(NonEmpty (Predicate Variable))
+        { predicates :: NonEmpty (Predicate Variable)
         }
 
 instance Pretty WarnDecidePredicateUnknown where
-    pretty (WarnDecidePredicateUnknown (predicate :| sideConditions)) =
+    pretty WarnDecidePredicateUnknown { predicates } =
         (Pretty.vsep . concat)
         [ ["Failed to decide predicate:", Pretty.indent 4 (unparse predicate)]
         , do
             sideCondition <- sideConditions
             ["with side condition:", Pretty.indent 4 (unparse sideCondition)]
         ]
+      where
+       predicate :| sideConditions = predicates
 
 instance Entry WarnDecidePredicateUnknown where
     entrySeverity _ = Warning

--- a/kore/src/Kore/Profiler/Data.hs
+++ b/kore/src/Kore/Profiler/Data.hs
@@ -51,6 +51,7 @@ import System.Clock
     , toNanoSecs
     )
 
+import Control.Monad.Counter
 import ListT
     ( ListT (..)
     )
@@ -274,3 +275,5 @@ instance (MonadProfiler m, Monoid w) => MonadProfiler (AccumT w m)
   where
     profile a action = AccumT (profile a . runAccumT action)
     {-# INLINE profile #-}
+
+instance MonadProfiler m => MonadProfiler (CounterT m)

--- a/kore/src/Kore/Profiler/Profile.hs
+++ b/kore/src/Kore/Profiler/Profile.hs
@@ -23,6 +23,9 @@ import Prelude.Kore
 import Control.Monad
     ( when
     )
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
 import Data.Text.Prettyprint.Doc
     ( Pretty (..)
     )
@@ -223,10 +226,10 @@ isSelected identifierFilter = (== identifierFilter) . oneLiner
 
 smtDecision
     :: MonadProfiler profiler
-    => SExpr
+    => NonEmpty SExpr
     -> profiler result
     -> profiler result
-smtDecision sexpr action = do
+smtDecision (sexpr :| _) action = do
     Configuration {logSmt} <- profileConfiguration
     if logSmt
         then profile ["SMT", show $ length $ show sexpr] action

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -68,6 +68,9 @@ import qualified Kore.Internal.TermLike as TermLike
 import Kore.Log.DebugEvaluateCondition
     ( debugEvaluateCondition
     )
+import Kore.Log.WarnDecidePredicateUnknown
+    ( warnDecidePredicateUnknown
+    )
 import qualified Kore.Profiler.Profile as Profile
     ( smtDecision
     )
@@ -151,10 +154,9 @@ filterMultiOr multiOr = do
 The predicate is always sent to the external solver, even if it is trivial.
 -}
 decidePredicate
-    :: forall variable simplifier.
-        ( InternalVariable variable
-        , MonadSimplify simplifier
-        )
+    :: forall variable simplifier
+    .  InternalVariable variable
+    => MonadSimplify simplifier
     => Maybe (SideCondition variable)
     -> Predicate variable
     -> simplifier (Maybe Bool)
@@ -174,10 +176,7 @@ decidePredicate sideCondition predicate =
             Unsat   -> return False
             Sat     -> empty
             Unknown -> do
-                (logWarning . Text.pack . show . Pretty.vsep)
-                    [ "Failed to decide predicate:"
-                    , Pretty.indent 4 (unparse predicate)
-                    ]
+                warnDecidePredicateUnknown sideCondition predicate
                 empty
 
 translatePredicate

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -68,7 +68,7 @@ import Kore.Internal.TermLike
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Log.DebugEvaluateCondition
-    ( debugEvaluateCondition
+    ( whileDebugEvaluateCondition
     )
 import Kore.Log.WarnDecidePredicateUnknown
     ( warnDecidePredicateUnknown
@@ -182,8 +182,8 @@ decidePredicate
     => NonEmpty (Predicate variable)
     -> simplifier (Maybe Bool)
 decidePredicate predicates =
-    SMT.withSolver $ runMaybeT $ evalTranslator $ do
-        debugEvaluateCondition predicates
+    whileDebugEvaluateCondition predicates
+    $ SMT.withSolver $ runMaybeT $ evalTranslator $ do
         tools <- Simplifier.askMetadataTools
         predicates' <- traverse (translatePredicate tools) predicates
         result <- Profile.smtDecision predicates' $ SMT.withSolver $ do

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -68,7 +68,8 @@ import Kore.Internal.TermLike
     )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Log.DebugEvaluateCondition
-    ( whileDebugEvaluateCondition
+    ( debugEvaluateConditionResult
+    , whileDebugEvaluateCondition
     )
 import Kore.Log.WarnDecidePredicateUnknown
     ( warnDecidePredicateUnknown
@@ -189,9 +190,10 @@ decidePredicate predicates =
         result <- Profile.smtDecision predicates' $ SMT.withSolver $ do
             Foldable.traverse_ SMT.assert predicates'
             SMT.check
+        debugEvaluateConditionResult result
         case result of
-            Unsat   -> return False
-            Sat     -> empty
+            Unsat -> return False
+            Sat -> empty
             Unknown -> do
                 warnDecidePredicateUnknown predicates
                 empty

--- a/kore/src/Kore/Step/SMT/Evaluator.hs
+++ b/kore/src/Kore/Step/SMT/Evaluator.hs
@@ -106,11 +106,29 @@ instance InternalVariable variable => Evaluable (Predicate variable) where
             Predicate.PredicateFalse -> return (Just False)
             _ -> decidePredicate Nothing predicate
 
+instance
+    InternalVariable variable
+    => Evaluable (SideCondition variable, Predicate variable)
+  where
+    evaluate (sideCondition, predicate) =
+        case predicate of
+            Predicate.PredicateTrue -> return (Just True)
+            Predicate.PredicateFalse -> return (Just False)
+            _ -> decidePredicate (Just sideCondition) predicate
+
 instance InternalVariable variable => Evaluable (Conditional variable term)
   where
     evaluate conditional =
         assert (Conditional.isNormalized conditional)
         $ evaluate (Conditional.predicate conditional)
+
+instance
+    InternalVariable variable
+    => Evaluable (SideCondition variable, Conditional variable term)
+  where
+    evaluate (sideCondition, conditional) =
+        assert (Conditional.isNormalized conditional)
+        $ evaluate (sideCondition, Conditional.predicate conditional)
 
 {- | Removes all branches refuted by an external SMT solver.
  -}

--- a/kore/src/Kore/Step/SMT/Lemma.hs
+++ b/kore/src/Kore/Step/SMT/Lemma.hs
@@ -76,7 +76,7 @@ declareSMTLemmas m = do
         guard (isSmtLemma $ Attribute.smtLemma atts)
         (lemma, TranslatorState { terms }) <-
             runTranslator
-            $ translatePredicate translateUninterpreted
+            $ translatePredicateWith translateUninterpreted
             $ wrapPredicate $ sentenceAxiomPattern axiomDeclaration
         SMT.assert (addQuantifiers terms lemma)
 

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -9,7 +9,7 @@ Portability : portable
 -}
 
 module Kore.Step.SMT.Translate
-    ( translatePredicate
+    ( translatePredicateWith
     , Translator
     , TranslateItem (..)
     , TranslatorState (..)
@@ -90,7 +90,7 @@ not builtins or predicates. All other patterns are not translated and prevent
 the predicate from being sent to SMT.
 
  -}
-translatePredicate
+translatePredicateWith
     :: forall p variable m .
         ( Given (SmtMetadataTools Attribute.Symbol)
         , p ~ TermLike variable
@@ -100,7 +100,7 @@ translatePredicate
     => (SExpr -> TranslateItem variable -> Translator m variable SExpr)
     -> Predicate variable
     -> Translator m variable SExpr
-translatePredicate translateTerm predicate =
+translatePredicateWith translateTerm predicate =
     translatePredicatePattern $ unwrapPredicate predicate
   where
     translateUninterpreted t pat = translateTerm t (UninterpretedTerm pat)

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -62,6 +62,7 @@ import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
 import Branch
+import Control.Monad.Counter
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import Kore.Debug
@@ -226,6 +227,8 @@ instance (WithLog LogMessage m, MonadSimplify m, Monoid w)
     {-# INLINE localSimplifierAxioms #-}
 
 deriving instance MonadSimplify m => MonadSimplify (BranchT m)
+
+instance MonadSimplify m => MonadSimplify (CounterT m)
 
 instance MonadSimplify m => MonadSimplify (ExceptT e m)
 

--- a/kore/src/SQL.hs
+++ b/kore/src/SQL.hs
@@ -56,6 +56,9 @@ import Data.Text
 import qualified Database.SQLite.Simple as SQLite
 import qualified Generics.SOP as SOP
 
+import qualified SMT.SimpleSMT as SMT
+    ( Result (..)
+    )
 import SQL.ColumnDef
 import SQL.Key
 import SQL.SOP
@@ -112,6 +115,13 @@ instance (Column a, Typeable a) => Column (NonEmpty a) where
 
 defineTextColumn :: TableName -> proxy a -> SQL ColumnDef
 defineTextColumn tableName _ = defineColumn tableName (Proxy @Text)
+
+instance Column SMT.Result where
+    defineColumn = defineTextColumn
+
+    toColumn SMT.Unsat = toColumn @Text "unsat"
+    toColumn SMT.Sat = toColumn @Text "sat"
+    toColumn SMT.Unknown = toColumn @Text "unknown"
 
 {- | Reify a 'Column' constraint into a concrete implementation 'ColumnImpl'.
  -}

--- a/kore/test/Test/Kore/Log/DebugEvaluateCondition.hs
+++ b/kore/test/Test/Kore/Log/DebugEvaluateCondition.hs
@@ -2,9 +2,16 @@ module Test.Kore.Log.DebugEvaluateCondition
     ( test_instance_Table_DebugEvaluateCondition
     ) where
 
-import Prelude.Kore ()
+import Prelude.Kore
 
 import Test.Tasty
+
+import Data.List
+    ( inits
+    )
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
 
 import Kore.Internal.Predicate
 import Kore.Internal.TermLike
@@ -15,10 +22,11 @@ import Test.SQL
 
 test_instance_Table_DebugEvaluateCondition :: TestTree
 test_instance_Table_DebugEvaluateCondition =
-    testTable @DebugEvaluateCondition
-        [ DebugEvaluateCondition predicate1
-        , DebugEvaluateCondition predicate2
-        ]
+    testTable @DebugEvaluateCondition $ do
+        let predicates = [predicate1, predicate2]
+        predicate <- predicates
+        sideConditions <- inits predicates
+        [DebugEvaluateCondition (predicate :| sideConditions)]
 
 predicate1, predicate2 :: Predicate Variable
 predicate1 = makeEqualsPredicate_ (Mock.f Mock.a) (Mock.g Mock.b)

--- a/kore/test/Test/Kore/Step/SMT/Evaluator.hs
+++ b/kore/test/Test/Kore/Step/SMT/Evaluator.hs
@@ -227,7 +227,9 @@ q = vBool (testId "q")
 assertRefuted :: HasCallStack => Predicate Variable -> Assertion
 assertRefuted prop = do
     let expect = Just False
-    actual <- Test.runSimplifier testEnv $ SMT.Evaluator.decidePredicate prop
+    actual <-
+        SMT.Evaluator.decidePredicate Nothing prop
+        & Test.runSimplifier testEnv
     assertEqual "" expect actual
 
 true, false :: TermLike Variable

--- a/kore/test/Test/Kore/Step/SMT/Evaluator.hs
+++ b/kore/test/Test/Kore/Step/SMT/Evaluator.hs
@@ -15,6 +15,10 @@ import Hedgehog hiding
     )
 import Test.Tasty
 
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
+
 import Kore.Internal.Conditional
     ( Conditional (Conditional)
     )
@@ -228,7 +232,7 @@ assertRefuted :: HasCallStack => Predicate Variable -> Assertion
 assertRefuted prop = do
     let expect = Just False
     actual <-
-        SMT.Evaluator.decidePredicate Nothing prop
+        SMT.Evaluator.decidePredicate (prop :| [])
         & Test.runSimplifier testEnv
     assertEqual "" expect actual
 

--- a/kore/test/Test/Kore/Step/SMT/Symbols.hs
+++ b/kore/test/Test/Kore/Step/SMT/Symbols.hs
@@ -62,7 +62,7 @@ import qualified Kore.Step.SMT.Representation.All as Representation
     )
 import Kore.Step.SMT.Translate
     ( evalTranslator
-    , translatePredicate
+    , translatePredicateWith
     )
 import Kore.Syntax.ElementVariable
     ( ElementVariable (..)
@@ -223,11 +223,8 @@ test_sortDeclaration =
         -> m SExpr
     encodePredicate tools predicate = do
         expr <-
-            runMaybeT
-            $ evalTranslator
-                ( give tools
-                $ translatePredicate translateTerm predicate
-                )
+            runMaybeT $ evalTranslator $ give tools
+            $ translatePredicateWith translateTerm predicate
         maybe (error "Could not encode predicate") return expr
 
     sSortId :: Id

--- a/kore/test/Test/Kore/Step/SMT/Translate.hs
+++ b/kore/test/Test/Kore/Step/SMT/Translate.hs
@@ -157,9 +157,8 @@ test_goTranslatePredicate =
 
 translating :: HasCallStack => Predicate Variable -> IO (Maybe SExpr)
 translating =
-    Test.SMT.runNoSMT
-    . runMaybeT
-    . Evaluator.goTranslatePredicate Mock.metadataTools
+    Test.SMT.runNoSMT . runMaybeT
+    . Evaluator.translatePredicate Mock.metadataTools
 
 
 yields :: HasCallStack => IO (Maybe SExpr) -> SExpr -> IO ()

--- a/kore/test/Test/Kore/Step/SMT/Translate.hs
+++ b/kore/test/Test/Kore/Step/SMT/Translate.hs
@@ -26,6 +26,9 @@ import Kore.Internal.Variable
     ( Variable
     )
 import qualified Kore.Step.SMT.Evaluator as Evaluator
+import Kore.Step.SMT.Translate
+    ( evalTranslator
+    )
 import SMT
 import qualified SMT.SimpleSMT
 
@@ -157,7 +160,7 @@ test_goTranslatePredicate =
 
 translating :: HasCallStack => Predicate Variable -> IO (Maybe SExpr)
 translating =
-    Test.SMT.runNoSMT . runMaybeT
+    Test.SMT.runNoSMT . runMaybeT . evalTranslator
     . Evaluator.translatePredicate Mock.metadataTools
 
 


### PR DESCRIPTION
This pull request allows sending side conditions to the solver.

1. `decidePredicate` is modified to take a `NonEmpty` list of predicates.
1. `Evaluable` instances are added for pairs `(SideCondition variable, Predicate variable)` and `(SideCondition variable, Condition variable)`.
1. The solver's response is now added to the log.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
