### PR TITLE
Do not log SMT models

### DIFF
--- a/kore/src/SMT/SimpleSMT.hs
+++ b/kore/src/SMT/SimpleSMT.hs
@@ -285,7 +285,6 @@ newSolver exe opts logger = do
             debug (Solver solverHandle logger) errs
 
     setOption solver ":print-success" "true"
-    setOption solver ":produce-models" "true"
     Monad.when featureProduceAssertions
         $ setOption solver ":produce-assertions" "true"
 
@@ -643,10 +642,7 @@ check solver = do
                 asserts <- command solver (List [Atom "get-assertions"])
                 warn solver (buildText asserts)
             return Unknown
-        Atom "sat"     -> do
-            model <- command solver (List [Atom "get-model"])
-            debug solver (buildText model)
-            return Sat
+        Atom "sat"     -> return Sat
         _ -> fail $ unlines
             [ "Unexpected result from the SMT solver:"
             , "  Expected: unsat, unknown, or sat"


### PR DESCRIPTION
If the solver's model is desired, the user can load the query (see the
`--solver-transcript` option) into the solver offline to produce the model.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
