### PR TITLE
Add built-in symbolic evaluator for MAP.in_keys

### DIFF
--- a/kore/src/Kore/Builtin/AssocComm/CeilSimplifier.hs
+++ b/kore/src/Kore/Builtin/AssocComm/CeilSimplifier.hs
@@ -12,6 +12,9 @@ module Kore.Builtin.AssocComm.CeilSimplifier
 
 import Prelude.Kore
 
+import Control.Error
+    ( MaybeT
+    )
 import qualified Control.Lens as Lens
 import Control.Monad
     ( zipWithM
@@ -248,7 +251,7 @@ newBuiltinAssocCommCeilSimplifier mkBuiltin mkNotMember ceilSimplifierTermLike =
             allValues = concreteValues <> abstractValues
 
         let makeEvaluateTerm, defineAbstractKey, defineOpaque
-                :: TermLike variable -> simplifier (OrCondition variable)
+                :: TermLike variable -> MaybeT simplifier (OrCondition variable)
             makeEvaluateTerm termLike =
                 runCeilSimplifier ceilSimplifierTermLike
                     Ceil
@@ -261,7 +264,7 @@ newBuiltinAssocCommCeilSimplifier mkBuiltin mkNotMember ceilSimplifierTermLike =
 
             defineValue
                 ::  Domain.Value normalized (TermLike variable)
-                ->  simplifier (MultiAnd (OrCondition variable))
+                ->  MaybeT simplifier (MultiAnd (OrCondition variable))
             defineValue =
                 Foldable.foldlM worker mempty
               where
@@ -300,14 +303,14 @@ newBuiltinAssocCommCeilSimplifier mkBuiltin mkNotMember ceilSimplifierTermLike =
     distinctKey
         ::  TermLike variable
         ->  [TermLike variable]
-        ->  simplifier (MultiAnd (OrCondition variable))
+        ->  MaybeT simplifier (MultiAnd (OrCondition variable))
     distinctKey thisKey otherKeys =
         MultiAnd.make <$> traverse (notEquals thisKey) otherKeys
 
     notEquals
         ::  TermLike variable
         ->  TermLike variable
-        ->  simplifier (OrCondition variable)
+        ->  MaybeT simplifier (OrCondition variable)
     notEquals t1 t2 = do
         sideCondition <- Reader.ask
         Equals.makeEvaluateTermsToPredicate tMin tMax sideCondition

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -320,8 +320,13 @@ evalUpdate _ _ = Builtin.wrongArity Map.updateKey
 
 evalInKeys :: Builtin.Function
 evalInKeys resultSort [_key, _map] =
-    concreteMap <|> symbolicMap
+    emptyMap <|> concreteMap <|> symbolicMap
   where
+    -- The empty map contains no keys.
+    emptyMap = do
+        _map <- expectConcreteBuiltinMap Map.in_keysKey _map
+        Monad.guard (Map.null _map)
+        Bool.asPattern resultSort False & return
     -- When the map is concrete, decide if a concrete key is present or absent.
     concreteMap = do
         _map <- expectConcreteBuiltinMap Map.in_keysKey _map

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -24,6 +24,7 @@ module Kore.Builtin.Map
     , evalConcat
     , evalElement
     , evalUnit
+    , evalInKeys
     ) where
 
 import Prelude.Kore

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -188,9 +188,9 @@ makeEvaluateTerm sideCondition ceilChild =
         [ newPredicateCeilSimplifier
         , newDefinedCeilSimplifier
         , newApplicationCeilSimplifier
-        , newBuiltinCeilSimplifier
         , newInjCeilSimplifier
         , newAxiomCeilSimplifier
+        , newBuiltinCeilSimplifier
         ]
 
 ceilSimplifierTermLike

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -188,9 +188,9 @@ makeEvaluateTerm sideCondition ceilChild =
         [ newPredicateCeilSimplifier
         , newDefinedCeilSimplifier
         , newApplicationCeilSimplifier
+        , newBuiltinCeilSimplifier
         , newInjCeilSimplifier
         , newAxiomCeilSimplifier
-        , newBuiltinCeilSimplifier
         ]
 
 ceilSimplifierTermLike

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -240,7 +240,7 @@ ceilSimplifierTermLike
             (OrCondition variable)
 ceilSimplifierTermLike =
     CeilSimplifier $ \Ceil { ceilChild = termLike } ->
-    ReaderT $ \sideCondition ->
+    lift $ ReaderT $ \sideCondition ->
         makeEvaluateTerm sideCondition termLike
 
 {-| Evaluates the ceil of a domain value.

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -219,9 +219,9 @@ newDefinedCeilSimplifier
     => InternalVariable variable
     => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
 newDefinedCeilSimplifier = CeilSimplifier $ \input ->
-    case isDefinedPattern (ceilChild input) of
-        True -> return OrCondition.top
-        _ -> empty
+    if isDefinedPattern (ceilChild input)
+        then return OrCondition.top
+        else empty
 
 newApplicationCeilSimplifier
     :: MonadReader (SideCondition variable) simplifier

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -17,6 +17,10 @@ module Kore.Step.Simplification.Ceil
 
 import Prelude.Kore
 
+import Control.Error
+    ( MaybeT
+    , maybeT
+    )
 import Control.Monad.Reader
     ( ReaderT (..)
     )
@@ -188,6 +192,7 @@ makeEvaluateTerm
 
       | BuiltinF child <- projected =
         makeEvaluateBuiltin sideCondition child
+        & flip maybeT return (makeSimplifiedCeil sideCondition Nothing term)
 
       | InjF inj <- projected = do
         InjSimplifier { evaluateCeilInj } <- askInjSimplifier
@@ -246,7 +251,7 @@ makeEvaluateBuiltin
     => MonadSimplify simplifier
     => SideCondition variable
     -> Builtin (TermLike variable)
-    -> simplifier (OrCondition variable)
+    -> MaybeT simplifier (OrCondition variable)
 makeEvaluateBuiltin sideCondition (Domain.BuiltinMap internalAc) =
     runCeilSimplifierWith
         (AssocComm.newMapCeilSimplifier ceilSimplifierTermLike)

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -22,13 +22,18 @@ import Control.Error
     , maybeT
     )
 import Control.Monad.Reader
-    ( ReaderT (..)
+    ( MonadReader
+    , ReaderT (..)
     )
+import qualified Control.Monad.Reader as Reader
 import qualified Data.Foldable as Foldable
 import qualified Data.Functor.Foldable as Recursive
 
 import qualified Kore.Attribute.Symbol as Attribute.Symbol
     ( isTotal
+    )
+import Kore.Attribute.Synthetic
+    ( synthesize
     )
 import qualified Kore.Builtin.AssocComm.CeilSimplifier as AssocComm
 import qualified Kore.Domain.Builtin as Domain
@@ -52,7 +57,6 @@ import Kore.Internal.Pattern
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
     ( makeCeilPredicate_
-    , makeTruePredicate_
     )
 import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.SideCondition
@@ -168,68 +172,26 @@ makeEvaluateTerm
     => SideCondition variable
     -> TermLike variable
     -> simplifier (OrCondition variable)
-makeEvaluateTerm
-    sideCondition
-    term@(Recursive.project -> _ :< projected)
-  =
-    makeEvaluateTermWorker
+makeEvaluateTerm sideCondition ceilChild =
+    runCeilSimplifierWith
+        ceilSimplifier
+        sideCondition
+        Ceil
+            { ceilResultSort = Sort.predicateSort
+            , ceilOperandSort = termLikeSort ceilChild
+            , ceilChild
+            }
+    & maybeT (makeSimplifiedCeil sideCondition Nothing ceilChild) return
   where
-    makeEvaluateTermWorker
-      | isTop term            = return OrCondition.top
-      | isBottom term         = return OrCondition.bottom
-      | isDefinedPattern term = return OrCondition.top
-
-      | ApplySymbolF app <- projected
-      , let Application { applicationSymbolOrAlias = patternHead } = app
-      , let headAttributes = symbolAttributes patternHead
-      , Attribute.Symbol.isTotal headAttributes = do
-            let Application { applicationChildren = children } = app
-            simplifiedChildren <- mapM (makeEvaluateTerm sideCondition) children
-            let ceils = simplifiedChildren
-            And.simplifyEvaluatedMultiPredicate
-                sideCondition
-                (MultiAnd.make ceils)
-
-      | BuiltinF child <- projected =
-        makeEvaluateBuiltin sideCondition child
-        & flip maybeT return (makeSimplifiedCeil sideCondition Nothing term)
-
-      | InjF inj <- projected = do
-        InjSimplifier { evaluateCeilInj } <- askInjSimplifier
-        (makeEvaluateTerm sideCondition . ceilChild . evaluateCeilInj)
-            Ceil
-                { ceilResultSort = termLikeSort term -- sort is irrelevant
-                , ceilOperandSort = termLikeSort term
-                , ceilChild = inj
-                }
-
-      | otherwise = do
-        evaluation <- Axiom.evaluatePattern
-            sideCondition
-            Conditional
-                { term = ()
-                , predicate = makeTruePredicate_
-                , substitution = mempty
-                }
-            (mkCeil_ term)
-            (\maybeCondition ->
-                OrPattern.fromPatterns
-                . map Pattern.fromCondition
-                . OrCondition.toConditions
-                <$> makeSimplifiedCeil sideCondition maybeCondition term
-            )
-        return (fmap toCondition evaluation)
-
-    toCondition Conditional {term = Top_ _, predicate, substitution} =
-        Conditional {term = (), predicate, substitution}
-    toCondition patt =
-        error
-            (  "Ceil simplification is expected to result ai a predicate, but"
-            ++ " got (" ++ show patt ++ ")."
-            ++ " The most likely cases are: evaluating predicate symbols, "
-            ++ " and predicate symbols are currently unrecognized as such, "
-            ++ "and programming errors."
-            )
+    ceilSimplifier =
+        mconcat
+        [ newPredicateCeilSimplifier
+        , newDefinedCeilSimplifier
+        , newApplicationCeilSimplifier
+        , newBuiltinCeilSimplifier
+        , newInjCeilSimplifier
+        , newAxiomCeilSimplifier
+        ]
 
 ceilSimplifierTermLike
     ::  InternalVariable variable
@@ -242,6 +204,93 @@ ceilSimplifierTermLike =
     CeilSimplifier $ \Ceil { ceilChild = termLike } ->
     lift $ ReaderT $ \sideCondition ->
         makeEvaluateTerm sideCondition termLike
+
+newPredicateCeilSimplifier
+    :: Monad simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newPredicateCeilSimplifier = CeilSimplifier $ \input ->
+    case Predicate.makePredicate (ceilChild input) of
+        Left _ -> empty
+        Right predicate -> return (OrCondition.fromPredicate predicate)
+
+newDefinedCeilSimplifier
+    :: Monad simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newDefinedCeilSimplifier = CeilSimplifier $ \input ->
+    case isDefinedPattern (ceilChild input) of
+        True -> return OrCondition.top
+        _ -> empty
+
+newApplicationCeilSimplifier
+    :: MonadReader (SideCondition variable) simplifier
+    => MonadSimplify simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newApplicationCeilSimplifier = CeilSimplifier $ \input ->
+    case ceilChild input of
+        App_ patternHead children
+          | let headAttributes = symbolAttributes patternHead
+          , Attribute.Symbol.isTotal headAttributes -> do
+            sideCondition <- Reader.ask
+            simplifiedChildren <- mapM (makeEvaluateTerm sideCondition) children
+            let ceils = simplifiedChildren
+            And.simplifyEvaluatedMultiPredicate
+                sideCondition
+                (MultiAnd.make ceils)
+        _ -> empty
+
+newInjCeilSimplifier
+    :: MonadReader (SideCondition variable) simplifier
+    => MonadSimplify simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newInjCeilSimplifier = CeilSimplifier $ \input ->
+    case ceilChild input of
+        Inj_ inj -> do
+            InjSimplifier { evaluateCeilInj } <- askInjSimplifier
+            sideCondition <- Reader.ask
+            (makeEvaluateTerm sideCondition . ceilChild . evaluateCeilInj)
+                input { ceilChild = inj }
+        _ -> empty
+
+newBuiltinCeilSimplifier
+    :: MonadReader (SideCondition variable) simplifier
+    => MonadSimplify simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newBuiltinCeilSimplifier = CeilSimplifier $ \input ->
+    case ceilChild input of
+        Builtin_ builtin -> do
+            sideCondition <- Reader.ask
+            makeEvaluateBuiltin sideCondition builtin
+        _ -> empty
+
+newAxiomCeilSimplifier
+    :: MonadReader (SideCondition variable) simplifier
+    => MonadSimplify simplifier
+    => InternalVariable variable
+    => CeilSimplifier simplifier (TermLike variable) (OrCondition variable)
+newAxiomCeilSimplifier = CeilSimplifier $ \input -> do
+    sideCondition <- Reader.ask
+    evaluation <- Axiom.evaluatePattern
+        sideCondition
+        Condition.top
+        (synthesize $ CeilF input)
+        (const empty)
+    return (fmap toCondition evaluation)
+  where
+    toCondition Conditional {term = Top_ _, predicate, substitution} =
+        Conditional {term = (), predicate, substitution}
+    toCondition patt =
+        error
+            (  "Ceil simplification is expected to result ai a predicate, but"
+            ++ " got (" ++ show patt ++ ")."
+            ++ " The most likely cases are: evaluating predicate symbols, "
+            ++ " and predicate symbols are currently unrecognized as such, "
+            ++ "and programming errors."
+            )
 
 {-| Evaluates the ceil of a domain value.
 -}

--- a/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
@@ -37,6 +37,21 @@ instance Functor simplifier => Profunctor (CeilSimplifier simplifier) where
         CeilSimplifier (dimap (fmap fl) (fmap fr) simpl)
     {-# INLINE dimap #-}
 
+instance
+    Monad simplifier
+    => Semigroup (CeilSimplifier simplifier input output)
+  where
+    (<>) (CeilSimplifier simplifier1) (CeilSimplifier simplifier2) =
+        CeilSimplifier (\input -> simplifier1 input <|> simplifier2 input)
+    {-# INLINE (<>) #-}
+
+instance
+    Monad simplifier
+    => Monoid (CeilSimplifier simplifier input output)
+  where
+    mempty = CeilSimplifier (\_ -> empty)
+    {-# INLINE mempty #-}
+
 hoistCeilSimplifier
     :: Monad m
     => (forall x. m x -> n x)

--- a/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
@@ -84,7 +84,7 @@ instance
     Monad simplifier
     => Monoid (CeilSimplifier simplifier input output)
   where
-    mempty = CeilSimplifier (\_ -> empty)
+    mempty = CeilSimplifier (const empty)
     {-# INLINE mempty #-}
 
 hoistCeilSimplifier

--- a/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/CeilSimplifier.hs
@@ -10,8 +10,13 @@ module Kore.Step.Simplification.CeilSimplifier
     , runCeilSimplifierWith
     ) where
 
-import Prelude.Kore
+import Prelude.Kore hiding
+    ( (.)
+    )
 
+import Control.Category
+    ( Category (..)
+    )
 import Control.Error
     ( MaybeT
     )
@@ -37,6 +42,17 @@ newtype CeilSimplifier simplifier input output =
     CeilSimplifier {
         runCeilSimplifier :: Ceil Sort input -> MaybeT simplifier output
     }
+
+instance Monad simplifier => Category (CeilSimplifier simplifier) where
+    id = CeilSimplifier (return . ceilChild)
+    {-# INLINE id #-}
+
+    (.) (CeilSimplifier simpl2) (CeilSimplifier simpl1) =
+        CeilSimplifier $ \input1 -> do
+            ceilChild <- simpl1 input1
+            let input2 = input1 { ceilChild }
+            simpl2 input2
+    {-# INLINE (.) #-}
 
 instance Functor simplifier => Profunctor (CeilSimplifier simplifier) where
     dimap fl fr (CeilSimplifier simpl) =

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -48,6 +48,7 @@ import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Reader
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map.Strict as Map
 import Data.Text
@@ -243,6 +244,8 @@ instance MonadSimplify m => MonadSimplify (ListT m) where
     {-# INLINE localSimplifierAxioms #-}
 
 instance MonadSimplify m => MonadSimplify (MaybeT m)
+
+instance MonadSimplify m => MonadSimplify (ReaderT r m)
 
 instance MonadSimplify m => MonadSimplify (Strict.StateT s m)
 

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -1,11 +1,20 @@
 module Test.Expect
     ( expectRight
     , expectLeft
+    , expectOne
+    , assertNull
+    , assertTop
+    , expectBool
     ) where
 
 import Prelude.Kore
 
+import qualified Data.Foldable as Foldable
+
 import Debug
+import Kore.Domain.Builtin
+import Kore.Internal.TermLike
+import Kore.TopBottom
 
 import Test.Tasty.HUnit.Ext
 
@@ -14,3 +23,24 @@ expectRight = either (assertFailure . show . debug) return
 
 expectLeft :: HasCallStack => Debug right => Either left right -> IO left
 expectLeft = either return (assertFailure . show . debug)
+
+expectOne :: Foldable fold => HasCallStack => Debug [a] => fold a -> IO a
+expectOne as =
+    case Foldable.toList as of
+        [a] -> return a
+        as' -> (assertFailure . show) (debug as')
+
+assertNull :: Foldable fold => HasCallStack => Debug [a] => fold a -> IO ()
+assertNull as =
+    case Foldable.toList as of
+        [] -> return ()
+        as' -> (assertFailure . show) (debug as')
+
+assertTop :: HasCallStack => TopBottom a => Debug a => a -> IO ()
+assertTop a
+  | isTop a = return ()
+  | otherwise = (assertFailure . show) (debug a)
+
+expectBool :: HasCallStack => TermLike Variable -> IO Bool
+expectBool (BuiltinBool_ internalBool) = return (builtinBoolValue internalBool)
+expectBool term = (assertFailure . show) (debug term)

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -1335,9 +1335,9 @@ hprop_unparse =
 test_inKeys :: [TestTree]
 test_inKeys =
     [ testCase "empty Map contains no keys" $ do
-        actual1 <- inKeys concreteKey unitMap
+        actual1 <- inKeys concreteKey (asInternal [])
         assertEqual "no concrete keys" (Just False) actual1
-        actual2 <- inKeys symbolicKey unitMap
+        actual2 <- inKeys symbolicKey (asInternal [])
         assertEqual "no symbolic keys" (Just False) actual2
     , testGroup "concrete Map"
         [ testCase "concrete key is present" $ do

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -1339,6 +1339,8 @@ test_inKeys =
         assertEqual "no concrete keys" (Just False) actual1
         actual2 <- inKeys x (asInternal [])
         assertEqual "no symbolic keys" (Just False) actual2
+        actual3 <- inKeys (tdivInt y z) (asInternal [])
+        assertEqual "no partial keys" (Just False) actual3
     , testGroup "concrete Map"
         [ testCase "concrete key is present" $ do
             actual <- inKeys concreteKey concreteMap
@@ -1358,6 +1360,9 @@ test_inKeys =
         , testCase "concrete key is present" $ do
             actual <- inKeys concreteKey symbolicMap
             assertEqual "" (Just True) actual
+        , testCase "partial key is present" $ do
+            actual <- inKeys (tdivInt y z) symbolicMap
+            assertEqual "" (Just True) actual
         , testCase "symbolic key is undecided" $ do
             let key = mkIntVar (testId "z")
             actual <- inKeys key symbolicMap
@@ -1365,6 +1370,9 @@ test_inKeys =
         , testCase "concrete key is undecided" $ do
             let key = Test.Int.asInternal 2
             actual <- inKeys key symbolicMap
+            assertEqual "" Nothing actual
+        , testCase "partial key is undecided" $ do
+            actual <- inKeys (tdivInt x z) symbolicMap
             assertEqual "" Nothing actual
         ]
     ]
@@ -1385,7 +1393,7 @@ test_inKeys =
     symbolicMap =
         asInternal
         [ (x, u)
-        , (y, v)
+        , (tdivInt y z, v)
         , (Test.Int.asInternal 0, w)
         ]
     inKeys

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -623,10 +623,6 @@ test_inclusion =
         )
     ]
 
-
-
-
-
 -- | Check that simplification is carried out on map elements.
 test_simplify :: TestTree
 test_simplify =
@@ -676,20 +672,6 @@ test_isBuiltin =
         assertBool "" (not (Map.isSymbolUnit Mock.aSymbol))
         assertBool "" (not (Map.isSymbolUnit Mock.concatMapSymbol))
     ]
-
--- | Construct a pattern for a map which may have symbolic keys.
-asSymbolicPattern
-    :: Map (TermLike Variable) (TermLike Variable)
-    -> TermLike Variable
-asSymbolicPattern result
-    | Map.null result =
-        applyUnit
-    | otherwise =
-        foldr1 applyConcat (applyElement <$> Map.toAscList result)
-  where
-    applyUnit = mkApplySymbol unitMapSymbol []
-    applyElement (key, value) = elementMap key value
-    applyConcat map1 map2 = concatMap map1 map2
 
 {- | Unify two maps with concrete keys and variable values.
  -}
@@ -1336,6 +1318,22 @@ hprop_unparse =
         )
   where
     genValue = Test.Int.asInternal <$> genInteger
+
+-- * Helpers
+
+-- | Construct a pattern for a map which may have symbolic keys.
+asSymbolicPattern
+    :: Map (TermLike Variable) (TermLike Variable)
+    -> TermLike Variable
+asSymbolicPattern result
+    | Map.null result =
+        applyUnit
+    | otherwise =
+        foldr1 applyConcat (applyElement <$> Map.toAscList result)
+  where
+    applyUnit = mkApplySymbol unitMapSymbol []
+    applyElement (key, value) = elementMap key value
+    applyConcat map1 map2 = concatMap map1 map2
 
 -- | Specialize 'Map.asTermLike' to the builtin sort 'mapSort'.
 asTermLike :: Map (TermLike Concrete) (TermLike Variable) -> TermLike Variable

--- a/kore/test/Test/Kore/Builtin/Map.hs
+++ b/kore/test/Test/Kore/Builtin/Map.hs
@@ -1337,38 +1337,57 @@ test_inKeys =
     [ testCase "empty Map contains no keys" $ do
         actual1 <- inKeys concreteKey (asInternal [])
         assertEqual "no concrete keys" (Just False) actual1
-        actual2 <- inKeys symbolicKey (asInternal [])
+        actual2 <- inKeys x (asInternal [])
         assertEqual "no symbolic keys" (Just False) actual2
     , testGroup "concrete Map"
         [ testCase "concrete key is present" $ do
             actual <- inKeys concreteKey concreteMap
             assertEqual "" (Just True) actual
         , testCase "concrete key is absent" $ do
-            let key = Test.Int.asInternal 1
+            let key = Test.Int.asInternal 2
             actual <- inKeys key concreteMap
             assertEqual "" (Just False) actual
         , testCase "symbolic key is undecided" $ do
-            actual <- inKeys symbolicKey concreteMap
+            actual <- inKeys x concreteMap
             assertEqual "" Nothing actual
         ]
     , testGroup "symbolic Map"
         [ testCase "symbolic key is present" $ do
-            actual <- inKeys symbolicKey symbolicMap
+            actual <- inKeys x symbolicMap
             assertEqual "" (Just True) actual
-        , testCase "concrete key is undecided" $ do
+        , testCase "concrete key is present" $ do
             actual <- inKeys concreteKey symbolicMap
-            assertEqual "" Nothing actual
+            assertEqual "" (Just True) actual
         , testCase "symbolic key is undecided" $ do
-            let key = mkIntVar (testId "x'")
+            let key = mkIntVar (testId "z")
+            actual <- inKeys key symbolicMap
+            assertEqual "" Nothing actual
+        , testCase "concrete key is undecided" $ do
+            let key = Test.Int.asInternal 2
             actual <- inKeys key symbolicMap
             assertEqual "" Nothing actual
         ]
     ]
   where
     concreteKey = Test.Int.asInternal 0
-    concreteMap = asInternal [(Test.Int.asInternal 0, mkIntVar (testId "y"))]
-    symbolicKey = mkIntVar (testId "x")
-    symbolicMap = asInternal [(mkIntVar (testId "x"), mkIntVar (testId "y"))]
+    concreteMap =
+        asInternal
+        [ (Test.Int.asInternal 0, u)
+        , (Test.Int.asInternal 1, v)
+        ]
+    x, y, z, u, v, w :: TermLike Variable
+    x = mkIntVar (testId "x")
+    y = mkIntVar (testId "y")
+    z = mkIntVar (testId "z")
+    u = mkIntVar (testId "u")
+    v = mkIntVar (testId "v")
+    w = mkIntVar (testId "w")
+    symbolicMap =
+        asInternal
+        [ (x, u)
+        , (y, v)
+        , (Test.Int.asInternal 0, w)
+        ]
     inKeys
         :: HasCallStack
         => TermLike Variable


### PR DESCRIPTION
This pull request implements symbolic evaluation of the `MAP.in_keys` hook, the first part of fixing #1665.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
