### PR TITLE
Add a script for launching ghcid

### DIFF
--- a/ghcid.sh
+++ b/ghcid.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Load the entire project in GHCi.
+# Usage: ghcid.sh [⟨ghcid arguments⟩] -- ⟨ghci arguments⟩
+# Example: Load the kore-test test suite in GHCi:
+#   $ ghcid.sh -- Driver
+
+ghcid_args=()
+while [[ "$#" -gt 0 ]]
+do
+    arg="$1"
+    shift
+    if [[ "$arg" == "--" ]]
+    then
+        break
+    else
+        ghcid_args+=("$arg")
+    fi
+done
+
+ghci_args=( $(./hie-bios.sh) )
+while [[ "$#" -gt 0 ]]
+do
+    ghci_args+=("$1")
+    shift
+done
+
+ghci="ghci ${ghci_args[@]}"
+exec ghcid -c "$ghci" "${ghcid_args[@]}"

--- a/hie-bios.sh
+++ b/hie-bios.sh
@@ -18,11 +18,15 @@ out -ikore/src/
 out -ikore/test/
 out -ikore/app/share/
 out -ikore/bench/
-out -ikore/$(stack path --dist-dir)/build/autogen/
-out -clear-package-db
-out -package-db $(stack path --local-pkg-db)
-out -package-db $(stack path --snapshot-pkg-db)
-out -package-db $(stack path --global-pkg-db)
+
+# Set -package-db options, unless GHC_PACKAGE_PATH is set already.
+if [[ -z "${GHC_PACKAGE_PATH}" ]] && [[ -z "${IN_NIX_SHELL}" ]]
+then
+    out -clear-package-db
+    out -package-db $(stack path --local-pkg-db)
+    out -package-db $(stack path --snapshot-pkg-db)
+    out -package-db $(stack path --global-pkg-db)
+fi
 
 yq -r '. "ghc-options" []' < ./kore/package.yaml | while read opt
 do


### PR DESCRIPTION
The script loads the entire package into a single GHCi session, which (among other things) avoids building the library.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
