### PR TITLE
SubstitutionCoverageError: Report unassigned variables

### DIFF
--- a/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
+++ b/kore/src/Kore/Log/ErrorRewritesInstantiation.hs
@@ -195,7 +195,7 @@ checkSubstitutionCoverage initial unified
                     (fmap unTargetVariable)
                     (fmap unTargetVariable)
                 )
-                substitutionVariables
+                uncovered
         }
     configuration = Conditional
         { term = mapUnTargetTermLike $ Pattern.term initial


### PR DESCRIPTION
It seems that for the substitution coverage error we were reporting the assigned instead of the unassigned variables. This PR addresses this issue.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
