### PR TITLE
Allow local modications to Nix environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ cabal.project.local
 /result*
 /local.nix
 /shell.local.nix
+/TAGS
+/.TAGS*

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ cabal.project.local
 *.save-proofs.kore
 .envrc
 /result*
+/local.nix
+/shell.local.nix

--- a/default.nix
+++ b/default.nix
@@ -21,8 +21,13 @@ let
       };
     in import haskell-nix.sources.nixpkgs-1909 args;
   pkgs = nixpkgs;
+  local =
+    if builtins.pathExists ./local.nix
+    then import ./local.nix { inherit default; }
+    else x: x;
+  stackProject = args: pkgs.haskell-nix.stackProject (local args);
   project =
-    pkgs.haskell-nix.stackProject {
+    stackProject {
       src = pkgs.haskell-nix.haskellLib.cleanGit { name = "kore"; src = ./.; };
       modules = [
         {

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,14 @@
 
 let
   inherit (default) project pkgs;
+  local =
+    if builtins.pathExists ./shell.local.nix
+    then import ./shell.local.nix { inherit default; }
+    else x: x;
+  shellFor = args: project.shellFor (local args);
 in
 
-project.shellFor {
+shellFor {
   buildInputs =
     with pkgs;
     [


### PR DESCRIPTION
This adds `ghc-tags-plugin` to the `shell.nix` environment, so that GHC and GHCi can generate tags files for editors that use them (Emacs and Vim). Use the plugin by adding options `-plugin-package=ghc-tags-plugin -fplugin=Plugin.GhcTags -fplugin-opt=Plugin.GhcTags:--etags` to the GHCi command line. Omit the `-fplugin-opt=...` for Vim.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
