### PR TITLE
Replace tasty-ant-xml with tasty-test-reporter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,9 @@ pipeline {
           }
         }
         stage('Unit Tests') {
+          options {
+            timeout(time: 24, unit: 'MINUTES')
+          }
           steps {
             sh '''
               ./scripts/unit-test.sh
@@ -55,7 +58,7 @@ pipeline {
         }
         stage('Integration Tests') {
           options {
-            timeout(time: 32, unit: 'MINUTES')
+            timeout(time: 24, unit: 'MINUTES')
           }
           steps {
             sh '''

--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -215,11 +215,11 @@ tests:
       - hedgehog >=1.0
       - quickcheck-instances >=0.3
       - tasty >=1.2
-      - tasty-ant-xml >=1.1
-      - tasty-hedgehog >=1.0
       - tasty-golden >=2.3
       - tasty-hunit >=0.10
+      - tasty-hedgehog >=1.0
       - tasty-quickcheck >=0.10
+      - tasty-test-reporter >=0.1
       - template-haskell >=2.14
       - temporary >=1.3
     <<: *common-exe

--- a/kore/test/Driver.hs
+++ b/kore/test/Driver.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --hide-successes -optF --ingredient=Test.Tasty.Runners.consoleTestReporter -optF --ingredient=Test.Tasty.Runners.listingTests -optF --ingredient=Test.Tasty.Runners.AntXML.antXMLRunner -optF --generated-module=Driver #-}
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --hide-successes -optF --ingredient=Test.Tasty.Runners.Reporter.ingredient -optF --ingredient=Test.Tasty.Runners.listingTests -optF --generated-module=Driver #-}
 
 {- |
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,8 +48,12 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - ghc-trace-events-0.0.0.1@sha256:cef5cffd2d749b07ba948b27970c45b6e96705575853f9c14719ad2b9b3397e2
+
   - witherable-0.3.5@sha256:6590a15735b50ac14dcc138d4265ff1585d5f3e9d3047d5ebc5abf4cd5f50084,1476
   - witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
+
+  - tasty-test-reporter-0.1.1.1@sha256:e34ea27f5a8f6673de2952c29799da243adb2246b1912a207e903caa9a9dbe34,1779
+  - junit-xml-0.1.0.0@sha256:5da18fe01fdb2e32904499ad67f32229a1df4bd4422483dd4a26090aeaf5de0d,1417
 
 # TODO (thomas.tuegel): Remove this when stylish-haskell is updated upstream.
 allow-newer: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,6 +25,20 @@ packages:
       sha256: e99696bf95da593a3892c7b9a28db09ffd139b4b1b313f32cec9d26979aa7ce2
   original:
     hackage: witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
+- completed:
+    hackage: tasty-test-reporter-0.1.1.1@sha256:e34ea27f5a8f6673de2952c29799da243adb2246b1912a207e903caa9a9dbe34,1779
+    pantry-tree:
+      size: 410
+      sha256: e3897d9fc739f589ec76f5c94adfdca8e88434c8731aa27a75bfdd61d5d547cb
+  original:
+    hackage: tasty-test-reporter-0.1.1.1@sha256:e34ea27f5a8f6673de2952c29799da243adb2246b1912a207e903caa9a9dbe34,1779
+- completed:
+    hackage: junit-xml-0.1.0.0@sha256:5da18fe01fdb2e32904499ad67f32229a1df4bd4422483dd4a26090aeaf5de0d,1417
+    pantry-tree:
+      size: 384
+      sha256: c21b8b22bbbebb15a8d6babb7efbf3d31045ca2f1763d7fc2c44e99d180a1a59
+  original:
+    hackage: junit-xml-0.1.0.0@sha256:5da18fe01fdb2e32904499ad67f32229a1df4bd4422483dd4a26090aeaf5de0d,1417
 snapshots:
 - completed:
     size: 524996


### PR DESCRIPTION
tasty-test-reporter displays failing tests better in the console and can display
test failures in the CI logs while simultaneously producing a Jenkins XML
report.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
