### PR TITLE
test/include.mk: `true` is not `/bin/true`

### DIFF
--- a/test/include.mk
+++ b/test/include.mk
@@ -71,7 +71,7 @@ $(DEF_KORE_DEFAULT): $(DEF_DIR)/$(DEF).k $(K)
 	$(DIFF) $@.golden $@ || $(FAILED)
 
 %.verify.out: $(DEF_KORE_DEFAULT)
-	$(KORE_PARSER) $(DEF_KORE_DEFAULT) --verify >/dev/null 2>$@ || /bin/true
+	$(KORE_PARSER) $(DEF_KORE_DEFAULT) --verify >/dev/null 2>$@ || true
 	$(DIFF) $@.golden $@ || $(FAILED)
 
 ### SEARCH


### PR DESCRIPTION
This pull request is required to fix the integration tests on my machine.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
