### PR TITLE
Update 2019-08-27-Unification-modulo-overloaded-constructors.md

### DIFF
--- a/docs/2019-08-27-Unification-modulo-overloaded-constructors.md
+++ b/docs/2019-08-27-Unification-modulo-overloaded-constructors.md
@@ -59,7 +59,7 @@ axioms of the form:
 
 Note that, given the pair of overloaded symbols, these axioms can be
 automatically inferred. To assist tooling, the compilation process
-annotates these geenrated axioms with an `overload` attribute
+annotates these generated axioms with an `overload` attribute
 having the two symbols involved as arguments.
 
 Problems


### PR DESCRIPTION
---
I didn't have the rights to fix this small typo directly in the master branch
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
