### PR TITLE
kore: Build executables with -eventlog

### DIFF
--- a/kore/package.yaml
+++ b/kore/package.yaml
@@ -156,6 +156,7 @@ library:
   source-dirs: src
 
 _common-exe: &common-exe
+  ghc-options: -eventlog
   when:
     - condition: flag(threaded)
       then:


### PR DESCRIPTION
Compiling with -eventlog by default has no discernible overhead, but allows the
user to enable the eventlog at runtime without recompiling.

See also: #1897 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
