### PR TITLE
simplifyEvaluated: Use local mock simplifier

### DIFF
--- a/kore/test/Test/Kore/Step/Simplification/TermLike.hs
+++ b/kore/test/Test/Kore/Step/Simplification/TermLike.hs
@@ -34,7 +34,8 @@ test_simplify =
 
 simplifyEvaluated :: TermLike VariableName -> IO (OrPattern VariableName)
 simplifyEvaluated original =
-    runSimplifier env $ TermLike.simplify SideCondition.top original
+    runSimplifier env . getTestSimplifier
+    $ TermLike.simplify SideCondition.top original
   where
     env = Mock.env
         { simplifierCondition =


### PR DESCRIPTION
An earlier refactoring of this module disconnected the mock simplifier, using
the real simplifier instead.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
