### PR TITLE
Prelude.Kore: Export Semigroup and NonEmpty

### DIFF
--- a/kore/src/Prelude/Kore.hs
+++ b/kore/src/Prelude/Kore.hs
@@ -55,6 +55,10 @@ module Prelude.Kore
     , Category (..)
     , (<<<)
     , (>>>)
+    -- * Semigroup
+    , Semigroup (..)
+    -- * NonEmpty
+    , NonEmpty (..)
     ) where
 
 -- TODO (thomas.tuegel): Give an explicit export list so that the generated
@@ -106,10 +110,16 @@ import Data.Function
 import Data.Hashable
     ( Hashable (..)
     )
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
 import Data.Maybe
     ( fromMaybe
     , isJust
     , isNothing
+    )
+import Data.Semigroup
+    ( Semigroup (..)
     )
 import Data.Typeable
     ( Typeable


### PR DESCRIPTION
The base Prelude does not export all of Semigroup's methods because they rely on
NonEmpty, which is also not in the default scope.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
