### PR TITLE
Synchronous logging

### DIFF
--- a/kore/src/Kore/BugReport.hs
+++ b/kore/src/Kore/BugReport.hs
@@ -20,6 +20,7 @@ import Control.Monad.Catch
     ( ExitCase (..)
     , displayException
     , generalBracket
+    , handleAll
     )
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import qualified Data.Foldable as Foldable
@@ -86,14 +87,17 @@ withBugReport
     -> BugReport
     -> (FilePath -> IO ExitCode)
     -> IO ExitCode
-withBugReport exeName bugReport act = do
-    (exitCode, _) <-
-        generalBracket
-            acquireTempDirectory
-            releaseTempDirectory
-            act
-    pure exitCode
+withBugReport exeName bugReport act =
+    do
+        (exitCode, _) <-
+            generalBracket
+                acquireTempDirectory
+                releaseTempDirectory
+                act
+        pure exitCode
+    & handleAll handler
   where
+    handler _ = pure (ExitFailure 1)
     acquireTempDirectory = do
         tmp <- getCanonicalTemporaryDirectory
         createTempDirectory tmp (getExeName exeName)

--- a/kore/src/Kore/Log.hs
+++ b/kore/src/Kore/Log.hs
@@ -190,9 +190,7 @@ filterSeverity level ActualEntry { actualEntry = SomeEntry entry } =
 -- | Run a 'LoggerT' with the given options.
 runKoreLog :: FilePath -> KoreLogOptions -> LoggerT IO a -> IO a
 runKoreLog reportDirectory options loggerT =
-    withLogger reportDirectory options $ \logAction ->
-    withAsyncLogger logAction $ \asyncLogAction ->
-        runLoggerT loggerT asyncLogAction
+    withLogger reportDirectory options $ runLoggerT loggerT
 
 withAsyncLogger
     :: LogAction IO a


### PR DESCRIPTION
The logging infrastructure is changed to write the log synchronously from the main thread. This reduces memory use slightly, but dramatically reduces runtime by up to 50%!

Exception logging is simplified so that `withBugReport` is the final exception handler; it logs any uncaught exception, creates the bug report archive, and sets the exit code.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
