### PR TITLE
default.nix: Add kore attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,8 @@ let
 
   shell = import ./shell.nix { inherit default; };
 
+  version = project.kore.components.exes.kore-exec.version;
+
   default =
     {
       inherit pkgs project;
@@ -48,6 +50,10 @@ let
         project.roots
         (pkgs.haskell-nix.withInputs shell)
       ];
+      kore = pkgs.symlinkJoin {
+        name = "kore-${version}";
+        paths = pkgs.lib.attrValues project.kore.components.exes;
+      };
     };
 
 in default


### PR DESCRIPTION
Updating haskell.nix removed `project.kore.components.all`, so we are adding a
virtual package `kore` that combines all the executables.


---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
