### PR TITLE
Kore.Step.Transition: Lazy orElse

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -172,6 +172,11 @@
 
 - ignore: {name: "Redundant compare", within: [Kore.Syntax.Id]}
 
+- ignore:
+    name: "Use void"
+    within:
+      - Test.Kore.Step.Transition
+
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -10,7 +10,9 @@ License     : NCSA
 
 module Kore.Step.Transition
     ( TransitionT (..)
+    , Transition
     , runTransitionT
+    , runTransition
     , tryTransitionT
     , mapTransitionT
     , scatter
@@ -35,6 +37,10 @@ import Control.Monad.Reader
 import Control.Monad.Trans.Accum
 import qualified Control.Monad.Trans.Accum as Accum
 import qualified Data.Foldable as Foldable
+import Data.Functor.Identity
+    ( Identity
+    , runIdentity
+    )
 import Data.Sequence
     ( Seq
     )
@@ -78,6 +84,8 @@ newtype TransitionT rule m a =
         , Typeable
         )
 
+type Transition r = TransitionT r Identity
+
 instance MonadLog m => MonadLog (TransitionT rule m) where
     logWhile entry = mapTransitionT $ logWhile entry
 
@@ -119,6 +127,9 @@ instance MonadCatch m => MonadCatch (TransitionT rule m) where
 
 runTransitionT :: Monad m => TransitionT rule m a -> m [(a, Seq rule)]
 runTransitionT (TransitionT edge) = Logic.observeAllT (runAccumT edge mempty)
+
+runTransition :: Transition rule a -> [(a, Seq rule)]
+runTransition = runIdentity . runTransitionT
 
 tryTransitionT
     :: Monad m

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -176,16 +176,28 @@ mapRules f trans = do
     let results' = map (fmap (fmap f)) results
     scatter results'
 
+{- |
+
+If the first branch returns /any/ values, return /all/ such values; otherwise,
+proceed down the second branch. In pseudo-Haskell:
+
+@
+orElse first second
+  | first /= empty = first
+  | otherwise      = second
+@
+
+See also: 'ifte'
+
+ -}
 orElse
     :: Monad m
     => TransitionT rule m a
     -> TransitionT rule m a
     -> TransitionT rule m a
-orElse first second = do
-    results <- tryTransitionT first
-    if null results then second else scatter results
+orElse first = ifte first return -- 'return' is the unit of '>>='
 
-{- | Logical conditional: if-then-else
+{- |
 
 If the conditional returns /any/ values, send /all/ such values down the "then"
 branch; otherwise, proceed down the "else" branch. In pseudo-Haskell:

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -186,6 +186,16 @@ orElse first second = do
     if null results then second else scatter results
 
 {- | Logical conditional: if-then-else
+
+If the conditional returns /any/ values, send /all/ such values down the "then"
+branch; otherwise, proceed down the "else" branch. In pseudo-Haskell:
+
+@
+ifte cond thenBranch elseBranch
+  | cond /= empty = cond >>= thenBranch
+  | otherwise     = elseBranch
+@
+
  -}
 ifte
     :: Monad m

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -188,8 +188,15 @@ orElse first second = do
 {- | Logical conditional: if-then-else
  -}
 ifte
-    :: TransitionT rule m a
+    :: Monad m
+    => TransitionT rule m a
     -> (a -> TransitionT rule m b)
     -> TransitionT rule m b
     -> TransitionT rule m b
-ifte _ _ e = e
+ifte p t e = TransitionT $ AccumT $ \w0 ->
+    Logic.ifte
+        (toLogicT w0 p)
+        (\(a, w1) -> toLogicT w1 (t a))
+        (toLogicT w0 e)
+  where
+    toLogicT w = flip runAccumT w . getTransitionT

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -20,6 +20,7 @@ module Kore.Step.Transition
     , addRules
     , mapRules
     , orElse
+    , ifte
     -- * Re-exports
     , Seq
     ) where
@@ -183,3 +184,12 @@ orElse
 orElse first second = do
     results <- tryTransitionT first
     if null results then second else scatter results
+
+{- | Logical conditional: if-then-else
+ -}
+ifte
+    :: TransitionT rule m a
+    -> (a -> TransitionT rule m b)
+    -> TransitionT rule m b
+    -> TransitionT rule m b
+ifte _ _ e = e

--- a/kore/src/Kore/Step/Transition.hs
+++ b/kore/src/Kore/Step/Transition.hs
@@ -196,7 +196,10 @@ ifte
 ifte p t e = TransitionT $ AccumT $ \w0 ->
     Logic.ifte
         (toLogicT w0 p)
-        (\(a, w1) -> toLogicT w1 (t a))
+        (\(a, w1) -> do
+            (b, w2) <- toLogicT w1 (t a)
+            pure (b, w1 <> w2)
+        )
         (toLogicT w0 e)
   where
     toLogicT w = flip runAccumT w . getTransitionT

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -30,6 +30,14 @@ test_ifte =
                         (\() -> return 0)
                         (return 1 <|> return 2)
             check expect actual
+        , testCase "forgets accumulator from conditional" $ do
+            let expect = return False
+                actual =
+                    ifte
+                        (addRule 0 >> empty)
+                        (\() -> return True)
+                        (return False)
+            check expect actual
         ]
     , testGroup "\"then\" branch"
         [ testCase "returns value" $ do

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -12,20 +12,33 @@ import Test.Tasty.HUnit.Ext
 
 test_ifte :: [TestTree]
 test_ifte =
-    [ testCase "chooses \"else\" branch" $ do
-        let expect = return False
-            actual =
-                ifte
-                    (empty :: Transition Integer Integer)
-                    (\_ -> return True)
-                    (return False)
-        on (assertEqual "") runTransition expect actual
-    , testCase "chooses the \"then\" branch" $ do
-        let expect = return True
-            actual =
-                ifte
-                    (return 1 :: Transition Integer Integer)
-                    (\_ -> return True)
-                    (return False)
-        on (assertEqual "") runTransition expect actual
+    [ testGroup "\"else\" branch"
+        [ testCase "chooses value" $ do
+            let expect = return False
+                actual =
+                    ifte
+                        empty
+                        (\() -> return True)
+                        (return False)
+            check expect actual
+        ]
+    , testGroup "\"then\" branch"
+        [ testCase "chooses value" $ do
+            let expect = return True
+                actual =
+                    ifte
+                        (return ())
+                        (\() -> return True)
+                        (return False)
+            check expect actual
+        ]
     ]
+  where
+    check
+        :: HasCallStack
+        => (Debug a, Diff a)
+        => Transition Integer a
+        -> Transition Integer a
+        -> Assertion
+    check expect actual =
+        on (assertEqual "") runTransition expect actual

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -26,6 +26,10 @@ test_ifte =
                 elseBranch = return False
                 condition = addRule 0 >> empty
             checkElse condition thenBranch elseBranch
+        , testCase "takes accumulator from branch" $ do
+            let thenBranch () = return True
+                elseBranch = addRule 2 >> return False
+            checkElse empty thenBranch elseBranch
         ]
     , testGroup "\"then\" branch"
         [ testCase "returns value" $ do
@@ -45,6 +49,11 @@ test_ifte =
             checkThen condition thenBranch elseBranch
         , testCase "remembers accumulator from conditional" $ do
             let thenBranch () = return True
+                elseBranch = return False
+                condition = addRule 0 >> return ()
+            checkThen condition thenBranch elseBranch
+        , testCase "takes accumulator from branch" $ do
+            let thenBranch () = addRule 1 >> return True
                 elseBranch = return False
                 condition = addRule 0 >> return ()
             checkThen condition thenBranch elseBranch

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -1,0 +1,23 @@
+module Test.Kore.Step.Transition
+    ( test_ifte
+    ) where
+
+import Prelude.Kore
+
+import Test.Tasty
+
+import Kore.Step.Transition
+
+import Test.Tasty.HUnit.Ext
+
+test_ifte :: [TestTree]
+test_ifte =
+    [ testCase "chooses \"else\" branch" $ do
+        let expect = return False
+            actual =
+                ifte
+                    (empty :: Transition Integer Integer)
+                    (\_ -> return True)
+                    (return False)
+        on (assertEqual "") runTransition expect actual
+    ]

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -49,6 +49,14 @@ test_ifte =
                         (\() -> return 1 <|> return 2)
                         (return 0)
             check expect actual
+        , testCase "branches on multiple values" $ do
+            let expect = return True <|> return True
+                actual =
+                    ifte
+                        (return () <|> return ())
+                        (\() -> return True)
+                        (return False)
+            check expect actual
         ]
     ]
   where

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -21,6 +21,11 @@ test_ifte =
             let thenBranch () = return True
                 elseBranch = return False <|> return False
             checkElse empty thenBranch elseBranch
+        , testCase "is empty when branch is empty" $ do
+            let thenBranch () = return True
+                elseBranch = empty
+                condition = empty
+            checkElse condition thenBranch elseBranch
         , testCase "forgets accumulator from conditional" $ do
             let thenBranch () = return True
                 elseBranch = return False
@@ -39,6 +44,11 @@ test_ifte =
             checkThen condition thenBranch elseBranch
         , testCase "returns multiple values" $ do
             let thenBranch () = return True <|> return True
+                elseBranch = return False
+                condition = return ()
+            checkThen condition thenBranch elseBranch
+        , testCase "is empty when branch is empty" $ do
+            let thenBranch () = empty
                 elseBranch = return False
                 condition = return ()
             checkThen condition thenBranch elseBranch

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -13,7 +13,7 @@ import Test.Tasty.HUnit.Ext
 test_ifte :: [TestTree]
 test_ifte =
     [ testGroup "\"else\" branch"
-        [ testCase "chooses value" $ do
+        [ testCase "returns value" $ do
             let expect = return False
                 actual =
                     ifte
@@ -21,15 +21,33 @@ test_ifte =
                         (\() -> return True)
                         (return False)
             check expect actual
+        , testCase "returns multiple values" $ do
+            let expect, actual :: Transition Integer Integer
+                expect = return 1 <|> return 2
+                actual =
+                    ifte
+                        empty
+                        (\() -> return 0)
+                        (return 1 <|> return 2)
+            check expect actual
         ]
     , testGroup "\"then\" branch"
-        [ testCase "chooses value" $ do
+        [ testCase "returns value" $ do
             let expect = return True
                 actual =
                     ifte
                         (return ())
                         (\() -> return True)
                         (return False)
+            check expect actual
+        , testCase "returns multiple values" $ do
+            let expect, actual :: Transition Integer Integer
+                expect = return 1 <|> return 2
+                actual =
+                    ifte
+                        (return ())
+                        (\() -> return 1 <|> return 2)
+                        (return 0)
             check expect actual
         ]
     ]

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -20,4 +20,12 @@ test_ifte =
                     (\_ -> return True)
                     (return False)
         on (assertEqual "") runTransition expect actual
+    , testCase "chooses the \"then\" branch" $ do
+        let expect = return True
+            actual =
+                ifte
+                    (return 1 :: Transition Integer Integer)
+                    (\_ -> return True)
+                    (return False)
+        on (assertEqual "") runTransition expect actual
     ]

--- a/kore/test/Test/Kore/Step/Transition.hs
+++ b/kore/test/Test/Kore/Step/Transition.hs
@@ -65,6 +65,14 @@ test_ifte =
                         (\() -> return True)
                         (return False)
             check expect actual
+        , testCase "remembers accumulator from conditional" $ do
+            let expect = addRule 0 >> return True
+                actual =
+                    ifte
+                        (addRule 0 >> return ())
+                        (\() -> return True)
+                        (return False)
+            check expect actual
         ]
     ]
   where


### PR DESCRIPTION
Implementing `ifte` for `TransitionT` allows us to write a simple, lazy implementation of `orElse`, which improves memory use (#2028). Normally, we think of laziness as increasing memory use, but the problem here is partial laziness: the former implementation of `orElse` would only force the _spine_ of the list and not the values (that is, `_ : _ : _ : []`) so we would end up with a large list of unevaluated thunks. This fully-lazy implementation of `orElse` only forces conses `(:)` on-demand.

I wrote this in a TDD style as a demonstration, but I also caught a bug doing it that way.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
