### PR TITLE
translatePredicateWith: Erase predicate sorts

### DIFF
--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -67,7 +67,7 @@ data SideCondition variable =
         { representation :: !SideCondition.Representation
         , assumedTrue :: !(Condition variable)
         }
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
     deriving (GHC.Generic)
 
 instance SOP.Generic (SideCondition variable)

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -66,6 +66,7 @@ import Kore.Internal.TermLike
 import Kore.Log.WarnSymbolSMTRepresentation
     ( warnSymbolSMTRepresentation
     )
+import qualified Kore.Sort as Sort
 import Kore.Step.SMT.Resolvers
     ( translateSort
     , translateSymbol
@@ -107,7 +108,9 @@ translatePredicateWith
     -> Predicate variable
     -> Translator m variable SExpr
 translatePredicateWith translateTerm predicate =
-    translatePredicatePattern $ unwrapPredicate predicate
+    translatePredicatePattern
+    $ unwrapPredicate
+    $ coerceSort Sort.predicateSort predicate
   where
     translateUninterpreted t pat = translateTerm t (UninterpretedTerm pat)
     translatePredicatePattern :: p -> Translator m variable SExpr

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -5,10 +5,15 @@ module Test.Expect
     , assertNull
     , assertTop
     , expectBool
+    , expectJustT
     ) where
 
 import Prelude.Kore
 
+import Control.Error
+    ( MaybeT
+    , maybeT
+    )
 import qualified Data.Foldable as Foldable
 
 import Debug
@@ -44,3 +49,9 @@ assertTop a
 expectBool :: HasCallStack => TermLike VariableName -> IO Bool
 expectBool (BuiltinBool_ internalBool) = return (builtinBoolValue internalBool)
 expectBool term = (assertFailure . show) (debug term)
+
+expectJustT :: MonadIO io => HasCallStack => MaybeT io a -> io a
+expectJustT =
+    maybeT
+        (liftIO $ assertFailure "expected Just")
+        return

--- a/kore/test/Test/Kore/Equation/Application.hs
+++ b/kore/test/Test/Kore/Equation/Application.hs
@@ -206,6 +206,7 @@ test_attemptEquation =
                 WhileCheckRequires CheckRequiresError
                 { matchPredicate = makeTruePredicate_
                 , equationRequires = requires1
+                , sideCondition = SideCondition.top
                 }
         attemptEquation SideCondition.top initial equation
             >>= expectLeft >>= assertEqual "" expect1
@@ -241,6 +242,7 @@ test_attemptEquation =
                 WhileCheckRequires CheckRequiresError
                     { matchPredicate = makeTruePredicate_
                     , equationRequires = makeFalsePredicate sortR
+                    , sideCondition = SideCondition.top
                     }
             initial = Mock.a
         attemptEquation SideCondition.top initial equationRequiresBottom


### PR DESCRIPTION
Outer predicate sorts are erased before sending to the solver.

Fixes: #2076 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
