### PR TITLE
MultiOr: INLINE observeAllT and gather

### DIFF
--- a/kore/src/Kore/Internal/MultiOr.hs
+++ b/kore/src/Kore/Internal/MultiOr.hs
@@ -355,9 +355,11 @@ crossProductGeneric joiner (MultiOr first) (MultiOr second) =
 
 gather :: (Ord a, TopBottom a, MonadLogic m) => m a -> m (MultiOr a)
 gather act = make <$> Logic.gather act
+{-# INLINE gather #-}
 
 observeAllT :: (Ord a, TopBottom a, Monad m) => LogicT m a -> m (MultiOr a)
 observeAllT act = make <$> Logic.observeAllT act
+{-# INLINE observeAllT #-}
 
 map
     :: Ord child2


### PR DESCRIPTION
These are higher-order functions and inlining them might expose more optimizations. It will also produce cleaner profiles.

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
