### PR TITLE
Normalize order of terms in \equals

### DIFF
--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -717,11 +717,12 @@ functionAnd first second
     & pure
   | otherwise = empty
   where
-    (first', second') =
-        case compareForEquals first second of
-            LT -> (first, second)
-            _  -> (second, first)
+    (first', second') = minMaxBy compareForEquals first second
 
+
+{- | Gives an order for terms in \equals(_, ) to avoid duplicate clauses
+
+-}
 compareForEquals
     :: InternalVariable variable
     => TermLike variable

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -720,7 +720,9 @@ functionAnd first second
     (first', second') = minMaxBy compareForEquals first second
 
 
-{- | Gives an order for terms in \equals(_, ) to avoid duplicate clauses
+{- | Normal ordering for terms in @\equals(_, _)@.
+
+The normal ordering is arbitrary, but important to avoid duplication.
 
 -}
 compareForEquals

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -728,9 +728,9 @@ compareForEquals
     -> TermLike variable
     -> Ordering
 compareForEquals first second
-      | isConstructorLike first = LT
-      | isConstructorLike second = GT
-      | otherwise = compare first second
+  | isConstructorLike first = LT
+  | isConstructorLike second = GT
+  | otherwise = compare first second
 
 bytesDifferent
     :: InternalVariable variable

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -17,6 +17,7 @@ module Kore.Step.Simplification.AndTerms
     , functionAnd
     , equalsFunctions
     , andFunctions
+    , compareForEquals
     ) where
 
 import Prelude.Kore
@@ -716,10 +717,20 @@ functionAnd first second
     & pure
   | otherwise = empty
   where
-    (first', second')
-      | isConstructorLike first = (first, second)
-      | isConstructorLike second = (second, first)
-      | otherwise = minMax first second
+    (first', second') =
+        case compareForEquals first second of
+            LT -> (first, second)
+            _  -> (second, first)
+
+compareForEquals
+    :: InternalVariable variable
+    => TermLike variable
+    -> TermLike variable
+    -> Ordering
+compareForEquals first second
+      | isConstructorLike first = LT
+      | isConstructorLike second = GT
+      | otherwise = compare first second
 
 bytesDifferent
     :: InternalVariable variable

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -54,8 +54,8 @@ import qualified Kore.Step.Simplification.AndPredicates as And
     ( simplifyEvaluatedMultiPredicate
     )
 import Kore.Step.Simplification.AndTerms
-    ( maybeTermEquals
-    , compareForEquals
+    ( compareForEquals
+    , maybeTermEquals
     )
 import qualified Kore.Step.Simplification.Iff as Iff
     ( makeEvaluate

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -164,7 +164,7 @@ simplify
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify sideCondition Equals { equalsFirst = first, equalsSecond = second } =
-    simplifyEvaluated sideCondition first second
+    simplifyEvaluated sideCondition (min first second) (max first second)
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -160,8 +160,7 @@ Normalization of the compared terms is not implemented yet, so
 Equals(a and b, b and a) will not be evaluated to Top.
 -}
 simplify
-    :: forall variable simplifier
-    .  (InternalVariable variable, MonadSimplify simplifier)
+    :: (InternalVariable variable, MonadSimplify simplifier)
     => SideCondition variable
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -164,7 +164,9 @@ simplify
     -> Equals Sort (OrPattern variable)
     -> simplifier (OrPattern variable)
 simplify sideCondition Equals { equalsFirst = first, equalsSecond = second } =
-    simplifyEvaluated sideCondition (min first second) (max first second)
+    simplifyEvaluated sideCondition minTerm maxTerm
+  where
+    (minTerm, maxTerm) = minMax first second
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 

--- a/kore/src/Kore/Step/Simplification/Equals.hs
+++ b/kore/src/Kore/Step/Simplification/Equals.hs
@@ -168,13 +168,7 @@ simplify sideCondition Equals { equalsFirst = first, equalsSecond = second } =
     simplifyEvaluated sideCondition first' second'
   where
     (first', second') =
-        case compareForEquals
-                (OrPattern.toTermLike first)
-                (OrPattern.toTermLike second)
-            of
-                LT -> (first, second)
-                _  -> (second, first)
-
+        minMaxBy (on compareForEquals OrPattern.toTermLike) first second
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -245,8 +245,9 @@ matchesToVariableSubstitution
   , Substitution.null boundSubstitution
   , not (TermLike.hasFreeVariable (inject $ variableName variable) term)
   = do
-    matchResult <- matchIncremental first second
-    case matchResult of
+    matchResultFS <- matchIncremental first second
+    matchResultSF <- matchIncremental second first
+    case matchResultFS <|> matchResultSF of
         Just (Predicate.PredicateTrue, results) ->
             return (singleVariableSubstitution variable results)
         _ -> return False

--- a/kore/src/Kore/Step/Simplification/Exists.hs
+++ b/kore/src/Kore/Step/Simplification/Exists.hs
@@ -231,7 +231,7 @@ makeEvaluate sideCondition variables original = do
                 (Conditional.substitution original)
 
 
-
+-- TODO (andrei.burdusa): this function must go away
 matchesToVariableSubstitution
     :: (InternalVariable variable, MonadSimplify simplifier)
     => ElementVariable variable

--- a/kore/src/Prelude/Kore.hs
+++ b/kore/src/Prelude/Kore.hs
@@ -9,6 +9,7 @@ module Prelude.Kore
     , module Debug.Trace
     -- * Ord
     , minMax
+    , minMaxBy
     -- * Functions
     , (&)
     , on
@@ -156,4 +157,9 @@ import Injection
 minMax :: Ord a => a -> a -> (a, a)
 minMax a b
   | a < b     = (a, b)
+  | otherwise = (b, a)
+
+minMaxBy :: (a -> a -> Ordering) -> a -> a -> (a, a)
+minMaxBy cmp a b
+  | cmp a b == LT = (a, b)
   | otherwise = (b, a)

--- a/kore/test/Test/Kore/Equation/Application.hs
+++ b/kore/test/Test/Kore/Equation/Application.hs
@@ -203,14 +203,14 @@ test_attemptEquation =
         let
             requires =
                 makeEqualsPredicate sortR
-                    (Mock.functional11 (mkElemVar Mock.x))
                     (Mock.functional10 (mkElemVar Mock.x))
+                    (Mock.functional11 (mkElemVar Mock.x))
             equation = equationId { requires }
             initial = Mock.a
         let requires1 =
                 makeEqualsPredicate sortR
-                    (Mock.functional11 Mock.a)
                     (Mock.functional10 Mock.a)
+                    (Mock.functional11 Mock.a)
             expect1 =
                 WhileCheckRequires CheckRequiresError
                 { matchPredicate = makeTruePredicate_
@@ -221,8 +221,8 @@ test_attemptEquation =
             >>= expectLeft >>= assertEqual "" expect1
         let requires2 =
                 makeEqualsPredicate sortR
-                    (Mock.functional11 Mock.a)
                     (Mock.functional10 Mock.a)
+                    (Mock.functional11 Mock.a)
             sideCondition2 =
                 SideCondition.fromCondition . Condition.fromPredicate
                 $ requires2

--- a/kore/test/Test/Kore/Internal/OrPattern.hs
+++ b/kore/test/Test/Kore/Internal/OrPattern.hs
@@ -4,6 +4,7 @@ module Test.Kore.Internal.OrPattern
     , hprop_flattenIdemOr
     , test_distributeAnd
     , test_distributeApplication
+    , hprop_preserveOrdOr
     -- * Re-exports
     , OrTestPattern
     , module OrPattern
@@ -53,6 +54,12 @@ type OrTestPattern = OrPattern VariableName
 orPatternGen :: Gen OrTestPattern
 orPatternGen =
     OrPattern.fromPatterns <$> Gen.list (Range.linear 0 64) internalPatternGen
+
+hprop_preserveOrdOr :: Property
+hprop_preserveOrdOr = Hedgehog.property $ do
+    ors1 <- Hedgehog.forAll (standaloneGen orPatternGen)
+    ors2 <- Hedgehog.forAll (standaloneGen orPatternGen)
+    compare ors1 ors1 === compare (toPattern ors1) (toPattern ors2)
 
 -- | Check that 'merge' preserves the @\\or@-idempotency condition.
 hprop_mergeIdemOr :: Property

--- a/kore/test/Test/Kore/Internal/OrPattern.hs
+++ b/kore/test/Test/Kore/Internal/OrPattern.hs
@@ -4,7 +4,6 @@ module Test.Kore.Internal.OrPattern
     , hprop_flattenIdemOr
     , test_distributeAnd
     , test_distributeApplication
-    , hprop_preserveOrdOr
     -- * Re-exports
     , OrTestPattern
     , module OrPattern
@@ -54,12 +53,6 @@ type OrTestPattern = OrPattern VariableName
 orPatternGen :: Gen OrTestPattern
 orPatternGen =
     OrPattern.fromPatterns <$> Gen.list (Range.linear 0 64) internalPatternGen
-
-hprop_preserveOrdOr :: Property
-hprop_preserveOrdOr = Hedgehog.property $ do
-    ors1 <- Hedgehog.forAll (standaloneGen orPatternGen)
-    ors2 <- Hedgehog.forAll (standaloneGen orPatternGen)
-    compare ors1 ors1 === compare (toPattern ors1) (toPattern ors2)
 
 -- | Check that 'merge' preserves the @\\or@-idempotency condition.
 hprop_mergeIdemOr :: Property

--- a/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
+++ b/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
@@ -667,11 +667,11 @@ test_onePathStrategy =
                     { term = Mock.a
                     , predicate =
                         makeEqualsPredicate Mock.testSort
+                            (Mock.builtinBool True)
                             (Mock.lessInt
                                 (Mock.fTestInt Mock.b)
                                 (Mock.builtinInt 0)
                             )
-                            (Mock.builtinBool True)
                     , substitution = mempty
                     }
                 (fromTermLike Mock.a)
@@ -750,11 +750,11 @@ test_onePathStrategy =
                     { term = Mock.a
                     , predicate =
                         makeEqualsPredicate Mock.testSort
+                            (Mock.builtinBool True)
                             (Mock.lessInt
                                 (Mock.fTestInt Mock.b)
                                 (Mock.builtinInt 0)
                             )
-                            (Mock.builtinBool True)
                     , substitution = mempty
                     }
                 (fromTermLike Mock.a)

--- a/kore/test/Test/Kore/Step.hs
+++ b/kore/test/Test/Kore/Step.hs
@@ -350,11 +350,11 @@ smtSyntaxPredicate
     :: TermLike VariableName -> PredicateState -> Predicate VariableName
 smtSyntaxPredicate term predicateState =
     makeEqualsPredicate_
+        (Mock.builtinBool (predicateStateToBool predicateState))
         (Mock.lessInt
             (Mock.fTestInt term)
             (Mock.builtinInt 0)
         )
-        (Mock.builtinBool (predicateStateToBool predicateState))
 
 smtCondition :: TermLike VariableName -> PredicateState -> Condition VariableName
 smtCondition term predicateState =
@@ -435,11 +435,11 @@ test_SMT =
                 { term = Mock.a
                 , predicate =
                     makeEqualsPredicate Mock.testSort
+                        (Mock.builtinBool True)
                         (Mock.lessInt
                             (Mock.fTestInt Mock.b)
                             (Mock.builtinInt 0)
                         )
-                        (Mock.builtinBool True)
                 , substitution = mempty
                 }
             ]

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -350,7 +350,7 @@ test_functionIntegration =
                 Conditional
                     { term = Mock.f Mock.e
                     , predicate = makeEqualsPredicate Mock.testSort
-                        (Mock.f Mock.e) Mock.e
+                        Mock.e (Mock.f Mock.e)
                     , substitution = mempty
                     }
         actual <-
@@ -811,7 +811,7 @@ test_functionIntegrationUnification =
                 Conditional
                     { term = Mock.f Mock.e
                     , predicate = makeEqualsPredicate Mock.testSort
-                        (Mock.f Mock.e) Mock.e
+                        Mock.e (Mock.f Mock.e)
                     , substitution = mempty
                     }
         actual <-

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -1267,8 +1267,8 @@ test_applyRewriteRulesParallel =
             initial = pure (Mock.functionalConstr10 (mkElemVar Mock.x))
             requirement =
                 makeEqualsPredicate Mock.testSort
-                    (Mock.f (mkElemVar Mock.x))
                     Mock.b
+                    (Mock.f (mkElemVar Mock.x))
         actual <- applyRewriteRulesParallel initial [axiomSignum]
         checkResults results actual
         checkRemainders remainders actual

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -81,7 +81,6 @@ import Test.Kore.Internal.Pattern as Pattern
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty.HUnit.Ext
-import Kore.Unparser (unparseToString)
 
 type RewriteRule' = RewriteRule VariableName
 type Results' = Step.Results (RulePattern RewritingVariableName)
@@ -120,12 +119,12 @@ test_applyInitialConditions =
             initial = Condition.fromPredicate expect1
             expect1 =
                 Predicate.makeEqualsPredicate_
-                    (Mock.f $ mkElemVar Mock.x)
                     Mock.a
+                    (Mock.f $ mkElemVar Mock.x)
             expect2 =
                 Predicate.makeEqualsPredicate_
-                    (Mock.f $ mkElemVar Mock.y)
                     Mock.b
+                    (Mock.f $ mkElemVar Mock.y)
             expect =
                 MultiOr.singleton (Predicate.makeAndPredicate expect1 expect2)
         [applied] <- applyInitialConditions initial unification
@@ -773,8 +772,8 @@ test_applyRewriteRule_ =
                             { term = Mock.sigma fb fb
                             , predicate =
                                 makeEqualsPredicate Mock.testSort
-                                    (Mock.functional11 fb)
                                     (Mock.functional10 fb)
+                                    (Mock.functional11 fb)
                             , substitution =
                                 Substitution.wrap
                                 $ Substitution.mkUnwrappedSubstitution
@@ -815,8 +814,8 @@ test_applyRewriteRule_ =
                     [ Conditional
                         { term = mkElemVar Mock.y
                         , predicate = makeEqualsPredicate Mock.testSort
-                            (Mock.functional11 (mkElemVar Mock.y))
                             (Mock.functional10 (mkElemVar Mock.y))
+                            (Mock.functional11 (mkElemVar Mock.y))
                         , substitution = mempty
                         }
                     ]

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -81,6 +81,7 @@ import Test.Kore.Internal.Pattern as Pattern
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty.HUnit.Ext
+import Kore.Unparser (unparseToString)
 
 type RewriteRule' = RewriteRule VariableName
 type Results' = Step.Results (RulePattern RewritingVariableName)
@@ -842,8 +843,8 @@ test_applyRewriteRule_ =
         let
             requires =
                 makeEqualsPredicate_
-                    (Mock.functional11 (mkElemVar Mock.x))
                     (Mock.functional10 (mkElemVar Mock.x))
+                    (Mock.functional11 (mkElemVar Mock.x))
             expect =
                 [ OrPattern.fromPatterns
                     [ initialTerm

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -44,8 +44,6 @@ import qualified Kore.Step.Simplification.SubstitutionSimplifier as Substitution
 import qualified Test.Kore.Step.MockSymbols as Mock
 import qualified Test.Kore.Step.Simplification as Test
 import Test.Tasty.HUnit.Ext
-import qualified Data.Foldable as Foldable
-import Kore.Unparser (unparseToString)
 
 test_predicateSimplification :: [TestTree]
 test_predicateSimplification =

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -44,6 +44,8 @@ import qualified Kore.Step.Simplification.SubstitutionSimplifier as Substitution
 import qualified Test.Kore.Step.MockSymbols as Mock
 import qualified Test.Kore.Step.Simplification as Test
 import Test.Tasty.HUnit.Ext
+import qualified Data.Foldable as Foldable
+import Kore.Unparser (unparseToString)
 
 test_predicateSimplification :: [TestTree]
 test_predicateSimplification =
@@ -231,8 +233,8 @@ test_predicateSimplification =
                     { term = ()
                     , predicate =
                         makeEqualsPredicate_
-                            (Mock.g Mock.b)
                             (Mock.g Mock.a)
+                            (Mock.g Mock.b)
                     , substitution = Substitution.unsafeWrap
                         [ (inject Mock.x, Mock.a)
                         , (inject Mock.y, Mock.b)
@@ -267,6 +269,10 @@ test_predicateSimplification =
                         [ (inject Mock.y, Mock.b)
                         ]
                     }
+        traceM "actual"
+        Foldable.traverse_ (traceM . unparseToString) actual
+        traceM "expected"
+        Foldable.traverse_ (traceM . unparseToString) (MultiOr.singleton expect)
         assertEqual "" (MultiOr.singleton expect) actual
     ]
 

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -117,7 +117,7 @@ test_predicateSimplification =
         let expect =
                 Conditional
                     { term = ()
-                    , predicate = makeEqualsPredicate_ Mock.functional00 Mock.a
+                    , predicate = makeEqualsPredicate_ Mock.a Mock.functional00
                     , substitution = Substitution.unsafeWrap
                         [ (inject Mock.x, Mock.functional00)
                         , (inject Mock.y, Mock.functional01)
@@ -269,10 +269,6 @@ test_predicateSimplification =
                         [ (inject Mock.y, Mock.b)
                         ]
                     }
-        traceM "actual"
-        Foldable.traverse_ (traceM . unparseToString) actual
-        traceM "expected"
-        Foldable.traverse_ (traceM . unparseToString) (MultiOr.singleton expect)
         assertEqual "" (MultiOr.singleton expect) actual
     ]
 

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -37,7 +37,6 @@ import Test.Kore.Internal.Predicate as Predicate
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty.HUnit.Ext
-import qualified Data.Foldable as Foldable
 
 test_simplify :: [TestTree]
 test_simplify =
@@ -299,16 +298,12 @@ test_makeEvaluate =
                 Mock.x
                 Conditional
                     { term = fOfA
-                    , predicate = makeEqualsPredicate_ fOfX (Mock.f Mock.a)
+                    , predicate = makeEqualsPredicate_ (Mock.f Mock.a) fOfX
                     , substitution =
                         Substitution.wrap
                         $ Substitution.mkUnwrappedSubstitution
                         [(inject Mock.y, fOfA)]
                     }
-        traceM "expect"
-        Foldable.traverse_ (traceM . unparseToString) expect
-        traceM "actual"
-        Foldable.traverse_ (traceM . unparseToString) actual
         assertEqual "exists matching" expect actual
     , testCase "exists does not match equality if free var in subst" $ do
         -- exists x . (f(x) = f(a)) and (y=f(x))

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -280,7 +280,7 @@ test_makeEvaluate =
                         [(inject Mock.x, gOfA)]
                     }
         assertEqual "exists reevaluates" expect actual
-    , testCase "qqexists matches equality if result is top" $ do
+    , testCase "exists matches equality if result is top" $ do
         -- exists x . (f(x) = f(a))
         --    = top.s
         let expect = OrPattern.fromPatterns

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -37,6 +37,7 @@ import Test.Kore.Internal.Predicate as Predicate
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty.HUnit.Ext
+import qualified Data.Foldable as Foldable
 
 test_simplify :: [TestTree]
 test_simplify =
@@ -280,7 +281,7 @@ test_makeEvaluate =
                         [(inject Mock.x, gOfA)]
                     }
         assertEqual "exists reevaluates" expect actual
-    , testCase "exists matches equality if result is top" $ do
+    , testCase "qqexists matches equality if result is top" $ do
         -- exists x . (f(x) = f(a))
         --    = top.s
         let expect = OrPattern.fromPatterns
@@ -304,6 +305,10 @@ test_makeEvaluate =
                         $ Substitution.mkUnwrappedSubstitution
                         [(inject Mock.y, fOfA)]
                     }
+        traceM "expect"
+        Foldable.traverse_ (traceM . unparseToString) expect
+        traceM "actual"
+        Foldable.traverse_ (traceM . unparseToString) actual
         assertEqual "exists matching" expect actual
     , testCase "exists does not match equality if free var in subst" $ do
         -- exists x . (f(x) = f(a)) and (y=f(x))

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -68,8 +68,8 @@ test_simplify =
         (Pattern.topOf Mock.testSort)
             { Conditional.predicate =
                 Predicate.makeEqualsPredicate_
-                    (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.z))
                     (Mock.functional20 (mkElemVar Mock.y) (mkElemVar Mock.z))
+                    (Mock.sigma (mkElemVar Mock.x) (mkElemVar Mock.z))
             }
     quantifyPredicate predicated@Conditional { predicate } =
         predicated

--- a/kore/test/Test/Kore/Step/Simplification/Exists.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Exists.hs
@@ -315,7 +315,7 @@ test_makeEvaluate =
                         makeExistsPredicate
                             Mock.x
                             (makeAndPredicate
-                                (makeEqualsPredicate_ fOfX (Mock.f Mock.a))
+                                (makeEqualsPredicate_ (Mock.f Mock.a) fOfX)
                                 (makeEqualsPredicate_ (mkElemVar Mock.y) fOfX)
                             )
                     , substitution =

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -596,6 +596,7 @@ test_simplificationIntegration =
                                     )
                                 )
                                 (makeEqualsPredicate_
+                                    Mock.functionalInjective00
                                     (Mock.g
                                         (Mock.functionalConstr30
                                             (Mock.functionalTopConstr21
@@ -606,7 +607,6 @@ test_simplificationIntegration =
                                             Mock.cg
                                         )
                                     )
-                                    Mock.functionalInjective00
                                 )
                             )
                     , substitution = mempty
@@ -633,6 +633,7 @@ test_simplificationIntegration =
                             )
                             (makeAndPredicate
                                 (makeEqualsPredicate_
+                                    Mock.functionalInjective00
                                     (Mock.g
                                         (Mock.functionalConstr30
                                             (Mock.functionalTopConstr21
@@ -643,7 +644,6 @@ test_simplificationIntegration =
                                             Mock.cg
                                         )
                                     )
-                                    Mock.functionalInjective00
                                 )
                                 (makeNotPredicate
                                     (makeFloorPredicate_ (Mock.builtinList []))
@@ -776,10 +776,10 @@ test_simplificationIntegration =
                                 )
                             )
                             (makeIffPredicate
+                                (makeEqualsPredicate_ Mock.aSubSubsort mkTop_)
                                 (makeFloorPredicate_
                                     (mkEvaluated (mkBottom Mock.testSort))
                                 )
-                                (makeEqualsPredicate_ Mock.aSubSubsort mkTop_)
                             )
                         )
                         (makeImpliesPredicate
@@ -804,10 +804,10 @@ test_simplificationIntegration =
                                 )
                             )
                             (makeIffPredicate
+                                (makeEqualsPredicate_ Mock.aSubSubsort mkTop_)
                                 (makeFloorPredicate_
                                     (mkEvaluated (mkBottom Mock.testSort))
                                 )
-                                (makeEqualsPredicate_ Mock.aSubSubsort mkTop_)
                             )
                         )
                     , substitution = mempty

--- a/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
@@ -106,11 +106,11 @@ test_orPatternSimplification =
 positive :: TermLike VariableName -> Predicate VariableName
 positive u =
     makeEqualsPredicate Mock.testSort
+        (Mock.builtinBool False)
         (Mock.lessInt
             (Mock.fTestInt u)  -- wrap the given term for sort agreement
             (Mock.builtinInt 0)
         )
-        (Mock.builtinBool False)
 
 negative :: TermLike VariableName -> Predicate VariableName
 negative u =

--- a/test/bmc/fail-2-non-positive-bmc-spec.k.out.golden
+++ b/test/bmc/fail-2-non-positive-bmc-spec.k.out.golden
@@ -8,13 +8,13 @@
   </T>
 #And
   {
-    X <Int 0
+    false
   #Equals
-    true
+    X >Int 0
   }
 #And
   {
-    X >Int 0
+    true
   #Equals
-    false
+    X <Int 0
   }

--- a/test/bmc/fail-2-positive-bmc-spec.k.out.golden
+++ b/test/bmc/fail-2-positive-bmc-spec.k.out.golden
@@ -8,13 +8,13 @@
   </T>
 #And
   {
-    X >Int 0
-  #Equals
     true
+  #Equals
+    X >Int 0
   }
 #And
   {
-    X >Int 5
-  #Equals
     true
+  #Equals
+    X >Int 5
   }

--- a/test/bmc/fail-3-bmc-spec.k.out.golden
+++ b/test/bmc/fail-3-bmc-spec.k.out.golden
@@ -8,13 +8,13 @@
   </T>
 #And
   {
-    0 <Int X
-  #Equals
     true
+  #Equals
+    0 <Int X
   }
 #And
   {
-    X <=Int 5
-  #Equals
     true
+  #Equals
+    X <=Int 5
   }

--- a/test/bmc/fail-4-bmc-spec.k.out.golden
+++ b/test/bmc/fail-4-bmc-spec.k.out.golden
@@ -8,12 +8,6 @@
   </T>
 #And
   {
-    X >Int 5
-  #Equals
-    true
-  }
-#And
-  {
     true
   #Equals
     5 <Int X
@@ -23,4 +17,10 @@
     true
   #Equals
     X <Int 8
+  }
+#And
+  {
+    true
+  #Equals
+    X >Int 5
   }

--- a/test/imp/2.merge.out.golden
+++ b/test/imp/2.merge.out.golden
@@ -7,6 +7,7 @@
         \and{SortGeneratedTopCell{}}(
             /* Sfc */
             \equals{SortBool{}, SortGeneratedTopCell{}}(
+                /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("false"),
                 /* Fl Fn D Sfc */
                 Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(
                     /* Fl Fn D Sfc */
@@ -14,8 +15,7 @@
                         /* Fl Fn D Sfa */ VarX:SortId{}
                     ),
                     /* Fl Fn D Sfa */ Var'Unds'DotVar3:SortMap{}
-                ),
-                /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("false")
+                )
             ),
             /* Sfc */
             \equals{SortMap{}, SortGeneratedTopCell{}}(

--- a/test/imp/sum-save-proofs-spec.k.out.golden
+++ b/test/imp/sum-save-proofs-spec.k.out.golden
@@ -15,7 +15,7 @@
   </T>
 #And
   {
-    N >=Int 0
-  #Equals
     true
+  #Equals
+    N >=Int 0
   }

--- a/test/imp/sum-save-proofs-spec.k.save-proofs.kore.golden
+++ b/test/imp/sum-save-proofs-spec.k.save-proofs.kore.golden
@@ -8,12 +8,12 @@ module haskell-backend-saved-claims-43943e50-f723-47cd-99fd-07104d664c6d
         \and{SortGeneratedTopCell{}}(
             /* Spa */
             \equals{SortBool{}, SortGeneratedTopCell{}}(
+                /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true"),
                 /* Fl Fn D Spa */
                 Lbl'Unds-GT-Eqls'Int'Unds'{}(
                     /* Fl Fn D Sfa */ VarN:SortInt{},
                     /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortInt{}}("0")
-                ),
-                /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true")
+                )
             ),
             /* Fl Fn D Spa */
             Lbl'-LT-'generatedTop'-GT-'{}(

--- a/test/issue-1872/1.test.out.golden
+++ b/test/issue-1872/1.test.out.golden
@@ -8,7 +8,7 @@
   </generatedTop>
 #And
   {
-    'QuesUnds'0 %Int 2
-  #Equals
     1
+  #Equals
+    'QuesUnds'0 %Int 2
   }

--- a/test/issue-2095/test-issue-2095.sh.out.golden
+++ b/test/issue-2095/test-issue-2095.sh.out.golden
@@ -4969,6 +4969,8 @@
                                     \not{SortGeneratedTopCell{}}(
                                         /* Sfc */
                                         \equals{SortInt{}, SortGeneratedTopCell{}}(
+                                            /* Fl Fn D Sfa Cl */
+                                            /* builtin: */ \dv{SortInt{}}("0"),
                                             /* Fn Sfc */
                                             Lbl'Hash'DoCompare'LParUndsCommUndsRParUnds'MICHELSON'Unds'Int'Unds'Data'Unds'Data{}(
                                                 /* Fl Fn D Sfc */
@@ -5012,9 +5014,7 @@
                                                         )
                                                     )
                                                 )
-                                            ),
-                                            /* Fl Fn D Sfa Cl */
-                                            /* builtin: */ \dv{SortInt{}}("0")
+                                            )
                                         )
                                     )
                                 )
@@ -6907,6 +6907,8 @@
                             \and{SortGeneratedTopCell{}}(
                                 /* Sfc */
                                 \equals{SortInt{}, SortGeneratedTopCell{}}(
+                                    /* Fl Fn D Sfa Cl */
+                                    /* builtin: */ \dv{SortInt{}}("0"),
                                     /* Fn Sfc */
                                     Lbl'Hash'DoCompare'LParUndsCommUndsRParUnds'MICHELSON'Unds'Int'Unds'Data'Unds'Data{}(
                                         /* Fl Fn D Sfc */
@@ -6950,9 +6952,7 @@
                                                 )
                                             )
                                         )
-                                    ),
-                                    /* Fl Fn D Sfa Cl */
-                                    /* builtin: */ \dv{SortInt{}}("0")
+                                    )
                                 ),
                                 /* Sfc */
                                 \equals{SortOptionData{}, SortGeneratedTopCell{}}(

--- a/test/k-equal/iszero-ge-spec.k.out.golden
+++ b/test/k-equal/iszero-ge-spec.k.out.golden
@@ -11,7 +11,7 @@
   </T>
 #And
   {
-    I >=Int 0
-  #Equals
     true
+  #Equals
+    I >=Int 0
   }

--- a/test/k-equal/iszero-gt-spec.k.out.golden
+++ b/test/k-equal/iszero-gt-spec.k.out.golden
@@ -5,7 +5,7 @@
   </T>
 #And
   {
-    I >Int 0
-  #Equals
     true
+  #Equals
+    I >Int 0
   }

--- a/test/priority/1.merge.out.golden
+++ b/test/priority/1.merge.out.golden
@@ -10,39 +10,39 @@
             \and{SortGeneratedTopCell{}}(
                 /* Sfa */
                 \equals{SortBool{}, SortGeneratedTopCell{}}(
+                    /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true"),
                     /* Fl Fn D Sfa */
                     Lbl'Unds-GT-'Int'Unds'{}(
                         /* Fl Fn D Sfa */ VarX0:SortInt{},
                         /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortInt{}}("8")
-                    ),
-                    /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true")
+                    )
                 ),
                 /* Created: Kore.Internal.MultiAnd.makeAndPredicate */
                 /* Spa */
                 \and{SortGeneratedTopCell{}}(
                     /* Sfa */
                     \equals{SortBool{}, SortGeneratedTopCell{}}(
+                        /* Fl Fn D Sfa Cl */
+                        /* builtin: */ \dv{SortBool{}}("true"),
                         /* Fl Fn D Sfa */
                         Lbl'Unds-LT-'Int'Unds'{}(
                             /* Fl Fn D Sfa */ VarX0:SortInt{},
                             /* Fl Fn D Sfa Cl */
                             /* builtin: */ \dv{SortInt{}}("10")
-                        ),
-                        /* Fl Fn D Sfa Cl */
-                        /* builtin: */ \dv{SortBool{}}("true")
+                        )
                     ),
                     /* Sfa */
                     \not{SortGeneratedTopCell{}}(
                         /* Sfa */
                         \equals{SortBool{}, SortGeneratedTopCell{}}(
+                            /* Fl Fn D Sfa Cl */
+                            /* builtin: */ \dv{SortBool{}}("true"),
                             /* Fl Fn D Sfa */
                             Lbl'Unds-LT-'Int'Unds'{}(
                                 /* Fl Fn D Sfa */ VarX0:SortInt{},
                                 /* Fl Fn D Sfa Cl */
                                 /* builtin: */ \dv{SortInt{}}("6")
-                            ),
-                            /* Fl Fn D Sfa Cl */
-                            /* builtin: */ \dv{SortBool{}}("true")
+                            )
                         )
                     )
                 )

--- a/test/priority/2.merge.out.golden
+++ b/test/priority/2.merge.out.golden
@@ -10,12 +10,12 @@
             \and{SortGeneratedTopCell{}}(
                 /* Sfa */
                 \equals{SortBool{}, SortGeneratedTopCell{}}(
+                    /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true"),
                     /* Fl Fn D Sfa */
                     Lbl'Unds-LT-'Int'Unds'{}(
                         /* Fl Fn D Sfa */ VarX0:SortInt{},
                         /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortInt{}}("10")
-                    ),
-                    /* Fl Fn D Sfa Cl */ /* builtin: */ \dv{SortBool{}}("true")
+                    )
                 ),
                 /* Created: Kore.Internal.MultiAnd.makeAndPredicate */
                 /* Spa */
@@ -24,28 +24,28 @@
                     \not{SortGeneratedTopCell{}}(
                         /* Sfa */
                         \equals{SortBool{}, SortGeneratedTopCell{}}(
+                            /* Fl Fn D Sfa Cl */
+                            /* builtin: */ \dv{SortBool{}}("true"),
                             /* Fl Fn D Sfa */
                             Lbl'Unds-GT-'Int'Unds'{}(
                                 /* Fl Fn D Sfa */ VarX0:SortInt{},
                                 /* Fl Fn D Sfa Cl */
                                 /* builtin: */ \dv{SortInt{}}("8")
-                            ),
-                            /* Fl Fn D Sfa Cl */
-                            /* builtin: */ \dv{SortBool{}}("true")
+                            )
                         )
                     ),
                     /* Sfa */
                     \not{SortGeneratedTopCell{}}(
                         /* Sfa */
                         \equals{SortBool{}, SortGeneratedTopCell{}}(
+                            /* Fl Fn D Sfa Cl */
+                            /* builtin: */ \dv{SortBool{}}("true"),
                             /* Fl Fn D Sfa */
                             Lbl'Unds-LT-'Int'Unds'{}(
                                 /* Fl Fn D Sfa */ VarX0:SortInt{},
                                 /* Fl Fn D Sfa Cl */
                                 /* builtin: */ \dv{SortInt{}}("6")
-                            ),
-                            /* Fl Fn D Sfa Cl */
-                            /* builtin: */ \dv{SortBool{}}("true")
+                            )
                         )
                     )
                 )

--- a/test/remove-destination/test-1-spec.k.out.golden
+++ b/test/remove-destination/test-1-spec.k.out.golden
@@ -40,7 +40,7 @@
   </k>
 #And
   {
-    K:Int in_keys ( M )
-  #Equals
     false
+  #Equals
+    K:Int in_keys ( M )
   }

--- a/test/symbolic-ensures/1.strict.out.golden
+++ b/test/symbolic-ensures/1.strict.out.golden
@@ -5,5 +5,11 @@
   {
     true
   #Equals
+    ?X <=Int 3
+  }
+#And
+  {
+    true
+  #Equals
     ?X >=Int 1
   }

--- a/test/symbolic-ensures/1.strict.out.golden
+++ b/test/symbolic-ensures/1.strict.out.golden
@@ -3,12 +3,6 @@
   </k>
 #And
   {
-    ?X <=Int 3
-  #Equals
-    true
-  }
-#And
-  {
     true
   #Equals
     ?X <=Int 3


### PR DESCRIPTION
---
Fixes #2137 
###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
