### PR TITLE
Made git ignore hie.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ cabal.project.local
 /TAGS
 /.TAGS*
 kore-exec.tar.gz
+hie.yaml


### PR DESCRIPTION
The symlink `hie.yaml` used for running the Language Server is often highlighted by git so I think it should be added to `.gitignore`

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
