### PR TITLE
Ignore KORE_EXEC_OPTS outside kore-exec

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -31,7 +31,7 @@ KRUN_OPTS = --haskell-backend-command $(KORE_EXEC)
 export KRUN_OPTS
 KPROVE_OPTS = --haskell-backend-command $(KORE_EXEC)
 export KPROVE_OPTS
-KPROVE_REPL_OPTS = --haskell-backend-command "$(KORE_REPL) $(KORE_REPL_OPTS)"
+KPROVE_REPL_OPTS = --haskell-backend-command $(KORE_REPL)
 export KPROVE_REPL_OPTS
 
 HS_TOP = $(TOP)/kore

--- a/kore/app/exec/Main.hs
+++ b/kore/app/exec/Main.hs
@@ -533,6 +533,10 @@ writeOptionsAndKoreFiles
 exeName :: ExeName
 exeName = ExeName "kore-exec"
 
+-- | Environment variable name for extra arguments
+envName :: String
+envName = "KORE_EXEC_OPTS"
+
 -- TODO(virgil): Maybe add a regression test for main.
 -- | Loads a kore definition file and uses it to execute kore programs
 main :: IO ()
@@ -541,6 +545,7 @@ main = do
     options <-
         mainGlobal
             Main.exeName
+            (Just envName)
             (parseKoreExecOptions startTime)
             parserInfoModifiers
     Foldable.for_ (localOptions options) mainWithOptions

--- a/kore/app/format/Main.hs
+++ b/kore/app/format/Main.hs
@@ -52,7 +52,12 @@ infoMod =
 main :: IO ()
 main =
     do
-        options <- mainGlobal (ExeName "kore-format") commandLine infoMod
+        options <-
+            mainGlobal
+                (ExeName "kore-format")
+                Nothing  -- environment variable name for extra arguments
+                commandLine
+                infoMod
         case localOptions options of
             Nothing ->
                 {-  Global options were parsed, but local options were not.

--- a/kore/app/parser/Main.hs
+++ b/kore/app/parser/Main.hs
@@ -125,7 +125,11 @@ parserInfoModifiers =
 main :: IO ()
 main = do
     options <-
-        mainGlobal (ExeName "kore-parser") commandLineParser parserInfoModifiers
+        mainGlobal
+            (ExeName "kore-parser")
+            Nothing  -- environment variable name for extra arguments
+            commandLineParser
+            parserInfoModifiers
     case localOptions options of
         Nothing ->  -- global options parsed, but local failed; exit gracefully
             return ()

--- a/kore/app/repl/Main.hs
+++ b/kore/app/repl/Main.hs
@@ -157,12 +157,17 @@ parserInfoModifiers =
 exeName :: ExeName
 exeName = ExeName "kore-repl"
 
+-- | Environment variable name for extra arguments
+envName :: String
+envName = "KORE_REPL_OPTS"
+
 main :: IO ()
 main = do
     startTime <- getTime Monotonic
     options <-
         mainGlobal
             Main.exeName
+            (Just envName)
             (parseKoreReplOptions startTime)
             parserInfoModifiers
     case localOptions options of

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -10,7 +10,6 @@ module GlobalMain
     , parseKoreProveOptions
     , parseKoreMergeOptions
     , mainGlobal
-    , defaultMainGlobal
     , enableDisableFlag
     , clockSomething
     , clockSomethingIO
@@ -74,9 +73,7 @@ import Options.Applicative
     ( InfoMod
     , Parser
     , ParserHelp (..)
-    , argument
     , defaultPrefs
-    , disabled
     , execParserPure
     , flag
     , flag'
@@ -297,15 +294,6 @@ mainGlobal exeName maybeEnv localOptionsParser modifiers = do
     options <- commandLineParse exeName maybeEnv localOptionsParser modifiers
     when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion)
     return options
-
-defaultMainGlobal :: IO (MainOptions options)
-defaultMainGlobal =
-    mainGlobal
-        (ExeName "kore-exec")
-        (Just "KORE_EXEC_OPTS")
-        (argument disabled mempty)
-        mempty
-
 
 -- | main function to print version information
 mainVersion :: ZonedTime -> IO ()

--- a/kore/app/share/GlobalMain.hs
+++ b/kore/app/share/GlobalMain.hs
@@ -288,17 +288,23 @@ and returns the parsed options
 -}
 mainGlobal
     :: ExeName
+    -> Maybe String
+    -- ^ environment variable name for extra arguments
     -> Parser options                -- ^ local options parser
     -> InfoMod (MainOptions options) -- ^ option parser information
     -> IO      (MainOptions options)
-mainGlobal exeName localOptionsParser modifiers = do
-    options <- commandLineParse exeName localOptionsParser modifiers
+mainGlobal exeName maybeEnv localOptionsParser modifiers = do
+    options <- commandLineParse exeName maybeEnv localOptionsParser modifiers
     when (willVersion $ globalOptions options) (getZonedTime >>= mainVersion)
     return options
 
 defaultMainGlobal :: IO (MainOptions options)
 defaultMainGlobal =
-    mainGlobal (ExeName "kore-exec") (argument disabled mempty) mempty
+    mainGlobal
+        (ExeName "kore-exec")
+        (Just "KORE_EXEC_OPTS")
+        (argument disabled mempty)
+        mempty
 
 
 -- | main function to print version information
@@ -331,37 +337,48 @@ globalCommandLineParser =
         (  long "version"
         <> help "Print version information" )
 
+getArgs
+    :: Maybe String  -- ^ environment variable name for extra arguments
+    -> IO ([String], [String])
+getArgs maybeEnv = do
+    args0 <- Env.getArgs
+    args1 <-
+        case maybeEnv of
+            Nothing -> pure []
+            Just env -> words . fromMaybe "" <$> Env.lookupEnv env
+    pure (args0, args1)
+
 -- | Run argument parser for local executable
 commandLineParse
     :: ExeName
-    -> Parser a                -- ^ local options parser
-    -> InfoMod (MainOptions a) -- ^ local parser info modifiers
+    -> Maybe String
+    -- ^ environment variable name for extra arguments
+    -> Parser a
+    -- ^ local options parser
+    -> InfoMod (MainOptions a)
+    -- ^ local parser info modifiers
     -> IO (MainOptions a)
-commandLineParse (ExeName exeName) localCommandLineParser modifiers = do
-    args' <- Env.getArgs
-    env <- Env.lookupEnv "KORE_EXEC_OPTS"
-    let opts' = fromMaybe "" env
-        args = case env of
-            Nothing -> args'
-            Just opts -> args' <> words opts
-        parseResult = execParserPure
-            defaultPrefs
-            ( info
-                ( MainOptions
-                    <$> globalCommandLineParser
-                    <*> optional localCommandLineParser
-                <**> helper
-                )
-                modifiers
-            )
-            args
+commandLineParse (ExeName exeName) maybeEnv parser infoMod = do
+    (args, argsEnv) <- getArgs maybeEnv
+    let allArgs = args <> argsEnv
+        parseResult =
+            execParserPure
+                defaultPrefs
+                (info parseMainOptions infoMod)
+                allArgs
         changeHelpOverFailure
-          | exeName == "kore-exec" = overFailure (changeHelp args opts')
+          | Just env <- maybeEnv = overFailure (changeHelp args env argsEnv)
           | otherwise = id
     handleParseResult $ changeHelpOverFailure parseResult
   where
-    changeHelp :: [String] -> String -> ParserHelp -> ParserHelp
-    changeHelp commandLine koreExecOpts parserHelp@ParserHelp { helpError } =
+    parseMainOptions =
+        MainOptions
+            <$> globalCommandLineParser
+            <*> optional parser
+        <**> helper
+
+    changeHelp :: [String] -> String -> [String] -> ParserHelp -> ParserHelp
+    changeHelp args env argsEnv parserHelp@ParserHelp { helpError } =
         parserHelp
             { helpError =
                 vsepChunks [Chunk . Just $ commandWithOpts, helpError]
@@ -370,8 +387,8 @@ commandLineParse (ExeName exeName) localCommandLineParser modifiers = do
         commandWithOpts =
             Pretty.vsep
                 [ Pretty.linebreak
-                , Pretty.pretty ("kore-exec " <> unwords commandLine)
-                , Pretty.pretty ("KORE_EXEC_OPTS = " <> koreExecOpts)
+                , Pretty.pretty (unwords (exeName : args))
+                , Pretty.pretty env <> "=" <> Pretty.squotes (Pretty.pretty $ unwords argsEnv)
                 ]
 
 


### PR DESCRIPTION
Fixes #2235 

---

###### Reviewer checklist

- [ ] Test coverage: `stack test --coverage`
- [ ] Public API documentation: `stack haddock`
