### PR TITLE
Clean up built-in types

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -174,7 +174,10 @@ library
       Kore.Internal.Condition
       Kore.Internal.Conditional
       Kore.Internal.Inj
+      Kore.Internal.InternalBool
       Kore.Internal.InternalBytes
+      Kore.Internal.InternalInt
+      Kore.Internal.InternalString
       Kore.Internal.MultiAnd
       Kore.Internal.MultiOr
       Kore.Internal.OrCondition
@@ -287,7 +290,10 @@ library
       Kore.Step.Simplification.Inhabitant
       Kore.Step.Simplification.Inj
       Kore.Step.Simplification.InjSimplifier
+      Kore.Step.Simplification.InternalBool
       Kore.Step.Simplification.InternalBytes
+      Kore.Step.Simplification.InternalInt
+      Kore.Step.Simplification.InternalString
       Kore.Step.Simplification.Mu
       Kore.Step.Simplification.Next
       Kore.Step.Simplification.NoConfusion

--- a/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
+++ b/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
@@ -30,9 +30,6 @@ import Kore.Internal.Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
-import Kore.Internal.InternalInt
-    ( InternalInt
-    )
 import Kore.Internal.Symbol
     ( Symbol
     )
@@ -232,10 +229,6 @@ instance Synthetic ConstructorLike (Const StringLiteral) where
     {-# INLINE synthetic #-}
 
 instance Synthetic ConstructorLike (Const InternalBytes) where
-    synthetic = const (ConstructorLike . Just $ ConstructorLikeHead)
-    {-# INLINE synthetic #-}
-
-instance Synthetic ConstructorLike (Const InternalInt) where
     synthetic = const (ConstructorLike . Just $ ConstructorLikeHead)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
+++ b/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
@@ -186,7 +186,6 @@ instance HasConstructorLike key => Synthetic ConstructorLike (Builtin key)
   where
     synthetic =
         \case
-            BuiltinBool _   -> ConstructorLike . Just $ ConstructorLikeHead
             BuiltinString _ -> ConstructorLike . Just $ ConstructorLikeHead
             (BuiltinMap InternalAc
                     {builtinAcChild = NormalizedMap builtinMapChild}

--- a/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
+++ b/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
@@ -186,7 +186,6 @@ instance HasConstructorLike key => Synthetic ConstructorLike (Builtin key)
   where
     synthetic =
         \case
-            BuiltinString _ -> ConstructorLike . Just $ ConstructorLikeHead
             (BuiltinMap InternalAc
                     {builtinAcChild = NormalizedMap builtinMapChild}
                 ) -> normalizedAcConstructorLike builtinMapChild

--- a/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
+++ b/kore/src/Kore/Attribute/Pattern/ConstructorLike.hs
@@ -30,6 +30,9 @@ import Kore.Internal.Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
+import Kore.Internal.InternalInt
+    ( InternalInt
+    )
 import Kore.Internal.Symbol
     ( Symbol
     )
@@ -186,7 +189,6 @@ instance HasConstructorLike key => Synthetic ConstructorLike (Builtin key)
   where
     synthetic =
         \case
-            BuiltinInt _    -> ConstructorLike . Just $ ConstructorLikeHead
             BuiltinBool _   -> ConstructorLike . Just $ ConstructorLikeHead
             BuiltinString _ -> ConstructorLike . Just $ ConstructorLikeHead
             (BuiltinMap InternalAc
@@ -230,6 +232,10 @@ instance Synthetic ConstructorLike (Const StringLiteral) where
     {-# INLINE synthetic #-}
 
 instance Synthetic ConstructorLike (Const InternalBytes) where
+    synthetic = const (ConstructorLike . Just $ ConstructorLikeHead)
+    {-# INLINE synthetic #-}
+
+instance Synthetic ConstructorLike (Const InternalInt) where
     synthetic = const (ConstructorLike . Just $ ConstructorLikeHead)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -6,6 +6,7 @@ License     : NCSA
 
 module Kore.Attribute.Pattern.Defined
     ( Defined (..)
+    , alwaysDefined
     ) where
 
 import Prelude.Kore
@@ -25,12 +26,6 @@ import Kore.Internal.Inj
     ( Inj
     )
 import qualified Kore.Internal.Inj as Inj
-import Kore.Internal.InternalBytes
-    ( InternalBytes
-    )
-import Kore.Internal.InternalInt
-    ( InternalInt
-    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -43,6 +38,9 @@ newtype Defined = Defined { isDefined :: Bool }
     deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
     deriving anyclass (Debug, Diff)
     deriving (Semigroup, Monoid) via All
+
+alwaysDefined :: a -> Defined
+alwaysDefined = const (Defined True)
 
 instance Synthetic Defined (And sort) where
     synthetic = const (Defined False)
@@ -169,36 +167,26 @@ normalizedAcDefined ac@(NormalizedAc _ _ _) =
   where
     sameAsChildren = fold ac
 
-
 -- | A 'Top' pattern is always 'Defined'.
 instance Synthetic Defined (Top sort) where
-    synthetic = const (Defined True)
+    synthetic = alwaysDefined
     {-# INLINE synthetic #-}
 
 -- | A 'StringLiteral' pattern is always 'Defined'.
 instance Synthetic Defined (Const StringLiteral) where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
-
--- | An 'InternalBytes' pattern is always 'Defined'.
-instance Synthetic Defined (Const InternalBytes) where
-    synthetic = const (Defined True)
-    {-# INLINE synthetic #-}
-
--- | A 'InternalInt' pattern is always 'Defined'.
-instance Synthetic Defined (Const InternalInt) where
-    synthetic = const (Defined True)
+    synthetic = alwaysDefined
     {-# INLINE synthetic #-}
 
 -- | An 'Inhabitant' pattern is always 'Defined'.
 instance Synthetic Defined Inhabitant where
-    synthetic = const (Defined True)
+    synthetic = alwaysDefined
     {-# INLINE synthetic #-}
 
 -- | An element variable pattern is always 'Defined'.
 --   A set variable is not.
 instance Synthetic Defined (Const (SomeVariable variable)) where
-    synthetic (Const unifiedVariable)= Defined (isElementVariable unifiedVariable)
+    synthetic (Const unifiedVariable) =
+        Defined (isElementVariable unifiedVariable)
     {-# INLINE synthetic #-}
 
 instance Synthetic Defined Inj where

--- a/kore/src/Kore/Attribute/Pattern/Defined.hs
+++ b/kore/src/Kore/Attribute/Pattern/Defined.hs
@@ -28,6 +28,9 @@ import qualified Kore.Internal.Inj as Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
+import Kore.Internal.InternalInt
+    ( InternalInt
+    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -177,8 +180,13 @@ instance Synthetic Defined (Const StringLiteral) where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 
--- | A 'Bytes' pattern is always 'Defined'.
+-- | An 'InternalBytes' pattern is always 'Defined'.
 instance Synthetic Defined (Const InternalBytes) where
+    synthetic = const (Defined True)
+    {-# INLINE synthetic #-}
+
+-- | A 'InternalInt' pattern is always 'Defined'.
+instance Synthetic Defined (Const InternalInt) where
     synthetic = const (Defined True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -27,6 +27,9 @@ import qualified Kore.Internal.Inj as Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
+import Kore.Internal.InternalInt
+    ( InternalInt
+    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -139,8 +142,13 @@ instance Synthetic Function (Const StringLiteral) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 
--- | A 'Bytes' pattern is always 'Function'.
+-- | An 'InternalBytes' pattern is always 'Function'.
 instance Synthetic Function (Const InternalBytes) where
+    synthetic = const (Function True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalInt' pattern is always 'Function'.
+instance Synthetic Function (Const InternalInt) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Function.hs
+++ b/kore/src/Kore/Attribute/Pattern/Function.hs
@@ -6,6 +6,7 @@ License     : NCSA
 
 module Kore.Attribute.Pattern.Function
     ( Function (..)
+    , alwaysFunction
     ) where
 
 import Prelude.Kore
@@ -24,12 +25,6 @@ import Kore.Internal.Inj
     ( Inj
     )
 import qualified Kore.Internal.Inj as Inj
-import Kore.Internal.InternalBytes
-    ( InternalBytes
-    )
-import Kore.Internal.InternalInt
-    ( InternalInt
-    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -42,6 +37,10 @@ newtype Function = Function { isFunction :: Bool }
     deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
     deriving anyclass (Debug, Diff)
     deriving (Semigroup, Monoid) via All
+
+alwaysFunction :: a -> Function
+alwaysFunction = const (Function True)
+{-# INLINE alwaysFunction #-}
 
 instance Synthetic Function (And sort) where
     -- TODO (thomas.tuegel):
@@ -139,16 +138,6 @@ instance Synthetic Function (Top sort) where
 
 -- | A 'StringLiteral' pattern is always 'Function'.
 instance Synthetic Function (Const StringLiteral) where
-    synthetic = const (Function True)
-    {-# INLINE synthetic #-}
-
--- | An 'InternalBytes' pattern is always 'Function'.
-instance Synthetic Function (Const InternalBytes) where
-    synthetic = const (Function True)
-    {-# INLINE synthetic #-}
-
--- | An 'InternalInt' pattern is always 'Function'.
-instance Synthetic Function (Const InternalInt) where
     synthetic = const (Function True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -28,6 +28,9 @@ import qualified Kore.Internal.Inj as Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
+import Kore.Internal.InternalInt
+    ( InternalInt
+    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -185,8 +188,13 @@ instance Synthetic Functional (Const StringLiteral) where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 
--- | A 'Bytes' pattern is always 'Functional'.
+-- | An 'InternalBytes' pattern is always 'Functional'.
 instance Synthetic Functional (Const InternalBytes) where
+    synthetic = const (Functional True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalInt' pattern is always 'Functional'.
+instance Synthetic Functional (Const InternalInt) where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Functional.hs
+++ b/kore/src/Kore/Attribute/Pattern/Functional.hs
@@ -6,6 +6,7 @@ License     : NCSA
 
 module Kore.Attribute.Pattern.Functional
     ( Functional (..)
+    , alwaysFunctional
     ) where
 
 import Prelude.Kore
@@ -25,12 +26,6 @@ import Kore.Internal.Inj
     ( Inj
     )
 import qualified Kore.Internal.Inj as Inj
-import Kore.Internal.InternalBytes
-    ( InternalBytes
-    )
-import Kore.Internal.InternalInt
-    ( InternalInt
-    )
 import qualified Kore.Internal.Symbol as Internal
 import Kore.Syntax
 
@@ -39,18 +34,13 @@ import Kore.Syntax
 newtype Functional = Functional { isFunctional :: Bool }
     deriving (Eq, GHC.Generic, Ord, Show)
     deriving (Semigroup, Monoid) via All
+    deriving anyclass (Hashable, NFData)
+    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+    deriving anyclass (Debug, Diff)
 
-instance SOP.Generic Functional
-
-instance SOP.HasDatatypeInfo Functional
-
-instance Debug Functional
-
-instance Diff Functional
-
-instance NFData Functional
-
-instance Hashable Functional
+alwaysFunctional :: a -> Functional
+alwaysFunctional = const (Functional True)
+{-# INLINE alwaysFunctional #-}
 
 instance Synthetic Functional (And sort) where
     synthetic = const (Functional False)
@@ -185,16 +175,6 @@ instance Synthetic Functional (Const (SomeVariable variable)) where
 
 -- | A 'StringLiteral' pattern is always 'Functional'.
 instance Synthetic Functional (Const StringLiteral) where
-    synthetic = const (Functional True)
-    {-# INLINE synthetic #-}
-
--- | An 'InternalBytes' pattern is always 'Functional'.
-instance Synthetic Functional (Const InternalBytes) where
-    synthetic = const (Functional True)
-    {-# INLINE synthetic #-}
-
--- | An 'InternalInt' pattern is always 'Functional'.
-instance Synthetic Functional (Const InternalInt) where
     synthetic = const (Functional True)
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -37,6 +37,9 @@ import qualified Kore.Internal.Inj as Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
     )
+import Kore.Internal.InternalInt
+    ( InternalInt
+    )
 import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
     )
@@ -294,6 +297,10 @@ instance Synthetic Simplified (Const InternalBytes) where
     synthetic = alwaysSimplified
     {-# INLINE synthetic #-}
 
+instance Synthetic Simplified (Const InternalInt) where
+    synthetic = alwaysSimplified
+    {-# INLINE synthetic #-}
+
 instance Synthetic Simplified (Const (SomeVariable variable)) where
     synthetic = alwaysSimplified
     {-# INLINE synthetic #-}
@@ -367,7 +374,6 @@ instance Synthetic Simplified (Rewrites sort) where
     {-# INLINE synthetic #-}
 
 instance Synthetic Simplified (Builtin key) where
-    synthetic (BuiltinInt    _) = fullySimplified
     synthetic (BuiltinBool   _) = fullySimplified
     synthetic (BuiltinString _) = fullySimplified
     synthetic b@(BuiltinMap    _) = notSimplified b

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -13,6 +13,7 @@ module Kore.Attribute.Pattern.Simplified
     , isFullySimplified
     , simplifiedTo
     , fullySimplified
+    , alwaysSimplified
     , simplifiedConditionally
     , simplifiableConditionally
     , unparseTag
@@ -36,9 +37,6 @@ import Kore.Internal.Inj
 import qualified Kore.Internal.Inj as Inj
 import Kore.Internal.InternalBytes
     ( InternalBytes
-    )
-import Kore.Internal.InternalInt
-    ( InternalInt
     )
 import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
     ( Representation
@@ -294,10 +292,6 @@ instance Synthetic Simplified (Const StringLiteral) where
     {-# INLINE synthetic #-}
 
 instance Synthetic Simplified (Const InternalBytes) where
-    synthetic = alwaysSimplified
-    {-# INLINE synthetic #-}
-
-instance Synthetic Simplified (Const InternalInt) where
     synthetic = alwaysSimplified
     {-# INLINE synthetic #-}
 

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -368,7 +368,6 @@ instance Synthetic Simplified (Rewrites sort) where
     {-# INLINE synthetic #-}
 
 instance Synthetic Simplified (Builtin key) where
-    synthetic (BuiltinBool   _) = fullySimplified
     synthetic (BuiltinString _) = fullySimplified
     synthetic b@(BuiltinMap    _) = notSimplified b
     synthetic b@(BuiltinList   _) = notSimplified b

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -368,7 +368,6 @@ instance Synthetic Simplified (Rewrites sort) where
     {-# INLINE synthetic #-}
 
 instance Synthetic Simplified (Builtin key) where
-    synthetic (BuiltinString _) = fullySimplified
     synthetic b@(BuiltinMap    _) = notSimplified b
     synthetic b@(BuiltinList   _) = notSimplified b
     synthetic b@(BuiltinSet    _) = notSimplified b

--- a/kore/src/Kore/Builtin/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool.hs
@@ -36,6 +36,7 @@ import Control.Error
     ( MaybeT
     )
 import qualified Control.Monad as Monad
+import Data.Functor.Const
 import qualified Data.HashMap.Strict as HashMap
 import Data.Map.Strict
     ( Map
@@ -44,7 +45,6 @@ import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text
     )
-import qualified Data.Text as Text
 import qualified Text.Megaparsec as Parsec
 import qualified Text.Megaparsec.Char as Parsec
 
@@ -53,8 +53,8 @@ import Kore.Attribute.Hook
     )
 import Kore.Builtin.Bool.Bool
 import qualified Kore.Builtin.Builtin as Builtin
-import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Error
+import Kore.Internal.InternalBool
 import Kore.Internal.Pattern
     ( Pattern
     )
@@ -122,11 +122,11 @@ patternVerifierHook =
     patternVerifierWorker domainValue =
         case externalChild of
             StringLiteral_ lit -> do
-                builtinBoolValue <- Builtin.parseString parse lit
-                (return . BuiltinF . Domain.BuiltinBool)
-                    Domain.InternalBool
-                        { builtinBoolSort = domainValueSort
-                        , builtinBoolValue
+                internalBoolValue <- Builtin.parseString parse lit
+                (return . InternalBoolF . Const)
+                    InternalBool
+                        { internalBoolSort = domainValueSort
+                        , internalBoolValue
                         }
             _ -> Kore.Error.koreFail "Expected literal string"
       where
@@ -136,15 +136,9 @@ patternVerifierHook =
 -- | get the value from a (possibly encoded) domain value
 extractBoolDomainValue
     :: Text -- ^ error message Context
-    -> Builtin child
-    -> Bool
-extractBoolDomainValue ctx =
-    \case
-        Domain.BuiltinBool Domain.InternalBool { builtinBoolValue } ->
-            builtinBoolValue
-        _ ->
-            Builtin.verifierBug
-            $ Text.unpack ctx ++ ": Bool builtin should be internal"
+    -> TermLike variable
+    -> Maybe Bool
+extractBoolDomainValue _ = matchBool
 
 {- | Parse an integer string literal.
  -}
@@ -171,9 +165,9 @@ builtinFunctions =
     ]
   where
     unaryOperator =
-        Builtin.unaryOperator extractBoolDomainValue asPattern
+        Builtin.unaryOperator' extractBoolDomainValue asPattern
     binaryOperator =
-        Builtin.binaryOperator extractBoolDomainValue asPattern
+        Builtin.binaryOperator' extractBoolDomainValue asPattern
     xor a b = (a && not b) || (not a && b)
     implies a b = not a || b
 
@@ -285,8 +279,8 @@ unifyBoolNot unifyChildren a b =
 {- | Match a @BOOL.Bool@ builtin value.
  -}
 matchBool :: TermLike variable -> Maybe Bool
-matchBool (BuiltinBool_ Domain.InternalBool { builtinBoolValue }) =
-    Just builtinBoolValue
+matchBool (BuiltinBool_ InternalBool { internalBoolValue }) =
+    Just internalBoolValue
 matchBool _ = Nothing
 
 {- | The @BOOL.and@ hooked symbol applied to @term@-type arguments.

--- a/kore/src/Kore/Builtin/Bool/Bool.hs
+++ b/kore/src/Kore/Builtin/Bool/Bool.hs
@@ -30,7 +30,7 @@ import Data.Text
     ( Text
     )
 
-import qualified Kore.Domain.Builtin as Domain
+import Kore.Internal.InternalBool
 import Kore.Internal.Pattern
     ( Pattern
     )
@@ -38,13 +38,12 @@ import qualified Kore.Internal.Pattern as Pattern
     ( fromTermLike
     )
 import Kore.Internal.TermLike
-    ( Concrete
-    , DomainValue (DomainValue)
+    ( DomainValue (DomainValue)
     , InternalVariable
     , Sort
     , TermLike
-    , mkBuiltin
     , mkDomainValue
+    , mkInternalBool
     , mkStringLiteral
     )
 import qualified Kore.Internal.TermLike as TermLike
@@ -71,18 +70,14 @@ asInternal
     -> Bool  -- ^ builtin value to render
     -> TermLike variable
 asInternal builtinBoolSort builtinBoolValue =
-    TermLike.markSimplified . mkBuiltin
+    TermLike.markSimplified . mkInternalBool
     $ asBuiltin builtinBoolSort builtinBoolValue
 
 asBuiltin
     :: Sort  -- ^ resulting sort
     -> Bool  -- ^ builtin value to render
-    -> Domain.Builtin (TermLike Concrete) (TermLike variable)
-asBuiltin builtinBoolSort builtinBoolValue =
-    Domain.BuiltinBool Domain.InternalBool
-        { builtinBoolSort
-        , builtinBoolValue
-        }
+    -> InternalBool
+asBuiltin = InternalBool
 
 {- | Render a 'Bool' as a domain value pattern of the given sort.
 
@@ -94,16 +89,16 @@ asBuiltin builtinBoolSort builtinBoolValue =
  -}
 asTermLike
     :: InternalVariable variable
-    => Domain.InternalBool  -- ^ builtin value to render
+    => InternalBool  -- ^ builtin value to render
     -> TermLike variable
 asTermLike builtin =
     mkDomainValue DomainValue
-        { domainValueSort = builtinBoolSort
+        { domainValueSort = internalBoolSort
         , domainValueChild = mkStringLiteral literal
         }
   where
-    Domain.InternalBool { builtinBoolSort } = builtin
-    Domain.InternalBool { builtinBoolValue = bool } = builtin
+    InternalBool { internalBoolSort } = builtin
+    InternalBool { internalBoolValue = bool } = builtin
     literal
       | bool      = "true"
       | otherwise = "false"

--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -260,7 +260,7 @@ binaryOperator' extractVal asPattern ctx op =
     binaryOperator0 :: Function
     binaryOperator0 resultSort children =
         case children of
-            [(get -> Just a), (get -> Just b)] -> do
+            [get -> Just a, get -> Just b] -> do
                 -- Apply the operator to two domain values
                 let r = op a b
                 return (asPattern resultSort r)
@@ -337,7 +337,7 @@ ternaryOperator' extractVal asPattern ctx op =
     ternaryOperator0 :: Function
     ternaryOperator0 resultSort children =
         case children of
-            [(get -> Just a), (get -> Just b), (get -> Just c)] -> do
+            [get -> Just a, get -> Just b, get -> Just c] -> do
                 -- Apply the operator to three domain values
                 let r = op a b c
                 return (asPattern resultSort r)

--- a/kore/src/Kore/Builtin/External.hs
+++ b/kore/src/Kore/Builtin/External.hs
@@ -68,15 +68,13 @@ externalize =
                     Domain.BuiltinSet  builtin ->
                         (toPatternF . Recursive.project)
                             (Set.asTermLike builtin)
-                    Domain.BuiltinBool builtin ->
-                        (toPatternF . Recursive.project)
-                            (Bool.asTermLike builtin)
                     Domain.BuiltinString builtin ->
                         (toPatternF . Recursive.project)
                             (String.asTermLike builtin)
+            InternalBoolF (Const internalBool) ->
+                (toPatternF . Recursive.project) (Bool.asTermLike internalBool)
             InternalIntF (Const internalInt) ->
-                (toPatternF . Recursive.project)
-                    (Int.asTermLike internalInt)
+                (toPatternF . Recursive.project) (Int.asTermLike internalInt)
             InternalBytesF (Const internalBytes) ->
                 (toPatternF . Recursive.project)
                     (InternalBytes.asTermLike internalBytes)
@@ -145,4 +143,5 @@ externalize =
             InjF _ -> error "Unexpected sort injection"
             BuiltinF _ -> error "Unexpected internal builtin"
             InternalBytesF _ -> error "Unexpected internal builtin"
+            InternalBoolF _ -> error "Unexpected internal builtin"
             InternalIntF _ -> error "Unexpected internal builtin"

--- a/kore/src/Kore/Builtin/External.hs
+++ b/kore/src/Kore/Builtin/External.hs
@@ -68,15 +68,15 @@ externalize =
                     Domain.BuiltinSet  builtin ->
                         (toPatternF . Recursive.project)
                             (Set.asTermLike builtin)
-                    Domain.BuiltinInt  builtin ->
-                        (toPatternF . Recursive.project)
-                            (Int.asTermLike builtin)
                     Domain.BuiltinBool builtin ->
                         (toPatternF . Recursive.project)
                             (Bool.asTermLike builtin)
                     Domain.BuiltinString builtin ->
                         (toPatternF . Recursive.project)
                             (String.asTermLike builtin)
+            InternalIntF (Const internalInt) ->
+                (toPatternF . Recursive.project)
+                    (Int.asTermLike internalInt)
             InternalBytesF (Const internalBytes) ->
                 (toPatternF . Recursive.project)
                     (InternalBytes.asTermLike internalBytes)
@@ -145,3 +145,4 @@ externalize =
             InjF _ -> error "Unexpected sort injection"
             BuiltinF _ -> error "Unexpected internal builtin"
             InternalBytesF _ -> error "Unexpected internal builtin"
+            InternalIntF _ -> error "Unexpected internal builtin"

--- a/kore/src/Kore/Builtin/External.hs
+++ b/kore/src/Kore/Builtin/External.hs
@@ -68,9 +68,6 @@ externalize =
                     Domain.BuiltinSet  builtin ->
                         (toPatternF . Recursive.project)
                             (Set.asTermLike builtin)
-                    Domain.BuiltinString builtin ->
-                        (toPatternF . Recursive.project)
-                            (String.asTermLike builtin)
             InternalBoolF (Const internalBool) ->
                 (toPatternF . Recursive.project) (Bool.asTermLike internalBool)
             InternalIntF (Const internalInt) ->
@@ -78,6 +75,9 @@ externalize =
             InternalBytesF (Const internalBytes) ->
                 (toPatternF . Recursive.project)
                     (InternalBytes.asTermLike internalBytes)
+            InternalStringF (Const internalString) ->
+                (toPatternF . Recursive.project)
+                    (String.asTermLike internalString)
             InjF inj ->
                 (toPatternF . Recursive.project . synthesize . ApplySymbolF)
                     (Inj.toApplication inj)
@@ -142,6 +142,7 @@ externalize =
                 $ getDefined definedF
             InjF _ -> error "Unexpected sort injection"
             BuiltinF _ -> error "Unexpected internal builtin"
-            InternalBytesF _ -> error "Unexpected internal builtin"
             InternalBoolF _ -> error "Unexpected internal builtin"
+            InternalBytesF _ -> error "Unexpected internal builtin"
             InternalIntF _ -> error "Unexpected internal builtin"
+            InternalStringF _ -> error "Unexpected internal builtin"

--- a/kore/src/Kore/Builtin/Int.hs
+++ b/kore/src/Kore/Builtin/Int.hs
@@ -232,7 +232,7 @@ extractIntDomainValue
     -> Maybe Integer
 extractIntDomainValue _ =
     \case
-        BuiltinInt_ InternalInt { internalIntValue } -> Just internalIntValue
+        InternalInt_ InternalInt { internalIntValue } -> Just internalIntValue
         _ -> Nothing
 
 {- | Parse a string literal as an integer.
@@ -256,7 +256,7 @@ expectBuiltinInt
     -> MaybeT m Integer
 expectBuiltinInt _ =
     \case
-        BuiltinInt_ InternalInt { internalIntValue } -> return internalIntValue
+        InternalInt_ InternalInt { internalIntValue } -> return internalIntValue
         _ -> empty
 
 {- | Implement builtin function evaluation.

--- a/kore/src/Kore/Builtin/Int/Int.hs
+++ b/kore/src/Kore/Builtin/Int/Int.hs
@@ -51,7 +51,7 @@ import Data.Text
     )
 import qualified Data.Text as Text
 
-import qualified Kore.Domain.Builtin as Domain
+import Kore.Internal.InternalInt
 import Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike as TermLike
 
@@ -74,18 +74,15 @@ asInternal
     -> Integer  -- ^ builtin value to render
     -> TermLike variable
 asInternal builtinIntSort builtinIntValue =
-    TermLike.fromConcrete . TermLike.markSimplified . mkBuiltin
+    TermLike.fromConcrete . TermLike.markSimplified . mkInternalInt
     $ asBuiltin builtinIntSort builtinIntValue
 
 asBuiltin
     :: Sort  -- ^ resulting sort
     -> Integer  -- ^ builtin value to render
-    -> Domain.Builtin (TermLike Concrete) (TermLike variable)
-asBuiltin builtinIntSort builtinIntValue =
-    Domain.BuiltinInt Domain.InternalInt
-        { builtinIntSort
-        , builtinIntValue
-        }
+    -> InternalInt
+asBuiltin internalIntSort internalIntValue =
+    InternalInt { internalIntSort, internalIntValue }
 
 {- | Render an 'Integer' as a domain value pattern of the given sort.
 
@@ -97,16 +94,15 @@ asBuiltin builtinIntSort builtinIntValue =
  -}
 asTermLike
     :: InternalVariable variable
-    => Domain.InternalInt  -- ^ builtin value to render
+    => InternalInt  -- ^ builtin value to render
     -> TermLike variable
 asTermLike builtin =
     mkDomainValue DomainValue
-        { domainValueSort = builtinIntSort
-        , domainValueChild = mkStringLiteral . Text.pack $ show int
+        { domainValueSort = internalIntSort
+        , domainValueChild = mkStringLiteral . Text.pack $ show internalIntValue
         }
   where
-    Domain.InternalInt { builtinIntSort } = builtin
-    Domain.InternalInt { builtinIntValue = int } = builtin
+    InternalInt { internalIntSort, internalIntValue } = builtin
 
 asPattern
     :: InternalVariable variable

--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -32,7 +32,6 @@ import Control.Error
     , hoistMaybe
     )
 import qualified Control.Monad as Monad
-import qualified Data.Functor.Foldable as Recursive
 import qualified Data.HashMap.Strict as HashMap
 import Data.Map.Strict
     ( Map
@@ -182,14 +181,8 @@ evalKIte (_ :< app) =
             evalIte expr t1 t2
         _ -> Builtin.wrongArity iteKey
   where
-    evaluate
-        :: TermLike variable
-        -> Maybe Bool
-    evaluate (Recursive.project -> _ :< pat) =
-        case pat of
-            BuiltinF dv ->
-                Just (Bool.extractBoolDomainValue iteKey dv)
-            _ -> Nothing
+    evaluate :: TermLike variable -> Maybe Bool
+    evaluate = Bool.matchBool
 
     evalIte expr t1 t2 =
         case evaluate expr of

--- a/kore/src/Kore/Builtin/String/String.hs
+++ b/kore/src/Kore/Builtin/String/String.hs
@@ -36,7 +36,7 @@ import Data.Text
     ( Text
     )
 
-import qualified Kore.Domain.Builtin as Domain
+import Kore.Internal.InternalString
 import Kore.Internal.Pattern
     ( Pattern
     )
@@ -62,18 +62,14 @@ asInternal
     -> Text  -- ^ builtin value to render
     -> TermLike variable
 asInternal internalStringSort internalStringValue =
-    TermLike.fromConcrete . mkBuiltin
+    TermLike.fromConcrete . mkInternalString
     $ asBuiltin internalStringSort internalStringValue
 
 asBuiltin
     :: Sort  -- ^ resulting sort
     -> Text  -- ^ builtin value to render
-    -> Domain.Builtin (TermLike Concrete) (TermLike variable)
-asBuiltin internalStringSort internalStringValue =
-    Domain.BuiltinString Domain.InternalString
-        { internalStringSort
-        , internalStringValue
-        }
+    -> InternalString
+asBuiltin = InternalString
 
 {- | Render an 'String' as a domain value pattern of the given sort.
 
@@ -85,7 +81,7 @@ asBuiltin internalStringSort internalStringValue =
  -}
 asTermLike
     :: InternalVariable variable
-    => Domain.InternalString  -- ^ builtin value to render
+    => InternalString  -- ^ builtin value to render
     -> TermLike variable
 asTermLike internal =
     mkDomainValue DomainValue
@@ -93,8 +89,8 @@ asTermLike internal =
         , domainValueChild = mkStringLiteral internalStringValue
         }
   where
-    Domain.InternalString { internalStringSort } = internal
-    Domain.InternalString { internalStringValue } = internal
+    InternalString { internalStringSort } = internal
+    InternalString { internalStringValue } = internal
 
 asPattern
     :: InternalVariable variable

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -41,7 +41,6 @@ module Kore.Domain.Builtin
     , SetValue
     , NormalizedSet (..)
     --
-    , InternalBool (..)
     , InternalString (..)
     ) where
 
@@ -638,38 +637,6 @@ type InternalSet key child = InternalAc key NormalizedSet child
 
 -- * Builtin Bool
 
-{- | Internal representation of the builtin @BOOL.Bool@ domain.
- -}
-data InternalBool =
-    InternalBool
-        { builtinBoolSort :: !Sort
-        , builtinBoolValue :: !Bool
-        }
-    deriving (Eq, Ord, Show)
-    deriving (GHC.Generic)
-    deriving anyclass (Hashable, NFData)
-    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
-    deriving anyclass (Debug, Diff)
-
-instance Unparse InternalBool where
-    unparse InternalBool { builtinBoolSort, builtinBoolValue } =
-        "\\dv"
-        <> parameters [builtinBoolSort]
-        <> Pretty.parens (Pretty.dquotes value)
-      where
-        value
-          | builtinBoolValue = "true"
-          | otherwise        = "false"
-
-    unparse2 InternalBool { builtinBoolSort, builtinBoolValue } =
-        "\\dv2"
-        <> parameters2 [builtinBoolSort]
-        <> arguments' [Pretty.dquotes value]
-      where
-        value
-          | builtinBoolValue = "true"
-          | otherwise        = "false"
-
 -- * Builtin String
 
 {- | Internal representation of the builtin @STRING.String@ domain.
@@ -702,7 +669,6 @@ data Builtin key child
     = BuiltinMap !(InternalMap key child)
     | BuiltinList !(InternalList child)
     | BuiltinSet !(InternalSet key child)
-    | BuiltinBool !InternalBool
     | BuiltinString !InternalString
     deriving (Eq, Ord, Show)
     deriving (Foldable, Functor, Traversable)
@@ -720,7 +686,6 @@ instance (Unparse key, Unparse child) => Unparse (Builtin key child) where
 builtinSort :: Builtin key child -> Sort
 builtinSort builtin =
     case builtin of
-        BuiltinBool InternalBool { builtinBoolSort } -> builtinBoolSort
         BuiltinString InternalString { internalStringSort } ->
             internalStringSort
         BuiltinMap InternalAc { builtinAcSort } -> builtinAcSort

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -40,8 +40,6 @@ module Kore.Domain.Builtin
     , SetElement
     , SetValue
     , NormalizedSet (..)
-    --
-    , InternalString (..)
     ) where
 
 import Prelude.Kore
@@ -63,9 +61,6 @@ import Data.Map.Strict
 import qualified Data.Map.Strict as Map
 import Data.Sequence
     ( Seq
-    )
-import Data.Text
-    ( Text
     )
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
@@ -635,41 +630,12 @@ instance AcWrapper NormalizedSet where
  -}
 type InternalSet key child = InternalAc key NormalizedSet child
 
--- * Builtin Bool
-
--- * Builtin String
-
-{- | Internal representation of the builtin @STRING.String@ domain.
- -}
-data InternalString =
-    InternalString
-        { internalStringSort :: !Sort
-        , internalStringValue :: !Text
-        }
-    deriving (Eq, Ord, Show)
-    deriving (GHC.Generic)
-    deriving anyclass (Hashable, NFData)
-    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
-    deriving anyclass (Debug, Diff)
-
-instance Unparse InternalString where
-    unparse InternalString { internalStringSort, internalStringValue } =
-        "\\dv"
-        <> parameters [internalStringSort]
-        <> Pretty.parens (unparse $ StringLiteral internalStringValue)
-
-    unparse2 InternalString { internalStringSort, internalStringValue } =
-        "\\dv2"
-        <> parameters2 [internalStringSort]
-        <> arguments2 [StringLiteral internalStringValue]
-
 -- * Builtin domain representations
 
 data Builtin key child
     = BuiltinMap !(InternalMap key child)
     | BuiltinList !(InternalList child)
     | BuiltinSet !(InternalSet key child)
-    | BuiltinString !InternalString
     deriving (Eq, Ord, Show)
     deriving (Foldable, Functor, Traversable)
     deriving (GHC.Generic)
@@ -686,8 +652,6 @@ instance (Unparse key, Unparse child) => Unparse (Builtin key child) where
 builtinSort :: Builtin key child -> Sort
 builtinSort builtin =
     case builtin of
-        BuiltinString InternalString { internalStringSort } ->
-            internalStringSort
         BuiltinMap InternalAc { builtinAcSort } -> builtinAcSort
         BuiltinList InternalList { builtinListSort } -> builtinListSort
         BuiltinSet InternalAc { builtinAcSort } -> builtinAcSort

--- a/kore/src/Kore/Domain/Builtin.hs
+++ b/kore/src/Kore/Domain/Builtin.hs
@@ -41,7 +41,6 @@ module Kore.Domain.Builtin
     , SetValue
     , NormalizedSet (..)
     --
-    , InternalInt (..)
     , InternalBool (..)
     , InternalString (..)
     ) where
@@ -637,32 +636,6 @@ instance AcWrapper NormalizedSet where
  -}
 type InternalSet key child = InternalAc key NormalizedSet child
 
--- * Builtin Int
-
-{- | Internal representation of the builtin @INT.Int@ domain.
- -}
-data InternalInt =
-    InternalInt
-        { builtinIntSort :: !Sort
-        , builtinIntValue :: !Integer
-        }
-    deriving (Eq, Ord, Show)
-    deriving (GHC.Generic)
-    deriving anyclass (Hashable, NFData)
-    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
-    deriving anyclass (Debug, Diff)
-
-instance Unparse InternalInt where
-    unparse InternalInt { builtinIntSort, builtinIntValue } =
-        "\\dv"
-        <> parameters [builtinIntSort]
-        <> Pretty.parens (Pretty.dquotes $ Pretty.pretty builtinIntValue)
-
-    unparse2 InternalInt { builtinIntSort, builtinIntValue } =
-        "\\dv2"
-        <> parameters2 [builtinIntSort]
-        <> arguments' [Pretty.dquotes $ Pretty.pretty builtinIntValue]
-
 -- * Builtin Bool
 
 {- | Internal representation of the builtin @BOOL.Bool@ domain.
@@ -729,7 +702,6 @@ data Builtin key child
     = BuiltinMap !(InternalMap key child)
     | BuiltinList !(InternalList child)
     | BuiltinSet !(InternalSet key child)
-    | BuiltinInt !InternalInt
     | BuiltinBool !InternalBool
     | BuiltinString !InternalString
     deriving (Eq, Ord, Show)
@@ -748,7 +720,6 @@ instance (Unparse key, Unparse child) => Unparse (Builtin key child) where
 builtinSort :: Builtin key child -> Sort
 builtinSort builtin =
     case builtin of
-        BuiltinInt InternalInt { builtinIntSort } -> builtinIntSort
         BuiltinBool InternalBool { builtinBoolSort } -> builtinBoolSort
         BuiltinString InternalString { internalStringSort } ->
             internalStringSort

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -312,7 +312,7 @@ getExitCode indexedModule configs =
         return exitCode
   where
     extractExit = \case
-        BuiltinInt_ InternalInt { internalIntValue = exit }
+        InternalInt_ InternalInt { internalIntValue = exit }
           | exit == 0 -> ExitSuccess
           | otherwise -> ExitFailure (fromInteger exit)
         _ -> ExitFailure 111

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -63,7 +63,6 @@ import Kore.Attribute.Symbol
     ( StepperAttributes
     )
 import qualified Kore.Builtin as Builtin
-import qualified Kore.Domain.Builtin as Domain
 import Kore.Equation
     ( Equation
     )
@@ -81,6 +80,7 @@ import Kore.IndexedModule.Resolvers
     ( resolveInternalSymbol
     )
 import qualified Kore.Internal.Condition as Condition
+import Kore.Internal.InternalInt
 import qualified Kore.Internal.MultiOr as MultiOr
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern
@@ -312,7 +312,7 @@ getExitCode indexedModule configs =
         return exitCode
   where
     extractExit = \case
-        Builtin_ (Domain.BuiltinInt (Domain.InternalInt _ exit))
+        BuiltinInt_ InternalInt { internalIntValue = exit }
           | exit == 0 -> ExitSuccess
           | otherwise -> ExitFailure (fromInteger exit)
         _ -> ExitFailure 111

--- a/kore/src/Kore/Internal/InternalBool.hs
+++ b/kore/src/Kore/Internal/InternalBool.hs
@@ -1,0 +1,91 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+ -}
+module Kore.Internal.InternalBool
+    ( InternalBool (..)
+    ) where
+
+import Prelude.Kore
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Functor.Const
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Attribute.Pattern.ConstructorLike
+import Kore.Attribute.Pattern.Defined
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Attribute.Pattern.Function
+import Kore.Attribute.Pattern.Functional
+import Kore.Attribute.Pattern.Simplified
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Sort
+import Kore.Unparser
+import qualified Pretty
+
+{- | Internal representation of the builtin @BOOL.Bool@ domain.
+ -}
+data InternalBool =
+    InternalBool
+        { internalBoolSort :: !Sort
+        , internalBoolValue :: !Bool
+        }
+    deriving (Eq, Ord, Show)
+    deriving (GHC.Generic)
+    deriving anyclass (Hashable, NFData)
+    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+    deriving anyclass (Debug, Diff)
+
+instance Unparse InternalBool where
+    unparse InternalBool { internalBoolSort, internalBoolValue } =
+        "\\dv"
+        <> parameters [internalBoolSort]
+        <> Pretty.parens (Pretty.dquotes value)
+      where
+        value
+          | internalBoolValue = "true"
+          | otherwise        = "false"
+
+    unparse2 InternalBool { internalBoolSort, internalBoolValue } =
+        "\\dv2"
+        <> parameters2 [internalBoolSort]
+        <> arguments' [Pretty.dquotes value]
+      where
+        value
+          | internalBoolValue = "true"
+          | otherwise        = "false"
+
+instance Synthetic Sort (Const InternalBool) where
+    synthetic (Const InternalBool { internalBoolSort }) = internalBoolSort
+    {-# INLINE synthetic #-}
+
+instance Synthetic (FreeVariables variable) (Const InternalBool) where
+    synthetic _ = emptyFreeVariables
+    {-# INLINE synthetic #-}
+
+instance Synthetic ConstructorLike (Const InternalBool) where
+    synthetic _ = ConstructorLike . Just $ ConstructorLikeHead
+    {-# INLINE synthetic #-}
+
+-- | A 'InternalInt' pattern is always 'Defined'.
+instance Synthetic Defined (Const InternalBool) where
+    synthetic = alwaysDefined
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalBool' pattern is always 'Function'.
+instance Synthetic Function (Const InternalBool) where
+    synthetic = const (Function True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalBool' pattern is always 'Functional'.
+instance Synthetic Functional (Const InternalBool) where
+    synthetic = const (Functional True)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Simplified (Const InternalBool) where
+    synthetic = alwaysSimplified
+    {-# INLINE synthetic #-}

--- a/kore/src/Kore/Internal/InternalBytes.hs
+++ b/kore/src/Kore/Internal/InternalBytes.hs
@@ -18,7 +18,10 @@ import Data.ByteString
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
+import Kore.Attribute.Pattern.Defined
 import Kore.Attribute.Pattern.FreeVariables
+import Kore.Attribute.Pattern.Function
+import Kore.Attribute.Pattern.Functional
 import Kore.Attribute.Synthetic
 import qualified Kore.Builtin.Encoding as Encoding
 import Kore.Debug
@@ -57,4 +60,19 @@ instance Synthetic Sort (Const InternalBytes) where
 
 instance Synthetic (FreeVariables variable) (Const InternalBytes) where
     synthetic = const emptyFreeVariables
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalBytes' pattern is always 'Defined'.
+instance Synthetic Defined (Const InternalBytes) where
+    synthetic = alwaysDefined
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalBytes' pattern is always 'Function'.
+instance Synthetic Function (Const InternalBytes) where
+    synthetic = const (Function True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalBytes' pattern is always 'Functional'.
+instance Synthetic Functional (Const InternalBytes) where
+    synthetic = const (Functional True)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Internal/InternalInt.hs
+++ b/kore/src/Kore/Internal/InternalInt.hs
@@ -15,10 +15,12 @@ import Data.Functor.Const
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
+import Kore.Attribute.Pattern.ConstructorLike
+import Kore.Attribute.Pattern.Defined
 import Kore.Attribute.Pattern.FreeVariables
-    ( FreeVariables
-    , emptyFreeVariables
-    )
+import Kore.Attribute.Pattern.Function
+import Kore.Attribute.Pattern.Functional
+import Kore.Attribute.Pattern.Simplified
 import Kore.Attribute.Synthetic
 import Kore.Debug
 import Kore.Sort
@@ -51,3 +53,26 @@ instance Synthetic Sort (Const InternalInt) where
 
 instance Synthetic (FreeVariables variable) (Const InternalInt) where
     synthetic _ = emptyFreeVariables
+
+instance Synthetic ConstructorLike (Const InternalInt) where
+    synthetic = const (ConstructorLike . Just $ ConstructorLikeHead)
+    {-# INLINE synthetic #-}
+
+-- | A 'InternalInt' pattern is always 'Defined'.
+instance Synthetic Defined (Const InternalInt) where
+    synthetic = alwaysDefined
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalInt' pattern is always 'Function'.
+instance Synthetic Function (Const InternalInt) where
+    synthetic = const (Function True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalInt' pattern is always 'Functional'.
+instance Synthetic Functional (Const InternalInt) where
+    synthetic = const (Functional True)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Simplified (Const InternalInt) where
+    synthetic = alwaysSimplified
+    {-# INLINE synthetic #-}

--- a/kore/src/Kore/Internal/InternalInt.hs
+++ b/kore/src/Kore/Internal/InternalInt.hs
@@ -1,0 +1,53 @@
+{- |
+Copyright   : (c) Runtime Verification, 2020
+License     : NCSA
+-}
+module Kore.Internal.InternalInt
+    ( InternalInt (..)
+    ) where
+
+import Prelude.Kore
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Functor.Const
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables
+    , emptyFreeVariables
+    )
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Sort
+import Kore.Unparser
+import qualified Pretty
+
+{- | Internal representation of the builtin @INT.Int@ domain.
+ -}
+data InternalInt =
+    InternalInt { internalIntSort :: !Sort, internalIntValue :: !Integer }
+    deriving (Eq, Ord, Show)
+    deriving (GHC.Generic)
+    deriving anyclass (Hashable, NFData)
+    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+    deriving anyclass (Debug, Diff)
+
+instance Unparse InternalInt where
+    unparse InternalInt { internalIntSort, internalIntValue } =
+        "\\dv"
+        <> parameters [internalIntSort]
+        <> Pretty.parens (Pretty.dquotes $ Pretty.pretty internalIntValue)
+
+    unparse2 InternalInt { internalIntSort, internalIntValue } =
+        "\\dv2"
+        <> parameters2 [internalIntSort]
+        <> arguments' [Pretty.dquotes $ Pretty.pretty internalIntValue]
+
+instance Synthetic Sort (Const InternalInt) where
+    synthetic (Const InternalInt { internalIntSort }) = internalIntSort
+
+instance Synthetic (FreeVariables variable) (Const InternalInt) where
+    synthetic _ = emptyFreeVariables

--- a/kore/src/Kore/Internal/InternalString.hs
+++ b/kore/src/Kore/Internal/InternalString.hs
@@ -1,0 +1,88 @@
+{- |
+Copyright   : (c) Runtime Verification, 2019
+License     : NCSA
+ -}
+module Kore.Internal.InternalString
+    ( InternalString (..)
+    ) where
+
+import Prelude.Kore
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Functor.Const
+import Data.Text
+    ( Text
+    )
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Kore.Attribute.Pattern.ConstructorLike
+import Kore.Attribute.Pattern.Defined
+import Kore.Attribute.Pattern.FreeVariables
+import Kore.Attribute.Pattern.Function
+import Kore.Attribute.Pattern.Functional
+import Kore.Attribute.Pattern.Simplified
+import Kore.Attribute.Synthetic
+import Kore.Debug
+import Kore.Sort
+import Kore.Syntax.StringLiteral
+import Kore.Unparser
+import qualified Pretty
+
+
+{- | Internal representation of the builtin @STRING.String@ domain.
+ -}
+data InternalString =
+    InternalString
+        { internalStringSort :: !Sort
+        , internalStringValue :: !Text
+        }
+    deriving (Eq, Ord, Show)
+    deriving (GHC.Generic)
+    deriving anyclass (Hashable, NFData)
+    deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+    deriving anyclass (Debug, Diff)
+
+instance Unparse InternalString where
+    unparse InternalString { internalStringSort, internalStringValue } =
+        "\\dv"
+        <> parameters [internalStringSort]
+        <> Pretty.parens (unparse $ StringLiteral internalStringValue)
+
+    unparse2 InternalString { internalStringSort, internalStringValue } =
+        "\\dv2"
+        <> parameters2 [internalStringSort]
+        <> arguments2 [StringLiteral internalStringValue]
+
+instance Synthetic Sort (Const InternalString) where
+    synthetic (Const InternalString { internalStringSort }) = internalStringSort
+    {-# INLINE synthetic #-}
+
+instance Synthetic (FreeVariables variable) (Const InternalString) where
+    synthetic _ = emptyFreeVariables
+    {-# INLINE synthetic #-}
+
+instance Synthetic ConstructorLike (Const InternalString) where
+    synthetic _ = ConstructorLike . Just $ ConstructorLikeHead
+    {-# INLINE synthetic #-}
+
+-- | A 'InternalInt' pattern is always 'Defined'.
+instance Synthetic Defined (Const InternalString) where
+    synthetic = alwaysDefined
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalString' pattern is always 'Function'.
+instance Synthetic Function (Const InternalString) where
+    synthetic = const (Function True)
+    {-# INLINE synthetic #-}
+
+-- | An 'InternalString' pattern is always 'Functional'.
+instance Synthetic Functional (Const InternalString) where
+    synthetic = const (Functional True)
+    {-# INLINE synthetic #-}
+
+instance Synthetic Simplified (Const InternalString) where
+    synthetic = alwaysSimplified
+    {-# INLINE synthetic #-}

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -120,7 +120,7 @@ module Kore.Internal.TermLike
     , pattern InternalBytes_
     , pattern Builtin_
     , pattern BuiltinBool_
-    , pattern BuiltinInt_
+    , pattern InternalInt_
     , pattern BuiltinList_
     , pattern BuiltinMap_
     , pattern BuiltinSet_
@@ -352,7 +352,7 @@ hasConstructorLikeTop = \case
     App_ symbol _ -> isConstructor symbol
     DV_ _ _ -> True
     BuiltinBool_ _ -> True
-    BuiltinInt_ _ -> True
+    InternalInt_ _ -> True
     BuiltinList_ _ -> True
     BuiltinMap_ _ -> True
     BuiltinSet_ _ -> True
@@ -1736,7 +1736,7 @@ pattern BuiltinBool_
     :: Domain.InternalBool
     -> TermLike variable
 
-pattern BuiltinInt_
+pattern InternalInt_
     :: InternalInt
     -> TermLike variable
 
@@ -1888,7 +1888,7 @@ pattern Builtin_ builtin <- (Recursive.project -> _ :< BuiltinF builtin)
 
 pattern BuiltinBool_ internalBool <- Builtin_ (Domain.BuiltinBool internalBool)
 
-pattern BuiltinInt_ internalInt <-
+pattern InternalInt_ internalInt <-
     (Recursive.project -> _ :< InternalIntF (Const internalInt))
 
 pattern BuiltinList_ internalList <- Builtin_ (Domain.BuiltinList internalList)

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -78,6 +78,7 @@ import Kore.Debug
 import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.Alias
 import Kore.Internal.Inj
+import Kore.Internal.InternalBool
 import Kore.Internal.InternalBytes
 import Kore.Internal.InternalInt
 import Kore.Internal.Symbol hiding
@@ -198,6 +199,7 @@ data TermLikeF variable child
     | TopF           !(Top Sort child)
     | InhabitantF    !(Inhabitant child)
     | BuiltinF       !(Builtin child)
+    | InternalBoolF  !(Const InternalBool child)
     | InternalIntF   !(Const InternalInt child)
     | EvaluatedF     !(Evaluated child)
     | StringLiteralF !(Const StringLiteral child)
@@ -251,6 +253,7 @@ instance
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -286,6 +289,7 @@ instance Synthetic Sort (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -321,6 +325,7 @@ instance Synthetic Pattern.Functional (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -356,6 +361,7 @@ instance Synthetic Pattern.Function (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -391,6 +397,7 @@ instance Synthetic Pattern.Defined (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -426,6 +433,7 @@ instance Synthetic Pattern.Simplified (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -461,6 +469,7 @@ instance Synthetic Pattern.ConstructorLike (TermLikeF variable) where
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
+            InternalBoolF internalBool -> synthetic internalBool
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -703,6 +712,8 @@ instance
             BuiltinF builtin -> locationFromAst (Domain.builtinSort builtin)
             InternalIntF (Const InternalInt { internalIntSort }) ->
                 locationFromAst internalIntSort
+            InternalBoolF (Const InternalBool { internalBoolSort }) ->
+                locationFromAst internalBoolSort
             DefinedF Defined { getDefined } ->
                 locationFromAst getDefined
 
@@ -747,8 +758,9 @@ traverseVariablesF adj =
         OrF orP -> pure (OrF orP)
         RewritesF rewP -> pure (RewritesF rewP)
         StringLiteralF strP -> pure (StringLiteralF strP)
+        InternalBoolF boolP -> pure (InternalBoolF boolP)
         InternalBytesF bytesP -> pure (InternalBytesF bytesP)
-        InternalIntF bytesP -> pure (InternalIntF bytesP)
+        InternalIntF intP -> pure (InternalIntF intP)
         TopF topP -> pure (TopF topP)
         InhabitantF s -> pure (InhabitantF s)
         EvaluatedF childP -> pure (EvaluatedF childP)

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -81,6 +81,7 @@ import Kore.Internal.Inj
 import Kore.Internal.InternalBool
 import Kore.Internal.InternalBytes
 import Kore.Internal.InternalInt
+import Kore.Internal.InternalString
 import Kore.Internal.Symbol hiding
     ( isConstructorLike
     )
@@ -177,38 +178,39 @@ instance {-# OVERLAPS #-} Synthetic Pattern.Defined Defined where
 
 -}
 data TermLikeF variable child
-    = AndF           !(And Sort child)
-    | ApplySymbolF   !(Application Symbol child)
-    | ApplyAliasF    !(Application (Alias (TermLike VariableName)) child)
-    | BottomF        !(Bottom Sort child)
-    | CeilF          !(Ceil Sort child)
-    | DomainValueF   !(DomainValue Sort child)
-    | EqualsF        !(Equals Sort child)
-    | ExistsF        !(Exists Sort variable child)
-    | FloorF         !(Floor Sort child)
-    | ForallF        !(Forall Sort variable child)
-    | IffF           !(Iff Sort child)
-    | ImpliesF       !(Implies Sort child)
-    | InF            !(In Sort child)
-    | MuF            !(Mu variable child)
-    | NextF          !(Next Sort child)
-    | NotF           !(Not Sort child)
-    | NuF            !(Nu variable child)
-    | OrF            !(Or Sort child)
-    | RewritesF      !(Rewrites Sort child)
-    | TopF           !(Top Sort child)
-    | InhabitantF    !(Inhabitant child)
-    | BuiltinF       !(Builtin child)
-    | InternalBoolF  !(Const InternalBool child)
-    | InternalIntF   !(Const InternalInt child)
-    | EvaluatedF     !(Evaluated child)
-    | StringLiteralF !(Const StringLiteral child)
-    | InternalBytesF !(Const InternalBytes child)
-    | VariableF      !(Const (SomeVariable variable) child)
-    | EndiannessF    !(Const Endianness child)
-    | SignednessF    !(Const Signedness child)
-    | InjF           !(Inj child)
-    | DefinedF       !(Defined child)
+    = AndF            !(And Sort child)
+    | ApplySymbolF    !(Application Symbol child)
+    | ApplyAliasF     !(Application (Alias (TermLike VariableName)) child)
+    | BottomF         !(Bottom Sort child)
+    | CeilF           !(Ceil Sort child)
+    | DomainValueF    !(DomainValue Sort child)
+    | EqualsF         !(Equals Sort child)
+    | ExistsF         !(Exists Sort variable child)
+    | FloorF          !(Floor Sort child)
+    | ForallF         !(Forall Sort variable child)
+    | IffF            !(Iff Sort child)
+    | ImpliesF        !(Implies Sort child)
+    | InF             !(In Sort child)
+    | MuF             !(Mu variable child)
+    | NextF           !(Next Sort child)
+    | NotF            !(Not Sort child)
+    | NuF             !(Nu variable child)
+    | OrF             !(Or Sort child)
+    | RewritesF       !(Rewrites Sort child)
+    | TopF            !(Top Sort child)
+    | InhabitantF     !(Inhabitant child)
+    | BuiltinF        !(Builtin child)
+    | EvaluatedF      !(Evaluated child)
+    | StringLiteralF  !(Const StringLiteral child)
+    | InternalBoolF   !(Const InternalBool child)
+    | InternalBytesF  !(Const InternalBytes child)
+    | InternalIntF    !(Const InternalInt child)
+    | InternalStringF !(Const InternalString child)
+    | VariableF       !(Const (SomeVariable variable) child)
+    | EndiannessF     !(Const Endianness child)
+    | SignednessF     !(Const Signedness child)
+    | InjF            !(Inj child)
+    | DefinedF        !(Defined child)
     deriving (Eq, Ord, Show)
     deriving (Foldable, Functor, Traversable)
     deriving (GHC.Generic)
@@ -251,9 +253,10 @@ instance
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -287,9 +290,10 @@ instance Synthetic Sort (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -323,9 +327,10 @@ instance Synthetic Pattern.Functional (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -359,9 +364,10 @@ instance Synthetic Pattern.Function (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -395,9 +401,10 @@ instance Synthetic Pattern.Defined (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -431,9 +438,10 @@ instance Synthetic Pattern.Simplified (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -467,9 +475,10 @@ instance Synthetic Pattern.ConstructorLike (TermLikeF variable) where
             BuiltinF builtin -> synthetic builtin
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
+            InternalBoolF internalBool -> synthetic internalBool
             InternalBytesF internalBytes -> synthetic internalBytes
             InternalIntF internalInt -> synthetic internalInt
-            InternalBoolF internalBool -> synthetic internalBool
+            InternalStringF internalString -> synthetic internalString
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -707,13 +716,15 @@ instance
             InjF Inj { injChild } -> locationFromAst injChild
             SignednessF (Const signedness) -> locationFromAst signedness
             EndiannessF (Const endianness) -> locationFromAst endianness
-            InternalBytesF (Const InternalBytes { bytesSort }) ->
-                locationFromAst bytesSort
             BuiltinF builtin -> locationFromAst (Domain.builtinSort builtin)
-            InternalIntF (Const InternalInt { internalIntSort }) ->
-                locationFromAst internalIntSort
             InternalBoolF (Const InternalBool { internalBoolSort }) ->
                 locationFromAst internalBoolSort
+            InternalBytesF (Const InternalBytes { bytesSort }) ->
+                locationFromAst bytesSort
+            InternalIntF (Const InternalInt { internalIntSort }) ->
+                locationFromAst internalIntSort
+            InternalStringF (Const InternalString { internalStringSort }) ->
+                locationFromAst internalStringSort
             DefinedF Defined { getDefined } ->
                 locationFromAst getDefined
 
@@ -761,6 +772,7 @@ traverseVariablesF adj =
         InternalBoolF boolP -> pure (InternalBoolF boolP)
         InternalBytesF bytesP -> pure (InternalBytesF bytesP)
         InternalIntF intP -> pure (InternalIntF intP)
+        InternalStringF boolP -> pure (InternalStringF boolP)
         TopF topP -> pure (TopF topP)
         InhabitantF s -> pure (InhabitantF s)
         EvaluatedF childP -> pure (EvaluatedF childP)

--- a/kore/src/Kore/Internal/TermLike/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike/TermLike.hs
@@ -79,6 +79,7 @@ import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.Alias
 import Kore.Internal.Inj
 import Kore.Internal.InternalBytes
+import Kore.Internal.InternalInt
 import Kore.Internal.Symbol hiding
     ( isConstructorLike
     )
@@ -197,6 +198,7 @@ data TermLikeF variable child
     | TopF           !(Top Sort child)
     | InhabitantF    !(Inhabitant child)
     | BuiltinF       !(Builtin child)
+    | InternalIntF   !(Const InternalInt child)
     | EvaluatedF     !(Evaluated child)
     | StringLiteralF !(Const StringLiteral child)
     | InternalBytesF !(Const InternalBytes child)
@@ -248,6 +250,7 @@ instance
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -282,6 +285,7 @@ instance Synthetic Sort (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -316,6 +320,7 @@ instance Synthetic Pattern.Functional (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -350,6 +355,7 @@ instance Synthetic Pattern.Function (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -384,6 +390,7 @@ instance Synthetic Pattern.Defined (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -418,6 +425,7 @@ instance Synthetic Pattern.Simplified (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -452,6 +460,7 @@ instance Synthetic Pattern.ConstructorLike (TermLikeF variable) where
             EvaluatedF evaluated -> synthetic evaluated
             StringLiteralF stringLiteral -> synthetic stringLiteral
             InternalBytesF internalBytes -> synthetic internalBytes
+            InternalIntF internalInt -> synthetic internalInt
             VariableF variable -> synthetic variable
             EndiannessF endianness -> synthetic endianness
             SignednessF signedness -> synthetic signedness
@@ -692,6 +701,8 @@ instance
             InternalBytesF (Const InternalBytes { bytesSort }) ->
                 locationFromAst bytesSort
             BuiltinF builtin -> locationFromAst (Domain.builtinSort builtin)
+            InternalIntF (Const InternalInt { internalIntSort }) ->
+                locationFromAst internalIntSort
             DefinedF Defined { getDefined } ->
                 locationFromAst getDefined
 
@@ -737,6 +748,7 @@ traverseVariablesF adj =
         RewritesF rewP -> pure (RewritesF rewP)
         StringLiteralF strP -> pure (StringLiteralF strP)
         InternalBytesF bytesP -> pure (InternalBytesF bytesP)
+        InternalIntF bytesP -> pure (InternalIntF bytesP)
         TopF topP -> pure (TopF topP)
         InhabitantF s -> pure (InhabitantF s)
         EvaluatedF childP -> pure (EvaluatedF childP)

--- a/kore/src/Kore/Step/Axiom/Matcher.hs
+++ b/kore/src/Kore/Step/Axiom/Matcher.hs
@@ -122,7 +122,7 @@ findClass (Constraint (Pair left _)) = findClassWorker left
     findClassWorker (ElemVar_ _)       = Variables
     findClassWorker (SetVar_ _)        = Variables
     findClassWorker (StringLiteral_ _) = ConcreteBuiltins
-    findClassWorker (BuiltinInt_ _)    = ConcreteBuiltins
+    findClassWorker (InternalInt_ _)    = ConcreteBuiltins
     findClassWorker (BuiltinBool_ _)   = ConcreteBuiltins
     findClassWorker (BuiltinString_ _) = ConcreteBuiltins
     findClassWorker (App_ symbol _) =
@@ -226,7 +226,7 @@ matchEqualHeads
 -- Terminal patterns
 matchEqualHeads (Pair (StringLiteral_ string1) (StringLiteral_ string2)) =
     Monad.guard (string1 == string2)
-matchEqualHeads (Pair (BuiltinInt_ int1) (BuiltinInt_ int2)) =
+matchEqualHeads (Pair (InternalInt_ int1) (InternalInt_ int2)) =
     Monad.guard (int1 == int2)
 matchEqualHeads (Pair (BuiltinBool_ bool1) (BuiltinBool_ bool2)) =
     Monad.guard (bool1 == bool2)

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -70,6 +70,7 @@ import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Int as Builtin.Int
 import Kore.IndexedModule.MetadataTools
+import Kore.Internal.InternalBool
 import Kore.Internal.InternalInt
 import Kore.Internal.Predicate
 import Kore.Internal.TermLike
@@ -174,6 +175,7 @@ translatePredicateWith translateTerm predicate =
             VariableF _ -> empty
             StringLiteralF _ -> empty
             InternalBytesF _ -> empty
+            InternalBoolF _ -> empty
             InternalIntF _ -> empty
             InhabitantF _ -> empty
             EndiannessF _ -> empty
@@ -311,9 +313,8 @@ translatePattern translateTerm sort pat =
     translateBool pat' =
         case Cofree.tailF (Recursive.project pat') of
             VariableF _ -> translateUninterpreted translateTerm SMT.tBool pat'
-            BuiltinF dv ->
-                return $ SMT.bool $ Builtin.Bool.extractBoolDomainValue
-                    "while translating dv to SMT.bool" dv
+            InternalBoolF (Const InternalBool { internalBoolValue }) ->
+                return $ SMT.bool internalBoolValue
             NotF Not { notChild } ->
                 -- \not is equivalent to BOOL.not for functional patterns.
                 -- The following is safe because non-functional patterns

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -50,6 +50,7 @@ import Control.Monad.State.Strict
     )
 import qualified Control.Monad.State.Strict as State
 import Data.Default
+import Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
 import Data.Generics.Product.Fields
 import Data.Map.Strict
@@ -69,6 +70,7 @@ import qualified Kore.Attribute.Symbol as Attribute
 import qualified Kore.Builtin.Bool as Builtin.Bool
 import qualified Kore.Builtin.Int as Builtin.Int
 import Kore.IndexedModule.MetadataTools
+import Kore.Internal.InternalInt
 import Kore.Internal.Predicate
 import Kore.Internal.TermLike
 import Kore.Log.WarnSymbolSMTRepresentation
@@ -172,6 +174,7 @@ translatePredicateWith translateTerm predicate =
             VariableF _ -> empty
             StringLiteralF _ -> empty
             InternalBytesF _ -> empty
+            InternalIntF _ -> empty
             InhabitantF _ -> empty
             EndiannessF _ -> empty
             SignednessF _ -> empty
@@ -294,9 +297,8 @@ translatePattern translateTerm sort pat =
     translateInt pat' =
         case Cofree.tailF (Recursive.project pat') of
             VariableF _ -> translateUninterpreted translateTerm SMT.tInt pat'
-            BuiltinF dv ->
-                return $ SMT.int $ Builtin.Int.extractIntDomainValue
-                    "while translating dv to SMT.int" dv
+            InternalIntF (Const InternalInt { internalIntValue }) ->
+                return $ SMT.int internalIntValue
             ApplySymbolF app ->
                 translateApplication (Just SMT.tInt) pat' app
             DefinedF (Defined child) ->

--- a/kore/src/Kore/Step/SMT/Translate.hs
+++ b/kore/src/Kore/Step/SMT/Translate.hs
@@ -174,9 +174,10 @@ translatePredicateWith translateTerm predicate =
             RewritesF _ -> empty
             VariableF _ -> empty
             StringLiteralF _ -> empty
-            InternalBytesF _ -> empty
             InternalBoolF _ -> empty
+            InternalBytesF _ -> empty
             InternalIntF _ -> empty
+            InternalStringF _ -> empty
             InhabitantF _ -> empty
             EndiannessF _ -> empty
             SignednessF _ -> empty

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -40,7 +40,6 @@ import qualified Kore.Builtin.Map as Builtin.Map
 import qualified Kore.Builtin.Set as Builtin.Set
 import qualified Kore.Builtin.Signedness as Builtin.Signedness
 import qualified Kore.Builtin.String as Builtin.String
-import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.Condition as Condition
 import Kore.Internal.InternalInt
 import qualified Kore.Internal.OrCondition as OrCondition
@@ -664,10 +663,6 @@ domainValueAndEqualsAssumesDifferent
 domainValueAndEqualsAssumesDifferent
     first@(InternalInt_ _)
     second@(InternalInt_ _)
-  = lift $ cannotUnifyDomainValues first second
-domainValueAndEqualsAssumesDifferent
-    first@(Builtin_ (Domain.BuiltinString _))
-    second@(Builtin_ (Domain.BuiltinString _))
   = lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent _ _ = empty
 

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -578,7 +578,7 @@ unifyInternalInt
     => TermLike variable
     -> TermLike variable
     -> MaybeT unifier (Pattern variable)
-unifyInternalInt term1@(BuiltinInt_ int1) term2@(BuiltinInt_ int2) =
+unifyInternalInt term1@(InternalInt_ int1) term2@(InternalInt_ int2) =
     assert (on (==) internalIntSort int1 int2) $ lift worker
   where
     worker :: unifier (Pattern variable)
@@ -662,8 +662,8 @@ domainValueAndEqualsAssumesDifferent
     second@(DV_ _ _)
   = lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
-    first@(BuiltinInt_ _)
-    second@(BuiltinInt_ _)
+    first@(InternalInt_ _)
+    second@(InternalInt_ _)
   = lift $ cannotUnifyDomainValues first second
 domainValueAndEqualsAssumesDifferent
     first@(Builtin_ (Domain.BuiltinString _))

--- a/kore/src/Kore/Step/Simplification/Builtin.hs
+++ b/kore/src/Kore/Step/Simplification/Builtin.hs
@@ -60,8 +60,6 @@ simplifyBuiltin =
             fmap mkBuiltin <$> simplifyInternalList list'
         Domain.BuiltinSet set' ->
             fmap mkBuiltin <$> simplifyInternalSet set'
-        Domain.BuiltinString string ->
-            (return . pure . mkBuiltin) (Domain.BuiltinString string)
 
 simplifyInternal
     :: (InternalVariable variable, Traversable t)

--- a/kore/src/Kore/Step/Simplification/Builtin.hs
+++ b/kore/src/Kore/Step/Simplification/Builtin.hs
@@ -60,8 +60,6 @@ simplifyBuiltin =
             fmap mkBuiltin <$> simplifyInternalList list'
         Domain.BuiltinSet set' ->
             fmap mkBuiltin <$> simplifyInternalSet set'
-        Domain.BuiltinInt int ->
-            (return . pure . mkBuiltin) (Domain.BuiltinInt int)
         Domain.BuiltinBool bool ->
             (return . pure . mkBuiltin) (Domain.BuiltinBool bool)
         Domain.BuiltinString string ->

--- a/kore/src/Kore/Step/Simplification/Builtin.hs
+++ b/kore/src/Kore/Step/Simplification/Builtin.hs
@@ -60,8 +60,6 @@ simplifyBuiltin =
             fmap mkBuiltin <$> simplifyInternalList list'
         Domain.BuiltinSet set' ->
             fmap mkBuiltin <$> simplifyInternalSet set'
-        Domain.BuiltinBool bool ->
-            (return . pure . mkBuiltin) (Domain.BuiltinBool bool)
         Domain.BuiltinString string ->
             (return . pure . mkBuiltin) (Domain.BuiltinString string)
 

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -343,7 +343,6 @@ makeEvaluateBuiltin sideCondition (Domain.BuiltinList l) = do
         ceils = children
     And.simplifyEvaluatedMultiPredicate sideCondition (MultiAnd.make ceils)
 makeEvaluateBuiltin _ (Domain.BuiltinMap _) = empty
-makeEvaluateBuiltin _ (Domain.BuiltinBool _) = return OrCondition.top
 makeEvaluateBuiltin _ (Domain.BuiltinString _) = return OrCondition.top
 
 {-| This handles the case when we can't simplify a term's ceil.
@@ -398,7 +397,6 @@ makeSimplifiedCeil
         BuiltinF (Domain.BuiltinMap _) -> True
         BuiltinF (Domain.BuiltinList _) -> True
         BuiltinF (Domain.BuiltinSet _) -> True
-        BuiltinF (Domain.BuiltinBool _) -> unexpectedError
         BuiltinF (Domain.BuiltinString _) -> unexpectedError
         DomainValueF _ -> True
         FloorF _ -> False
@@ -412,6 +410,7 @@ makeSimplifiedCeil
         TopF _ -> unexpectedError
         StringLiteralF _ -> unexpectedError
         InternalBytesF _ -> unexpectedError
+        InternalBoolF _ -> unexpectedError
         InternalIntF _ -> unexpectedError
         VariableF _ -> False
 

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -344,7 +344,6 @@ makeEvaluateBuiltin sideCondition (Domain.BuiltinList l) = do
     And.simplifyEvaluatedMultiPredicate sideCondition (MultiAnd.make ceils)
 makeEvaluateBuiltin _ (Domain.BuiltinMap _) = empty
 makeEvaluateBuiltin _ (Domain.BuiltinBool _) = return OrCondition.top
-makeEvaluateBuiltin _ (Domain.BuiltinInt _) = return OrCondition.top
 makeEvaluateBuiltin _ (Domain.BuiltinString _) = return OrCondition.top
 
 {-| This handles the case when we can't simplify a term's ceil.
@@ -399,7 +398,6 @@ makeSimplifiedCeil
         BuiltinF (Domain.BuiltinMap _) -> True
         BuiltinF (Domain.BuiltinList _) -> True
         BuiltinF (Domain.BuiltinSet _) -> True
-        BuiltinF (Domain.BuiltinInt _) -> unexpectedError
         BuiltinF (Domain.BuiltinBool _) -> unexpectedError
         BuiltinF (Domain.BuiltinString _) -> unexpectedError
         DomainValueF _ -> True
@@ -414,6 +412,7 @@ makeSimplifiedCeil
         TopF _ -> unexpectedError
         StringLiteralF _ -> unexpectedError
         InternalBytesF _ -> unexpectedError
+        InternalIntF _ -> unexpectedError
         VariableF _ -> False
 
     unsimplified =

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -343,7 +343,6 @@ makeEvaluateBuiltin sideCondition (Domain.BuiltinList l) = do
         ceils = children
     And.simplifyEvaluatedMultiPredicate sideCondition (MultiAnd.make ceils)
 makeEvaluateBuiltin _ (Domain.BuiltinMap _) = empty
-makeEvaluateBuiltin _ (Domain.BuiltinString _) = return OrCondition.top
 
 {-| This handles the case when we can't simplify a term's ceil.
 
@@ -397,7 +396,6 @@ makeSimplifiedCeil
         BuiltinF (Domain.BuiltinMap _) -> True
         BuiltinF (Domain.BuiltinList _) -> True
         BuiltinF (Domain.BuiltinSet _) -> True
-        BuiltinF (Domain.BuiltinString _) -> unexpectedError
         DomainValueF _ -> True
         FloorF _ -> False
         ForallF _ -> False
@@ -409,9 +407,10 @@ makeSimplifiedCeil
         RewritesF _ -> False
         TopF _ -> unexpectedError
         StringLiteralF _ -> unexpectedError
-        InternalBytesF _ -> unexpectedError
         InternalBoolF _ -> unexpectedError
+        InternalBytesF _ -> unexpectedError
         InternalIntF _ -> unexpectedError
+        InternalStringF _ -> unexpectedError
         VariableF _ -> False
 
     unsimplified =

--- a/kore/src/Kore/Step/Simplification/Condition.hs
+++ b/kore/src/Kore/Step/Simplification/Condition.hs
@@ -63,13 +63,13 @@ import Kore.Internal.Symbol
     )
 import Kore.Internal.TermLike
     ( pattern App_
-    , pattern BuiltinInt_
     , pattern Builtin_
     , pattern Equals_
     , pattern Exists_
     , pattern Forall_
     , pattern Inj_
     , pattern InternalBytes_
+    , pattern InternalInt_
     , pattern Mu_
     , pattern Not_
     , pattern Nu_
@@ -343,7 +343,7 @@ retractLocalFunction =
               | isConstructor symbol2 -> Just (Pair term1 term2)
             Inj_ _     -> Just (Pair term1 term2)
             Builtin_ _ -> Just (Pair term1 term2)
-            BuiltinInt_ _ -> Just (Pair term1 term2)
+            InternalInt_ _ -> Just (Pair term1 term2)
             InternalBytes_ _ _ -> Just (Pair term1 term2)
             _          -> Nothing
     go _ _ = Nothing

--- a/kore/src/Kore/Step/Simplification/Condition.hs
+++ b/kore/src/Kore/Step/Simplification/Condition.hs
@@ -63,11 +63,13 @@ import Kore.Internal.Symbol
     )
 import Kore.Internal.TermLike
     ( pattern App_
+    , pattern BuiltinInt_
     , pattern Builtin_
     , pattern Equals_
     , pattern Exists_
     , pattern Forall_
     , pattern Inj_
+    , pattern InternalBytes_
     , pattern Mu_
     , pattern Not_
     , pattern Nu_
@@ -341,5 +343,7 @@ retractLocalFunction =
               | isConstructor symbol2 -> Just (Pair term1 term2)
             Inj_ _     -> Just (Pair term1 term2)
             Builtin_ _ -> Just (Pair term1 term2)
+            BuiltinInt_ _ -> Just (Pair term1 term2)
+            InternalBytes_ _ _ -> Just (Pair term1 term2)
             _          -> Nothing
     go _ _ = Nothing

--- a/kore/src/Kore/Step/Simplification/InternalBool.hs
+++ b/kore/src/Kore/Step/Simplification/InternalBool.hs
@@ -1,0 +1,22 @@
+{-|
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+module Kore.Step.Simplification.InternalBool
+    ( simplify
+    ) where
+
+import Prelude.Kore
+
+import Kore.Internal.InternalBool
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+import Kore.Internal.TermLike
+
+simplify
+    :: InternalVariable variable
+    => InternalBool
+    -> OrPattern variable
+simplify = OrPattern.fromPattern . pure . mkInternalBool

--- a/kore/src/Kore/Step/Simplification/InternalInt.hs
+++ b/kore/src/Kore/Step/Simplification/InternalInt.hs
@@ -1,0 +1,22 @@
+{-|
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+module Kore.Step.Simplification.InternalInt
+    ( simplify
+    ) where
+
+import Prelude.Kore
+
+import Kore.Internal.InternalInt
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+import Kore.Internal.TermLike
+
+simplify
+    :: InternalVariable variable
+    => InternalInt
+    -> OrPattern variable
+simplify = OrPattern.fromPattern . pure . mkInternalInt

--- a/kore/src/Kore/Step/Simplification/InternalString.hs
+++ b/kore/src/Kore/Step/Simplification/InternalString.hs
@@ -1,0 +1,22 @@
+{-|
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+-}
+module Kore.Step.Simplification.InternalString
+    ( simplify
+    ) where
+
+import Prelude.Kore
+
+import Kore.Internal.InternalString
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
+import qualified Kore.Internal.OrPattern as OrPattern
+import Kore.Internal.TermLike
+
+simplify
+    :: InternalVariable variable
+    => InternalString
+    -> OrPattern variable
+simplify = OrPattern.fromPattern . pure . mkInternalString

--- a/kore/src/Kore/Step/Simplification/Overloading.hs
+++ b/kore/src/Kore/Step/Simplification/Overloading.hs
@@ -432,7 +432,7 @@ notUnifiableError
     :: Monad unifier => TermLike variable -> OverloadingResult unifier a
 notUnifiableError (DV_ _ _) = throwBottom "injected domain value"
 notUnifiableError (BuiltinBool_ _) = throwBottom "injected builtin bool"
-notUnifiableError (BuiltinInt_ _) = throwBottom "injected builtin int"
+notUnifiableError (InternalInt_ _) = throwBottom "injected builtin int"
 notUnifiableError (BuiltinList_ _) = throwBottom "injected builtin list"
 notUnifiableError (BuiltinMap_ _) = throwBottom "injected builtin map"
 notUnifiableError (BuiltinSet_ _) = throwBottom "injected builtin set"

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -110,6 +110,9 @@ import qualified Kore.Step.Simplification.Inj as Inj
 import qualified Kore.Step.Simplification.InternalBytes as InternalBytes
     ( simplify
     )
+import qualified Kore.Step.Simplification.InternalInt as InternalInt
+    ( simplify
+    )
 import qualified Kore.Step.Simplification.Mu as Mu
     ( simplify
     )
@@ -432,6 +435,8 @@ simplify sideCondition = \termLike ->
                 return $ StringLiteral.simplify (getConst stringLiteralF)
             InternalBytesF internalBytesF ->
                 return $ InternalBytes.simplify (getConst internalBytesF)
+            InternalIntF internalIntF ->
+                return $ InternalInt.simplify (getConst internalIntF)
             VariableF variableF ->
                 return $ Variable.simplify (getConst variableF)
             DefinedF definedF ->

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -116,6 +116,9 @@ import qualified Kore.Step.Simplification.InternalBytes as InternalBytes
 import qualified Kore.Step.Simplification.InternalInt as InternalInt
     ( simplify
     )
+import qualified Kore.Step.Simplification.InternalString as InternalString
+    ( simplify
+    )
 import qualified Kore.Step.Simplification.Mu as Mu
     ( simplify
     )
@@ -436,12 +439,14 @@ simplify sideCondition = \termLike ->
             --
             StringLiteralF stringLiteralF ->
                 return $ StringLiteral.simplify (getConst stringLiteralF)
-            InternalBytesF internalBytesF ->
-                return $ InternalBytes.simplify (getConst internalBytesF)
             InternalBoolF internalBoolF ->
                 return $ InternalBool.simplify (getConst internalBoolF)
+            InternalBytesF internalBytesF ->
+                return $ InternalBytes.simplify (getConst internalBytesF)
             InternalIntF internalIntF ->
                 return $ InternalInt.simplify (getConst internalIntF)
+            InternalStringF internalStringF ->
+                return $ InternalString.simplify (getConst internalStringF)
             VariableF variableF ->
                 return $ Variable.simplify (getConst variableF)
             DefinedF definedF ->

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -107,6 +107,9 @@ import qualified Kore.Step.Simplification.Inhabitant as Inhabitant
 import qualified Kore.Step.Simplification.Inj as Inj
     ( simplify
     )
+import qualified Kore.Step.Simplification.InternalBool as InternalBool
+    ( simplify
+    )
 import qualified Kore.Step.Simplification.InternalBytes as InternalBytes
     ( simplify
     )
@@ -435,6 +438,8 @@ simplify sideCondition = \termLike ->
                 return $ StringLiteral.simplify (getConst stringLiteralF)
             InternalBytesF internalBytesF ->
                 return $ InternalBytes.simplify (getConst internalBytesF)
+            InternalBoolF internalBoolF ->
+                return $ InternalBool.simplify (getConst internalBoolF)
             InternalIntF internalIntF ->
                 return $ InternalInt.simplify (getConst internalIntF)
             VariableF variableF ->

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -60,9 +60,6 @@ import Kore.Builtin.Map.Map as BuiltinMap
 import Kore.Builtin.Set.Set as BuiltinSet
     ( isSymbolElement
     )
-import qualified Kore.Builtin.String.String as BuiltinString
-    ( asBuiltin
-    )
 import qualified Kore.Domain.Builtin as Domain
 import Kore.IndexedModule.MetadataTools
     ( SmtMetadataTools
@@ -74,6 +71,7 @@ import qualified Kore.Internal.Alias as Alias.DoNotUse
 import Kore.Internal.ApplicationSorts
     ( ApplicationSorts (ApplicationSorts)
     )
+import Kore.Internal.InternalString
 import qualified Kore.Internal.Symbol as Internal
     ( Symbol (Symbol)
     )
@@ -98,6 +96,7 @@ import Kore.Internal.TermLike
     , mkIn
     , mkInternalBool
     , mkInternalInt
+    , mkInternalString
     , mkMu
     , mkNot
     , mkNu
@@ -324,9 +323,10 @@ _checkTermImplemented term@(Recursive.project -> _ :< termF) =
     checkTermF (TopF _) = term
     checkTermF (VariableF _) = term
     checkTermF (StringLiteralF _) = term
-    checkTermF (InternalBytesF _) = term
     checkTermF (InternalBoolF _) = term
+    checkTermF (InternalBytesF _) = term
     checkTermF (InternalIntF _) = term
+    checkTermF (InternalStringF _) = term
     checkTermF (EvaluatedF _) = term
     checkTermF (InhabitantF _) = term  -- Not implemented.
     checkTermF (EndiannessF _) = term  -- Not implemented.
@@ -617,7 +617,6 @@ _checkAllBuiltinImplemented builtin =
         Domain.BuiltinList _ -> builtin
         Domain.BuiltinMap _ -> builtin
         Domain.BuiltinSet _ -> builtin
-        Domain.BuiltinString _ -> builtin
 
 allBuiltinGenerators :: Gen (Map.Map SortRequirements TermGenerator)
 allBuiltinGenerators = do
@@ -672,7 +671,7 @@ maybeStringBuiltinGenerator Setup { maybeStringBuiltinSort } =
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
         -> Gen (Maybe (TermLike VariableName))
     stringGenerator stringSort _childGenerator =
-        Just . mkBuiltin . BuiltinString.asBuiltin stringSort <$> stringGen
+        Just . mkInternalString . InternalString stringSort <$> stringGen
 
 maybeBoolBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
 maybeBoolBuiltinGenerator Setup { maybeBoolSort } =

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -96,6 +96,7 @@ import Kore.Internal.TermLike
     , mkIff
     , mkImplies
     , mkIn
+    , mkInternalBool
     , mkInternalInt
     , mkMu
     , mkNot
@@ -324,6 +325,7 @@ _checkTermImplemented term@(Recursive.project -> _ :< termF) =
     checkTermF (VariableF _) = term
     checkTermF (StringLiteralF _) = term
     checkTermF (InternalBytesF _) = term
+    checkTermF (InternalBoolF _) = term
     checkTermF (InternalIntF _) = term
     checkTermF (EvaluatedF _) = term
     checkTermF (InhabitantF _) = term  -- Not implemented.
@@ -612,7 +614,6 @@ _checkAllBuiltinImplemented
     -> Domain.Builtin (TermLike Concrete) (TermLike variable)
 _checkAllBuiltinImplemented builtin =
     case builtin of
-        Domain.BuiltinBool _ -> builtin
         Domain.BuiltinList _ -> builtin
         Domain.BuiltinMap _ -> builtin
         Domain.BuiltinSet _ -> builtin
@@ -693,7 +694,7 @@ maybeBoolBuiltinGenerator Setup { maybeBoolSort } =
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
         -> Gen (Maybe (TermLike VariableName))
     boolGenerator boolSort _childGenerator =
-        Just . mkBuiltin . BuiltinBool.asBuiltin boolSort <$> Gen.bool
+        Just . mkInternalBool . BuiltinBool.asBuiltin boolSort <$> Gen.bool
 
 maybeIntBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
 maybeIntBuiltinGenerator Setup { maybeIntSort } =

--- a/kore/test/Test/ConsistentKore.hs
+++ b/kore/test/Test/ConsistentKore.hs
@@ -96,6 +96,7 @@ import Kore.Internal.TermLike
     , mkIff
     , mkImplies
     , mkIn
+    , mkInternalInt
     , mkMu
     , mkNot
     , mkNu
@@ -147,7 +148,7 @@ data BuiltinGenerator = BuiltinGenerator
     , attributes :: !AttributeRequirements
     , generator
         :: (Sort -> Gen (Maybe (TermLike VariableName)))
-        -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+        -> Gen (Maybe (TermLike VariableName))
     }
 
 data CollectionSorts = CollectionSorts
@@ -323,6 +324,7 @@ _checkTermImplemented term@(Recursive.project -> _ :< termF) =
     checkTermF (VariableF _) = term
     checkTermF (StringLiteralF _) = term
     checkTermF (InternalBytesF _) = term
+    checkTermF (InternalIntF _) = term
     checkTermF (EvaluatedF _) = term
     checkTermF (InhabitantF _) = term  -- Not implemented.
     checkTermF (EndiannessF _) = term  -- Not implemented.
@@ -611,7 +613,6 @@ _checkAllBuiltinImplemented
 _checkAllBuiltinImplemented builtin =
     case builtin of
         Domain.BuiltinBool _ -> builtin
-        Domain.BuiltinInt _ -> builtin
         Domain.BuiltinList _ -> builtin
         Domain.BuiltinMap _ -> builtin
         Domain.BuiltinSet _ -> builtin
@@ -647,8 +648,7 @@ allBuiltinGenerators = do
                             when
                                 (generatedSort /= resultSort)
                                 (error "Sort mismatch.")
-                    builtin <- generator childGenerator
-                    return (mkBuiltin <$> builtin)
+                    generator childGenerator
             }
 
 maybeStringBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
@@ -669,9 +669,9 @@ maybeStringBuiltinGenerator Setup { maybeStringBuiltinSort } =
     stringGenerator
         :: Sort
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
-        -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+        -> Gen (Maybe (TermLike VariableName))
     stringGenerator stringSort _childGenerator =
-        Just . BuiltinString.asBuiltin stringSort <$> stringGen
+        Just . mkBuiltin . BuiltinString.asBuiltin stringSort <$> stringGen
 
 maybeBoolBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
 maybeBoolBuiltinGenerator Setup { maybeBoolSort } =
@@ -691,9 +691,9 @@ maybeBoolBuiltinGenerator Setup { maybeBoolSort } =
     boolGenerator
         :: Sort
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
-        -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+        -> Gen (Maybe (TermLike VariableName))
     boolGenerator boolSort _childGenerator =
-        Just . BuiltinBool.asBuiltin boolSort <$> Gen.bool
+        Just . mkBuiltin . BuiltinBool.asBuiltin boolSort <$> Gen.bool
 
 maybeIntBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
 maybeIntBuiltinGenerator Setup { maybeIntSort } =
@@ -713,10 +713,10 @@ maybeIntBuiltinGenerator Setup { maybeIntSort } =
     intGenerator
         :: Sort
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
-        -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+        -> Gen (Maybe (TermLike VariableName))
     intGenerator intSort _childGenerator = do
         value <- Gen.integral (Range.constant 0 2000)
-        return (Just (BuiltinInt.asBuiltin intSort value))
+        (pure . Just . mkInternalInt) (BuiltinInt.asBuiltin intSort value)
 
 maybeListBuiltinGenerator :: Setup -> Maybe BuiltinGenerator
 maybeListBuiltinGenerator Setup { maybeListSorts } =
@@ -739,14 +739,14 @@ maybeListBuiltinGenerator Setup { maybeListSorts } =
         :: Sort
         -> Sort
         -> (Sort -> Gen (Maybe (TermLike VariableName)))
-        -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+        -> Gen (Maybe (TermLike VariableName))
     listGenerator listSort listElementSort childGenerator = do
         (Setup {metadataTools}, _) <- Reader.ask
         elements <-
             Gen.seq (Range.constant 0 5)
             (childGenerator listElementSort)
         return
-            (   BuiltinList.asBuiltin metadataTools listSort
+            (   mkBuiltin . BuiltinList.asBuiltin metadataTools listSort
             <$> sequenceA elements
             )
 
@@ -826,7 +826,7 @@ acGenerator
         -> Gen (Maybe (Domain.Value normalized (TermLike VariableName)))
         )
     -> (Sort -> Gen (Maybe (TermLike VariableName)))
-    -> Gen (Maybe (Domain.Builtin (TermLike Concrete) (TermLike VariableName)))
+    -> Gen (Maybe (TermLike VariableName))
 acGenerator mapSort keySort valueGenerator childGenerator = do
     let concreteKeyGenerator :: Gen (Maybe (TermLike Concrete))
         concreteKeyGenerator =
@@ -861,7 +861,7 @@ acGenerator mapSort keySort valueGenerator childGenerator = do
     let variablePairs :: [Domain.Element normalized (TermLike VariableName)]
         variablePairs = catMaybes maybeVariablePairs
     (Setup {metadataTools}, _) <- Reader.ask
-    return $ Just $
+    return $ Just . mkBuiltin $
         AssociativeCommutative.asInternalBuiltin
             metadataTools
             mapSort

--- a/kore/test/Test/Expect.hs
+++ b/kore/test/Test/Expect.hs
@@ -17,7 +17,7 @@ import Control.Error
     )
 
 import Debug
-import Kore.Domain.Builtin
+import Kore.Internal.InternalBool
 import Kore.Internal.TermLike
 import Kore.TopBottom
 
@@ -50,7 +50,7 @@ assertTop a
   | otherwise = (assertFailure . show) (debug a)
 
 expectBool :: HasCallStack => TermLike VariableName -> IO Bool
-expectBool (BuiltinBool_ internalBool) = return (builtinBoolValue internalBool)
+expectBool (BuiltinBool_ internalBool) = return (internalBoolValue internalBool)
 expectBool term = (assertFailure . show) (debug term)
 
 expectJustT :: MonadIO io => HasCallStack => MaybeT io a -> io a

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -24,9 +24,9 @@ module Test.Kore
     , setTargetVariableGen
     , unifiedTargetVariableGen
     , unifiedVariableGen
-    , genBuiltin
     , genInternalInt
     , genInternalBool
+    , genInternalString
     , couple
     , symbolOrAliasGen
     , addVariable
@@ -57,13 +57,13 @@ import Data.Text
     )
 import qualified Data.Text as Text
 
-import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.ApplicationSorts
     ( ApplicationSorts (ApplicationSorts)
     )
 import qualified Kore.Internal.ApplicationSorts as ApplicationSorts.DoNotUse
 import Kore.Internal.InternalBool
 import Kore.Internal.InternalInt
+import Kore.Internal.InternalString
 import Kore.Internal.Predicate
     ( Predicate
     )
@@ -402,11 +402,6 @@ genDomainValue :: (Sort -> Gen child) -> Sort -> Gen (DomainValue Sort child)
 genDomainValue childGen domainValueSort =
     DomainValue domainValueSort <$> childGen stringMetaSort
 
-genBuiltin :: Sort -> Gen (TermLike.Builtin (TermLike variable))
-genBuiltin domainValueSort = Gen.choice
-    [ Domain.BuiltinString <$> genInternalString domainValueSort
-    ]
-
 genInternalInt :: Sort -> Gen InternalInt
 genInternalInt builtinIntSort =
     InternalInt builtinIntSort <$> genInteger
@@ -417,9 +412,9 @@ genInternalBool :: Sort -> Gen InternalBool
 genInternalBool builtinBoolSort =
     InternalBool builtinBoolSort <$> Gen.bool
 
-genInternalString :: Sort -> Gen Domain.InternalString
+genInternalString :: Sort -> Gen InternalString
 genInternalString internalStringSort =
-    Domain.InternalString internalStringSort
+    InternalString internalStringSort
     <$> Gen.text (Range.linear 0 1024) (Reader.lift Gen.unicode)
 
 existsGen :: (Sort -> Gen child) -> Sort -> Gen (Exists Sort VariableName child)

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -26,6 +26,7 @@ module Test.Kore
     , unifiedVariableGen
     , genBuiltin
     , genInternalInt
+    , genInternalBool
     , couple
     , symbolOrAliasGen
     , addVariable
@@ -61,6 +62,7 @@ import Kore.Internal.ApplicationSorts
     ( ApplicationSorts (ApplicationSorts)
     )
 import qualified Kore.Internal.ApplicationSorts as ApplicationSorts.DoNotUse
+import Kore.Internal.InternalBool
 import Kore.Internal.InternalInt
 import Kore.Internal.Predicate
     ( Predicate
@@ -402,8 +404,7 @@ genDomainValue childGen domainValueSort =
 
 genBuiltin :: Sort -> Gen (TermLike.Builtin (TermLike variable))
 genBuiltin domainValueSort = Gen.choice
-    [ Domain.BuiltinBool <$> genInternalBool domainValueSort
-    , Domain.BuiltinString <$> genInternalString domainValueSort
+    [ Domain.BuiltinString <$> genInternalString domainValueSort
     ]
 
 genInternalInt :: Sort -> Gen InternalInt
@@ -412,9 +413,9 @@ genInternalInt builtinIntSort =
   where
     genInteger = Gen.integral (Range.linear (-1024) 1024)
 
-genInternalBool :: Sort -> Gen Domain.InternalBool
+genInternalBool :: Sort -> Gen InternalBool
 genInternalBool builtinBoolSort =
-    Domain.InternalBool builtinBoolSort <$> Gen.bool
+    InternalBool builtinBoolSort <$> Gen.bool
 
 genInternalString :: Sort -> Gen Domain.InternalString
 genInternalString internalStringSort =

--- a/kore/test/Test/Kore.hs
+++ b/kore/test/Test/Kore.hs
@@ -25,6 +25,7 @@ module Test.Kore
     , unifiedTargetVariableGen
     , unifiedVariableGen
     , genBuiltin
+    , genInternalInt
     , couple
     , symbolOrAliasGen
     , addVariable
@@ -60,6 +61,7 @@ import Kore.Internal.ApplicationSorts
     ( ApplicationSorts (ApplicationSorts)
     )
 import qualified Kore.Internal.ApplicationSorts as ApplicationSorts.DoNotUse
+import Kore.Internal.InternalInt
 import Kore.Internal.Predicate
     ( Predicate
     )
@@ -400,14 +402,13 @@ genDomainValue childGen domainValueSort =
 
 genBuiltin :: Sort -> Gen (TermLike.Builtin (TermLike variable))
 genBuiltin domainValueSort = Gen.choice
-    [ Domain.BuiltinInt <$> genInternalInt domainValueSort
-    , Domain.BuiltinBool <$> genInternalBool domainValueSort
+    [ Domain.BuiltinBool <$> genInternalBool domainValueSort
     , Domain.BuiltinString <$> genInternalString domainValueSort
     ]
 
-genInternalInt :: Sort -> Gen Domain.InternalInt
+genInternalInt :: Sort -> Gen InternalInt
 genInternalInt builtinIntSort =
-    Domain.InternalInt builtinIntSort <$> genInteger
+    InternalInt builtinIntSort <$> genInteger
   where
     genInteger = Gen.integral (Range.linear (-1024) 1024)
 

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -38,6 +38,7 @@ import qualified Kore.Builtin.Signedness as Signedness
 import Kore.Domain.Builtin
 import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.ApplicationSorts
+import Kore.Internal.InternalInt
 import Kore.Internal.Symbol
     ( constructor
     , function
@@ -1026,10 +1027,10 @@ intSortDecl =
         [ hasDomainValuesAttribute, hookAttribute "INT.Int" ]
 
 builtinInt :: Integer -> InternalInt
-builtinInt builtinIntValue =
+builtinInt internalIntValue =
     InternalInt
-        { builtinIntSort = intSort
-        , builtinIntValue
+        { internalIntSort = intSort
+        , internalIntValue
         }
 
 -- ** KEQUAL

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -38,6 +38,7 @@ import qualified Kore.Builtin.Signedness as Signedness
 import Kore.Domain.Builtin
 import qualified Kore.Domain.Builtin as Domain
 import Kore.Internal.ApplicationSorts
+import Kore.Internal.InternalBool
 import Kore.Internal.InternalInt
 import Kore.Internal.Symbol
     ( constructor
@@ -1004,10 +1005,10 @@ boolSortDecl =
         [ hasDomainValuesAttribute, hookAttribute "BOOL.Bool" ]
 
 builtinBool :: Bool -> InternalBool
-builtinBool builtinBoolValue =
+builtinBool internalBoolValue =
     InternalBool
-        { builtinBoolSort = boolSort
-        , builtinBoolValue
+        { internalBoolSort = boolSort
+        , internalBoolValue
         }
 
 -- ** Int

--- a/kore/test/Test/Kore/Builtin/Int.hs
+++ b/kore/test/Test/Kore/Builtin/Int.hs
@@ -67,8 +67,8 @@ import Kore.Builtin.Int
     , tmod
     )
 import qualified Kore.Builtin.Int as Int
-import qualified Kore.Domain.Builtin as Domain
 import qualified Kore.Internal.Condition as Condition
+import Kore.Internal.InternalInt
 import Kore.Internal.Pattern
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate
@@ -382,9 +382,8 @@ test_euclidian_division_theorem =
     extractValue :: Pattern VariableName -> Integer
     extractValue (Pattern.toTermLike -> term) =
         case term of
-            Builtin_
-                (Domain.BuiltinInt Domain.InternalInt { builtinIntValue }) ->
-                    builtinIntValue
+            BuiltinInt_ InternalInt { internalIntValue } ->
+                internalIntValue
             _ -> error "Expecting builtin int."
 
 testDivEvaluatedArguments

--- a/kore/test/Test/Kore/Builtin/Int.hs
+++ b/kore/test/Test/Kore/Builtin/Int.hs
@@ -382,7 +382,7 @@ test_euclidian_division_theorem =
     extractValue :: Pattern VariableName -> Integer
     extractValue (Pattern.toTermLike -> term) =
         case term of
-            BuiltinInt_ InternalInt { internalIntValue } ->
+            InternalInt_ InternalInt { internalIntValue } ->
                 internalIntValue
             _ -> error "Expecting builtin int."
 

--- a/kore/test/Test/Kore/Internal/TermLike.hs
+++ b/kore/test/Test/Kore/Internal/TermLike.hs
@@ -86,8 +86,9 @@ termLikeChildGen patternSort =
               | otherwise ->
                 Gen.choice
                     [ mkElemVar <$> elementVariableGen patternSort
-                    , mkBuiltin <$> genBuiltin patternSort
+                    , mkInternalBool <$> genInternalBool patternSort
                     , mkInternalInt <$> genInternalInt patternSort
+                    , mkInternalString <$> genInternalString patternSort
                     ]
       | otherwise =
         (Gen.small . Gen.frequency)

--- a/kore/test/Test/Kore/Internal/TermLike.hs
+++ b/kore/test/Test/Kore/Internal/TermLike.hs
@@ -42,11 +42,8 @@ import Kore.Attribute.Pattern.FreeVariables
 import Kore.Attribute.Synthetic
     ( resynthesize
     )
-import Kore.Domain.Builtin
-    ( Builtin (..)
-    , InternalInt (..)
-    )
 import Kore.Internal.ApplicationSorts
+import Kore.Internal.InternalInt
 import Kore.Internal.SideCondition
     ( SideCondition
     )
@@ -90,6 +87,7 @@ termLikeChildGen patternSort =
                 Gen.choice
                     [ mkElemVar <$> elementVariableGen patternSort
                     , mkBuiltin <$> genBuiltin patternSort
+                    , mkInternalInt <$> genInternalInt patternSort
                     ]
       | otherwise =
         (Gen.small . Gen.frequency)
@@ -329,16 +327,13 @@ test_hasConstructorLikeTop =
                 True
                 $ isConstructorLikeTop (mkDomainValue dv)
             let
-                b :: Kore.Domain.Builtin.Builtin key child
-                b = BuiltinInt
-                        (InternalInt
-                            { builtinIntSort = Mock.intSort
-                            , builtinIntValue = 1
-                            }
-                        )
+                b = InternalInt
+                    { internalIntSort = Mock.intSort
+                    , internalIntValue = 1
+                    }
             assertEqual "BuiltinF is constructor-like-top"
                 True
-                (isConstructorLikeTop $ mkBuiltin b)
+                (isConstructorLikeTop $ mkInternalInt b)
             assertEqual "StringLiteralF is constructor-like-top"
                 True
                 (isConstructorLikeTop $ mkStringLiteral "")

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -72,9 +72,6 @@ import Kore.Step.RulePattern
     ( mkRewritingRule
     , rulePattern
     )
-import Kore.Step.Simplification.AndTerms
-    ( cannotUnifyDistinctDomainValues
-    )
 import qualified Kore.Step.Simplification.Data as Kore
 import Kore.Syntax.Module
     ( ModuleName (..)
@@ -341,8 +338,7 @@ unificationFailure =
         command = Try . ByIndex . Left $ AxiomIndex 0
     in do
         Result { output, continue, state } <- run command axioms [claim] claim
-        expectedOutput <-
-            formatUnificationError cannotUnifyDistinctDomainValues one zero
+        expectedOutput <- formatUnificationError "distinct integers" one zero
         output `equalsOutput` expectedOutput
         continue `equals` Continue
         state `hasCurrentNode` ReplNode 0
@@ -358,8 +354,7 @@ unificationFailureWithName =
         command = Try . ByName . RuleName $ "impossible"
     in do
         Result { output, continue, state } <- run command axioms [claim] claim
-        expectedOutput <-
-            formatUnificationError cannotUnifyDistinctDomainValues one zero
+        expectedOutput <- formatUnificationError "distinct integers" one zero
         output `equalsOutput` expectedOutput
         continue `equals` Continue
         state `hasCurrentNode` ReplNode 0
@@ -407,8 +402,7 @@ forceFailure =
         command = TryF . ByIndex . Left $ AxiomIndex 0
     in do
         Result { output, continue, state } <- run command axioms [claim] claim
-        expectedOutput <-
-            formatUnificationError cannotUnifyDistinctDomainValues one zero
+        expectedOutput <- formatUnificationError "distinct integers" one zero
         output `equalsOutput` expectedOutput
         continue `equals` Continue
         state `hasCurrentNode` ReplNode 0
@@ -424,8 +418,7 @@ forceFailureWithName =
         command = TryF . ByName . RuleName $ "impossible"
     in do
         Result { output, continue, state } <- run command axioms [claim] claim
-        expectedOutput <-
-            formatUnificationError cannotUnifyDistinctDomainValues one zero
+        expectedOutput <- formatUnificationError "distinct integers" one zero
         output `equalsOutput` expectedOutput
         continue `equals` Continue
         state `hasCurrentNode` ReplNode 0

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -1143,6 +1143,21 @@ test_andTermsSimplification =
             actual <- unify input1 input2
             assertEqual "" expect actual
         ]
+
+    , testGroup "internal Bool values"
+        [ testCase "distinct values" $ do
+            let expect = []
+                input1 = Mock.builtinBool True
+                input2 = Mock.builtinBool False
+            actual <- unify input1 input2
+            assertEqual "Expected \\bottom" expect actual
+        , testCase "identical values" $ do
+            let expect = [Pattern.fromTermLike input1]
+                input1 = Mock.builtinBool True
+                input2 = Mock.builtinBool True
+            actual <- unify input1 input2
+            assertEqual "" expect actual
+        ]
     ]
 
 mkVariable :: Text -> Variable VariableName

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -1128,6 +1128,21 @@ test_andTermsSimplification =
                 assertEqual "" expect actual
             ]
         ]
+
+    , testGroup "internal Int values"
+        [ testCase "distinct values" $ do
+            let expect = []
+                input1 = Mock.builtinInt 1
+                input2 = Mock.builtinInt 2
+            actual <- unify input1 input2
+            assertEqual "Expected \\bottom" expect actual
+        , testCase "identical values" $ do
+            let expect = [Pattern.fromTermLike input1]
+                input1 = Mock.builtinInt 1
+                input2 = Mock.builtinInt 1
+            actual <- unify input1 input2
+            assertEqual "" expect actual
+        ]
     ]
 
 mkVariable :: Text -> Variable VariableName

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -61,11 +61,12 @@ test_simplify_local_functions =
     , test "contradiction: injA = f(x) ∧ f(x) = injB" f (Left  injA) (Right injB)
     , test "contradiction: injA = f(x) ∧ injB = f(x)" f (Left  injA) (Left  injB)
     , test "contradiction: f(x) = injA ∧ injB = f(x)" f (Right injA) (Left  injB)
-    -- Builtin at top
+    -- Int at top
     , test "contradiction: f(x) = 2 ∧ f(x) = 3" fInt (Right int2) (Right int3)
     , test "contradiction: 2 = f(x) ∧ f(x) = 3" fInt (Left  int2) (Right int3)
     , test "contradiction: 2 = f(x) ∧ 3 = f(x)" fInt (Left  int2) (Left  int3)
     , test "contradiction: f(x) = 2 ∧ 3 = f(x)" fInt (Right int2) (Left  int3)
+    -- TODO (thomas.tuegel): Bool at top
     ]
   where
     f = Mock.f (mkElemVar Mock.x)

--- a/kore/test/Test/Kore/Step/Simplification/Condition.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Condition.hs
@@ -1,5 +1,6 @@
 module Test.Kore.Step.Simplification.Condition
-    ( test_predicateSimplification
+    ( test_simplify_local_functions
+    , test_predicateSimplification
     ) where
 
 import Prelude.Kore
@@ -12,6 +13,7 @@ import Kore.Internal.Condition
     ( Condition
     , Conditional (..)
     )
+import qualified Kore.Internal.Condition as Condition
 import qualified Kore.Internal.Condition as Conditional
 import qualified Kore.Internal.MultiOr as MultiOr
 import Kore.Internal.OrCondition
@@ -20,6 +22,7 @@ import Kore.Internal.OrCondition
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Predicate
     ( makeAndPredicate
+    , makeCeilPredicate_
     , makeEqualsPredicate_
     , makeTruePredicate_
     )
@@ -40,10 +43,54 @@ import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
 import qualified Kore.Step.Simplification.Condition as Condition
 import Kore.Step.Simplification.Simplify
 import qualified Kore.Step.Simplification.SubstitutionSimplifier as SubstitutionSimplifier
+import Kore.TopBottom
 
 import qualified Test.Kore.Step.MockSymbols as Mock
 import qualified Test.Kore.Step.Simplification as Test
 import Test.Tasty.HUnit.Ext
+
+test_simplify_local_functions :: [TestTree]
+test_simplify_local_functions =
+    [ -- Constructor at top
+      test "contradiction: f(x) = a ∧ f(x) = b" f (Right a) (Right b)
+    , test "contradiction: a = f(x) ∧ f(x) = b" f (Left  a) (Right b)
+    , test "contradiction: a = f(x) ∧ b = f(x)" f (Left  a) (Left  b)
+    , test "contradiction: f(x) = a ∧ b = f(x)" f (Right a) (Left  b)
+    -- Sort injection at top
+    , test "contradiction: f(x) = injA ∧ f(x) = injB" f (Right injA) (Right injB)
+    , test "contradiction: injA = f(x) ∧ f(x) = injB" f (Left  injA) (Right injB)
+    , test "contradiction: injA = f(x) ∧ injB = f(x)" f (Left  injA) (Left  injB)
+    , test "contradiction: f(x) = injA ∧ injB = f(x)" f (Right injA) (Left  injB)
+    -- Builtin at top
+    , test "contradiction: f(x) = 2 ∧ f(x) = 3" fInt (Right int2) (Right int3)
+    , test "contradiction: 2 = f(x) ∧ f(x) = 3" fInt (Left  int2) (Right int3)
+    , test "contradiction: 2 = f(x) ∧ 3 = f(x)" fInt (Left  int2) (Left  int3)
+    , test "contradiction: f(x) = 2 ∧ 3 = f(x)" fInt (Right int2) (Left  int3)
+    ]
+  where
+    f = Mock.f (mkElemVar Mock.x)
+    fInt = Mock.fInt (mkElemVar Mock.xInt)
+    defined = makeCeilPredicate_ f & Condition.fromPredicate
+
+    a = Mock.a
+    b = Mock.b
+
+    injA = Mock.sortInjection10 Mock.a
+    injB = Mock.sortInjection10 Mock.b
+
+    int2 = Mock.builtinInt 2
+    int3 = Mock.builtinInt 3
+
+    mkLocalDefn func (Left t)  = makeEqualsPredicate_ t func
+    mkLocalDefn func (Right t) = makeEqualsPredicate_ func t
+
+    test name func eitherC1 eitherC2 =
+        testCase name $ do
+            let equals1 = mkLocalDefn func eitherC1 & Condition.fromPredicate
+                equals2 = mkLocalDefn func eitherC2 & Condition.fromPredicate
+                condition = defined <> equals1 <> defined <> equals2
+            actual <- simplify condition
+            assertBool "Expected \\bottom" $ isBottom actual
 
 test_predicateSimplification :: [TestTree]
 test_predicateSimplification =
@@ -269,6 +316,9 @@ test_predicateSimplification =
                     }
         assertEqual "" (MultiOr.singleton expect) actual
     ]
+
+simplify :: Condition VariableName -> IO (OrCondition VariableName)
+simplify condition = runSimplifier mempty condition
 
 runSimplifier
     :: BuiltinAndAxiomSimplifierMap


### PR DESCRIPTION
Before #2012 

The `Builtin` type is a mix of many unrelated things. It exists only for historical reasons. I have wanted to break this type up for a long time. Now, as part of the changes I would make for #2012, I would have to change every place that `Builtin` appears. I thought it would be better to finally break it up, and then the bug fix (later) will only touch the parts that it actually needs to touch.

#### TODO

- [x] Test Map and Set simplifiers.
- [ ] Test local function definitions with non-constructor built-ins.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
