### PR TITLE
Always output fully-simplified states

### DIFF
--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -102,19 +102,21 @@ retractRemaining _ = Nothing
 -}
 executionStrategy :: Stream (Strategy Prim)
 executionStrategy =
-    (Strategy.sequence . fmap Strategy.apply)
-        [ Begin
-        , Simplify
-        , Rewrite
-        , Simplify
-        ]
-     Stream.:> (
-    (Strategy.sequence . fmap Strategy.apply)
-        [ Begin
-        , Rewrite
-        , Simplify
-        ]
-    & Stream.iterate id)
+    step1 Stream.:> Stream.iterate id stepN
+  where
+    step1 =
+        (Strategy.sequence . fmap Strategy.apply)
+            [ Begin
+            , Simplify
+            , Rewrite
+            , Simplify
+            ]
+    stepN =
+        (Strategy.sequence . fmap Strategy.apply)
+            [ Begin
+            , Rewrite
+            , Simplify
+            ]
 
 limitedExecutionStrategy :: Limit Natural -> [Strategy Prim]
 limitedExecutionStrategy depthLimit =
@@ -126,7 +128,7 @@ data Prim
     = Begin
     | Simplify
     | Rewrite
-    deriving (Eq,Show)
+    deriving (Eq, Show)
 
 {- The two modes of symbolic execution. Each mode determines the way
     rewrite rules are applied during a rewrite step.

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -106,8 +106,15 @@ executionStrategy =
         [ Begin
         , Simplify
         , Rewrite
+        , Simplify
         ]
-    & Stream.iterate id
+     Stream.:> (
+    (Strategy.sequence . fmap Strategy.apply)
+        [ Begin
+        , Rewrite
+        , Simplify
+        ]
+    & Stream.iterate id)
 
 limitedExecutionStrategy :: Limit Natural -> [Strategy Prim]
 limitedExecutionStrategy depthLimit =
@@ -119,7 +126,7 @@ data Prim
     = Begin
     | Simplify
     | Rewrite
-    deriving (Show)
+    deriving (Eq,Show)
 
 {- The two modes of symbolic execution. Each mode determines the way
     rewrite rules are applied during a rewrite step.

--- a/kore/src/Kore/Step.hs
+++ b/kore/src/Kore/Step.hs
@@ -118,6 +118,11 @@ executionStrategy =
             , Simplify
             ]
 
+{- | The sequence of transitions under the specified depth limit.
+
+See also: 'executionStrategy'
+
+ -}
 limitedExecutionStrategy :: Limit Natural -> [Strategy Prim]
 limitedExecutionStrategy depthLimit =
     Limit.takeWithin depthLimit (toList executionStrategy)


### PR DESCRIPTION
Fixes #2299 

Update `executionStrategy` so that `Simplify` always appears after `Rewrite`. If execution is stopped by the depth limit, fully-simplified states will be printed for the user.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [x] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [x] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [x] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [x] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
