### PR TITLE
Make Conditional's term a strict field

### DIFF
--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -90,7 +90,7 @@ quadratic complexity.
  -}
 data Conditional variable child =
     Conditional
-        { term :: child
+        { term :: !child
         , predicate :: !(Predicate variable)
         , substitution :: !(Substitution variable)
         }

--- a/kore/src/Kore/Reachability/Claim.hs
+++ b/kore/src/Kore/Reachability/Claim.hs
@@ -40,6 +40,7 @@ import Control.Lens
     ( Lens'
     )
 import qualified Control.Lens as Lens
+import qualified Control.Monad as Monad
 import Control.Monad.Catch
     ( Exception (..)
     , SomeException (..)
@@ -604,6 +605,7 @@ simplify' lensClaimPattern claim = do
 
     simplifyLeftHandSide =
         Lens.traverseOf (lensClaimPattern . field @"left") $ \config -> do
+            Monad.guard (not . isBottom . Conditional.term $ config)
             let definedConfig =
                     Pattern.andCondition (mkDefined <$> config)
                     $ from $ makeCeilPredicate (Conditional.term config)

--- a/kore/test/Test/Kore/Reachability/Prove.hs
+++ b/kore/test/Test/Kore/Reachability/Prove.hs
@@ -658,6 +658,21 @@ test_proveClaims =
         [ mkTest "OnePath" simpleOnePathClaim
         , mkTest "AllPath" simpleAllPathClaim
         ]
+    , testGroup "LHS is undefined" $
+        let mkTest name mkSimpleClaim =
+                testCase name $ do
+                    let claims = [mkSimpleClaim mkBottom_ Mock.a]
+                    actual <- proveClaims_
+                        Unlimited
+                        Unlimited
+                        []
+                        claims
+                        []
+                    assertEqual "Result is \\top" MultiAnd.top actual
+        in
+        [ mkTest "OnePath" simpleOnePathClaim
+        , mkTest "AllPath" simpleAllPathClaim
+        ]
     ]
 
 simpleAxiom


### PR DESCRIPTION
- makes `Kore.Internal.Conditional.Conditional`'s `term` field strict. 
- fixes bug where we would potentially mark `\\bottom` terms as defined in the `simplify` strategy step


---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
