### PR TITLE
Print NoSuchThing errors only to screen

### DIFF
--- a/kore/src/Kore/BugReport.hs
+++ b/kore/src/Kore/BugReport.hs
@@ -19,11 +19,8 @@ import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Compression.GZip as GZip
 import Control.Exception
     ( AsyncException (UserInterrupt)
-    , fromException, IOException
-    )
-import GHC.IO.Exception
-    ( IOErrorType(..)
-    , IOException (ioe_type)
+    , IOException
+    , fromException
     )
 import Control.Monad.Catch
     ( ExitCase (..)
@@ -35,6 +32,10 @@ import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Debug
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
+import GHC.IO.Exception
+    ( IOErrorType (..)
+    , IOException (ioe_type)
+    )
 import Options.Applicative
 import System.Directory
     ( listDirectory


### PR DESCRIPTION
Fixes #2426 
If a file is missing, the error will look like this:
```
non-existent-file: copyFile:atomicCopyFileContents:withReplacementFile:copyFileToHandle:openBinaryFile: does not exist (No such file or directory)
```

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
