### PR TITLE
Use SideConditionRepr as newtype over Representation

### DIFF
--- a/kore/kore.cabal
+++ b/kore/kore.cabal
@@ -317,8 +317,8 @@ library
     Kore.Internal.OrPattern
     Kore.Internal.Pattern
     Kore.Internal.Predicate
+    Kore.Internal.Representation
     Kore.Internal.SideCondition
-    Kore.Internal.SideCondition.SideCondition
     Kore.Internal.Substitution
     Kore.Internal.Symbol
     Kore.Internal.TermLike

--- a/kore/src/Kore/Attribute/Pattern.hs
+++ b/kore/src/Kore/Attribute/Pattern.hs
@@ -28,57 +28,55 @@ module Kore.Attribute.Pattern (
 
 import qualified Control.Lens as Lens
 import Data.Generics.Product
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 import Kore.Attribute.Pattern.ConstructorLike
-import Kore.Attribute.Pattern.Created (
-    Created (..),
-    hasKnownCreator,
- )
-import Kore.Attribute.Pattern.Defined (
-    Defined (..),
- )
-import Kore.Attribute.Pattern.FreeVariables (
-    FreeVariables,
-    HasFreeVariables,
-    bindVariable,
-    bindVariables,
-    emptyFreeVariables,
-    freeVariable,
-    getFreeElementVariables,
-    isFreeVariable,
-    mapFreeVariables,
-    nullFreeVariables,
-    toList,
-    toNames,
-    toSet,
-    traverseFreeVariables,
- )
-import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables (
-    freeVariables,
- )
+import Kore.Attribute.Pattern.Created
+    ( Created (..)
+    , hasKnownCreator
+    )
+import Kore.Attribute.Pattern.Defined
+    ( Defined (..)
+    )
+import Kore.Attribute.Pattern.FreeVariables
+    ( FreeVariables
+    , HasFreeVariables
+    , bindVariable
+    , bindVariables
+    , emptyFreeVariables
+    , freeVariable
+    , getFreeElementVariables
+    , isFreeVariable
+    , mapFreeVariables
+    , nullFreeVariables
+    , toList
+    , toNames
+    , toSet
+    , traverseFreeVariables
+    )
+import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+    ( freeVariables
+    )
 import Kore.Attribute.Pattern.Function
 import Kore.Attribute.Pattern.Functional
-import Kore.Attribute.Pattern.Simplified hiding (
-    isSimplified,
-    isSimplifiedAnyCondition,
-    isSimplifiedSomeCondition,
- )
-import qualified Kore.Attribute.Pattern.Simplified as Simplified (
-    isSimplified,
-    isSimplifiedAnyCondition,
-    isSimplifiedSomeCondition,
- )
+import Kore.Attribute.Pattern.Simplified hiding
+    ( isSimplified
+    , isSimplifiedAnyCondition
+    , isSimplifiedSomeCondition
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Simplified
+    ( isSimplified
+    , isSimplifiedAnyCondition
+    , isSimplifiedSomeCondition
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Sort (
-    Sort,
- )
+import Kore.Sort
+    ( Sort
+    )
 import Kore.Syntax.Variable
 import Prelude.Kore
+
 
 -- | @Pattern@ are the attributes of a pattern collected during verification.
 data Pattern variable = Pattern
@@ -149,7 +147,7 @@ condition.
 -}
 isSimplified ::
     HasCallStack =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     Pattern variable ->
     Bool
 isSimplified sideCondition patt@Pattern{simplified} =

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -72,6 +72,7 @@ import Pretty
     ( Pretty
     )
 
+-- | Wrapper for 'Representation's which are 'SideCondition's.
 newtype SideConditionRepr =
     SideConditionRepr
         { sideConditionRepr :: Representation
@@ -82,6 +83,9 @@ newtype SideConditionRepr =
     deriving newtype (Debug, Diff)
     deriving newtype (Pretty)
 
+{- | Creates a 'SideConditionRepr'. Should not be used directly.
+ See 'Kore.Internal.SideCondition.toRepresentation'.
+-}
 mkSideConditionRepr
     :: (Ord a, Hashable a, Typeable a, Pretty a)
     => a -> SideConditionRepr

--- a/kore/src/Kore/Attribute/Pattern/Simplified.hs
+++ b/kore/src/Kore/Attribute/Pattern/Simplified.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoStrict     #-}
+{-# LANGUAGE NoStrict #-}
 {-# LANGUAGE NoStrictData #-}
 
 {- |
@@ -24,59 +24,58 @@ module Kore.Attribute.Pattern.Simplified (
     unparseTag,
 ) where
 
-import Data.Text
-    ( Text
-    )
-import qualified Generics.SOP as SOP
+import Data.Text (
+    Text,
+ )
 import qualified GHC.Generics as GHC
+import qualified Generics.SOP as SOP
 import Kore.Attribute.Synthetic
 import Kore.Debug
-import Kore.Internal.Inj
-    ( Inj
-    )
+import Kore.Internal.Inj (
+    Inj,
+ )
 import qualified Kore.Internal.Inj as Inj
-import Kore.Internal.InternalBytes
-    ( InternalBytes
-    )
-import Kore.Internal.Representation
-    ( Representation
-    , mkRepresentation
-    )
-import Kore.Syntax
-    ( And
-    , Application
-    , Bottom
-    , Ceil
-    , Const
-    , DomainValue
-    , Equals
-    , Exists
-    , Floor
-    , Forall
-    , Iff
-    , Implies
-    , In
-    , Inhabitant
-    , Mu
-    , Next
-    , Not
-    , Nu
-    , Or
-    , Rewrites
-    , StringLiteral
-    , Top
-    )
+import Kore.Internal.InternalBytes (
+    InternalBytes,
+ )
+import Kore.Internal.Representation (
+    Representation,
+    mkRepresentation,
+ )
+import Kore.Syntax (
+    And,
+    Application,
+    Bottom,
+    Ceil,
+    Const,
+    DomainValue,
+    Equals,
+    Exists,
+    Floor,
+    Forall,
+    Iff,
+    Implies,
+    In,
+    Inhabitant,
+    Mu,
+    Next,
+    Not,
+    Nu,
+    Or,
+    Rewrites,
+    StringLiteral,
+    Top,
+ )
 import Kore.Syntax.Variable
 import Prelude.Kore
-import Pretty
-    ( Pretty
-    )
+import Pretty (
+    Pretty,
+ )
 
 -- | Wrapper for 'Representation's which are 'SideCondition's.
-newtype SideConditionRepr =
-    SideConditionRepr
-        { sideConditionRepr :: Representation
-        }
+newtype SideConditionRepr = SideConditionRepr
+    { sideConditionRepr :: Representation
+    }
     deriving stock (Show)
     deriving newtype (Eq, Ord)
     deriving newtype (Hashable, NFData)
@@ -86,9 +85,10 @@ newtype SideConditionRepr =
 {- | Creates a 'SideConditionRepr'. Should not be used directly.
  See 'Kore.Internal.SideCondition.toRepresentation'.
 -}
-mkSideConditionRepr
-    :: (Ord a, Hashable a, Typeable a, Pretty a)
-    => a -> SideConditionRepr
+mkSideConditionRepr ::
+    (Ord a, Hashable a, Typeable a, Pretty a) =>
+    a ->
+    SideConditionRepr
 mkSideConditionRepr = SideConditionRepr . mkRepresentation
 
 -- | How well simplified is a pattern.

--- a/kore/src/Kore/Attribute/PredicatePattern.hs
+++ b/kore/src/Kore/Attribute/PredicatePattern.hs
@@ -23,33 +23,30 @@ module Kore.Attribute.PredicatePattern (
 
 import qualified Control.Lens as Lens
 import Data.Generics.Product
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
-import Kore.Attribute.Pattern (
-    Pattern,
- )
+import qualified GHC.Generics as GHC
+import Kore.Attribute.Pattern
+    ( Pattern
+    )
 import qualified Kore.Attribute.Pattern as Pattern
-import Kore.Attribute.Pattern.FreeVariables hiding (
-    freeVariables,
- )
-import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables (
-    freeVariables,
- )
-import Kore.Attribute.Pattern.Simplified hiding (
-    isSimplified,
-    isSimplifiedAnyCondition,
-    isSimplifiedSomeCondition,
- )
-import qualified Kore.Attribute.Pattern.Simplified as Simplified (
-    isSimplified,
-    isSimplifiedAnyCondition,
-    isSimplifiedSomeCondition,
- )
+import Kore.Attribute.Pattern.FreeVariables hiding
+    ( freeVariables
+    )
+import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
+    ( freeVariables
+    )
+import Kore.Attribute.Pattern.Simplified hiding
+    ( isSimplified
+    , isSimplifiedAnyCondition
+    , isSimplifiedSomeCondition
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Simplified
+    ( isSimplified
+    , isSimplifiedAnyCondition
+    , isSimplifiedSomeCondition
+    )
 import Kore.Attribute.Synthetic
 import Kore.Debug
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
 import Kore.Syntax.Variable
 import Prelude.Kore
 
@@ -93,7 +90,7 @@ simplifiedAttribute PredicatePattern{simplified} = simplified
 condition.
 -}
 isSimplified ::
-    SideCondition.Representation -> PredicatePattern variable -> Bool
+    SideConditionRepr -> PredicatePattern variable -> Bool
 isSimplified sideCondition = Simplified.isSimplified sideCondition . simplifiedAttribute
 
 {- Checks whether the pattern is simplified relative to some side condition.

--- a/kore/src/Kore/Internal/Condition.hs
+++ b/kore/src/Kore/Internal/Condition.hs
@@ -32,31 +32,31 @@ module Kore.Internal.Condition (
 ) where
 
 import ErrorContext
-import Kore.Attribute.Pattern.FreeVariables (
-    freeVariables,
-    isFreeVariable,
- )
-import qualified Kore.Attribute.Pattern.Simplified as Attribute (
-    Simplified,
- )
-import Kore.Internal.Conditional (
-    Conditional (..),
- )
+import Kore.Attribute.Pattern.FreeVariables
+    ( freeVariables
+    , isFreeVariable
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Attribute
+    ( Simplified
+    )
+import Kore.Internal.Conditional
+    ( Conditional (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import Kore.Internal.Predicate (
-    Predicate,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.Substitution (
-    Normalization (..),
- )
+import Kore.Internal.Substitution
+    ( Normalization (..)
+    )
 import qualified Kore.Internal.Substitution as Substitution
-import qualified Kore.Internal.TermLike as TermLike (
-    simplifiedAttribute,
- )
+import Kore.Internal.TermLike
+    ( SideConditionRepr
+    )
+import qualified Kore.Internal.TermLike as TermLike
+    ( simplifiedAttribute
+    )
 import Kore.Internal.Variable
 import Kore.Syntax
 import Prelude.Kore
@@ -64,7 +64,7 @@ import Prelude.Kore
 -- | A predicate and substitution without an accompanying term.
 type Condition variable = Conditional variable ()
 
-isSimplified :: SideCondition.Representation -> Condition variable -> Bool
+isSimplified :: SideConditionRepr -> Condition variable -> Bool
 isSimplified sideCondition Conditional{term = (), predicate, substitution} =
     Predicate.isSimplified sideCondition predicate
         && Substitution.isSimplified sideCondition substitution

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -24,50 +24,50 @@ module Kore.Internal.Conditional (
     setPredicateSimplified,
 ) where
 
-import Data.Map.Strict (
-    Map,
- )
-import qualified GHC.Generics as GHC
+import Data.Map.Strict
+    ( Map
+    )
 import qualified Generics.SOP as SOP
-import Kore.Attribute.Pattern.FreeVariables (
-    HasFreeVariables (..),
- )
-import qualified Kore.Attribute.Pattern.Simplified as Attribute (
-    Simplified,
- )
+import qualified GHC.Generics as GHC
+import Kore.Attribute.Pattern.FreeVariables
+    ( HasFreeVariables (..)
+    )
+import Kore.Attribute.Pattern.Simplified
+    ( SideConditionRepr
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Attribute
+    ( Simplified
+    )
 import Kore.Debug
-import Kore.Internal.Predicate (
-    Predicate,
-    unparse2WithSort,
-    unparseWithSort,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    , unparse2WithSort
+    , unparseWithSort
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.Substitution (
-    Assignment,
-    Substitution,
- )
+import Kore.Internal.Substitution
+    ( Assignment
+    , Substitution
+    )
 import qualified Kore.Internal.Substitution as Substitution
-import Kore.Internal.TermLike (
-    AdjSomeVariableName,
-    InternalVariable,
-    SomeVariable,
-    Sort,
-    SubstitutionOrd,
-    TermLike,
-    termLikeSort,
- )
-import Kore.TopBottom (
-    TopBottom (..),
- )
+import Kore.Internal.TermLike
+    ( AdjSomeVariableName
+    , InternalVariable
+    , SomeVariable
+    , Sort
+    , SubstitutionOrd
+    , TermLike
+    , termLikeSort
+    )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
 import Kore.Unparser
 import Prelude.Kore
-import Pretty (
-    Doc,
-    Pretty (..),
- )
+import Pretty
+    ( Doc
+    , Pretty (..)
+    )
 import qualified Pretty
 import qualified SQL
 
@@ -487,7 +487,7 @@ markPredicateSimplified conditional@Conditional{predicate} =
 
 markPredicateSimplifiedConditional ::
     (HasCallStack, InternalVariable variable) =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     Conditional variable term ->
     Conditional variable term
 markPredicateSimplifiedConditional

--- a/kore/src/Kore/Internal/OrCondition.hs
+++ b/kore/src/Kore/Internal/OrCondition.hs
@@ -18,33 +18,30 @@ module Kore.Internal.OrCondition (
     toPredicate,
 ) where
 
-import Kore.Internal.Condition (
-    Condition,
- )
+import Kore.Internal.Condition
+    ( Condition
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.MultiOr (
-    MultiOr,
- )
+import Kore.Internal.MultiOr
+    ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import Kore.Internal.Predicate (
-    Predicate,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.TermLike hiding (
-    isSimplified,
- )
-import Kore.TopBottom (
-    TopBottom (..),
- )
+import Kore.Internal.TermLike hiding
+    ( isSimplified
+    )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
 import Prelude.Kore
 
 -- | The disjunction of 'Condition'.
 type OrCondition variable = MultiOr (Condition variable)
 
-isSimplified :: SideCondition.Representation -> OrCondition variable -> Bool
+isSimplified :: SideConditionRepr -> OrCondition variable -> Bool
 isSimplified sideCondition = all (Condition.isSimplified sideCondition)
 
 -- | A "disjunction" of one 'Condition'.

--- a/kore/src/Kore/Internal/OrPattern.hs
+++ b/kore/src/Kore/Internal/OrPattern.hs
@@ -31,54 +31,52 @@ module Kore.Internal.OrPattern (
     MultiOr.traverse,
 ) where
 
-import Data.Map.Strict (
-    Map,
- )
-import Kore.Internal.Condition (
-    Condition,
- )
-import qualified Kore.Internal.Condition as Condition (
-    fromPredicate,
-    toPredicate,
- )
+import Data.Map.Strict
+    ( Map
+    )
+import Kore.Internal.Condition
+    ( Condition
+    )
+import qualified Kore.Internal.Condition as Condition
+    ( fromPredicate
+    , toPredicate
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import Kore.Internal.MultiOr (
-    MultiOr,
- )
+import Kore.Internal.MultiOr
+    ( MultiOr
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import Kore.Internal.Pattern (
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.TermLike (
-    InternalVariable,
-    Sort,
-    TermLike,
-    mkBottom_,
-    mkOr,
- )
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , SideConditionRepr
+    , Sort
+    , TermLike
+    , mkBottom_
+    , mkOr
+    )
 import Kore.Syntax.Variable
-import Kore.TopBottom (
-    TopBottom (..),
- )
-import Kore.Variables.Binding (
-    Binder (..),
- )
-import Kore.Variables.Target (
-    Target (..),
-    mkElementTarget,
-    targetIfEqual,
- )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
+import Kore.Variables.Binding
+    ( Binder (..)
+    )
+import Kore.Variables.Target
+    ( Target (..)
+    , mkElementTarget
+    , targetIfEqual
+    )
 import Prelude.Kore
 
 -- | The disjunction of 'Pattern'.
 type OrPattern variable = MultiOr (Pattern variable)
 
-isSimplified :: SideCondition.Representation -> OrPattern variable -> Bool
+isSimplified :: SideConditionRepr -> OrPattern variable -> Bool
 isSimplified sideCondition = all (Pattern.isSimplified sideCondition)
 
 {- | Checks whether all patterns in the disjunction have simplified children.
@@ -87,7 +85,7 @@ See also: 'Pattern.hasSimplifiedChildren'
 -}
 hasSimplifiedChildren ::
     InternalVariable variable =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     OrPattern variable ->
     Bool
 hasSimplifiedChildren sideCondition =

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -45,52 +45,50 @@ module Kore.Internal.Pattern (
     Condition,
 ) where
 
-import Data.Map.Strict (
-    Map,
- )
-import Kore.Attribute.Pattern.FreeVariables (
-    freeVariables,
-    getFreeElementVariables,
- )
-import qualified Kore.Attribute.Pattern.Simplified as Attribute (
-    Simplified,
- )
-import Kore.Internal.Condition (
-    Condition,
- )
+import Data.Map.Strict
+    ( Map
+    )
+import Kore.Attribute.Pattern.FreeVariables
+    ( freeVariables
+    , getFreeElementVariables
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Attribute
+    ( Simplified
+    )
+import Kore.Internal.Condition
+    ( Condition
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional (
-    Conditional (..),
- )
+import Kore.Internal.Conditional
+    ( Conditional (..)
+    )
 import qualified Kore.Internal.Conditional as Conditional
-import Kore.Internal.MultiAnd (
-    MultiAnd,
- )
+import Kore.Internal.MultiAnd
+    ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
-import Kore.Internal.Predicate (
-    Predicate,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
 import qualified Kore.Internal.Substitution as Substitution
-import Kore.Internal.TermLike (
-    InternalVariable,
-    Sort,
-    TermLike,
-    mkAnd,
-    mkBottom,
-    mkBottom_,
-    mkTop,
-    mkTop_,
-    termLikeSort,
- )
+import Kore.Internal.TermLike
+    ( InternalVariable
+    , SideConditionRepr
+    , Sort
+    , TermLike
+    , mkAnd
+    , mkBottom
+    , mkBottom_
+    , mkTop
+    , mkTop_
+    , termLikeSort
+    )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Syntax.Variable
-import Kore.TopBottom (
-    TopBottom (..),
- )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
 import Prelude.Kore
 
 {- | The conjunction of a pattern, predicate, and substitution.
@@ -110,24 +108,28 @@ fromTermAndPredicate term predicate =
         , predicate
         , substitution = mempty
         }
+
 fromCondition_ ::
     InternalVariable variable =>
     Condition variable ->
     Pattern variable
 fromCondition_ = (<$) mkTop_
+
 fromCondition ::
     InternalVariable variable =>
     Sort ->
     Condition variable ->
     Pattern variable
 fromCondition sort = (<$) (mkTop sort)
+
 fromPredicateSorted ::
     InternalVariable variable =>
     Sort ->
     Predicate variable ->
     Pattern variable
 fromPredicateSorted sort = fromCondition sort . Condition.fromPredicate
-isSimplified :: SideCondition.Representation -> Pattern variable -> Bool
+
+isSimplified :: SideConditionRepr -> Pattern variable -> Bool
 isSimplified sideCondition (splitTerm -> (t, p)) =
     TermLike.isSimplified sideCondition t
         && Condition.isSimplified sideCondition p
@@ -144,7 +146,7 @@ simplified.
 -}
 hasSimplifiedChildren ::
     Ord variable =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     Pattern variable ->
     Bool
 hasSimplifiedChildren sideCondition patt =

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -64,99 +64,96 @@ import qualified Control.Comonad.Trans.Env as Env
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Either as Either
 import qualified Data.Foldable as Foldable
-import Data.Functor.Compose (
-    Compose (..),
- )
-import Data.Functor.Const (
-    Const (Const),
- )
-import Data.Functor.Foldable (
-    Base,
-    Corecursive,
-    Recursive,
- )
+import Data.Functor.Compose
+    ( Compose (..)
+    )
+import Data.Functor.Const
+    ( Const (Const)
+    )
+import Data.Functor.Foldable
+    ( Base
+    , Corecursive
+    , Recursive
+    )
 import qualified Data.Functor.Foldable as Recursive
-import Data.Functor.Identity (
-    Identity (..),
- )
-import Data.List.Extra (
-    nubOrd,
- )
-import Data.Map.Strict (
-    Map,
- )
+import Data.Functor.Identity
+    ( Identity (..)
+    )
+import Data.List.Extra
+    ( nubOrd
+    )
+import Data.Map.Strict
+    ( Map
+    )
 import qualified Data.Map.Strict as Map
-import Data.Set (
-    Set,
- )
+import Data.Set
+    ( Set
+    )
 import qualified Data.Set as Set
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 import qualified Kore.Attribute.Pattern as APattern
-import Kore.Attribute.Pattern.FreeVariables as FreeVariables (
-    FreeVariables,
-    HasFreeVariables (..),
-    getFreeElementVariables,
-    isFreeVariable,
-    toNames,
-    toSet,
- )
-import Kore.Attribute.Pattern.Simplified (
-    Simplified (NotSimplified),
- )
+import Kore.Attribute.Pattern.FreeVariables as FreeVariables
+    ( FreeVariables
+    , HasFreeVariables (..)
+    , getFreeElementVariables
+    , isFreeVariable
+    , toNames
+    , toSet
+    )
+import Kore.Attribute.Pattern.Simplified
+    ( Simplified (NotSimplified)
+    )
 import qualified Kore.Attribute.Pattern.Simplified as Simplified
-import Kore.Attribute.PredicatePattern (
-    PredicatePattern,
- )
+import Kore.Attribute.PredicatePattern
+    ( PredicatePattern
+    )
 import qualified Kore.Attribute.PredicatePattern as Attribute
 import Kore.Attribute.Synthetic
 import Kore.Debug
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.TermLike hiding (
-    AndF,
-    BottomF,
-    CeilF,
-    EqualsF,
-    ExistsF,
-    FloorF,
-    ForallF,
-    IffF,
-    ImpliesF,
-    InF,
-    NotF,
-    OrF,
-    TopF,
-    depth,
-    extractAttributes,
-    forgetSimplified,
-    hasFreeVariable,
-    isSimplified,
-    isSimplifiedSomeCondition,
-    mapVariables,
-    markSimplified,
-    markSimplifiedConditional,
-    markSimplifiedMaybeConditional,
-    setSimplified,
-    simplifiedAttribute,
-    substitute,
- )
+import Kore.Internal.TermLike hiding
+    ( AndF
+    , BottomF
+    , CeilF
+    , EqualsF
+    , ExistsF
+    , FloorF
+    , ForallF
+    , IffF
+    , ImpliesF
+    , InF
+    , NotF
+    , OrF
+    , TopF
+    , depth
+    , extractAttributes
+    , forgetSimplified
+    , hasFreeVariable
+    , isSimplified
+    , isSimplifiedSomeCondition
+    , mapVariables
+    , markSimplified
+    , markSimplifiedConditional
+    , markSimplifiedMaybeConditional
+    , setSimplified
+    , simplifiedAttribute
+    , substitute
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import Kore.Sort (
-    predicateSort,
- )
-import Kore.TopBottom (
-    TopBottom (..),
- )
+import Kore.Sort
+    ( predicateSort
+    )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
 import Kore.Unparser
-import Kore.Variables.Fresh (
-    refreshElementVariable,
- )
+import Kore.Variables.Fresh
+    ( refreshElementVariable
+    )
 import Prelude.Kore
-import Pretty (
-    Pretty (..),
- )
+import Pretty
+    ( Pretty (..)
+    )
 import qualified Pretty
 import qualified SQL
 
@@ -928,7 +925,7 @@ simplifiedAttribute = Attribute.simplifiedAttribute . extractAttributes
 
 See also: 'isSimplifiedSomeCondition'.
 -}
-isSimplified :: SideCondition.Representation -> Predicate variable -> Bool
+isSimplified :: SideConditionRepr -> Predicate variable -> Bool
 isSimplified condition = Attribute.isSimplified condition . extractAttributes
 
 {- | Is the 'Predicate' fully simplified under some side condition?
@@ -992,7 +989,7 @@ markSimplified (Recursive.project -> attrs :< predF) =
 
 markSimplifiedConditional ::
     (HasCallStack, InternalVariable variable) =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     Predicate variable ->
     Predicate variable
 markSimplifiedConditional
@@ -1009,7 +1006,7 @@ markSimplifiedConditional
 
 markSimplifiedMaybeConditional ::
     (HasCallStack, InternalVariable variable) =>
-    Maybe SideCondition.Representation ->
+    Maybe SideConditionRepr ->
     Predicate variable ->
     Predicate variable
 markSimplifiedMaybeConditional Nothing = markSimplified

--- a/kore/src/Kore/Internal/Representation.hs
+++ b/kore/src/Kore/Internal/Representation.hs
@@ -78,9 +78,10 @@ instance Pretty Representation where
 adding new representation types.
 See 'Kore.Attribute.Pattern.Simplified.mkSideConditionRepr'.
 -}
-mkRepresentation
-    :: (Ord a, Hashable a, Typeable a, Pretty a)
-    => a -> Representation
+mkRepresentation ::
+    (Ord a, Hashable a, Typeable a, Pretty a) =>
+    a ->
+    Representation
 mkRepresentation = Representation typeRep . hashed
 
 instance Debug Representation where

--- a/kore/src/Kore/Internal/Representation.hs
+++ b/kore/src/Kore/Internal/Representation.hs
@@ -1,37 +1,37 @@
-{-# LANGUAGE NoStrict #-}
+{-# LANGUAGE NoStrict     #-}
 {-# LANGUAGE NoStrictData #-}
 
 {- |
 Copyright   : (c) Runtime Verification, 2020
 License     : NCSA
 -}
-module Kore.Internal.SideCondition.SideCondition (
+module Kore.Internal.Representation (
     Representation,
     mkRepresentation,
 ) where
 
-import Data.Hashable (
-    Hashed,
-    hashed,
-    unhashed,
- )
-import Data.Type.Equality (
-    testEquality,
-    (:~:) (..),
- )
-import Kore.Debug (
-    Debug (..),
-    Diff (..),
- )
+import Data.Hashable
+    ( Hashed
+    , hashed
+    , unhashed
+    )
+import Data.Type.Equality
+    ( (:~:) (..)
+    , testEquality
+    )
+import Kore.Debug
+    ( Debug (..)
+    , Diff (..)
+    )
 import Prelude.Kore
-import Pretty (
-    Pretty (..),
- )
-import Type.Reflection (
-    SomeTypeRep (..),
-    TypeRep,
-    typeRep,
- )
+import Pretty
+    ( Pretty (..)
+    )
+import Type.Reflection
+    ( SomeTypeRep (..)
+    , TypeRep
+    , typeRep
+    )
 
 data Representation where
     Representation ::

--- a/kore/src/Kore/Internal/Representation.hs
+++ b/kore/src/Kore/Internal/Representation.hs
@@ -74,10 +74,13 @@ instance NFData Representation where
 instance Pretty Representation where
     pretty (Representation _ h) = pretty (unhashed h)
 
-{- | Creates a 'Representation'. Should not be used directly.
- See 'Kore.Internal.SideCondition.toRepresentation'.
+{- | Creates a 'Representation'. Should only be used when
+adding new representation types.
+See 'Kore.Attribute.Pattern.Simplified.mkSideConditionRepr'.
 -}
-mkRepresentation :: (Ord a, Hashable a, Typeable a, Pretty a) => a -> Representation
+mkRepresentation
+    :: (Ord a, Hashable a, Typeable a, Pretty a)
+    => a -> Representation
 mkRepresentation = Representation typeRep . hashed
 
 instance Debug Representation where

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -25,114 +25,117 @@ module Kore.Internal.SideCondition (
 
 import Changed
 import qualified Control.Lens as Lens
-import Control.Monad.State.Strict (
-    StateT,
-    runStateT,
- )
+import Control.Monad.State.Strict
+    ( StateT
+    , runStateT
+    )
 import qualified Control.Monad.State.Strict as State
 import qualified Data.Bifunctor as Bifunctor
 import qualified Data.Functor.Foldable as Recursive
-import Data.Generics.Product (
-    field,
- )
-import Data.HashMap.Strict (
-    HashMap,
- )
+import Data.Generics.Product
+    ( field
+    )
+import Data.HashMap.Strict
+    ( HashMap
+    )
 import qualified Data.HashMap.Strict as HashMap
-import Data.HashSet (
-    HashSet,
- )
+import Data.HashSet
+    ( HashSet
+    )
 import qualified Data.HashSet as HashSet
-import Data.List (
-    sortOn,
- )
+import Data.List
+    ( sortOn
+    )
 import Debug
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Pattern.Defined as Pattern
-import Kore.Attribute.Pattern.FreeVariables (
-    HasFreeVariables (..),
- )
-import Kore.Attribute.Synthetic (
-    synthesize,
- )
-import Kore.Internal.Condition (
-    Condition,
- )
+import Kore.Attribute.Pattern.FreeVariables
+    ( HasFreeVariables (..)
+    )
+import Kore.Attribute.Pattern.Simplified
+    ( SideConditionRepr
+    , mkSideConditionRepr
+    )
+import Kore.Attribute.Synthetic
+    ( synthesize
+    )
+import Kore.Internal.Condition
+    ( Condition
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.InternalList (
-    InternalList (..),
- )
-import Kore.Internal.MultiAnd (
-    MultiAnd,
- )
+import Kore.Internal.InternalList
+    ( InternalList (..)
+    )
+import Kore.Internal.MultiAnd
+    ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
-import Kore.Internal.NormalizedAc (
-    AcWrapper (..),
-    InternalAc (..),
-    NormalizedAc (..),
-    PairWiseElements (..),
-    emptyNormalizedAc,
-    generatePairWiseElements,
-    getConcreteKeysOfAc,
-    getConcreteValuesOfAc,
-    getSymbolicKeysOfAc,
-    getSymbolicValuesOfAc,
-    pattern AcPair,
- )
-import Kore.Internal.Predicate (
-    Predicate,
-    makeFalsePredicate,
-    makeTruePredicate,
-    pattern PredicateEquals,
-    pattern PredicateExists,
-    pattern PredicateForall,
-    pattern PredicateNot,
- )
+import Kore.Internal.NormalizedAc
+    ( pattern AcPair
+    , AcWrapper (..)
+    , InternalAc (..)
+    , NormalizedAc (..)
+    , PairWiseElements (..)
+    , emptyNormalizedAc
+    , generatePairWiseElements
+    , getConcreteKeysOfAc
+    , getConcreteValuesOfAc
+    , getSymbolicKeysOfAc
+    , getSymbolicValuesOfAc
+    )
+import Kore.Internal.Predicate
+    ( Predicate
+    , pattern PredicateEquals
+    , pattern PredicateExists
+    , pattern PredicateForall
+    , pattern PredicateNot
+    , makeFalsePredicate
+    , makeTruePredicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition.SideCondition as SideCondition
-import Kore.Internal.Symbol (
-    isConstructor,
-    isFunction,
-    isFunctional,
- )
-import Kore.Internal.TermLike (
-    Key,
-    TermLike,
-    extractAttributes,
-    pattern App_,
-    pattern Equals_,
-    pattern Exists_,
-    pattern Forall_,
-    pattern Inj_,
-    pattern InternalBool_,
-    pattern InternalBytes_,
-    pattern InternalInt_,
-    pattern InternalList_,
-    pattern InternalMap_,
-    pattern InternalSet_,
-    pattern InternalString_,
-    pattern Mu_,
-    pattern Nu_,
- )
+import Kore.Internal.Symbol
+    ( isConstructor
+    , isFunction
+    , isFunctional
+    )
+import Kore.Internal.TermLike
+    ( pattern App_
+    , pattern Equals_
+    , pattern Exists_
+    , pattern Forall_
+    , pattern Inj_
+    , pattern InternalBool_
+    , pattern InternalBytes_
+    , pattern InternalInt_
+    , pattern InternalList_
+    , pattern InternalMap_
+    , pattern InternalSet_
+    , pattern InternalString_
+    , Key
+    , pattern Mu_
+    , pattern Nu_
+    , TermLike
+    , extractAttributes
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import Kore.Internal.Variable (
-    InternalVariable,
- )
+import Kore.Internal.Variable
+    ( InternalVariable
+    )
 import Kore.Syntax.Variable
-import Kore.Unparser (
-    Unparse (..),
- )
+import Kore.Unparser
+    ( Unparse (..)
+    )
 import Pair
-import Partial (
-    Partial (..),
-    getPartial,
- )
+import Partial
+    ( Partial (..)
+    , getPartial
+    )
 import Prelude.Kore
-import Pretty (
-    Pretty (..),
- )
+import Pretty
+    ( Pretty (..)
+    )
 import qualified Pretty
 import qualified SQL
 
@@ -385,8 +388,8 @@ fromDefinedTerms definedTerms =
 toRepresentation ::
     InternalVariable variable =>
     SideCondition variable ->
-    SideCondition.Representation
-toRepresentation = mkRepresentation
+    SideConditionRepr
+toRepresentation = mkSideConditionRepr
 
 -- | Looks up the term in the table of replacements.
 replaceTerm ::

--- a/kore/src/Kore/Internal/Substitution.hs
+++ b/kore/src/Kore/Internal/Substitution.hs
@@ -50,50 +50,50 @@ module Kore.Internal.Substitution (
 ) where
 
 import qualified Data.List as List
-import Data.Map.Strict (
-    Map,
- )
+import Data.Map.Strict
+    ( Map
+    )
 import qualified Data.Map.Strict as Map
-import Data.Set (
-    Set,
- )
+import Data.Set
+    ( Set
+    )
 import qualified Data.Set as Set
 import ErrorContext
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 import Kore.Attribute.Pattern.FreeVariables as FreeVariables
-import qualified Kore.Attribute.Pattern.Simplified as Attribute (
-    Simplified (..),
- )
+import Kore.Attribute.Pattern.Simplified
+    ( SideConditionRepr
+    )
+import qualified Kore.Attribute.Pattern.Simplified as Attribute
+    ( Simplified (..)
+    )
 import Kore.Debug
-import Kore.Internal.Predicate (
-    Predicate,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.TermLike (
-    TermLike,
-    mkVar,
-    pattern Var_,
- )
+import Kore.Internal.TermLike
+    ( TermLike
+    , pattern Var_
+    , mkVar
+    )
 import qualified Kore.Internal.TermLike as TermLike
 import Kore.Internal.Variable
-import Kore.TopBottom (
-    TopBottom (..),
- )
-import Kore.Unparser (
-    Unparse,
-    unparse,
-    unparseToString,
- )
-import Prelude.Kore hiding (
-    null,
- )
-import Pretty (
-    Pretty,
- )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
+import Kore.Unparser
+    ( Unparse
+    , unparse
+    , unparseToString
+    )
+import Prelude.Kore hiding
+    ( null
+    )
+import Pretty
+    ( Pretty
+    )
 import qualified Pretty
 import qualified SQL
 
@@ -485,7 +485,7 @@ mapTerms mapper (NormalizedSubstitution s) =
 
 See also: 'isSimplifiedSomeCondition'.
 -}
-isSimplified :: SideCondition.Representation -> Substitution variable -> Bool
+isSimplified :: SideConditionRepr -> Substitution variable -> Bool
 isSimplified _ (Substitution _) = False
 isSimplified sideCondition (NormalizedSubstitution normalized) =
     all (TermLike.isSimplified sideCondition) normalized

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -160,6 +160,7 @@ module Kore.Internal.TermLike (
     SortActual (..),
     SortVariable (..),
     stringMetaSort,
+    SideConditionRepr,
     module Kore.Internal.Inj,
     module Kore.Internal.InternalBytes,
     module Kore.Syntax.And,
@@ -190,30 +191,30 @@ module Kore.Internal.TermLike (
 ) where
 
 import qualified Control.Comonad.Trans.Cofree as Cofree
-import Data.Align (
-    alignWith,
- )
-import Data.ByteString (
-    ByteString,
- )
+import Data.Align
+    ( alignWith
+    )
+import Data.ByteString
+    ( ByteString
+    )
 import qualified Data.Default as Default
-import Data.Functor.Const (
-    Const (..),
- )
-import Data.Functor.Foldable (
-    Base,
- )
+import Data.Functor.Const
+    ( Const (..)
+    )
+import Data.Functor.Foldable
+    ( Base
+    )
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map.Strict as Map
-import Data.Monoid (
-    Endo (..),
- )
-import Data.Set (
-    Set,
- )
-import Data.Text (
-    Text,
- )
+import Data.Monoid
+    ( Endo (..)
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Text
+    ( Text
+    )
 import qualified Data.Text as Text
 import Data.These
 import qualified Kore.Attribute.Pattern as Attribute
@@ -222,14 +223,17 @@ import Kore.Attribute.Pattern.FreeVariables
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import qualified Kore.Attribute.Pattern.Function as Pattern
 import qualified Kore.Attribute.Pattern.Functional as Pattern
+import Kore.Attribute.Pattern.Simplified
+    ( SideConditionRepr
+    )
 import qualified Kore.Attribute.Pattern.Simplified as Pattern
 import Kore.Attribute.Synthetic
-import Kore.Builtin.Endianness.Endianness (
-    Endianness,
- )
-import Kore.Builtin.Signedness.Signedness (
-    Signedness,
- )
+import Kore.Builtin.Endianness.Endianness
+    ( Endianness
+    )
+import Kore.Builtin.Signedness.Signedness
+    ( Signedness
+    )
 import Kore.Error
 import Kore.Internal.Alias
 import Kore.Internal.Inj
@@ -240,15 +244,12 @@ import Kore.Internal.InternalList
 import Kore.Internal.InternalMap
 import Kore.Internal.InternalSet
 import Kore.Internal.InternalString
-import Kore.Internal.Key (
-    Key,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Internal.Symbol hiding (
-    isConstructorLike,
- )
+import Kore.Internal.Key
+    ( Key
+    )
+import Kore.Internal.Symbol hiding
+    ( isConstructorLike
+    )
 import Kore.Internal.TermLike.TermLike
 import Kore.Internal.Variable
 import Kore.Sort
@@ -257,11 +258,11 @@ import Kore.Syntax.And
 import Kore.Syntax.Application
 import Kore.Syntax.Bottom
 import Kore.Syntax.Ceil
-import Kore.Syntax.Definition hiding (
-    Alias,
-    Symbol,
-    symbolConstructor,
- )
+import Kore.Syntax.Definition hiding
+    ( Alias
+    , Symbol
+    , symbolConstructor
+    )
 import qualified Kore.Syntax.Definition as Syntax
 import Kore.Syntax.DomainValue
 import Kore.Syntax.Equals
@@ -282,15 +283,15 @@ import Kore.Syntax.Rewrites
 import Kore.Syntax.StringLiteral
 import Kore.Syntax.Top
 import Kore.Syntax.Variable as Variable
-import Kore.Unparser (
-    Unparse (..),
- )
+import Kore.Unparser
+    ( Unparse (..)
+    )
 import qualified Kore.Unparser as Unparser
 import Kore.Variables.Binding
-import Kore.Variables.Fresh (
-    refreshElementVariable,
-    refreshSetVariable,
- )
+import Kore.Variables.Fresh
+    ( refreshElementVariable
+    , refreshSetVariable
+    )
 import qualified Kore.Variables.Fresh as Fresh
 import Prelude.Kore
 import qualified Pretty
@@ -407,7 +408,7 @@ fromConcrete = mapVariables (pure $ from @Concrete)
 
 See also: 'isSimplifiedAnyCondition', 'isSimplifiedSomeCondition'.
 -}
-isSimplified :: SideCondition.Representation -> TermLike variable -> Bool
+isSimplified :: SideConditionRepr -> TermLike variable -> Bool
 isSimplified sideCondition =
     Attribute.isSimplified sideCondition . extractAttributes
 
@@ -497,7 +498,7 @@ markSimplified (Recursive.project -> attrs :< termLikeF) =
 
 markSimplifiedMaybeConditional ::
     (HasCallStack, InternalVariable variable) =>
-    Maybe SideCondition.Representation ->
+    Maybe SideConditionRepr ->
     TermLike variable ->
     TermLike variable
 markSimplifiedMaybeConditional Nothing = markSimplified
@@ -542,7 +543,7 @@ unchanged.
 -}
 markSimplifiedConditional ::
     (HasCallStack, InternalVariable variable) =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     TermLike variable ->
     TermLike variable
 markSimplifiedConditional

--- a/kore/src/Kore/Step/Function/Evaluator.hs
+++ b/kore/src/Kore/Step/Function/Evaluator.hs
@@ -12,51 +12,48 @@ module Kore.Step.Function.Evaluator (
     evaluatePattern,
 ) where
 
-import Control.Error (
-    ExceptT,
-    MaybeT (..),
-    exceptT,
-    maybeT,
-    throwE,
- )
-import Control.Monad.Catch (
-    MonadThrow,
- )
+import Control.Error
+    ( ExceptT
+    , MaybeT (..)
+    , exceptT
+    , maybeT
+    , throwE
+    )
+import Control.Monad.Catch
+    ( MonadThrow
+    )
 import qualified Kore.Attribute.Pattern.Simplified as Attribute.Simplified
 import Kore.Attribute.Synthetic
-import qualified Kore.Internal.MultiOr as MultiOr (
-    flatten,
-    merge,
- )
-import Kore.Internal.OrPattern (
-    OrPattern,
- )
+import qualified Kore.Internal.MultiOr as MultiOr
+    ( flatten
+    , merge
+    )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import Kore.Internal.Pattern (
-    Condition,
-    Conditional (..),
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Condition
+    , Conditional (..)
+    , Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import qualified Kore.Internal.SideCondition as SideCondition
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
 import qualified Kore.Internal.Symbol as Symbol
 import Kore.Internal.TermLike as TermLike
-import Kore.Log.ErrorBottomTotalFunction (
-    errorBottomTotalFunction,
- )
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
- )
+import Kore.Log.ErrorBottomTotalFunction
+    ( errorBottomTotalFunction
+    )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    )
 import qualified Kore.Step.Function.Memo as Memo
-import Kore.Step.Simplification.Simplify as AttemptedAxiom (
-    AttemptedAxiom (..),
- )
+import Kore.Step.Simplification.Simplify as AttemptedAxiom
+    ( AttemptedAxiom (..)
+    )
 import Kore.Step.Simplification.Simplify as Simplifier
 import Kore.TopBottom
 import Kore.Unparser
@@ -112,7 +109,7 @@ evaluateApplication
 
         unevaluated ::
             Monad m =>
-            Maybe SideCondition.Representation ->
+            Maybe SideConditionRepr ->
             m (OrPattern RewritingVariableName)
         unevaluated maybeSideCondition =
             return $
@@ -122,7 +119,7 @@ evaluateApplication
                         childrenCondition
 
         markSimplifiedIfChildren ::
-            Maybe SideCondition.Representation ->
+            Maybe SideConditionRepr ->
             TermLike RewritingVariableName ->
             TermLike RewritingVariableName
         markSimplifiedIfChildren Nothing =
@@ -182,7 +179,7 @@ evaluatePattern ::
     -- | The pattern to be evaluated
     TermLike RewritingVariableName ->
     -- | The default value
-    ( Maybe SideCondition.Representation ->
+    ( Maybe SideConditionRepr ->
       simplifier (OrPattern RewritingVariableName)
     ) ->
     simplifier (OrPattern RewritingVariableName)
@@ -210,7 +207,7 @@ maybeEvaluatePattern ::
     -- | The pattern to be evaluated
     TermLike RewritingVariableName ->
     -- | The default value
-    ( Maybe SideCondition.Representation ->
+    ( Maybe SideConditionRepr ->
       simplifier (OrPattern RewritingVariableName)
     ) ->
     SideCondition RewritingVariableName ->

--- a/kore/src/Kore/Step/Simplification/Ceil.hs
+++ b/kore/src/Kore/Step/Simplification/Ceil.hs
@@ -10,70 +10,67 @@ module Kore.Step.Simplification.Ceil (
     Ceil (..),
 ) where
 
-import Control.Error (
-    MaybeT,
-    maybeT,
- )
-import Control.Monad.Reader (
-    MonadReader,
- )
+import Control.Error
+    ( MaybeT
+    , maybeT
+    )
+import Control.Monad.Reader
+    ( MonadReader
+    )
 import qualified Control.Monad.Reader as Reader
 import qualified Data.Functor.Foldable as Recursive
-import qualified Kore.Attribute.Symbol as Attribute.Symbol (
-    isTotal,
- )
-import Kore.Attribute.Synthetic (
-    synthesize,
- )
+import qualified Kore.Attribute.Symbol as Attribute.Symbol
+    ( isTotal
+    )
+import Kore.Attribute.Synthetic
+    ( synthesize
+    )
 import qualified Kore.Builtin.AssocComm.CeilSimplifier as AssocComm
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional (
-    Conditional (..),
- )
+import Kore.Internal.Conditional
+    ( Conditional (..)
+    )
 import Kore.Internal.InternalList
 import Kore.Internal.InternalMap
 import Kore.Internal.InternalSet
 import qualified Kore.Internal.MultiAnd as MultiAnd
 import qualified Kore.Internal.MultiOr as MultiOr
-import Kore.Internal.OrCondition (
-    OrCondition,
- )
+import Kore.Internal.OrCondition
+    ( OrCondition
+    )
 import qualified Kore.Internal.OrCondition as OrCondition
-import Kore.Internal.OrPattern (
-    OrPattern,
- )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import Kore.Internal.Pattern (
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import Kore.Internal.Predicate (
-    makeCeilPredicate,
- )
+import Kore.Internal.Predicate
+    ( makeCeilPredicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import qualified Kore.Internal.SideCondition as SideCondition
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
 import Kore.Internal.TermLike
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
- )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    )
 import qualified Kore.Sort as Sort
-import qualified Kore.Step.Function.Evaluator as Axiom (
-    evaluatePattern,
- )
+import qualified Kore.Step.Function.Evaluator as Axiom
+    ( evaluatePattern
+    )
 import qualified Kore.Step.Simplification.AndPredicates as And
 import Kore.Step.Simplification.CeilSimplifier
 import Kore.Step.Simplification.InjSimplifier
 import Kore.Step.Simplification.Simplify as Simplifier
 import Kore.TopBottom
-import Kore.Unparser (
-    unparseToString,
- )
+import Kore.Unparser
+    ( unparseToString
+    )
 import Prelude.Kore
 
 {- | Simplify a 'Ceil' of 'OrPattern'.
@@ -369,7 +366,7 @@ know how to simplify @ceil(g(x))@, the return value will be
 makeSimplifiedCeil ::
     MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
-    Maybe SideCondition.Representation ->
+    Maybe SideConditionRepr ->
     TermLike RewritingVariableName ->
     simplifier (OrCondition RewritingVariableName)
 makeSimplifiedCeil

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -43,13 +43,13 @@ module Kore.Step.Simplification.Simplify (
 
 import qualified Control.Monad as Monad
 import Control.Monad.Counter
-import Control.Monad.Morph (
-    MFunctor,
- )
+import Control.Monad.Morph
+    ( MFunctor
+    )
 import qualified Control.Monad.Morph as Monad.Morph
-import Control.Monad.RWS.Strict (
-    RWST,
- )
+import Control.Monad.RWS.Strict
+    ( RWST
+    )
 import qualified Control.Monad.State.Strict as Strict
 import Control.Monad.Trans.Accum
 import Control.Monad.Trans.Except
@@ -58,79 +58,77 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import qualified Data.Functor.Foldable as Recursive
 import qualified Data.Map.Strict as Map
-import Data.Text (
-    Text,
- )
-import qualified GHC.Generics as GHC
+import Data.Text
+    ( Text
+    )
 import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
 import qualified Kore.Attribute.Pattern as Attribute
 import qualified Kore.Attribute.Symbol as Attribute
 import Kore.Debug
-import Kore.IndexedModule.MetadataTools (
-    SmtMetadataTools,
- )
+import Kore.IndexedModule.MetadataTools
+    ( SmtMetadataTools
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional (
-    Conditional,
- )
+import Kore.Internal.Conditional
+    ( Conditional
+    )
 import qualified Kore.Internal.MultiOr as MultiOr
-import Kore.Internal.OrCondition (
-    OrCondition,
- )
+import Kore.Internal.OrCondition
+    ( OrCondition
+    )
 import qualified Kore.Internal.OrCondition as OrCondition
-import Kore.Internal.OrPattern (
-    OrPattern,
- )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import Kore.Internal.Pattern (
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import Kore.Internal.Symbol
-import Kore.Internal.TermLike (
-    TermLike,
-    TermLikeF (..),
-    pattern App_,
- )
-import Kore.Internal.Variable (
-    InternalVariable,
- )
-import Kore.Log.WarnFunctionWithoutEvaluators (
-    warnFunctionWithoutEvaluators,
- )
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
- )
-import Kore.Step.Axiom.Identifier (
-    AxiomIdentifier,
- )
+import Kore.Internal.TermLike
+    ( pattern App_
+    , SideConditionRepr
+    , TermLike
+    , TermLikeF (..)
+    )
+import Kore.Internal.Variable
+    ( InternalVariable
+    )
+import Kore.Log.WarnFunctionWithoutEvaluators
+    ( warnFunctionWithoutEvaluators
+    )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    )
+import Kore.Step.Axiom.Identifier
+    ( AxiomIdentifier
+    )
 import qualified Kore.Step.Axiom.Identifier as Axiom.Identifier
 import qualified Kore.Step.Function.Memo as Memo
-import Kore.Step.Simplification.InjSimplifier (
-    InjSimplifier,
- )
-import Kore.Step.Simplification.OverloadSimplifier (
-    OverloadSimplifier (..),
- )
+import Kore.Step.Simplification.InjSimplifier
+    ( InjSimplifier
+    )
+import Kore.Step.Simplification.OverloadSimplifier
+    ( OverloadSimplifier (..)
+    )
 import Kore.Syntax.Application
 import Kore.Unparser
 import Log
 import Logic
 import Prelude.Kore
-import Pretty (
-    (<+>),
- )
+import Pretty
+    ( (<+>)
+    )
 import qualified Pretty
-import SMT (
-    MonadSMT (..),
- )
+import SMT
+    ( MonadSMT (..)
+    )
 
 type TermSimplifier variable m =
     TermLike variable -> TermLike variable -> m (Pattern variable)
@@ -426,7 +424,7 @@ data AttemptedAxiom variable
     = NotApplicable
     | -- | The axiom(s) can't be applied with the given side condition, but
       -- we may be able to apply them when the side condition changes.
-      NotApplicableUntilConditionChanges !SideCondition.Representation
+      NotApplicableUntilConditionChanges !SideConditionRepr
     | Applied !(AttemptedAxiomResults variable)
     deriving stock (Eq, Ord, Show)
     deriving stock (GHC.Generic)

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -7,162 +7,160 @@ module Kore.Step.Simplification.TermLike (
 ) where
 
 import qualified Control.Lens.Combinators as Lens
-import Control.Monad.Catch (
-    MonadThrow,
- )
+import Control.Monad.Catch
+    ( MonadThrow
+    )
 import Data.Functor.Const
 import qualified Data.Functor.Foldable as Recursive
-import Kore.Attribute.Pattern.FreeVariables (
-    freeVariables,
- )
-import Kore.Internal.Condition (
-    Condition,
- )
+import Kore.Attribute.Pattern.FreeVariables
+    ( freeVariables
+    )
+import Kore.Internal.Condition
+    ( Condition
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.Conditional (
-    Conditional (Conditional),
- )
-import qualified Kore.Internal.Conditional as Conditional (
-    andCondition,
- )
+import Kore.Internal.Conditional
+    ( Conditional (Conditional)
+    )
+import qualified Kore.Internal.Conditional as Conditional
+    ( andCondition
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
 import qualified Kore.Internal.MultiOr as MultiOr
-import Kore.Internal.OrPattern (
-    OrPattern,
- )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import Kore.Internal.Pattern (
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    cannotReplaceTerm,
-    replaceTerm,
-    toRepresentation,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import qualified Kore.Internal.Substitution as Substitution (
-    toMap,
- )
-import Kore.Internal.TermLike (
-    TermLike,
-    TermLikeF (..),
-    termLikeSort,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( cannotReplaceTerm
+    , replaceTerm
+    , toRepresentation
+    )
+import qualified Kore.Internal.Substitution as Substitution
+    ( toMap
+    )
+import Kore.Internal.TermLike
+    ( SideConditionRepr
+    , TermLike
+    , TermLikeF (..)
+    , termLikeSort
+    )
 import qualified Kore.Internal.TermLike as TermLike
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
- )
-import qualified Kore.Step.Simplification.And as And (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Application as Application (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Bottom as Bottom (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Ceil as Ceil (
-    simplify,
- )
-import qualified Kore.Step.Simplification.DomainValue as DomainValue (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Equals as Equals (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Exists as Exists (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Floor as Floor (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Forall as Forall (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Iff as Iff (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Implies as Implies (
-    simplify,
- )
-import qualified Kore.Step.Simplification.In as In (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Inhabitant as Inhabitant (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Inj as Inj (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalBool as InternalBool (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalBytes as InternalBytes (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalInt as InternalInt (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalList as InternalList (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalMap as InternalMap (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalSet as InternalSet (
-    simplify,
- )
-import qualified Kore.Step.Simplification.InternalString as InternalString (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Mu as Mu (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Next as Next (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Not as Not (
-    notSimplifier,
-    simplify,
- )
-import qualified Kore.Step.Simplification.Nu as Nu (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Or as Or (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Rewrites as Rewrites (
-    simplify,
- )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    )
+import qualified Kore.Step.Simplification.And as And
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Application as Application
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Bottom as Bottom
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Ceil as Ceil
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.DomainValue as DomainValue
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Equals as Equals
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Exists as Exists
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Floor as Floor
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Forall as Forall
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Iff as Iff
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Implies as Implies
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.In as In
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Inhabitant as Inhabitant
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Inj as Inj
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalBool as InternalBool
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalBytes as InternalBytes
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalInt as InternalInt
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalList as InternalList
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalMap as InternalMap
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalSet as InternalSet
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.InternalString as InternalString
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Mu as Mu
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Next as Next
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Not as Not
+    ( notSimplifier
+    , simplify
+    )
+import qualified Kore.Step.Simplification.Nu as Nu
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Or as Or
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Rewrites as Rewrites
+    ( simplify
+    )
 import Kore.Step.Simplification.Simplify
-import qualified Kore.Step.Simplification.StringLiteral as StringLiteral (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Top as Top (
-    simplify,
- )
-import qualified Kore.Step.Simplification.Variable as Variable (
-    simplify,
- )
-import Kore.TopBottom (
-    TopBottom (..),
- )
-import Kore.Unparser (
-    unparse,
- )
+import qualified Kore.Step.Simplification.StringLiteral as StringLiteral
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Top as Top
+    ( simplify
+    )
+import qualified Kore.Step.Simplification.Variable as Variable
+    ( simplify
+    )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
+import Kore.Unparser
+    ( unparse
+    )
 import qualified Kore.Variables.Binding as Binding
 import qualified Logic
 import Prelude.Kore
-import Pretty (
-    Pretty (..),
- )
+import Pretty
+    ( Pretty (..)
+    )
 import qualified Pretty
 
 -- TODO(virgil): Add a Simplifiable class and make all pattern types
@@ -451,7 +449,7 @@ simplify sideCondition = \termLike ->
 -}
 ensureSimplifiedResult ::
     Monad simplifier =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     TermLike RewritingVariableName ->
     OrPattern RewritingVariableName ->
     simplifier (OrPattern RewritingVariableName)
@@ -471,7 +469,7 @@ ensureSimplifiedResult repr termLike results
 
 ensureSimplifiedCondition ::
     Monad simplifier =>
-    SideCondition.Representation ->
+    SideConditionRepr ->
     TermLike RewritingVariableName ->
     Condition RewritingVariableName ->
     simplifier (Condition RewritingVariableName)

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -12,56 +12,55 @@ module Test.Kore.Internal.Pattern (
     module Test.Kore.Internal.TermLike,
 ) where
 
-import Data.Align (
-    align,
- )
+import Data.Align
+    ( align
+    )
 import qualified Data.Map.Strict as Map
-import qualified GHC.Generics as GHC
 import qualified Generics.SOP as SOP
-import Kore.Attribute.Pattern.Simplified (
-    Condition (..),
-    Type (..),
-    pattern Simplified_,
- )
+import qualified GHC.Generics as GHC
+import Kore.Attribute.Pattern.Simplified
+    ( Condition (..)
+    , pattern Simplified_
+    , Type (..)
+    )
 import qualified Kore.Internal.Condition as Condition
-import Kore.Internal.MultiAnd (
-    MultiAnd,
- )
+import Kore.Internal.MultiAnd
+    ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
 import Kore.Internal.Pattern as Pattern
-import Kore.Internal.Predicate (
-    Predicate,
-    makeAndPredicate,
-    makeCeilPredicate,
-    makeEqualsPredicate,
-    makeFalsePredicate,
-    makeTruePredicate,
- )
+import Kore.Internal.Predicate
+    ( Predicate
+    , makeAndPredicate
+    , makeCeilPredicate
+    , makeEqualsPredicate
+    , makeFalsePredicate
+    , makeTruePredicate
+    )
 import qualified Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
 import qualified Kore.Internal.SideCondition as SideCondition
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition
-import Kore.Internal.Substitution (
-    Substitution,
- )
+import Kore.Internal.Substitution
+    ( Substitution
+    )
 import qualified Kore.Internal.Substitution as Substitution
 import qualified Kore.Internal.TermLike as TermLike
 import Prelude.Kore
 import Test.Expect
-import Test.Kore (
-    Gen,
-    sortGen,
- )
-import Test.Kore.Internal.TermLike hiding (
-    forgetSimplified,
-    isSimplified,
-    mapVariables,
-    markSimplified,
-    simplifiedAttribute,
-    substitute,
- )
+import Test.Kore
+    ( Gen
+    , sortGen
+    )
+import Test.Kore.Internal.TermLike hiding
+    ( forgetSimplified
+    , isSimplified
+    , mapVariables
+    , markSimplified
+    , simplifiedAttribute
+    , substitute
+    )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Variables.V
 import Test.Kore.Variables.W
@@ -338,19 +337,19 @@ test_hasSimplifiedChildren =
     mockPredicate1 = makeCeilPredicate mockTerm1
     mockPredicate2 = makeCeilPredicate mockTerm2
 
-    topSideCondition :: SideCondition.Representation
+    topSideCondition :: SideConditionRepr
     topSideCondition =
-        SideCondition.mkRepresentation
+        SideCondition.toRepresentation
             (SideCondition.top :: SideCondition VariableName)
 
-    mockSideCondition :: SideCondition.Representation
+    mockSideCondition :: SideConditionRepr
     mockSideCondition =
         makeEqualsPredicate
             (Mock.f (mkElemVar Mock.x))
             Mock.a
             & Condition.fromPredicate
             & SideCondition.fromCondition
-            & SideCondition.mkRepresentation
+            & SideCondition.toRepresentation
 
     setSimplifiedTerm = TermLike.setSimplified
     setSimplifiedPred = Predicate.setSimplified

--- a/kore/test/Test/Kore/Internal/Predicate.hs
+++ b/kore/test/Test/Kore/Internal/Predicate.hs
@@ -10,21 +10,18 @@ module Test.Kore.Internal.Predicate (
 import qualified Data.Set as Set
 import qualified Kore.Attribute.Pattern.FreeVariables as FreeVariables
 import Kore.Internal.Predicate as Predicate
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    toRepresentation,
-    top,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( toRepresentation
+    , top
+    )
 import Kore.Internal.TermLike
 import qualified Kore.Internal.TermLike as TermLike
-import Kore.TopBottom (
-    TopBottom (..),
- )
+import Kore.TopBottom
+    ( TopBottom (..)
+    )
 import Prelude.Kore
 import Test.Expect
 import Test.Kore
@@ -297,7 +294,7 @@ b = mkElementVariable (testId "b")
 c = mkElementVariable (testId "c")
 d = mkElementVariable (testId "d")
 
-sideRepresentation :: SideCondition.Representation
+sideRepresentation :: SideConditionRepr
 sideRepresentation =
     SideCondition.toRepresentation
         (SideCondition.top :: SideCondition VariableName)

--- a/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/test/Test/Kore/Step/Simplification/AndTerms.hs
@@ -6,67 +6,64 @@ module Test.Kore.Step.Simplification.AndTerms (
     test_functionAnd,
 ) where
 
-import Control.Error (
-    MaybeT (..),
- )
+import Control.Error
+    ( MaybeT (..)
+    )
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
-import Data.Maybe (
-    fromJust,
- )
+import Data.Maybe
+    ( fromJust
+    )
 import qualified Data.Set as Set
-import Data.Text (
-    Text,
- )
+import Data.Text
+    ( Text
+    )
 import qualified Kore.Builtin.AssociativeCommutative as Ac
 import Kore.Internal.Condition as Condition
 import qualified Kore.Internal.Conditional as Conditional
 import Kore.Internal.InternalSet
-import Kore.Internal.MultiAnd (
-    MultiAnd,
- )
+import Kore.Internal.MultiAnd
+    ( MultiAnd
+    )
 import qualified Kore.Internal.MultiAnd as MultiAnd
 import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern as Pattern
-import Kore.Internal.Predicate (
-    makeAndPredicate,
-    makeCeilPredicate,
-    makeEqualsPredicate,
-    makeNotPredicate,
-    makeTruePredicate,
- )
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    toRepresentation,
-    top,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
+import Kore.Internal.Predicate
+    ( makeAndPredicate
+    , makeCeilPredicate
+    , makeEqualsPredicate
+    , makeNotPredicate
+    , makeTruePredicate
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( toRepresentation
+    , top
+    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike as TermLike
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
-    configElementVariableFromId,
-    mkRewritingTerm,
- )
-import Kore.Step.Simplification.And (
-    termAnd,
- )
-import Kore.Step.Simplification.AndTerms (
-    functionAnd,
-    termUnification,
- )
-import Kore.Step.Simplification.Equals (
-    termEquals,
- )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    , configElementVariableFromId
+    , mkRewritingTerm
+    )
+import Kore.Step.Simplification.And
+    ( termAnd
+    )
+import Kore.Step.Simplification.AndTerms
+    ( functionAnd
+    , termUnification
+    )
+import Kore.Step.Simplification.Equals
+    ( termEquals
+    )
 import qualified Kore.Step.Simplification.Not as Not
 import Kore.Step.Simplification.Simplify
-import Kore.Syntax.Sentence (
-    SentenceAlias,
- )
+import Kore.Syntax.Sentence
+    ( SentenceAlias
+    )
 import qualified Kore.Unification.UnifierT as Monad.Unify
 import Prelude.Kore
 import Test.Kore
@@ -1579,7 +1576,7 @@ simplifyEquals simplifierAxioms first second =
   where
     mockEnv = Mock.env{simplifierAxioms}
 
-sideRepresentation :: SideCondition.Representation
+sideRepresentation :: SideConditionRepr
 sideRepresentation =
     SideCondition.toRepresentation
         (SideCondition.top :: SideCondition VariableName)

--- a/kore/test/Test/Kore/Step/Simplification/Ceil.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Ceil.hs
@@ -5,47 +5,44 @@ module Test.Kore.Step.Simplification.Ceil (
 import qualified Data.Map.Strict as Map
 import qualified Data.Sup as Sup
 import Kore.Internal.Condition as Condition
-import Kore.Internal.Predicate (
-    makeAndPredicate,
-    makeCeilPredicate,
-    makeEqualsPredicate,
-    makeTruePredicate,
- )
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    toRepresentation,
-    top,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
+import Kore.Internal.Predicate
+    ( makeAndPredicate
+    , makeCeilPredicate
+    , makeEqualsPredicate
+    , makeTruePredicate
+    )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( toRepresentation
+    , top
+    )
 import qualified Kore.Internal.Substitution as Substitution
 import Kore.Internal.TermLike as TermLike
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
- )
-import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier (
-    AxiomIdentifier (..),
- )
-import qualified Kore.Step.Simplification.Ceil as Ceil (
-    makeEvaluate,
-    simplify,
- )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    )
+import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
+    ( AxiomIdentifier (..)
+    )
+import qualified Kore.Step.Simplification.Ceil as Ceil
+    ( makeEvaluate
+    , simplify
+    )
 import Kore.Step.Simplification.Simplify
-import qualified Kore.Step.Simplification.Simplify as AttemptedAxiom (
-    AttemptedAxiom (..),
- )
+import qualified Kore.Step.Simplification.Simplify as AttemptedAxiom
+    ( AttemptedAxiom (..)
+    )
 import Prelude.Kore
-import Test.Kore.Internal.OrPattern (
-    OrPattern,
- )
+import Test.Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Test.Kore.Internal.OrPattern as OrPattern
 import Test.Kore.Internal.Pattern as Pattern
-import Test.Kore.Step.MockSymbols (
-    testSort,
- )
+import Test.Kore.Step.MockSymbols
+    ( testSort
+    )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty
@@ -529,7 +526,7 @@ makeEvaluateWithAxioms axiomIdToSimplifier child =
   where
     mockEnv = Mock.env{simplifierAxioms = axiomIdToSimplifier}
 
-sideRepresentation :: SideCondition.Representation
+sideRepresentation :: SideConditionRepr
 sideRepresentation =
     SideCondition.toRepresentation
         (SideCondition.top :: SideCondition RewritingVariableName)

--- a/kore/test/Test/Kore/Step/Simplification/Integration.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Integration.hs
@@ -16,55 +16,52 @@ import qualified Kore.Builtin.Int as Int
 import qualified Kore.Builtin.List as List
 import qualified Kore.Builtin.Map as Map
 import qualified Kore.Builtin.Set as Set
-import Kore.Equation (
-    Equation (..),
-    mkEquation,
- )
+import Kore.Equation
+    ( Equation (..)
+    , mkEquation
+    )
 import qualified Kore.Equation as Equation
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    toRepresentation,
-    top,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
-    mkConfigVariable,
-    mkRuleVariable,
- )
-import Kore.Step.Axiom.EvaluationStrategy (
-    builtinEvaluation,
-    simplifierWithFallback,
- )
-import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier (
-    AxiomIdentifier (..),
- )
-import Kore.Step.Axiom.Registry (
-    mkEvaluatorRegistry,
- )
-import qualified Kore.Step.Simplification.Pattern as Pattern (
-    makeEvaluate,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( toRepresentation
+    , top
+    )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    , mkConfigVariable
+    , mkRuleVariable
+    )
+import Kore.Step.Axiom.EvaluationStrategy
+    ( builtinEvaluation
+    , simplifierWithFallback
+    )
+import qualified Kore.Step.Axiom.Identifier as AxiomIdentifier
+    ( AxiomIdentifier (..)
+    )
+import Kore.Step.Axiom.Registry
+    ( mkEvaluatorRegistry
+    )
+import qualified Kore.Step.Simplification.Pattern as Pattern
+    ( makeEvaluate
+    )
 import Kore.Step.Simplification.Simplify
 import Prelude.Kore
 import Test.Kore
-import Test.Kore.Equation.Common (
-    functionAxiomUnification,
-    functionAxiomUnification_,
- )
+import Test.Kore.Equation.Common
+    ( functionAxiomUnification
+    , functionAxiomUnification_
+    )
 import qualified Test.Kore.Internal.OrPattern as OrPattern
-import Test.Kore.Internal.Pattern (
-    Conditional (..),
- )
+import Test.Kore.Internal.Pattern
+    ( Conditional (..)
+    )
 import qualified Test.Kore.Internal.Pattern as Pattern
 import Test.Kore.Internal.Predicate as Predicate
-import Test.Kore.Internal.Substitution as Substitution hiding (
-    test_substitute,
- )
+import Test.Kore.Internal.Substitution as Substitution hiding
+    ( test_substitute
+    )
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty
@@ -1447,6 +1444,6 @@ axiom left right requires =
         , attributes = Default.def
         }
 
-sideRepresentation :: SideCondition.Representation
+sideRepresentation :: SideConditionRepr
 sideRepresentation =
     SideCondition.toRepresentation (SideCondition.top :: SideCondition')

--- a/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
+++ b/kore/test/Test/Kore/Step/Simplification/IntegrationProperty.hs
@@ -3,55 +3,52 @@ module Test.Kore.Step.Simplification.IntegrationProperty (
     test_regressionGeneratedTerms,
 ) where
 
-import Control.Exception (
-    ErrorCall (..),
- )
-import Control.Monad.Catch (
-    MonadThrow,
-    catch,
-    throwM,
- )
-import Data.List (
-    isInfixOf,
- )
+import Control.Exception
+    ( ErrorCall (..)
+    )
+import Control.Monad.Catch
+    ( MonadThrow
+    , catch
+    , throwM
+    )
+import Data.List
+    ( isInfixOf
+    )
 import qualified Data.Map.Strict as Map
-import Hedgehog (
-    PropertyT,
-    annotate,
-    discard,
-    forAll,
-    (===),
- )
-import Kore.Internal.OrPattern (
-    OrPattern,
- )
+import Hedgehog
+    ( PropertyT
+    , annotate
+    , discard
+    , forAll
+    , (===)
+    )
+import Kore.Internal.OrPattern
+    ( OrPattern
+    )
 import qualified Kore.Internal.OrPattern as OrPattern
-import Kore.Internal.Pattern (
-    Pattern,
- )
+import Kore.Internal.Pattern
+    ( Pattern
+    )
 import qualified Kore.Internal.Pattern as Pattern
-import Kore.Internal.SideCondition (
-    SideCondition,
- )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    toRepresentation,
-    top,
- )
-import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
-    Representation,
- )
+import Kore.Internal.SideCondition
+    ( SideCondition
+    )
+import qualified Kore.Internal.SideCondition as SideCondition
+    ( toRepresentation
+    , top
+    )
 import Kore.Internal.TermLike
-import Kore.Rewriting.RewritingVariable (
-    RewritingVariableName,
-    mkRewritingTerm,
- )
-import Kore.Step.Axiom.EvaluationStrategy (
-    simplifierWithFallback,
- )
+import Kore.Rewriting.RewritingVariable
+    ( RewritingVariableName
+    , mkRewritingTerm
+    )
+import Kore.Step.Axiom.EvaluationStrategy
+    ( simplifierWithFallback
+    )
 import qualified Kore.Step.Simplification.Data as Simplification
-import qualified Kore.Step.Simplification.Pattern as Pattern (
-    simplify,
- )
+import qualified Kore.Step.Simplification.Pattern as Pattern
+    ( simplify
+    )
 import Kore.Step.Simplification.Simplify
 import Kore.Unparser
 import Prelude.Kore
@@ -59,9 +56,9 @@ import qualified SMT
 import Test.ConsistentKore
 import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
-import Test.SMT (
-    testPropertyWithoutSolver,
- )
+import Test.SMT
+    ( testPropertyWithoutSolver
+    )
 import Test.Tasty
 import Test.Tasty.HUnit.Ext
 
@@ -154,7 +151,7 @@ evaluateWithAxioms axioms =
             Mock.builtinSimplifiers
             axioms
 
-sideRepresentation :: SideCondition.Representation
+sideRepresentation :: SideConditionRepr
 sideRepresentation =
     SideCondition.toRepresentation
         (SideCondition.top :: SideCondition VariableName)


### PR DESCRIPTION
Part of #2454

In order to keep a set of sub-terms in the attributes, we need to avoid the cyclic dependency between `TermLike` and the attribute modules. We can use the trick we use in the `Simplified` attribute. This PR moves `Kore.Internal.SideCondition.SideCondition` to `Kore.Internal.Representation` and adds a newtype for the `SideCondition` representation.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
