### PR TITLE
Implement hooks string2base and base2string over 2 <= base <= 36

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -401,18 +401,27 @@ Convert an integer value to its base10 string representation.
 
 ~~~
     hooked-symbol int2string{}(Int{}) : String{}
-        [hook{}("STRING.string2int")]
+        [hook{}("STRING.int2string")]
 ~~~
 
 ### STRING.string2base
 
 Takes a string and a base and converts the string from `base` to its integer
 value.
-Currently only works for base 8, 10, and 16.
+Supports bases 2 to 36 inclusive.
 
 ~~~
     hooked-symbol string2base{}(String{}, Int{}) : Int{}
         [hook{}("STRING.string2base")]
+~~~
+
+### STRING.base2string
+
+Convert an integer value to its base string representation.
+
+~~~
+    hooked-symbol base2string{}(/* value */ Int{}, /* base */ Int{}) : String{}
+        [hook{}("STRING.base2string")]
 ~~~
 
 ### STRING.substr

--- a/kore/src/Kore/Builtin/String.hs
+++ b/kore/src/Kore/Builtin/String.hs
@@ -318,39 +318,39 @@ evalString2Base = Builtin.applicationEvaluator evalString2Base0
             _base <- Int.expectBuiltinInt string2BaseKey _baseTerm
             unless (2 <= _base && _base <= 36) $ warnNotImplemented app >> empty
             return $ case readWithBase _base (Text.unpack _str) of
-              [(result, "")] -> Int.asPattern resultSort result
-              _ -> Pattern.bottomOf resultSort
+                [(result, "")] -> Int.asPattern resultSort result
+                _ -> Pattern.bottomOf resultSort
     evalString2Base0 _ _ = Builtin.wrongArity string2BaseKey
 
 readWithBase :: Integer -> ReadS Integer
 readWithBase base = sign $ readInt base isDigit valDigit
   where
-    sign p ('-':cs) = do
-      (a, str') <- p cs
-      return (negate a, str')
-    sign p ('+':cs) = p cs
+    sign p ('-' : cs) = do
+        (a, str') <- p cs
+        return (negate a, str')
+    sign p ('+' : cs) = p cs
     sign p cs = p cs
     isDigit = maybe False (< base) . valDig
     valDigit = fromMaybe 0 . valDig
     valDig c
-      | '0' <= c && c <= '9' = Just $ fromIntegral $ ord c - ord '0'
-      | 'a' <= c && c <= 'z' = Just $ fromIntegral $ ord c - ord 'a' + 10
-      | 'A' <= c && c <= 'Z' = Just $ fromIntegral $ ord c - ord 'A' + 10
-      | otherwise = Nothing
+        | '0' <= c && c <= '9' = Just $ fromIntegral $ ord c - ord '0'
+        | 'a' <= c && c <= 'z' = Just $ fromIntegral $ ord c - ord 'a' + 10
+        | 'A' <= c && c <= 'Z' = Just $ fromIntegral $ ord c - ord 'A' + 10
+        | otherwise = Nothing
 
 evalBase2String :: BuiltinAndAxiomSimplifier
 evalBase2String = Builtin.applicationEvaluator evalBase2String0
   where
     evalBase2String0 _ app
-      | [_intTerm, _baseTerm] <- applicationChildren app = do
-          let Application{applicationSymbolOrAlias = symbol} = app
-              resultSort = symbolSorts symbol & applicationSortsResult
-          _int <- Int.expectBuiltinInt base2StringKey _intTerm
-          _base <- Int.expectBuiltinInt base2StringKey _baseTerm
-          unless (2 <= _base && _base <= 36) $ warnNotImplemented app >> empty
-          Text.pack (showWithBase _int _base)
-              & asPattern resultSort
-              & return
+        | [_intTerm, _baseTerm] <- applicationChildren app = do
+            let Application{applicationSymbolOrAlias = symbol} = app
+                resultSort = symbolSorts symbol & applicationSortsResult
+            _int <- Int.expectBuiltinInt base2StringKey _intTerm
+            _base <- Int.expectBuiltinInt base2StringKey _baseTerm
+            unless (2 <= _base && _base <= 36) $ warnNotImplemented app >> empty
+            Text.pack (showWithBase _int _base)
+                & asPattern resultSort
+                & return
     evalBase2String0 _ _ = Builtin.wrongArity base2StringKey
 
 showWithBase :: Integer -> Integer -> String
@@ -358,8 +358,8 @@ showWithBase int base = showSigned (showIntAtBase base toChar) 0 int ""
   where
     -- chr 48 == '0', chr 97 == 'a'
     toChar digit
-      | 0 <= digit && digit <= 9 = chr $ digit + 48
-      | otherwise = chr $ digit + 87
+        | 0 <= digit && digit <= 9 = chr $ digit + 48
+        | otherwise = chr $ digit + 87
 
 evalString2Int :: BuiltinAndAxiomSimplifier
 evalString2Int = Builtin.functionEvaluator evalString2Int0

--- a/kore/src/Kore/Builtin/String/String.hs
+++ b/kore/src/Kore/Builtin/String/String.hs
@@ -19,6 +19,7 @@ module Kore.Builtin.String.String (
     lengthKey,
     findKey,
     string2BaseKey,
+    base2StringKey,
     chrKey,
     ordKey,
     token2StringKey,
@@ -118,6 +119,9 @@ findKey = "STRING.find"
 
 string2BaseKey :: IsString s => s
 string2BaseKey = "STRING.string2base"
+
+base2StringKey :: IsString s => s
+base2StringKey = "STRING.base2string"
 
 chrKey :: IsString s => s
 chrKey = "STRING.chr"

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -692,7 +692,7 @@ string2BaseStringSymbol :: Internal.Symbol
 string2BaseStringSymbol =
     builtinSymbol "string2baseString" intSort [stringSort, intSort]
         & hook "STRING.string2base"
-base2StringStringSymbol :: InternalSymbol
+base2StringStringSymbol :: Internal.Symbol
 base2StringStringSymbol =
     builtinSymbol "base2stringString" stringSort [intSort, intSort]
         & hook "STRING.base2string"

--- a/kore/test/Test/Kore/Builtin/Definition.hs
+++ b/kore/test/Test/Kore/Builtin/Definition.hs
@@ -692,6 +692,10 @@ string2BaseStringSymbol :: Internal.Symbol
 string2BaseStringSymbol =
     builtinSymbol "string2baseString" intSort [stringSort, intSort]
         & hook "STRING.string2base"
+base2StringStringSymbol :: InternalSymbol
+base2StringStringSymbol =
+    builtinSymbol "base2stringString" stringSort [intSort, intSort]
+        & hook "STRING.base2string"
 string2IntStringSymbol :: Internal.Symbol
 string2IntStringSymbol =
     builtinSymbol "string2intString" intSort [stringSort]
@@ -1648,6 +1652,7 @@ stringModule =
             , hookedSymbolDecl ordStringSymbol
             , hookedSymbolDecl findStringSymbol
             , hookedSymbolDecl string2BaseStringSymbol
+            , hookedSymbolDecl base2StringStringSymbol
             , hookedSymbolDecl string2IntStringSymbol
             , hookedSymbolDecl int2StringStringSymbol
             , hookedSymbolDecl token2StringStringSymbol

--- a/kore/test/Test/Kore/Builtin/String.hs
+++ b/kore/test/Test/Kore/Builtin/String.hs
@@ -8,6 +8,7 @@ module Test.Kore.Builtin.String (
     test_ord,
     test_find,
     test_string2Base,
+    test_base2String,
     test_string2Int,
     test_int2String,
     test_token2String,
@@ -265,10 +266,10 @@ test_string2Base =
         [asInternal "42", Test.Int.asInternal 8]
         (Test.Int.asPattern 34)
     , Test.Int.testInt
-        "string2Base octal negative is bottom"
+        "string2Base octal negative"
         string2BaseStringSymbol
         [asInternal "-42", Test.Int.asInternal 8]
-        bottom
+        (Test.Int.asPattern (-34))
     , Test.Int.testInt
         "string2Base octal is bottom"
         string2BaseStringSymbol
@@ -321,13 +322,51 @@ test_string2Base =
         [asInternal "baad", Test.Int.asInternal 16]
         (Test.Int.asPattern 47789)
     , Test.Int.testInt
+        "string2Base base-36 from base-36"
+        string2BaseStringSymbol
+        [asInternal "zZ", Test.Int.asInternal 36]
+        (Test.Int.asPattern 1295)
+    , Test.Int.testInt
+        "string2Base base-36 negative"
+        string2BaseStringSymbol
+        [asInternal "-3k", Test.Int.asInternal 36]
+        (Test.Int.asPattern (-128))
+    , Test.Int.testInt
         "string2Base bad base"
         string2BaseStringSymbol
-        [asInternal "1", Test.Int.asInternal 17]
+        [asInternal "1", Test.Int.asInternal 37]
         ( Pattern.fromTermLike $
             mkApplySymbol
                 string2BaseStringSymbol
-                [asInternal "1", Test.Int.asInternal 17]
+                [asInternal "1", Test.Int.asInternal 37]
+        )
+    ]
+
+test_base2String :: [TestTree]
+test_base2String =
+    [ testString
+        "base2String basic decimal example"
+        base2StringStringSymbol
+        [Test.Int.asInternal 42, Test.Int.asInternal 10]
+        (asPattern "42")
+    , testString
+        "base2String decimal negative"
+        base2StringStringSymbol
+        [Test.Int.asInternal (-42), Test.Int.asInternal 10]
+        (asPattern "-42")
+    , testString
+        "base2String hexadecimal example"
+        base2StringStringSymbol
+        [Test.Int.asInternal 51966, Test.Int.asInternal 16]
+        (asPattern "cafe")
+    , testString
+        "base2String bad base"
+        base2StringStringSymbol
+        [Test.Int.asInternal 1, Test.Int.asInternal 37]
+        ( Pattern.fromTermLike $
+            mkApplySymbol
+                base2StringStringSymbol
+                [Test.Int.asInternal 1, Test.Int.asInternal 37]
         )
     ]
 


### PR DESCRIPTION
Fixes #2554 
Overwrites #2589 

* Extend evalString2Base to support bases 2-36
* Add evalBase2String to convert an integer to string representation with base 2-36
* Update string2Base tests, add base2String tests

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
