### PR TITLE
prelude.kore: Fix function equations for LLVM backend

### DIFF
--- a/src/main/kore/prelude.kore
+++ b/src/main/kore/prelude.kore
@@ -5,19 +5,24 @@ endmodule
 []
 module KSEQ
     import BASIC-K []
-    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [
-        constructor{}(),
-        functional{}()
-    ]
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}()]
     symbol dotk{}() : SortK{} [constructor{}(), functional{}()]
     symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
     axiom {R} \implies{R}(
         \and{R}(
             \top{R}(),
-            \and{R}(\in{SortK{}, R}(DotK:SortK{}, dotk{}()), \top{R}())
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
         ),
         \and{R}(
-            \equals{SortK{}, R}(append{}(DotK:SortK{}, K2:SortK{}), K2:SortK{}),
+            \equals{SortK{}, R}(
+                append{}(X0:SortK{}, X1:SortK{}),
+                TAIL:SortK{}
+            ),
             \top{R}()
         )
     ) []
@@ -25,17 +30,16 @@ module KSEQ
         \and{R}(
             \top{R}(),
             \and{R}(
-                \in{SortK{}, R}(
-                    KseqK1K2:SortK{},
-                    kseq{}(K1:SortKItem{}, K2:SortK{})
-                ),
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
                 \top{R}()
-            )
+            ))
         ),
         \and{R}(
             \equals{SortK{}, R}(
-                append{}(KseqK1K2:SortK{}, K3:SortK{}),
-                kseq{}(K1:SortKItem{}, append{}(K2:SortK{}, K3:SortK{}))
+                append{}(X0:SortK{}, X1:SortK{}),
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{}))
             ),
             \top{R}()
         )
@@ -44,19 +48,14 @@ endmodule
 []
 module INJ
     symbol inj{From, To}(From) : To [sortInjection{}()]
-    axiom {S1, S2, S3, R} \equals{S3, R}(
-        inj{S2, S3}(inj{S1, S2}(T:S1)),
-        inj{S1, S3}(T:S1)
-    ) [simplification{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
 endmodule
 []
 module K
     import KSEQ []
     import INJ []
-    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A
-    []
-    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A
-    []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
     alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
 endmodule
 []


### PR DESCRIPTION
The LLVM backend expects exactly one `\in` clause for each argument in the
argument matching field on the left-hand side of an equation, even if that
argument is not matched but passed directly through to the right-hand side.

Fixes kframework/k#1939

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
