### PR TITLE
Remove _PREDICATE sort (#2152)

### DIFF
--- a/kore/src/Kore/Builtin/Builtin.hs
+++ b/kore/src/Kore/Builtin/Builtin.hs
@@ -86,9 +86,6 @@ import Kore.Internal.SideCondition (
     SideCondition,
  )
 import Kore.Internal.TermLike as TermLike
-import Kore.Sort (
-    predicateSort,
- )
 import Kore.Step.Simplification.Simplify (
     AttemptedAxiom (..),
     AttemptedAxiomResults (AttemptedAxiomResults),
@@ -448,19 +445,18 @@ isSymbol builtinName Symbol{symbolAttributes = Attribute.Symbol{hook}} =
 
 {- | Is the given sort hooked to the named builtin?
 
+TO DO (callan): fix documentation here
+
 Returns Nothing if the sort is unknown (i.e. the _PREDICATE sort).
 Returns Just False if the sort is a variable.
 -}
 isSort :: Text -> SmtMetadataTools attr -> Sort -> Maybe Bool
 isSort builtinName tools sort
-    | isPredicateSort = Nothing
     | SortVariableSort _ <- sort = Nothing
     | otherwise =
         let MetadataTools{sortAttributes} = tools
             Attribute.Sort{hook} = sortAttributes sort
          in Just (getHook hook == Just builtinName)
-  where
-    isPredicateSort = sort == predicateSort
 
 -- | Run a function evaluator that can terminate early.
 getAttemptedAxiom ::

--- a/kore/src/Kore/Builtin/EqTerm.hs
+++ b/kore/src/Kore/Builtin/EqTerm.hs
@@ -68,10 +68,13 @@ unifyEqTerm unifyChildren (NotSimplifier notSimplifier) eqTerm termLike2
         lift $ do
             solution <- unifyChildren operand1 operand2 & OrPattern.gather
             let solution' = MultiOr.map eraseTerm solution
-            (if value2 then pure else notSimplifier SideCondition.top) solution'
-                >>= Unify.scatter
+            if value2
+                then Unify.scatter solution'
+                else mkNotSimplified solution' >>= Unify.scatter
     | otherwise = empty
   where
     sort = TermLike.termLikeSort termLike2
     EqTerm{operand1, operand2} = eqTerm
     eraseTerm = Pattern.fromCondition sort . Pattern.withoutTerm
+    mkNotSimplified notChild =
+        notSimplifier SideCondition.top Not{notSort = sort, notChild}

--- a/kore/src/Kore/Builtin/EqTerm.hs
+++ b/kore/src/Kore/Builtin/EqTerm.hs
@@ -72,5 +72,6 @@ unifyEqTerm unifyChildren (NotSimplifier notSimplifier) eqTerm termLike2
                 >>= Unify.scatter
     | otherwise = empty
   where
+    sort = TermLike.termLikeSort termLike2
     EqTerm{operand1, operand2} = eqTerm
-    eraseTerm = Pattern.fromCondition_ . Pattern.withoutTerm
+    eraseTerm = Pattern.fromCondition sort . Pattern.withoutTerm

--- a/kore/src/Kore/Builtin/Int.hs
+++ b/kore/src/Kore/Builtin/Int.hs
@@ -515,4 +515,4 @@ unifyIntEq unifyChildren (NotSimplifier notSimplifier) unifyData =
   where
     UnifyIntEq{eqTerm, value} = unifyData
     EqTerm{operand1, operand2} = eqTerm
-    eraseTerm = Pattern.fromCondition_ . Pattern.withoutTerm
+    eraseTerm = fmap (mkTop . termLikeSort)

--- a/kore/src/Kore/Builtin/Int/Int.hs
+++ b/kore/src/Kore/Builtin/Int/Int.hs
@@ -101,7 +101,7 @@ asPartialPattern ::
     Maybe Integer ->
     Pattern variable
 asPartialPattern resultSort =
-    maybe Pattern.bottom (asPattern resultSort)
+    maybe (Pattern.bottomOf resultSort) (asPattern resultSort)
 
 randKey :: IsString s => s
 randKey = "INT.rand"

--- a/kore/src/Kore/Builtin/KEqual.hs
+++ b/kore/src/Kore/Builtin/KEqual.hs
@@ -272,7 +272,7 @@ unifyKequalsEq unifyChildren (NotSimplifier notSimplifier) unifyData =
   where
     UnifyKequalsEq{eqTerm, value} = unifyData
     EqTerm{operand1, operand2} = eqTerm
-    eraseTerm = Pattern.fromCondition_ . Pattern.withoutTerm
+    eraseTerm = fmap (mkTop . termLikeSort)
 
 -- | The @KEQUAL.ite@ hooked symbol applied to @term@-type arguments.
 data IfThenElse term = IfThenElse

--- a/kore/src/Kore/Builtin/List.hs
+++ b/kore/src/Kore/Builtin/List.hs
@@ -272,7 +272,7 @@ evalGet _ resultSort [_list, _ix] = do
     emptyList <|> bothConcrete
   where
     maybeBottom =
-        maybe Pattern.bottom Pattern.fromTermLike
+        maybe (Pattern.bottomOf resultSort) Pattern.fromTermLike
 evalGet _ _ _ = Builtin.wrongArity getKey
 
 evalUpdate :: Builtin.Function
@@ -553,7 +553,7 @@ unifyEquals
                 "Cannot unify lists of different length."
                 first
                 second
-            return Pattern.bottom
+            return (Pattern.bottomOf sort1)
 
         unifyEqualsFramedRightRight ::
             TermLike.Symbol ->

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -631,8 +631,10 @@ unifyNotInKeys unifyChildren (NotSimplifier notSimplifier) a b =
             >>= Unify.scatter
             & lift
 
+    sort1 = TermLike.termLikeSort a
+
     eraseTerm =
-        Pattern.fromCondition_ . Pattern.withoutTerm
+        Pattern.fromCondition sort1 . Pattern.withoutTerm
 
     unifyAndNegate t1 t2 =
         do
@@ -646,7 +648,7 @@ unifyNotInKeys unifyChildren (NotSimplifier notSimplifier) a b =
                 (OrPattern.fromPatterns unificationSolutions)
             >>= Unify.scatter
 
-    collectConditions terms = fold terms & Pattern.fromCondition_
+    collectConditions terms = fold terms & Pattern.fromCondition sort1
 
     worker ::
         TermLike RewritingVariableName ->
@@ -663,7 +665,7 @@ unifyNotInKeys unifyChildren (NotSimplifier notSimplifier) a b =
                     mapKeys = symbolicKeys <> concreteKeys
                     opaqueElements = opaque . unwrapAc $ normalizedMap
                 if null mapKeys && null opaqueElements
-                    then return Pattern.top
+                    then return (Pattern.topOf sort1)
                     else do
                         Monad.guard (not (null mapKeys) || (length opaqueElements > 1))
                         -- Concrete keys are constructor-like, therefore they are defined

--- a/kore/src/Kore/Builtin/Map.hs
+++ b/kore/src/Kore/Builtin/Map.hs
@@ -88,6 +88,7 @@ import Kore.Internal.Symbol (
  )
 import Kore.Internal.TermLike (
     Key,
+    Not (..),
     TermLike,
     retractKey,
     termLikeSort,
@@ -641,11 +642,12 @@ unifyNotInKeys unifyChildren (NotSimplifier notSimplifier) a b =
             -- Erasing the unified term is valid here because
             -- the terms are all wrapped in \ceil below.
             unificationSolutions <-
-                fmap eraseTerm
-                    <$> Unify.gather (unifyChildren t1 t2)
-            notSimplifier
-                SideCondition.top
-                (OrPattern.fromPatterns unificationSolutions)
+                fmap eraseTerm <$> Unify.gather (unifyChildren t1 t2)
+            (notSimplifier SideCondition.top)
+                Not
+                    { notSort = sort1
+                    , notChild = OrPattern.fromPatterns unificationSolutions
+                    }
             >>= Unify.scatter
 
     collectConditions terms = fold terms & Pattern.fromCondition sort1

--- a/kore/src/Kore/Builtin/String/String.hs
+++ b/kore/src/Kore/Builtin/String/String.hs
@@ -91,7 +91,7 @@ asPartialPattern ::
     Maybe Text ->
     Pattern variable
 asPartialPattern resultSort =
-    maybe Pattern.bottom (asPattern resultSort)
+    maybe (Pattern.bottomOf resultSort) (asPattern resultSort)
 
 eqKey :: IsString s => s
 eqKey = "STRING.eq"

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -266,10 +266,13 @@ exec
                                 <$> finalConfigs
             exitCode <- getExitCode verifiedModule finalConfigs'
             let finalTerm =
-                    sameTermLikeSort initialSort $
-                        OrPattern.toTermLike
-                            _
-                            (MultiOr.map getRewritingPattern finalConfigs')
+                    MultiOr.map getRewritingPattern finalConfigs'
+                        & OrPattern.toTermLike dummySort
+                        & sameTermLikeSort initialSort
+                  where
+                    -- Dummy sort used to unparse configurations.
+                    -- This is only used for unparsing \bottom.
+                    dummySort = SortVariableSort (SortVariable "R")
             return (exitCode, finalTerm)
       where
         dropStrategy = snd

--- a/kore/src/Kore/Exec.hs
+++ b/kore/src/Kore/Exec.hs
@@ -266,8 +266,9 @@ exec
                                 <$> finalConfigs
             exitCode <- getExitCode verifiedModule finalConfigs'
             let finalTerm =
-                    forceSort initialSort $
+                    sameTermLikeSort initialSort $
                         OrPattern.toTermLike
+                            _
                             (MultiOr.map getRewritingPattern finalConfigs')
             return (exitCode, finalTerm)
       where
@@ -423,7 +424,7 @@ search
                 orPredicate =
                     makeMultipleOrPredicate (Condition.toPredicate <$> solutions)
             return
-                . forceSort patternSort
+                . sameTermLikeSort patternSort
                 . getRewritingTerm
                 . fromPredicate_
                 $ orPredicate

--- a/kore/src/Kore/Internal/Conditional.hs
+++ b/kore/src/Kore/Internal/Conditional.hs
@@ -323,6 +323,20 @@ instance
                 <$> Substitution.unwrap substitution
 
 instance
+    InternalVariable variable =>
+    Pretty (Conditional variable (TermLike variable))
+    where
+    pretty Conditional{term, predicate, substitution} =
+        prettyConditional'
+            (unparse term)
+            (pretty predicate)
+            (pretty <$> termLikeSubstitution)
+      where
+        termLikeSubstitution =
+            Substitution.singleSubstitutionToPredicate
+                <$> Substitution.unwrap substitution
+
+instance
     ( InternalVariable variable
     , SQL.Column term
     , Typeable term

--- a/kore/src/Kore/Internal/Inj.hs
+++ b/kore/src/Kore/Internal/Inj.hs
@@ -85,7 +85,7 @@ instance Unparse a => Unparse (Inj a) where
 
 instance Synthetic Sort Inj where
     synthetic Inj{injFrom, injTo, injChild} =
-        injTo & seq (matchSort injFrom injChild)
+        injTo & seq (sameSort injFrom injChild)
     {-# INLINE synthetic #-}
 
 instance Synthetic (FreeVariables variable) Inj where

--- a/kore/src/Kore/Internal/Pattern.hs
+++ b/kore/src/Kore/Internal/Pattern.hs
@@ -10,17 +10,14 @@ module Kore.Internal.Pattern (
     syncSort,
     patternSort,
     fromCondition,
-    fromCondition_,
     fromTermAndPredicate,
     fromPredicateSorted,
-    bottom,
     bottomOf,
     isBottom,
     isTop,
     Kore.Internal.Pattern.mapVariables,
     splitTerm,
     toTermLike,
-    top,
     topOf,
     fromTermLike,
     Kore.Internal.Pattern.freeElementVariables,
@@ -81,9 +78,7 @@ import Kore.Internal.TermLike (
     TermLike,
     mkAnd,
     mkBottom,
-    mkBottom_,
     mkTop,
-    mkTop_,
     termLikeSort,
  )
 import qualified Kore.Internal.TermLike as TermLike
@@ -110,11 +105,6 @@ fromTermAndPredicate term predicate =
         , predicate
         , substitution = mempty
         }
-fromCondition_ ::
-    InternalVariable variable =>
-    Condition variable ->
-    Pattern variable
-fromCondition_ = (<$) mkTop_
 fromCondition ::
     InternalVariable variable =>
     Sort ->
@@ -239,17 +229,6 @@ toTermLike Conditional{term, predicate, substitution} =
         predicateTermLike = Predicate.fromPredicate sort predicate'
         sort = termLikeSort pattern'
 
-{- |'bottom' is an expanded pattern that has a bottom condition and that
-should become Bottom when transformed to a ML pattern.
--}
-bottom :: InternalVariable variable => Pattern variable
-bottom =
-    Conditional
-        { term = mkBottom_
-        , predicate = Predicate.makeFalsePredicate
-        , substitution = mempty
-        }
-
 {- | An 'Pattern' where the 'term' is 'Bottom' of the given 'Sort'.
 
 The 'predicate' is set to 'makeFalsePredicate'.
@@ -259,17 +238,6 @@ bottomOf resultSort =
     Conditional
         { term = mkBottom resultSort
         , predicate = Predicate.makeFalsePredicate
-        , substitution = mempty
-        }
-
-{- |'top' is an expanded pattern that has a top condition and that
-should become Top when transformed to a ML pattern.
--}
-top :: InternalVariable variable => Pattern variable
-top =
-    Conditional
-        { term = mkTop_
-        , predicate = Predicate.makeTruePredicate
         , substitution = mempty
         }
 
@@ -342,7 +310,7 @@ coerceSort
             { term =
                 if isTop term
                     then mkTop sort
-                    else TermLike.forceSort sort term
+                    else TermLike.sameTermLikeSort sort term
             , -- Need to override this since a 'ceil' (say) over a predicate is that
               -- predicate with a different sort.
               predicate = predicate
@@ -410,9 +378,10 @@ substitute subst Conditional{term, predicate, substitution} =
 
 fromMultiAnd ::
     InternalVariable variable =>
+    Sort ->
     MultiAnd (Pattern variable) ->
     Pattern variable
-fromMultiAnd patterns =
+fromMultiAnd sort patterns =
     foldr
         ( \pattern1 ->
             pure
@@ -422,4 +391,4 @@ fromMultiAnd patterns =
         )
         Nothing
         patterns
-        & fromMaybe top
+        & fromMaybe (topOf sort)

--- a/kore/src/Kore/Internal/Predicate.hs
+++ b/kore/src/Kore/Internal/Predicate.hs
@@ -136,9 +136,6 @@ import Kore.Internal.TermLike hiding (
     substitute,
  )
 import qualified Kore.Internal.TermLike as TermLike
-import Kore.Sort (
-    predicateSort,
- )
 import Kore.TopBottom (
     TopBottom (..),
  )
@@ -504,7 +501,7 @@ fromPredicate_ ::
     InternalVariable variable =>
     Predicate variable ->
     TermLike variable
-fromPredicate_ = fromPredicate predicateSort
+fromPredicate_ = fromPredicate undefined
 
 {- | Simple type used to track whether a predicate building function performed
     a simplification that changed the shape of the resulting term. This is
@@ -728,7 +725,7 @@ makeInPredicate' ::
     TermLike variable ->
     (Predicate variable, HasChanged)
 makeInPredicate' t1 t2 =
-    (TermLike.makeSortsAgree makeInWorker t1 t2, NotChanged)
+    (TermLike.checkSortsAgree makeInWorker t1 t2, NotChanged)
   where
     makeInWorker t1' t2' _ = synthesize $ InF $ In () () t1' t2'
 
@@ -745,7 +742,7 @@ makeEqualsPredicate' ::
     TermLike variable ->
     (Predicate variable, HasChanged)
 makeEqualsPredicate' t1 t2 =
-    (TermLike.makeSortsAgree makeEqualsWorker t1 t2, NotChanged)
+    (TermLike.checkSortsAgree makeEqualsWorker t1 t2, NotChanged)
   where
     makeEqualsWorker t1' t2' _ = synthesize $ EqualsF $ Equals () () t1' t2'
 

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -528,7 +528,7 @@ simplifyConjunctionByAssumption (toList -> andPredicates) =
         assumeEqualTerms =
             case predicate of
                 PredicateEquals t1 t2 ->
-                    case retractLocalFunction (TermLike.mkEquals_ t1 t2) of
+                    case retractLocalFunction (TermLike.mkEquals (TermLike.termLikeSort t1) t1 t2) of
                         Just (Pair t1' t2') ->
                             Lens.over (field @"termLikeMap") $
                                 HashMap.insert t1' t2'

--- a/kore/src/Kore/Internal/TermLike.hs
+++ b/kore/src/Kore/Internal/TermLike.hs
@@ -38,10 +38,10 @@ module Kore.Internal.TermLike (
     refreshElementBinder,
     refreshSetBinder,
     depth,
-    makeSortsAgree,
+    checkSortsAgree,
 
     -- * Utility functions for dealing with sorts
-    forceSort,
+    sameTermLikeSort,
     fullyOverrideSort,
 
     -- * Reachability modalities and application
@@ -91,14 +91,6 @@ module Kore.Internal.TermLike (
     mkInhabitant,
     mkEndianness,
     mkSignedness,
-
-    -- * Predicate constructors
-    mkBottom_,
-    mkCeil_,
-    mkEquals_,
-    mkFloor_,
-    mkIn_,
-    mkTop_,
 
     -- * Sentence constructors
     mkAlias,
@@ -594,27 +586,18 @@ checkedSimplifiedFromChildren termLikeF =
 termLikeSort :: TermLike variable -> Sort
 termLikeSort = termSort . extractAttributes
 
--- | Attempts to modify p to have sort s.
-forceSort ::
+-- | Check the given `TermLike` has the same sort as that supplied
+sameTermLikeSort ::
     (InternalVariable variable, HasCallStack) =>
+    -- | expected sort
     Sort ->
     TermLike variable ->
     TermLike variable
-forceSort forcedSort =
-    if forcedSort == predicateSort
-        then id
-        else Recursive.apo forceSortWorker
+sameTermLikeSort expectedSort term
+    | expectedSort == termSort = term
+    | otherwise = illSorted expectedSort term
   where
-    forceSortWorker original@(Recursive.project -> attrs :< pattern') =
-        (:<)
-            (attrs{termSort = forcedSort})
-            ( case attrs of
-                TermAttributes{termSort = sort}
-                    | sort == forcedSort -> Left <$> pattern'
-                    | sort == predicateSort ->
-                        forceSortPredicate forcedSort original
-                    | otherwise -> illSorted forcedSort original
-            )
+    termSort = termLikeSort term
 
 {- | Attempts to modify the pattern to have the given sort, ignoring the
 previous sort and without assuming that the pattern's sorts are consistent.
@@ -727,35 +710,15 @@ forceSortPredicate
             SignednessF _ -> illSorted forcedSort original
             InjF _ -> illSorted forcedSort original
 
-{- | Call the argument function with two patterns whose sorts agree.
-
-If one pattern is flexibly sorted, the result is the rigid sort of the other
-pattern. If both patterns are flexibly sorted, then the result is
-'predicateSort'. If both patterns have the same rigid sort, that is the
-result. It is an error if the patterns are rigidly sorted but do not have the
-same sort.
--}
-makeSortsAgree ::
-    (InternalVariable variable, HasCallStack) =>
+checkSortsAgree ::
     (TermLike variable -> TermLike variable -> Sort -> a) ->
     TermLike variable ->
     TermLike variable ->
     a
-makeSortsAgree withPatterns = \pattern1 pattern2 ->
-    let sort1 = getRigidSort pattern1
-        sort2 = getRigidSort pattern2
-        sort = fromMaybe predicateSort (sort1 <|> sort2)
-        !pattern1' = forceSort sort pattern1
-        !pattern2' = forceSort sort pattern2
-     in withPatterns pattern1' pattern2' sort
-{-# INLINE makeSortsAgree #-}
-
-getRigidSort :: TermLike variable -> Maybe Sort
-getRigidSort pattern' =
-    case termLikeSort pattern' of
-        sort
-            | sort == predicateSort -> Nothing
-            | otherwise -> Just sort
+checkSortsAgree withPatterns t1 t2 = withPatterns t1 t2 (sameSort s1 s2)
+  where
+    s1 = termLikeSort t1
+    s2 = termLikeSort t2
 
 -- | Construct an 'And' pattern.
 mkAnd ::
@@ -764,7 +727,7 @@ mkAnd ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkAnd t1 t2 = updateCallStack $ makeSortsAgree mkAndWorker t1 t2
+mkAnd t1 t2 = updateCallStack $ checkSortsAgree mkAndWorker t1 t2
   where
     mkAndWorker andFirst andSecond andSort =
         synthesize (AndF And{andSort, andFirst, andSecond})
@@ -773,23 +736,21 @@ mkAnd t1 t2 = updateCallStack $ makeSortsAgree mkAndWorker t1 t2
 
 It is an error if the lists are not the same length, or if any 'TermLike' cannot
 be coerced to its corresponding 'Sort'.
-
-See also: 'forceSort'
 -}
-forceSorts ::
+sameTermLikeSorts ::
     HasCallStack =>
     InternalVariable variable =>
     [Sort] ->
     [TermLike variable] ->
     [TermLike variable]
-forceSorts operandSorts children =
+sameTermLikeSorts operandSorts children =
     alignWith forceTheseSorts operandSorts children
   where
     forceTheseSorts (This _) =
         (error . show . Pretty.vsep) ("Too few arguments:" : expected)
     forceTheseSorts (That _) =
         (error . show . Pretty.vsep) ("Too many arguments:" : expected)
-    forceTheseSorts (These sort termLike) = forceSort sort termLike
+    forceTheseSorts (These sort termLike) = sameTermLikeSort sort termLike
     expected =
         [ "Expected:"
         , Pretty.indent 4 (Unparser.arguments operandSorts)
@@ -819,7 +780,7 @@ mkApplyAlias alias children =
     application =
         Application
             { applicationSymbolOrAlias = alias
-            , applicationChildren = forceSorts operandSorts children
+            , applicationChildren = sameTermLikeSorts operandSorts children
             }
     operandSorts = applicationSortsOperands (aliasSorts alias)
 
@@ -854,7 +815,7 @@ symbolApplication ::
 symbolApplication symbol children =
     Application
         { applicationSymbolOrAlias = symbol
-        , applicationChildren = forceSorts operandSorts children
+        , applicationChildren = sameTermLikeSorts operandSorts children
         }
   where
     operandSorts = applicationSortsOperands (symbolSorts symbol)
@@ -902,7 +863,7 @@ applyAlias sentence params children =
       where
         forceChildSort =
             \case
-                These sort pattern' -> forceSort sort pattern'
+                These sort pattern' -> sameTermLikeSort sort pattern'
                 This _ ->
                     (error . show . Pretty.vsep)
                         ("Too few parameters:" : expected)
@@ -975,10 +936,7 @@ applySymbol_ ::
     TermLike variable
 applySymbol_ sentence = updateCallStack . applySymbol sentence []
 
-{- | Construct a 'Bottom' pattern in the given sort.
-
-See also: 'mkBottom_'
--}
+-- | Construct a 'Bottom' pattern in the given sort.
 mkBottom ::
     HasCallStack =>
     InternalVariable variable =>
@@ -987,23 +945,7 @@ mkBottom ::
 mkBottom bottomSort =
     updateCallStack $ synthesize (BottomF Bottom{bottomSort})
 
-{- | Construct a 'Bottom' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use
-'mkBottom' instead.
-
-See also: 'mkBottom'
--}
-mkBottom_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable
-mkBottom_ = updateCallStack $ mkBottom predicateSort
-
-{- | Construct a 'Ceil' pattern in the given sort.
-
-See also: 'mkCeil_'
--}
+-- | Construct a 'Ceil' pattern in the given sort.
 mkCeil ::
     HasCallStack =>
     InternalVariable variable =>
@@ -1015,20 +957,6 @@ mkCeil ceilResultSort ceilChild =
         synthesize (CeilF Ceil{ceilOperandSort, ceilResultSort, ceilChild})
   where
     ceilOperandSort = termLikeSort ceilChild
-
-{- | Construct a 'Ceil' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use 'mkCeil'
-instead.
-
-See also: 'mkCeil'
--}
-mkCeil_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable ->
-    TermLike variable
-mkCeil_ = updateCallStack . mkCeil predicateSort
 
 -- | Construct an internal bool pattern.
 mkInternalBool ::
@@ -1086,10 +1014,7 @@ mkDomainValue ::
     TermLike variable
 mkDomainValue = updateCallStack . synthesize . DomainValueF
 
-{- | Construct an 'Equals' pattern in the given sort.
-
-See also: 'mkEquals_'
--}
+-- | Construct an 'Equals' pattern in the given sort.
 mkEquals ::
     HasCallStack =>
     InternalVariable variable =>
@@ -1098,7 +1023,7 @@ mkEquals ::
     TermLike variable ->
     TermLike variable
 mkEquals equalsResultSort t1 =
-    updateCallStack . makeSortsAgree mkEqualsWorker t1
+    updateCallStack . checkSortsAgree mkEqualsWorker t1
   where
     mkEqualsWorker equalsFirst equalsSecond equalsOperandSort =
         synthesize (EqualsF equals)
@@ -1110,21 +1035,6 @@ mkEquals equalsResultSort t1 =
                 , equalsFirst
                 , equalsSecond
                 }
-
-{- | Construct a 'Equals' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use
-'mkEquals' instead.
-
-See also: 'mkEquals'
--}
-mkEquals_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable ->
-    TermLike variable ->
-    TermLike variable
-mkEquals_ t1 t2 = updateCallStack $ mkEquals predicateSort t1 t2
 
 -- | Construct an 'Exists' pattern.
 mkExists ::
@@ -1149,10 +1059,7 @@ mkExistsN ::
     TermLike variable
 mkExistsN = (updateCallStack .) . appEndo . foldMap (Endo . mkExists)
 
-{- | Construct a 'Floor' pattern in the given sort.
-
-See also: 'mkFloor_'
--}
+-- | Construct a 'Floor' pattern in the given sort.
 mkFloor ::
     HasCallStack =>
     InternalVariable variable =>
@@ -1164,20 +1071,6 @@ mkFloor floorResultSort floorChild =
         synthesize (FloorF Floor{floorOperandSort, floorResultSort, floorChild})
   where
     floorOperandSort = termLikeSort floorChild
-
-{- | Construct a 'Floor' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use 'mkFloor'
-instead.
-
-See also: 'mkFloor'
--}
-mkFloor_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable ->
-    TermLike variable
-mkFloor_ = updateCallStack . mkFloor predicateSort
 
 -- | Construct a 'Forall' pattern.
 mkForall ::
@@ -1209,7 +1102,7 @@ mkIff ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkIff t1 t2 = updateCallStack $ makeSortsAgree mkIffWorker t1 t2
+mkIff t1 t2 = updateCallStack $ checkSortsAgree mkIffWorker t1 t2
   where
     mkIffWorker iffFirst iffSecond iffSort =
         synthesize (IffF Iff{iffSort, iffFirst, iffSecond})
@@ -1221,7 +1114,7 @@ mkImplies ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkImplies t1 t2 = updateCallStack $ makeSortsAgree mkImpliesWorker t1 t2
+mkImplies t1 t2 = updateCallStack $ checkSortsAgree mkImpliesWorker t1 t2
   where
     mkImpliesWorker impliesFirst impliesSecond impliesSort =
         synthesize (ImpliesF implies')
@@ -1239,7 +1132,7 @@ mkIn ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkIn inResultSort t1 t2 = updateCallStack $ makeSortsAgree mkInWorker t1 t2
+mkIn inResultSort t1 t2 = updateCallStack $ checkSortsAgree mkInWorker t1 t2
   where
     mkInWorker inContainedChild inContainingChild inOperandSort =
         synthesize (InF in')
@@ -1252,21 +1145,6 @@ mkIn inResultSort t1 t2 = updateCallStack $ makeSortsAgree mkInWorker t1 t2
                 , inContainingChild
                 }
 
-{- | Construct a 'In' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use 'mkIn'
-instead.
-
-See also: 'mkIn'
--}
-mkIn_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable ->
-    TermLike variable ->
-    TermLike variable
-mkIn_ t1 t2 = updateCallStack $ mkIn predicateSort t1 t2
-
 -- | Construct a 'Mu' pattern.
 mkMu ::
     HasCallStack =>
@@ -1274,7 +1152,7 @@ mkMu ::
     SetVariable variable ->
     TermLike variable ->
     TermLike variable
-mkMu muVar = updateCallStack . makeSortsAgree mkMuWorker (mkSetVar muVar)
+mkMu muVar = updateCallStack . checkSortsAgree mkMuWorker (mkSetVar muVar)
   where
     mkMuWorker (SetVar_ muVar') muChild _ =
         synthesize (MuF Mu{muVariable = muVar', muChild})
@@ -1309,7 +1187,7 @@ mkNu ::
     SetVariable variable ->
     TermLike variable ->
     TermLike variable
-mkNu nuVar = updateCallStack . makeSortsAgree mkNuWorker (mkSetVar nuVar)
+mkNu nuVar = updateCallStack . checkSortsAgree mkNuWorker (mkSetVar nuVar)
   where
     mkNuWorker (SetVar_ nuVar') nuChild _ =
         synthesize (NuF Nu{nuVariable = nuVar', nuChild})
@@ -1322,7 +1200,7 @@ mkOr ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkOr t1 t2 = updateCallStack $ makeSortsAgree mkOrWorker t1 t2
+mkOr t1 t2 = updateCallStack $ checkSortsAgree mkOrWorker t1 t2
   where
     mkOrWorker orFirst orSecond orSort =
         synthesize (OrF Or{orSort, orFirst, orSecond})
@@ -1334,7 +1212,7 @@ mkRewrites ::
     TermLike variable ->
     TermLike variable ->
     TermLike variable
-mkRewrites t1 t2 = updateCallStack $ makeSortsAgree mkRewritesWorker t1 t2
+mkRewrites t1 t2 = updateCallStack $ checkSortsAgree mkRewritesWorker t1 t2
   where
     mkRewritesWorker rewritesFirst rewritesSecond rewritesSort =
         synthesize (RewritesF rewrites')
@@ -1352,19 +1230,6 @@ mkTop ::
     TermLike variable
 mkTop topSort =
     updateCallStack $ synthesize (TopF Top{topSort})
-
-{- | Construct a 'Top' pattern in 'predicateSort'.
-
-This should not be used outside "Kore.Internal.Predicate"; please use
-'mkTop' instead.
-
-See also: 'mkTop'
--}
-mkTop_ ::
-    HasCallStack =>
-    InternalVariable variable =>
-    TermLike variable
-mkTop_ = updateCallStack $ mkTop predicateSort
 
 -- | Construct an element variable pattern.
 mkElemVar ::

--- a/kore/src/Kore/ModelChecker/Simplification.hs
+++ b/kore/src/Kore/ModelChecker/Simplification.hs
@@ -21,7 +21,7 @@ import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.TermLike (
     TermLike,
     mkAnd,
-    mkCeil_,
+    mkCeil,
     mkElemVar,
     mkNot,
     pattern Forall_,
@@ -59,7 +59,8 @@ checkImplicationIsTop lhs rhs =
                 implicationLHS' = TermLike.substitute subst implicationLHS
                 implicationRHS' = TermLike.substitute subst implicationRHS
                 resultTerm =
-                    mkCeil_
+                    mkCeil
+                        sort
                         ( mkAnd
                             (mkAnd lhsMLPatt implicationLHS')
                             (mkNot implicationRHS')
@@ -87,6 +88,7 @@ checkImplicationIsTop lhs rhs =
             & map variableName
             & Set.fromList
     lhsMLPatt = Pattern.toTermLike lhs
+    sort = TermLike.termLikeSort rhs
 
 stripForallQuantifiers ::
     TermLike RewritingVariableName ->

--- a/kore/src/Kore/ModelChecker/Step.hs
+++ b/kore/src/Kore/ModelChecker/Step.hs
@@ -201,8 +201,9 @@ transitionRule
         transitionComputeWeakNext _ (Unprovable config) = return (Unprovable config)
         transitionComputeWeakNext rules (GoalLHS config) =
             transitionComputeWeakNextHelper rules config
-        transitionComputeWeakNext _ (GoalRemLHS _) =
-            return (GoalLHS Pattern.bottom)
+        transitionComputeWeakNext _ (GoalRemLHS pat) =
+            let patSort = Pattern.patternSort pat
+             in return (GoalLHS (Pattern.bottomOf patSort))
 
         transitionComputeWeakNextHelper ::
             [RewriteRule RewritingVariableName] ->

--- a/kore/src/Kore/Reachability/Claim.hs
+++ b/kore/src/Kore/Reachability/Claim.hs
@@ -97,6 +97,7 @@ import Kore.Internal.Symbol (
     Symbol,
  )
 import Kore.Internal.TermLike (
+    Not (..),
     Sort,
     isFunctionPattern,
     mkIn,
@@ -557,8 +558,11 @@ checkImplicationWorker (ClaimPattern.refreshExistentials -> claimPattern) =
             Exists.makeEvaluate sideCondition existentials removed
                 >>= Logic.scatter
             & OrPattern.observeAllT
-            & (>>= (Not.simplifyEvaluated sort) sideCondition)
+            & (>>= mkNotSimplified)
             & wereAnyUnified
+      where
+        mkNotSimplified notChild =
+            Not.simplify sideCondition Not{notSort = sort, notChild}
 
     wereAnyUnified :: StateT AnyUnified m a -> m (AnyUnified, a)
     wereAnyUnified act = swap <$> runStateT act mempty

--- a/kore/src/Kore/Reachability/Prove.hs
+++ b/kore/src/Kore/Reachability/Prove.hs
@@ -101,6 +101,9 @@ import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
     getRewritingPattern,
  )
+import Kore.Sort (
+    Sort,
+ )
 import Kore.Step.ClaimPattern (
     mkGoal,
  )
@@ -142,16 +145,17 @@ type CommonTransitionRule m =
  the configuration will be '\\bottom'.
 -}
 lhsClaimStateTransformer ::
+    Sort ->
     ClaimStateTransformer
         SomeClaim
         (Pattern RewritingVariableName)
-lhsClaimStateTransformer =
+lhsClaimStateTransformer sort =
     ClaimStateTransformer
         { claimedTransformer = getConfiguration
         , remainingTransformer = getConfiguration
         , rewrittenTransformer = getConfiguration
         , stuckTransformer = getConfiguration
-        , provenValue = Pattern.bottom
+        , provenValue = Pattern.bottomOf sort
         }
 
 {- | @Verifer a@ is a 'Simplifier'-based action which returns an @a@.

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -104,6 +104,9 @@ import qualified Kore.Reachability as Reachability
 import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
  )
+import Kore.Sort (
+    Sort,
+ )
 import Kore.Step.Simplification.Data (
     MonadSimplify (..),
  )
@@ -691,16 +694,17 @@ makeKoreReplOutput str =
 runUnifierWithExplanation ::
     forall m a.
     MonadSimplify m =>
+    Sort ->
     UnifierWithExplanation m a ->
     m (Either ReplOutput (NonEmpty a))
-runUnifierWithExplanation (UnifierWithExplanation unifier) =
+runUnifierWithExplanation currSort (UnifierWithExplanation unifier) =
     failWithExplanation <$> unificationResults
   where
     unificationResults ::
         m ([a], First ReplOutput)
     unificationResults =
         flip runAccumT mempty
-            . Monad.Unify.runUnifierT Not.notSimplifier
+            . Monad.Unify.runUnifierT (Not.notSimplifier currSort)
             $ unifier
     failWithExplanation ::
         ([a], First ReplOutput) ->

--- a/kore/src/Kore/Repl/Data.hs
+++ b/kore/src/Kore/Repl/Data.hs
@@ -104,9 +104,6 @@ import qualified Kore.Reachability as Reachability
 import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
  )
-import Kore.Sort (
-    Sort,
- )
 import Kore.Step.Simplification.Data (
     MonadSimplify (..),
  )
@@ -694,17 +691,16 @@ makeKoreReplOutput str =
 runUnifierWithExplanation ::
     forall m a.
     MonadSimplify m =>
-    Sort ->
     UnifierWithExplanation m a ->
     m (Either ReplOutput (NonEmpty a))
-runUnifierWithExplanation currSort (UnifierWithExplanation unifier) =
+runUnifierWithExplanation (UnifierWithExplanation unifier) =
     failWithExplanation <$> unificationResults
   where
     unificationResults ::
         m ([a], First ReplOutput)
     unificationResults =
         flip runAccumT mempty
-            . Monad.Unify.runUnifierT (Not.notSimplifier currSort)
+            . Monad.Unify.runUnifierT Not.notSimplifier
             $ unifier
     failWithExplanation ::
         ([a], First ReplOutput) ->

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -1394,7 +1394,7 @@ prettyClaimStateComponent transformation omitList =
             }
   where
     prettyComponent =
-        unparseToString . OrPattern.toTermLike
+        unparseToString . OrPattern.toTermLike _
             . MultiOr.map (fmap hide . getRewritingPattern)
             . transformation
     hide ::

--- a/kore/src/Kore/Repl/Interpreter.hs
+++ b/kore/src/Kore/Repl/Interpreter.hs
@@ -167,6 +167,7 @@ import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
     getRewritingPattern,
  )
+import Kore.Sort
 import qualified Kore.Step.RulePattern as RulePattern
 import Kore.Step.Simplification.Data (
     MonadSimplify,
@@ -1393,8 +1394,11 @@ prettyClaimStateComponent transformation omitList =
             , provenValue = makeAuxReplOutput "Proven."
             }
   where
+    -- Dummy sort used to unparse configurations.
+    -- This is only used for unparsing \bottom.
+    dummySort = SortVariableSort (SortVariable "R")
     prettyComponent =
-        unparseToString . OrPattern.toTermLike _
+        unparseToString . OrPattern.toTermLike dummySort
             . MultiOr.map (fmap hide . getRewritingPattern)
             . transformation
     hide ::

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -620,8 +620,9 @@ runUnifier ::
 runUnifier sideCondition first second = do
     unifier <- asks unifier
     mvar <- asks logger
+    let firstSort = TermLike.termLikeSort first
     liftSimplifierWithLogger mvar
-        . runUnifierWithExplanation
+        . (runUnifierWithExplanation firstSort)
         $ unifier sideCondition first second
 
 getNodeState :: InnerGraph -> Graph.Node -> Maybe (NodeState, Graph.Node)

--- a/kore/src/Kore/Repl/State.hs
+++ b/kore/src/Kore/Repl/State.hs
@@ -620,9 +620,8 @@ runUnifier ::
 runUnifier sideCondition first second = do
     unifier <- asks unifier
     mvar <- asks logger
-    let firstSort = TermLike.termLikeSort first
     liftSimplifierWithLogger mvar
-        . (runUnifierWithExplanation firstSort)
+        . runUnifierWithExplanation
         $ unifier sideCondition first second
 
 getNodeState :: InnerGraph -> Graph.Node -> Maybe (NodeState, Graph.Node)

--- a/kore/src/Kore/Step/Remainder.hs
+++ b/kore/src/Kore/Step/Remainder.hs
@@ -134,7 +134,7 @@ ceilChildOfApplicationOrTop sideCondition patt =
     case patt of
         App_ _ children -> do
             ceil <-
-                traverse (Ceil.makeEvaluateTerm sideCondition) children
+                traverse (Ceil.makeEvaluateTerm termSort sideCondition) children
                     >>= ( AndPredicates.simplifyEvaluatedMultiPredicate
                             sideCondition
                             . MultiAnd.make
@@ -149,3 +149,5 @@ ceilChildOfApplicationOrTop sideCondition patt =
                     , substitution = mempty
                     }
         _ -> pure Condition.top
+  where
+    termSort = termLikeSort patt

--- a/kore/src/Kore/Step/Rule.hs
+++ b/kore/src/Kore/Step/Rule.hs
@@ -427,9 +427,10 @@ mkEqualityAxiom lhs rhs requires =
                 Just requires' ->
                     TermLike.mkImplies
                         (requires' sortR)
-                        (TermLike.mkAnd function TermLike.mkTop_)
+                        (TermLike.mkAnd function (TermLike.mkTop sortLHS))
                 Nothing -> function
   where
+    sortLHS = TermLike.termLikeSort lhs
     sortVariableR = SortVariable "R"
     sortR = SortVariableSort sortVariableR
     function = TermLike.mkEquals sortR lhs rhs

--- a/kore/src/Kore/Step/Search.hs
+++ b/kore/src/Kore/Step/Search.hs
@@ -35,6 +35,7 @@ import Kore.Internal.Pattern (
     Pattern,
  )
 import qualified Kore.Internal.Pattern as Conditional
+import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.SideCondition (
     SideCondition,
  )
@@ -132,7 +133,7 @@ matchWith ::
 matchWith sideCondition e1 e2 = do
     unifiers <-
         lift $
-            Unifier.runUnifierT Not.notSimplifier $
+            Unifier.runUnifierT (Not.notSimplifier sort) $
                 unificationProcedure sideCondition t1 t2
     let mergeAndEvaluate ::
             Condition RewritingVariableName ->
@@ -177,3 +178,4 @@ matchWith sideCondition e1 e2 = do
   where
     t1 = Conditional.term e1
     t2 = Conditional.term e2
+    sort = Pattern.patternSort e1

--- a/kore/src/Kore/Step/Search.hs
+++ b/kore/src/Kore/Step/Search.hs
@@ -35,7 +35,6 @@ import Kore.Internal.Pattern (
     Pattern,
  )
 import qualified Kore.Internal.Pattern as Conditional
-import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.SideCondition (
     SideCondition,
  )
@@ -132,9 +131,9 @@ matchWith ::
     MaybeT m (OrCondition RewritingVariableName)
 matchWith sideCondition e1 e2 = do
     unifiers <-
-        lift $
-            Unifier.runUnifierT (Not.notSimplifier sort) $
-                unificationProcedure sideCondition t1 t2
+        unificationProcedure sideCondition t1 t2
+            & Unifier.runUnifierT Not.notSimplifier
+            & lift
     let mergeAndEvaluate ::
             Condition RewritingVariableName ->
             m (OrCondition RewritingVariableName)
@@ -178,4 +177,3 @@ matchWith sideCondition e1 e2 = do
   where
     t1 = Conditional.term e1
     t2 = Conditional.term e2
-    sort = Pattern.patternSort e1

--- a/kore/src/Kore/Step/Simplification/AndTerms.hs
+++ b/kore/src/Kore/Step/Simplification/AndTerms.hs
@@ -420,32 +420,28 @@ bottomTermEquals ::
     TermLike RewritingVariableName ->
     TermLike RewritingVariableName ->
     unifier (Pattern RewritingVariableName)
-bottomTermEquals
-    sideCondition
-    first
-    second =
-        do
-            -- MonadUnify
-            secondCeil <- makeEvaluateTermCeil sideCondition second
-            case toList secondCeil of
-                [] -> return Pattern.top
-                [Conditional{predicate = PredicateTrue, substitution}]
-                    | substitution == mempty -> do
-                        explainBottom
-                            "Cannot unify bottom with non-bottom pattern."
-                            first
-                            second
-                        empty
-                _ ->
-                    return
-                        Conditional
-                            { term = mkTop_
-                            , predicate =
-                                makeNotPredicate $
-                                    OrCondition.toPredicate $
-                                        OrPattern.map Condition.toPredicate secondCeil
-                            , substitution = mempty
-                            }
+bottomTermEquals sideCondition first second = do
+    let sort1 = termLikeSort first
+    secondCeil <- makeEvaluateTermCeil sideCondition second
+    case toList secondCeil of
+        [] -> return (Pattern.topOf sort1)
+        [Conditional{predicate = PredicateTrue, substitution}]
+            | substitution == mempty -> do
+                explainBottom
+                    "Cannot unify bottom with non-bottom pattern."
+                    first
+                    second
+                empty
+        _ ->
+            return
+                Conditional
+                    { term = mkTop sort1
+                    , predicate =
+                        makeNotPredicate $
+                            OrCondition.toPredicate $
+                                OrPattern.map Condition.toPredicate secondCeil
+                    , substitution = mempty
+                    }
 
 data UnifyVariables = UnifyVariables
     {variable1, variable2 :: !(ElementVariable RewritingVariableName)}

--- a/kore/src/Kore/Step/Simplification/Floor.hs
+++ b/kore/src/Kore/Step/Simplification/Floor.hs
@@ -44,8 +44,8 @@ floor(a and b) = floor(a) and floor(b).
 simplify ::
     Floor Sort (OrPattern RewritingVariableName) ->
     OrPattern RewritingVariableName
-simplify Floor{floorChild = child} =
-    simplifyEvaluatedFloor child
+simplify Floor{floorResultSort = resultSort, floorChild = child} =
+    simplifyEvaluatedFloor resultSort child
 
 {- TODO (virgil): Preserve pattern sorts under simplification.
 
@@ -61,35 +61,38 @@ to carry around.
 
 -}
 simplifyEvaluatedFloor ::
+    Sort ->
     OrPattern RewritingVariableName ->
     OrPattern RewritingVariableName
-simplifyEvaluatedFloor child =
+simplifyEvaluatedFloor resultSort child =
     case toList child of
-        [childP] -> makeEvaluateFloor childP
-        _ -> makeEvaluateFloor (OrPattern.toPattern child)
+        [childP] -> makeEvaluateFloor resultSort childP
+        _ -> makeEvaluateFloor resultSort (OrPattern.toPattern resultSort child)
 
 {- | 'makeEvaluateFloor' simplifies a 'Floor' of 'Pattern'.
 
 See 'simplify' for details.
 -}
 makeEvaluateFloor ::
+    Sort ->
     Pattern RewritingVariableName ->
     OrPattern RewritingVariableName
-makeEvaluateFloor child
-    | Pattern.isTop child = OrPattern.top
+makeEvaluateFloor resultSort child
+    | Pattern.isTop child = OrPattern.top resultSort
     | Pattern.isBottom child = OrPattern.bottom
-    | otherwise = makeEvaluateNonBoolFloor child
+    | otherwise = makeEvaluateNonBoolFloor resultSort child
 
 makeEvaluateNonBoolFloor ::
+    Sort ->
     Pattern RewritingVariableName ->
     OrPattern RewritingVariableName
-makeEvaluateNonBoolFloor patt@Conditional{term = Top_ _} =
-    OrPattern.fromPattern patt{term = mkTop_} -- remove the term's sort
+makeEvaluateNonBoolFloor resultSort patt@Conditional{term = Top_ _} =
+    OrPattern.fromPattern patt{term = mkTop resultSort} -- remove the term's sort
     -- TODO(virgil): Also evaluate functional patterns to bottom for non-singleton
     -- sorts, and maybe other cases also
-makeEvaluateNonBoolFloor patt =
+makeEvaluateNonBoolFloor resultSort patt =
     floorCondition <> condition
-        & Pattern.fromCondition_
+        & (Pattern.fromCondition resultSort)
         & OrPattern.fromPattern
   where
     (term, condition) = Pattern.splitTerm patt

--- a/kore/src/Kore/Step/Simplification/Forall.hs
+++ b/kore/src/Kore/Step/Simplification/Forall.hs
@@ -29,13 +29,16 @@ import Kore.Internal.Pattern (
     Pattern,
  )
 import qualified Kore.Internal.Pattern as Pattern (
-    bottom,
+    --    bottom,
+    bottomOf,
     fromTermLike,
     isBottom,
     isTop,
+    patternSort,
+    --    top,
     splitTerm,
     toTermLike,
-    top,
+    topOf,
  )
 import Kore.Internal.Predicate (
     makeForallPredicate,
@@ -115,8 +118,8 @@ makeEvaluate ::
     Pattern RewritingVariableName ->
     Pattern RewritingVariableName
 makeEvaluate variable patt
-    | Pattern.isTop patt = Pattern.top
-    | Pattern.isBottom patt = Pattern.bottom
+    | Pattern.isTop patt = Pattern.topOf sort
+    | Pattern.isBottom patt = Pattern.bottomOf sort
     | not variableInTerm && not variableInCondition = patt
     | predicateIsBoolean =
         TermLike.markSimplified (mkForall variable term)
@@ -133,6 +136,7 @@ makeEvaluate variable patt
                 mkForall variable $
                     Pattern.toTermLike patt
   where
+    sort = Pattern.patternSort patt
     (term, predicate) = Pattern.splitTerm patt
     someVariable = mkSomeVariable variable
     someVariableName = variableName someVariable

--- a/kore/src/Kore/Step/Simplification/Implies.hs
+++ b/kore/src/Kore/Step/Simplification/Implies.hs
@@ -60,8 +60,8 @@ simplify ::
     simplifier (OrPattern RewritingVariableName)
 simplify
     sideCondition
-    Implies{impliesFirst = first, impliesSecond = second} =
-        simplifyEvaluated sideCondition first second
+    Implies{impliesFirst = first, impliesSecond = second, impliesSort = sort} =
+        simplifyEvaluated sort sideCondition first second
 
 {- | simplifies an Implies given its two 'OrPattern' children.
 
@@ -84,35 +84,38 @@ carry around.
 -}
 simplifyEvaluated ::
     MonadSimplify simplifier =>
+    Sort ->
     SideCondition RewritingVariableName ->
     OrPattern RewritingVariableName ->
     OrPattern RewritingVariableName ->
     simplifier (OrPattern RewritingVariableName)
-simplifyEvaluated sideCondition first second
+simplifyEvaluated sort sideCondition first second
     | OrPattern.isTrue first = return second
-    | OrPattern.isFalse first = return OrPattern.top
-    | OrPattern.isTrue second = return OrPattern.top
-    | OrPattern.isFalse second = Not.simplifyEvaluated sideCondition first
+    | OrPattern.isFalse first = return (OrPattern.top sort)
+    | OrPattern.isTrue second = return (OrPattern.top sort)
+    | OrPattern.isFalse second = Not.simplifyEvaluated sort sideCondition first
     | otherwise =
         OrPattern.observeAllT $
             Logic.scatter second
-                >>= simplifyEvaluateHalfImplies sideCondition first
+                >>= simplifyEvaluateHalfImplies sort sideCondition first
 
 simplifyEvaluateHalfImplies ::
     MonadSimplify simplifier =>
+    Sort ->
     SideCondition RewritingVariableName ->
     OrPattern RewritingVariableName ->
     Pattern RewritingVariableName ->
     LogicT simplifier (Pattern RewritingVariableName)
 simplifyEvaluateHalfImplies
+    sort
     sideCondition
     first
     second
         | OrPattern.isTrue first = return second
-        | OrPattern.isFalse first = return Pattern.top
-        | Pattern.isTop second = return Pattern.top
+        | OrPattern.isFalse first = return (Pattern.topOf sort)
+        | Pattern.isTop second = return (Pattern.topOf sort)
         | Pattern.isBottom second =
-            Not.simplifyEvaluated sideCondition first
+            Not.simplifyEvaluated sort sideCondition first
                 >>= Logic.scatter
         | otherwise =
             case toList first of
@@ -129,10 +132,12 @@ distributeEvaluateImplies ::
     simplifier (OrPattern RewritingVariableName)
 distributeEvaluateImplies sideCondition firsts second =
     And.simplify
-        Not.notSimplifier
+        sort
+        (Not.notSimplifier sort)
         sideCondition
         (MultiAnd.make implications)
   where
+    sort = Pattern.patternSort second
     implications = map (\first -> makeEvaluateImplies first second) firsts
 
 makeEvaluateImplies ::
@@ -145,13 +150,15 @@ makeEvaluateImplies
         | Pattern.isTop first =
             OrPattern.fromPatterns [second]
         | Pattern.isBottom first =
-            OrPattern.fromPatterns [Pattern.top]
+            OrPattern.fromPatterns [Pattern.topOf sort]
         | Pattern.isTop second =
-            OrPattern.fromPatterns [Pattern.top]
+            OrPattern.fromPatterns [Pattern.topOf sort]
         | Pattern.isBottom second =
             Not.makeEvaluate first
         | otherwise =
             makeEvaluateImpliesNonBool first second
+      where
+        sort = Pattern.patternSort first
 
 makeEvaluateImpliesNonBool ::
     Pattern RewritingVariableName ->

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -98,9 +98,7 @@ makeEvaluateIn sideCondition first second
     | Pattern.isTop second = Ceil.makeEvaluate sideCondition first
     | Pattern.isBottom first || Pattern.isBottom second = return OrPattern.bottom
     | otherwise =
-        (And.makeEvaluate pattSort)
-            (Not.notSimplifier pattSort)
-            sideCondition
+        (And.makeEvaluate pattSort Not.notSimplifier sideCondition)
             (MultiAnd.make [first, second])
             & OrPattern.observeAllT
             >>= Ceil.simplifyEvaluated sideCondition

--- a/kore/src/Kore/Step/Simplification/In.hs
+++ b/kore/src/Kore/Step/Simplification/In.hs
@@ -98,9 +98,11 @@ makeEvaluateIn sideCondition first second
     | Pattern.isTop second = Ceil.makeEvaluate sideCondition first
     | Pattern.isBottom first || Pattern.isBottom second = return OrPattern.bottom
     | otherwise =
-        And.makeEvaluate
-            Not.notSimplifier
+        (And.makeEvaluate pattSort)
+            (Not.notSimplifier pattSort)
             sideCondition
             (MultiAnd.make [first, second])
             & OrPattern.observeAllT
             >>= Ceil.simplifyEvaluated sideCondition
+  where
+    pattSort = patternSort first

--- a/kore/src/Kore/Step/Simplification/NotSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/NotSimplifier.hs
@@ -15,10 +15,14 @@ import Kore.Internal.SideCondition (
 import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
  )
+import Kore.Syntax (
+    Not,
+    Sort,
+ )
 
 newtype NotSimplifier simplifier = NotSimplifier
     { runNotSimplifier ::
         SideCondition RewritingVariableName ->
-        OrPattern RewritingVariableName ->
+        Not Sort (OrPattern RewritingVariableName) ->
         simplifier (OrPattern RewritingVariableName)
     }

--- a/kore/src/Kore/Step/Simplification/Rewrites.hs
+++ b/kore/src/Kore/Step/Simplification/Rewrites.hs
@@ -1,0 +1,78 @@
+{- |
+Module      : Kore.Step.Simplification.Rewrites
+Description : Tools for Rewrites pattern simplification.
+Copyright   : (c) Runtime Verification, 2018
+License     : NCSA
+Maintainer  : virgil.serbanuta@runtimeverification.com
+Stability   : experimental
+Portability : portable
+-}
+module Kore.Step.Simplification.Rewrites (
+    simplify,
+) where
+
+import Kore.Internal.OrPattern (
+    OrPattern,
+ )
+import qualified Kore.Internal.OrPattern as OrPattern
+import Kore.Internal.Pattern as Pattern
+import Kore.Internal.TermLike
+import qualified Kore.Internal.TermLike as TermLike (
+    markSimplified,
+ )
+import Kore.Rewriting.RewritingVariable (
+    RewritingVariableName,
+ )
+import Prelude.Kore
+
+{- | Simplify a 'Rewrites' pattern with a 'OrPattern' child.
+
+Right now this does not do any actual simplification.
+
+TODO(virgil): Should I even bother to simplify Rewrites? Maybe to implies+next?
+-}
+simplify ::
+    Sort ->
+    Rewrites Sort (OrPattern RewritingVariableName) ->
+    OrPattern RewritingVariableName
+simplify
+    sort
+    Rewrites
+        { rewritesFirst = first
+        , rewritesSecond = second
+        } =
+        simplifyEvaluatedRewrites sort first second
+
+{- TODO (virgil): Preserve pattern sorts under simplification.
+
+One way to preserve the required sort annotations is to make
+'simplifyEvaluatedRewrites' take an argument of type
+
+> CofreeF (Or Sort) (Attribute.Pattern variable) (OrPattern variable)
+
+instead of two 'OrPattern' arguments. The type of
+'makeEvaluateRewrites' may be changed analogously. The 'Attribute.Pattern'
+annotation will eventually cache information besides the pattern sort, which
+will make it even more useful to carry around.
+
+-}
+simplifyEvaluatedRewrites ::
+    Sort ->
+    OrPattern RewritingVariableName ->
+    OrPattern RewritingVariableName ->
+    OrPattern RewritingVariableName
+simplifyEvaluatedRewrites sort first second =
+    makeEvaluateRewrites
+        (OrPattern.toPattern sort first)
+        (OrPattern.toPattern sort second)
+
+makeEvaluateRewrites ::
+    Pattern RewritingVariableName ->
+    Pattern RewritingVariableName ->
+    OrPattern RewritingVariableName
+makeEvaluateRewrites first second =
+    OrPattern.fromTermLike $
+        TermLike.markSimplified $
+            mkRewrites
+                (Pattern.toTermLike first)
+                (Pattern.toTermLike second)

--- a/kore/src/Kore/Step/Simplification/Simplify.hs
+++ b/kore/src/Kore/Step/Simplification/Simplify.hs
@@ -94,6 +94,7 @@ import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
  )
 import Kore.Internal.Symbol
 import Kore.Internal.TermLike (
+    Sort,
     TermAttributes,
     TermLike,
     TermLikeF (..),
@@ -557,16 +558,17 @@ makeEvaluateTermCeil sideCondition child =
 
 makeEvaluateCeil ::
     MonadSimplify simplifier =>
+    Sort ->
     SideCondition RewritingVariableName ->
     Pattern RewritingVariableName ->
     simplifier (OrPattern RewritingVariableName)
-makeEvaluateCeil sideCondition child =
+makeEvaluateCeil sort sideCondition child =
     do
         let (childTerm, childCondition) = Pattern.splitTerm child
         ceilCondition <-
             Predicate.makeCeilPredicate childTerm
                 & Condition.fromPredicate
                 & simplifyCondition sideCondition
-        Pattern.andCondition Pattern.top (ceilCondition <> childCondition)
+        Pattern.andCondition (Pattern.topOf sort) (ceilCondition <> childCondition)
             & pure
         & OrPattern.observeAllT

--- a/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
+++ b/kore/src/Kore/Step/Simplification/SubstitutionSimplifier.hs
@@ -165,8 +165,10 @@ simplifyAnds ::
     NonEmpty (TermLike RewritingVariableName) ->
     monad (Pattern RewritingVariableName)
 simplifyAnds MakeAnd{makeAnd} sideCondition (NonEmpty.sort -> patterns) =
-    foldM simplifyAnds' Pattern.top patterns
+    foldM simplifyAnds' (Pattern.topOf resultSort) patterns
   where
+    resultSort :: TermLike.Sort
+    resultSort = TermLike.termLikeSort (NonEmpty.head patterns)
     simplifyAnds' ::
         Pattern RewritingVariableName ->
         TermLike RewritingVariableName ->

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -369,7 +369,7 @@ simplify sideCondition = \termLike ->
                 --
                 AndF andF -> do
                     let conjuncts = foldMap MultiAnd.fromTermLike andF
-                    (And.simplify termSort) (Not.notSimplifier termSort) sideCondition
+                    (And.simplify termSort Not.notSimplifier sideCondition)
                         =<< MultiAnd.traverse
                             (simplifyTermLike sideCondition)
                             conjuncts

--- a/kore/src/Kore/Step/Simplification/Top.hs
+++ b/kore/src/Kore/Step/Simplification/Top.hs
@@ -26,6 +26,7 @@ import Prelude.Kore ()
 
 -- TODO (virgil): Preserve pattern sorts under simplification.
 simplify ::
+    Sort ->
     Top Sort child ->
     OrPattern RewritingVariableName
-simplify _ = OrPattern.top
+simplify sort _ = OrPattern.top sort

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -145,10 +145,9 @@ unifyRule initial rule = do
     -- Unify the left-hand side of the rule with the term of the initial
     -- configuration.
     let ruleLeft = matchingPattern rule
-    let initialSort = Pattern.patternSort initial
     unification <-
         unificationProcedure sideCondition initialTerm ruleLeft
-            & evalEnvUnifierT (Not.notSimplifier initialSort)
+            & evalEnvUnifierT Not.notSimplifier
     -- Combine the unification solution with the rule's requirement clause,
     let ruleRequires = precondition rule
         requires' = Condition.fromPredicate ruleRequires

--- a/kore/src/Kore/Step/Step.hs
+++ b/kore/src/Kore/Step/Step.hs
@@ -145,9 +145,10 @@ unifyRule initial rule = do
     -- Unify the left-hand side of the rule with the term of the initial
     -- configuration.
     let ruleLeft = matchingPattern rule
+    let initialSort = Pattern.patternSort initial
     unification <-
         unificationProcedure sideCondition initialTerm ruleLeft
-            & evalEnvUnifierT Not.notSimplifier
+            & evalEnvUnifierT (Not.notSimplifier initialSort)
     -- Combine the unification solution with the rule's requirement clause,
     let ruleRequires = precondition rule
         requires' = Condition.fromPredicate ruleRequires

--- a/kore/src/Kore/Syntax/And.hs
+++ b/kore/src/Kore/Syntax/And.hs
@@ -58,6 +58,6 @@ instance Ord variable => Synthetic (FreeVariables variable) (And sort) where
 instance Synthetic Sort (And Sort) where
     synthetic And{andSort, andFirst, andSecond} =
         andSort
-            & seq (matchSort andSort andFirst)
-                . seq (matchSort andSort andSecond)
+            & seq (sameSort andSort andFirst)
+                . seq (sameSort andSort andSecond)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Ceil.hs
+++ b/kore/src/Kore/Syntax/Ceil.hs
@@ -62,5 +62,5 @@ instance Synthetic (FreeVariables variable) (Ceil sort) where
 instance Synthetic Sort (Ceil Sort) where
     synthetic Ceil{ceilOperandSort, ceilResultSort, ceilChild} =
         ceilResultSort
-            & seq (matchSort ceilOperandSort ceilChild)
+            & seq (sameSort ceilOperandSort ceilChild)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/DomainValue.hs
+++ b/kore/src/Kore/Syntax/DomainValue.hs
@@ -56,7 +56,7 @@ instance Synthetic (FreeVariables variable) (DomainValue sort) where
 instance Synthetic Sort (DomainValue Sort) where
     synthetic DomainValue{domainValueSort, domainValueChild} =
         domainValueSort
-            & seq (matchSort stringMetaSort domainValueChild)
+            & seq (sameSort stringMetaSort domainValueChild)
     {-# INLINE synthetic #-}
 
 instance TopBottom a => TopBottom (DomainValue Sort a) where

--- a/kore/src/Kore/Syntax/Equals.hs
+++ b/kore/src/Kore/Syntax/Equals.hs
@@ -115,8 +115,8 @@ instance Ord variable => Synthetic (FreeVariables variable) (Equals sort) where
 instance Synthetic Sort (Equals Sort) where
     synthetic equals =
         equalsResultSort
-            & seq (matchSort equalsOperandSort equalsFirst)
-                . seq (matchSort equalsOperandSort equalsSecond)
+            & seq (sameSort equalsOperandSort equalsFirst)
+                . seq (sameSort equalsOperandSort equalsSecond)
       where
         Equals{equalsOperandSort, equalsResultSort} = equals
         Equals{equalsFirst, equalsSecond} = equals

--- a/kore/src/Kore/Syntax/Exists.hs
+++ b/kore/src/Kore/Syntax/Exists.hs
@@ -74,5 +74,5 @@ instance
 
 instance Synthetic Sort (Exists Sort variable) where
     synthetic Exists{existsSort, existsChild} =
-        existsSort `matchSort` existsChild
+        existsSort `sameSort` existsChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Floor.hs
+++ b/kore/src/Kore/Syntax/Floor.hs
@@ -60,5 +60,5 @@ instance Synthetic (FreeVariables variable) (Floor sort) where
 instance Synthetic Sort (Floor Sort) where
     synthetic Floor{floorOperandSort, floorResultSort, floorChild} =
         floorResultSort
-            & seq (matchSort floorOperandSort floorChild)
+            & seq (sameSort floorOperandSort floorChild)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Forall.hs
+++ b/kore/src/Kore/Syntax/Forall.hs
@@ -74,5 +74,5 @@ instance
 
 instance Synthetic Sort (Forall Sort variable) where
     synthetic Forall{forallSort, forallChild} =
-        forallSort `matchSort` forallChild
+        forallSort `sameSort` forallChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Iff.hs
+++ b/kore/src/Kore/Syntax/Iff.hs
@@ -70,6 +70,6 @@ instance Ord variable => Synthetic (FreeVariables variable) (Iff sort) where
 instance Synthetic Sort (Iff Sort) where
     synthetic Iff{iffSort, iffFirst, iffSecond} =
         iffSort
-            & seq (matchSort iffSort iffFirst)
-                . seq (matchSort iffSort iffSecond)
+            & seq (sameSort iffSort iffFirst)
+                . seq (sameSort iffSort iffSecond)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Implies.hs
+++ b/kore/src/Kore/Syntax/Implies.hs
@@ -70,6 +70,6 @@ instance Ord variable => Synthetic (FreeVariables variable) (Implies sort) where
 instance Synthetic Sort (Implies Sort) where
     synthetic Implies{impliesSort, impliesFirst, impliesSecond} =
         impliesSort
-            & seq (matchSort impliesSort impliesFirst)
-                . seq (matchSort impliesSort impliesSecond)
+            & seq (sameSort impliesSort impliesFirst)
+                . seq (sameSort impliesSort impliesSecond)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/In.hs
+++ b/kore/src/Kore/Syntax/In.hs
@@ -91,8 +91,8 @@ instance Ord variable => Synthetic (FreeVariables variable) (In sort) where
 instance Synthetic Sort (In Sort) where
     synthetic in' =
         inResultSort
-            & seq (matchSort inOperandSort inContainedChild)
-                . seq (matchSort inOperandSort inContainingChild)
+            & seq (sameSort inOperandSort inContainedChild)
+                . seq (sameSort inOperandSort inContainingChild)
       where
         In{inResultSort, inOperandSort} = in'
         In{inContainedChild, inContainingChild} = in'

--- a/kore/src/Kore/Syntax/Mu.hs
+++ b/kore/src/Kore/Syntax/Mu.hs
@@ -59,7 +59,7 @@ instance
 instance Synthetic Sort (Mu variable) where
     synthetic Mu{muVariable, muChild} =
         muSort
-            & seq (matchSort muSort muChild)
+            & seq (sameSort muSort muChild)
       where
         Variable{variableSort = muSort} = muVariable
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Next.hs
+++ b/kore/src/Kore/Syntax/Next.hs
@@ -47,5 +47,5 @@ instance Synthetic (FreeVariables variable) (Next sort) where
 
 instance Synthetic Sort (Next Sort) where
     synthetic Next{nextSort, nextChild} =
-        nextSort `matchSort` nextChild
+        nextSort `sameSort` nextChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Not.hs
+++ b/kore/src/Kore/Syntax/Not.hs
@@ -61,5 +61,5 @@ instance Synthetic (FreeVariables variable) (Not child) where
 
 instance Synthetic Sort (Not Sort) where
     synthetic Not{notSort, notChild} =
-        notSort `matchSort` notChild
+        notSort `sameSort` notChild
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Nu.hs
+++ b/kore/src/Kore/Syntax/Nu.hs
@@ -59,7 +59,7 @@ instance
 instance Synthetic Sort (Nu variable) where
     synthetic Nu{nuVariable, nuChild} =
         nuSort
-            & seq (matchSort nuSort nuChild)
+            & seq (sameSort nuSort nuChild)
       where
         Variable{variableSort = nuSort} = nuVariable
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Or.hs
+++ b/kore/src/Kore/Syntax/Or.hs
@@ -83,6 +83,6 @@ instance Ord variable => Synthetic (FreeVariables variable) (Or sort) where
 instance Synthetic Sort (Or Sort) where
     synthetic Or{orSort, orFirst, orSecond} =
         orSort
-            & seq (matchSort orSort orFirst)
-                . seq (matchSort orSort orSecond)
+            & seq (sameSort orSort orFirst)
+                . seq (sameSort orSort orSecond)
     {-# INLINE synthetic #-}

--- a/kore/src/Kore/Syntax/Rewrites.hs
+++ b/kore/src/Kore/Syntax/Rewrites.hs
@@ -55,5 +55,5 @@ instance Ord variable => Synthetic (FreeVariables variable) (Rewrites sort) wher
 instance Synthetic Sort (Rewrites Sort) where
     synthetic Rewrites{rewritesSort, rewritesFirst, rewritesSecond} =
         rewritesSort
-            & seq (matchSort rewritesSort rewritesFirst)
-                . seq (matchSort rewritesSort rewritesSecond)
+            & seq (sameSort rewritesSort rewritesFirst)
+                . seq (sameSort rewritesSort rewritesSecond)

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -57,7 +57,7 @@ unificationProcedure sideCondition p1 p2
     | p1Sort /= p2Sort =
         Monad.Unify.explainAndReturnBottom "Cannot unify different sorts." p1 p2
     | otherwise = infoAttemptUnification p1 p2 $ do
-        pat <- termUnification Not.notSimplifier p1 p2
+        pat <- termUnification (Not.notSimplifier p1Sort) p1 p2
         TopBottom.guardAgainstBottom pat
         let (term, conditions) = Conditional.splitTerm pat
         orCeil <- makeEvaluateTermCeil sideCondition term

--- a/kore/src/Kore/Unification/Procedure.hs
+++ b/kore/src/Kore/Unification/Procedure.hs
@@ -57,7 +57,7 @@ unificationProcedure sideCondition p1 p2
     | p1Sort /= p2Sort =
         Monad.Unify.explainAndReturnBottom "Cannot unify different sorts." p1 p2
     | otherwise = infoAttemptUnification p1 p2 $ do
-        pat <- termUnification (Not.notSimplifier p1Sort) p1 p2
+        pat <- termUnification Not.notSimplifier p1 p2
         TopBottom.guardAgainstBottom pat
         let (term, conditions) = Conditional.splitTerm pat
         orCeil <- makeEvaluateTermCeil sideCondition term

--- a/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/Imports.hs
+++ b/kore/test/Test/Kore/ASTVerifier/DefinitionVerifier/Imports.hs
@@ -405,7 +405,7 @@ sortVisibilityTests =
             SentenceAxiom
                 { sentenceAxiomParameters = []
                 , sentenceAxiomPattern =
-                    externalize $ mkAnd (mkTop sort) mkTop_
+                    externalize $ mkAnd (mkTop sort) (mkTop sort)
                 , sentenceAxiomAttributes = Attributes []
                 }
     sortReferenceInNextPatternSentence =
@@ -678,7 +678,8 @@ symbolVisibilityTests =
             SentenceAxiom
                 { sentenceAxiomParameters = []
                 , sentenceAxiomPattern =
-                    externalize $ mkAnd symbolPattern mkTop_
+                    mkAnd symbolPattern (mkTop $ termLikeSort symbolPattern)
+                        & externalize
                 , sentenceAxiomAttributes = Attributes []
                 }
     symbolReferenceInExistsPatternSentence =
@@ -901,7 +902,8 @@ aliasVisibilityTests =
             SentenceAxiom
                 { sentenceAxiomParameters = []
                 , sentenceAxiomPattern =
-                    externalize $ mkAnd aliasPattern mkTop_
+                    mkAnd aliasPattern (mkTop $ termLikeSort aliasPattern)
+                        & externalize
                 , sentenceAxiomAttributes = Attributes []
                 }
     aliasReferenceInExistsPatternSentence =

--- a/kore/test/Test/Kore/Builtin/Builtin.hs
+++ b/kore/test/Test/Kore/Builtin/Builtin.hs
@@ -11,6 +11,7 @@ module Test.Kore.Builtin.Builtin (
     simplify,
     evaluate,
     evaluateT,
+    evaluateExpectTopK,
     evaluateToList,
     indexedModule,
     verifiedModule,
@@ -60,6 +61,7 @@ import Kore.Internal.InternalSet
 import Kore.Internal.OrPattern (
     OrPattern,
  )
+import qualified Kore.Internal.OrPattern as OrPattern
 import Kore.Internal.Pattern (
     Pattern,
  )
@@ -254,6 +256,14 @@ evaluateT ::
     TermLike RewritingVariableName ->
     t smt (OrPattern RewritingVariableName)
 evaluateT = lift . evaluate
+
+evaluateExpectTopK ::
+    (MonadSMT smt, MonadLog smt, MonadProf smt, MonadMask smt) =>
+    TermLike RewritingVariableName ->
+    Hedgehog.PropertyT smt ()
+evaluateExpectTopK termLike = do
+    actual <- evaluateT termLike
+    OrPattern.top kSort Hedgehog.=== actual
 
 evaluateToList ::
     TermLike RewritingVariableName ->

--- a/kore/test/Test/Kore/Builtin/Int.hs
+++ b/kore/test/Test/Kore/Builtin/Int.hs
@@ -400,12 +400,13 @@ test_euclidian_division_theorem =
             (asInternal <$> [a, b])
             & evaluateT
             & fmap extractValue
+
     extractValue :: OrPattern RewritingVariableName -> Integer
-    extractValue (OrPattern.toTermLike -> term) =
+    extractValue (OrPattern.toTermLike intSort -> term) =
         case term of
             InternalInt_ InternalInt{internalIntValue} ->
                 internalIntValue
-            _ -> error "Expecting builtin int."
+            _ -> error "Expecting builtin Int"
 
 -- Bitwise operations
 test_and :: TestTree
@@ -485,7 +486,7 @@ test_unifyEqual_NotEqual =
     testCaseWithoutSMT "unifyEqual BuiltinInteger: Not Equal" $ do
         let dv1 = asInternal 1
             dv2 = asInternal 2
-        actual <- evaluate $ mkEquals_ dv1 dv2
+        actual <- evaluate $ mkEquals kSort dv1 dv2
         assertEqual' "" OrPattern.bottom actual
 
 -- | "\equal"ed internal Integers that are equal
@@ -493,8 +494,8 @@ test_unifyEqual_Equal :: TestTree
 test_unifyEqual_Equal =
     testCaseWithoutSMT "unifyEqual BuiltinInteger: Equal" $ do
         let dv1 = asInternal 2
-        actual <- evaluate $ mkEquals_ dv1 dv1
-        assertEqual' "" OrPattern.top actual
+        actual <- evaluate $ mkEquals kSort dv1 dv1
+        assertEqual' "" (OrPattern.top kSort) actual
 
 -- | "\and"ed internal Integers that are not equal
 test_unifyAnd_NotEqual :: TestTree
@@ -518,8 +519,8 @@ test_unifyAndEqual_Equal :: TestTree
 test_unifyAndEqual_Equal =
     testCaseWithoutSMT "unifyAnd BuiltinInteger: Equal" $ do
         let dv = asInternal 0
-        actual <- evaluate $ mkEquals_ dv $ mkAnd dv dv
-        assertEqual' "" OrPattern.top actual
+        actual <- evaluate $ mkEquals kSort dv $ mkAnd dv dv
+        assertEqual' "" (OrPattern.top kSort) actual
 
 -- | Internal Integer "\and"ed with builtin function applied to variable
 test_unifyAnd_Fn :: TestTree
@@ -574,7 +575,7 @@ test_unifyIntEq =
                 makeEqualsPredicate (mkElemVar x) (mkElemVar y)
                     & makeNotPredicate
                     & Condition.fromPredicate
-                    & Pattern.fromCondition_
+                    & Pattern.fromCondition boolSort
         -- unit test
         do
             actual <- unifyIntEq term1 term2
@@ -591,7 +592,7 @@ test_unifyIntEq =
             term2 = eqInt (mkElemVar x) (mkElemVar y)
             expect =
                 Condition.assign (inject x) (mkElemVar y)
-                    & Pattern.fromCondition_
+                    & Pattern.fromCondition boolSort
         -- unit test
         do
             actual <- unifyIntEq term1 term2
@@ -618,7 +619,7 @@ test_unifyIntEq =
                     (addInt (mkElemVar y) (asInternal 1))
                     & makeNotPredicate
                     & Condition.fromPredicate
-                    & Pattern.fromCondition_
+                    & Pattern.fromCondition boolSort
         -- unit test
         do
             actual <- unifyIntEq term1 term2

--- a/kore/test/Test/Kore/Builtin/KEqual.hs
+++ b/kore/test/Test/Kore/Builtin/KEqual.hs
@@ -83,11 +83,12 @@ test_KEqual =
         actual <- evaluate original
         assertEqual' "" expect actual
     , testCaseWithoutSMT "kseq(x, dotk) equals kseq(x, dotk)" $ do
-        let expect = OrPattern.top
+        let expect = OrPattern.top kSort
             xConfigElemVarKItemSort =
                 configElementVariableFromId "x" kItemSort
             original =
-                mkEquals_
+                mkEquals
+                    kSort
                     (Test.Bool.asInternal True)
                     ( keqBool
                         (kseq (mkElemVar xConfigElemVarKItemSort) dotk)
@@ -96,11 +97,12 @@ test_KEqual =
         actual <- evaluate original
         assertEqual' "" expect actual
     , testCaseWithoutSMT "kseq(inj(x), dotk) equals kseq(inj(x), dotk)" $ do
-        let expect = OrPattern.top
+        let expect = OrPattern.top kSort
             xConfigElemVarIdSort =
                 configElementVariableFromId "x" idSort
             original =
-                mkEquals_
+                mkEquals
+                    kSort
                     (Test.Bool.asInternal True)
                     ( keqBool
                         (kseq (inj kItemSort (mkElemVar xConfigElemVarIdSort)) dotk)
@@ -109,9 +111,10 @@ test_KEqual =
         actual <- evaluate original
         assertEqual' "" expect actual
     , testCaseWithoutSMT "distinct constructor-like terms" $ do
-        let expect = OrPattern.top
+        let expect = OrPattern.top kSort
             original =
-                mkEquals_
+                mkEquals
+                    kSort
                     (Test.Bool.asInternal False)
                     ( keqBool
                         (kseq (inj kItemSort dvX) dotk)
@@ -192,7 +195,7 @@ test_KEqualSimplification =
                 keqBool
                     (kseq (inj kItemSort dvX) dotk)
                     (kseq (inj kItemSort dvT) dotk)
-            expect = [Just Pattern.top]
+            expect = [Just (Pattern.topOf kSort)]
         actual <- runKEqualSimplification term1 term2
         assertEqual' "" expect actual
     ]

--- a/kore/test/Test/Kore/Builtin/String.hs
+++ b/kore/test/Test/Kore/Builtin/String.hs
@@ -474,7 +474,7 @@ test_unifyStringEq =
                 makeEqualsPredicate (mkElemVar x) (mkElemVar y)
                     & makeNotPredicate
                     & Condition.fromPredicate
-                    & Pattern.fromCondition_
+                    & Pattern.fromCondition boolSort
         -- unit test
         do
             actual <- unifyStringEq term1 term2
@@ -491,7 +491,7 @@ test_unifyStringEq =
             term2 = eqString (mkElemVar x) (mkElemVar y)
             expect =
                 Condition.assign (inject x) (mkElemVar y)
-                    & Pattern.fromCondition_
+                    & Pattern.fromCondition boolSort
         -- unit test
         do
             actual <- unifyStringEq term1 term2

--- a/kore/test/Test/Kore/Equation/Application.hs
+++ b/kore/test/Test/Kore/Equation/Application.hs
@@ -249,7 +249,7 @@ test_attemptEquation =
         "F(x) => G(x) doesn't apply to F(top)"
         (axiom_ (f x) (g x))
         SideCondition.top
-        (f mkTop_)
+        (f (mkTop Mock.testSort))
     , applies
         "F(x) => G(x) [concrete] applies to F(a)"
         (axiom_ (f x) (g x) & concrete [x])
@@ -436,7 +436,7 @@ test_attemptEquationUnification =
         "F(x) => G(x) doesn't apply to F(top)"
         (functionAxiomUnification_ fSymbol [x] (g x))
         SideCondition.top
-        (f mkTop_)
+        (f (mkTop Mock.testSort))
     , applies
         "F(x) => G(x) [concrete] applies to F(a)"
         (functionAxiomUnification_ fSymbol [x] (g x) & concrete [x])

--- a/kore/test/Test/Kore/Exec.hs
+++ b/kore/test/Test/Kore/Exec.hs
@@ -558,7 +558,7 @@ applyAliasToNoArgs sort name =
             , aliasParams = []
             , aliasSorts = applicationSorts [] sort
             , aliasLeft = []
-            , aliasRight = mkTop_
+            , aliasRight = mkTop sort
             }
         []
 

--- a/kore/test/Test/Kore/Internal/OrPattern.hs
+++ b/kore/test/Test/Kore/Internal/OrPattern.hs
@@ -122,7 +122,7 @@ test_distributeAnd =
     , testCase "\\top and (a or b) => a or b " $ do
         let conjunction =
                 MultiAnd.make
-                    [ MultiOr.singleton TermLike.mkTop_
+                    [ MultiOr.singleton (TermLike.mkTop Mock.testSort)
                     , MultiOr.make [a, b]
                     ]
             expect =
@@ -135,7 +135,7 @@ test_distributeAnd =
         let conjunction =
                 MultiAnd.make
                     [ MultiOr.singleton a
-                    , MultiOr.make [b, TermLike.mkBottom_]
+                    , MultiOr.make [b, TermLike.mkBottom Mock.testSort]
                     ]
             expect =
                 MultiOr.make
@@ -197,7 +197,7 @@ test_distributeApplication =
         let app =
                 sigma2
                     [ MultiOr.singleton a
-                    , MultiOr.make [b, TermLike.mkBottom_]
+                    , MultiOr.make [b, TermLike.mkBottom Mock.testSort]
                     ]
             expect =
                 MultiOr.make

--- a/kore/test/Test/Kore/Internal/Pattern.hs
+++ b/kore/test/Test/Kore/Internal/Pattern.hs
@@ -226,7 +226,7 @@ test_hasSimplifiedChildren =
                             (setSimplifiedPred simplified mockPredicate2)
                         )
                 patt =
-                    Pattern.fromCondition_
+                    Pattern.fromCondition Mock.testSort
                         . Condition.fromPredicate
                         $ predicate
             assertEqual
@@ -247,7 +247,7 @@ test_hasSimplifiedChildren =
                         (setSimplifiedPred simplified mockPredicate2)
                     )
             patt =
-                Pattern.fromCondition_
+                Pattern.fromCondition Mock.testSort
                     . Condition.fromPredicate
                     $ predicate
         assertEqual
@@ -285,7 +285,7 @@ test_hasSimplifiedChildren =
                     (setSimplifiedPred simplified mockPredicate1)
                     (setSimplifiedPred simplified mockPredicate2)
             patt =
-                Pattern.fromCondition_
+                Pattern.fromCondition Mock.testSort
                     . Condition.fromPredicate
                     $ predicate
         assertEqual
@@ -309,17 +309,17 @@ test_hasSimplifiedChildren =
                     ( Predicate.makeFloorPredicate
                         ( Mock.functional20
                             (mkNu Mock.setX Mock.c)
-                            (Mock.functionalConstr10 mkTop_)
+                            (Mock.functionalConstr10 (mkTop Mock.testSort))
                         )
                         & Predicate.setSimplified fullySimplified
                     )
                     ( Predicate.makeCeilPredicate
-                        (Mock.tdivInt mkTop_ mkTop_)
+                        (Mock.tdivInt (mkTop Mock.intSort) (mkTop Mock.intSort))
                         & Predicate.setSimplified fullySimplified
                     )
                     & Predicate.setSimplified partiallySimplified
             patt =
-                Pattern.fromCondition_
+                Pattern.fromCondition Mock.testSort
                     . Condition.fromPredicate
                     $ predicate
         assertEqual

--- a/kore/test/Test/Kore/Internal/Predicate.hs
+++ b/kore/test/Test/Kore/Internal/Predicate.hs
@@ -165,8 +165,8 @@ test_predicate =
             "makePredicate yields wrapPredicate"
             ( traverse_
                 (uncurry makePredicateYieldsWrapPredicate)
-                [ ("Top", mkTop_)
-                , ("Bottom", mkBottom_)
+                [ ("Top", mkTop Mock.testSort)
+                , ("Bottom", mkBottom Mock.testSort)
                 , ("And", mkAnd pa1 pa2)
                 , ("Or", mkOr pa1 pa2)
                 , ("Iff", mkIff pa1 pa2)
@@ -183,24 +183,27 @@ test_predicate =
         , testGroup
             "keeps simplified bit"
             [ testCase "unsimplified stays unsimplified" $
-                (mkEquals_ Mock.cf Mock.cg, NotSimplified)
+                (mkEquals Mock.topSort Mock.cf Mock.cg, NotSimplified)
                     `makesPredicate` (makeEqualsPredicate Mock.cf Mock.cg, NotSimplified)
             , testCase "simplified stays simplified" $
-                ( simplifiedTerm $ mkEquals_ Mock.cf Mock.cg
+                ( simplifiedTerm $ mkEquals Mock.topSort Mock.cf Mock.cg
                 , IsSimplified
                 )
                     `makesPredicate` (makeEqualsPredicate Mock.cf Mock.cg, IsSimplified)
             , testCase "Partial predicate stays simplified" $
                 ( simplifiedTerm $
-                    mkAnd mkTop_ (mkEquals_ Mock.cf Mock.cg)
+                    mkAnd (mkTop Mock.topSort) (mkEquals Mock.topSort Mock.cf Mock.cg)
                 , IsSimplified
                 )
                     `makesPredicate` (makeEqualsPredicate Mock.cf Mock.cg, IsSimplified)
             , testCase "changed simplified becomes unsimplified" $
                 ( simplifiedTerm $
                     mkAnd
-                        (mkAnd mkTop_ (mkEquals_ Mock.cf Mock.cg))
-                        (mkEquals_ Mock.cg Mock.ch)
+                        ( mkAnd
+                            (mkTop Mock.topSort)
+                            (mkEquals Mock.topSort Mock.cf Mock.cg)
+                        )
+                        (mkEquals Mock.topSort Mock.cg Mock.ch)
                 , IsSimplified
                 )
                     `makesPredicate` ( makeAndPredicate
@@ -267,29 +270,33 @@ pr2 =
 
 pa1 :: TermLike VariableName
 pa1 =
-    mkEquals_
+    mkEquals
+        Mock.topSort
         (mkElemVar $ a Mock.testSort)
         (mkElemVar $ b Mock.testSort)
 
 pa2 :: TermLike VariableName
 pa2 =
-    mkEquals_
+    mkEquals
+        Mock.topSort
         (mkElemVar $ c Mock.testSort)
         (mkElemVar $ d Mock.testSort)
 
 ceilA :: TermLike VariableName
 ceilA =
-    mkCeil_
+    mkCeil
+        Mock.topSort
         (mkElemVar $ a Mock.testSort)
 
 inA :: TermLike VariableName
 inA =
-    mkIn_
+    mkIn
+        Mock.topSort
         (mkElemVar $ a Mock.testSort)
         (mkElemVar $ b Mock.testSort)
 
 floorA :: TermLike VariableName
-floorA = mkFloor_ (mkElemVar $ a Mock.testSort)
+floorA = mkFloor Mock.topSort (mkElemVar $ a Mock.testSort)
 
 a, b, c, d :: Sort -> ElementVariable VariableName
 a = mkElementVariable (testId "a")

--- a/kore/test/Test/Kore/Internal/SideCondition.hs
+++ b/kore/test/Test/Kore/Internal/SideCondition.hs
@@ -38,12 +38,12 @@ test_assumeDefined :: [TestTree]
 test_assumeDefined =
     [ testCase "Fails on \\bottom" $ do
         let term :: TermLike VariableName
-            term = mkBottom_
+            term = mkBottom Mock.topSort
             actual = assumeDefined term
         assertEqual "" Nothing actual
     , testCase "Fails on nested \\bottom" $ do
         let term :: TermLike VariableName
-            term = Mock.f mkBottom_
+            term = Mock.f (mkBottom Mock.testSort)
             actual = assumeDefined term
         assertEqual "" Nothing actual
     , testCase "And: implies subterms are defined" $ do
@@ -72,7 +72,7 @@ test_assumeDefined =
         assertEqual "" expected actual
     , testCase "Ceil: implies subterms are defined" $ do
         let term :: TermLike VariableName
-            term = mkCeil_ Mock.plain00
+            term = mkCeil Mock.topSort Mock.plain00
             expected =
                 [term, Mock.plain00]
                     & HashSet.fromList
@@ -140,7 +140,8 @@ test_assumeDefined =
     , testCase "In: implies subterms are defined" $ do
         let term :: TermLike VariableName
             term =
-                mkIn_
+                mkIn
+                    Mock.topSort
                     (Mock.f (mkElemVar Mock.x))
                     (Mock.functional10 (Mock.g Mock.a))
             expected =

--- a/kore/test/Test/Kore/Reachability/Claim.hs
+++ b/kore/test/Test/Kore/Reachability/Claim.hs
@@ -229,7 +229,7 @@ test_checkImplication =
         actual <- checkImplication goal
         assertEqual "" [NotImpliedStuck goal] actual
     , testCase "Implied if both sides are \\bottom" $ do
-        let config = Pattern.bottom
+        let config = Pattern.bottomOf Mock.topSort
             dest = OrPattern.bottom
             goal = mkGoal config dest []
         actual <- checkImplication goal
@@ -243,19 +243,19 @@ test_simplifyRightHandSide =
                 Pattern.fromTermAndPredicate
                     Mock.b
                     ( makeEqualsPredicate
-                        TermLike.mkTop_
+                        (TermLike.mkTop Mock.testSort)
                         (Mock.builtinInt 3 `Mock.lessInt` Mock.builtinInt 2)
                     )
             claim =
                 mkGoal
-                    Pattern.top
+                    (Pattern.topOf Mock.testSort)
                     ( [Pattern.fromTermLike Mock.a, unsatisfiableBranch]
                         & OrPattern.fromPatterns
                     )
                     []
             expected =
                 mkGoal
-                    Pattern.top
+                    (Pattern.topOf Mock.testSort)
                     (Mock.a & OrPattern.fromTermLike)
                     []
         actual <-

--- a/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
+++ b/kore/test/Test/Kore/Reachability/OnePathStrategy.hs
@@ -821,7 +821,7 @@ test_onePathStrategy =
                                 Mock.a
                             )
                     )
-            right' = Pattern.bottom
+            right' = Pattern.bottomOf Mock.testSort
             original = makeOnePathGoalFromPatterns left right
             expect = makeOnePathGoalFromPatterns left' right'
         [_actual] <-

--- a/kore/test/Test/Kore/Reachability/Prove.hs
+++ b/kore/test/Test/Kore/Reachability/Prove.hs
@@ -658,7 +658,7 @@ test_proveClaims =
     , testGroup "LHS is undefined" $
         let mkTest name mkSimpleClaim =
                 testCase name $ do
-                    let claims = [mkSimpleClaim mkBottom_ Mock.a]
+                    let claims = [mkSimpleClaim (mkBottom Mock.testSort) Mock.a]
                     actual <-
                         proveClaims_
                             Unlimited

--- a/kore/test/Test/Kore/Repl/Interpreter.hs
+++ b/kore/test/Test/Kore/Repl/Interpreter.hs
@@ -39,7 +39,7 @@ import qualified Kore.Internal.OrPattern as OrPattern
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.TermLike (
     TermLike,
-    mkBottom_,
+    mkBottom,
     mkElemVar,
  )
 import qualified Kore.Log as Log
@@ -642,7 +642,10 @@ zeroToTen =
 emptyClaim :: SomeClaim
 emptyClaim =
     OnePath . OnePathClaim $
-        claimWithName mkBottom_ mkBottom_ "emptyClaim"
+        claimWithName
+            (mkBottom kSort)
+            (mkBottom kSort)
+            "emptyClaim"
 
 zeroToZero :: SomeClaim
 zeroToZero =

--- a/kore/test/Test/Kore/Step/AntiLeft.hs
+++ b/kore/test/Test/Kore/Step/AntiLeft.hs
@@ -22,12 +22,12 @@ import Kore.Internal.Predicate (
 import Kore.Internal.TermLike (
     mkAnd,
     mkApplyAlias,
-    mkBottom_,
-    mkCeil_,
+    mkBottom,
+    mkCeil,
     mkElemVar,
     mkExists,
     mkOr,
-    mkTop_,
+    mkTop,
  )
 import Kore.Internal.TermLike.TermLike (
     TermLike,
@@ -60,8 +60,11 @@ test_antiLeft =
                     ( applyAliasToNoArgs
                         "A"
                         ( mkOr
-                            (applyAliasToNoArgs "B" (mkAnd mkTop_ Mock.a))
-                            mkBottom_
+                            ( applyAliasToNoArgs
+                                "B"
+                                (mkAnd (mkTop Mock.testSort) Mock.a)
+                            )
+                            (mkBottom Mock.testSort)
                         )
                     )
                 )
@@ -80,9 +83,9 @@ test_antiLeft =
                         ( mkOr
                             ( applyAliasToNoArgs
                                 "B"
-                                (mkAnd (mkCeil_ Mock.cg) Mock.a)
+                                (mkAnd (mkCeil Mock.testSort Mock.cg) Mock.a)
                             )
-                            mkBottom_
+                            (mkBottom Mock.testSort)
                         )
                     )
                 )
@@ -99,10 +102,16 @@ test_antiLeft =
                     ( applyAliasToNoArgs
                         "A"
                         ( mkOr
-                            (applyAliasToNoArgs "B" (mkAnd mkTop_ Mock.a))
+                            ( applyAliasToNoArgs
+                                "B"
+                                (mkAnd (mkTop Mock.testSort) Mock.a)
+                            )
                             ( mkOr
-                                (applyAliasToNoArgs "C" (mkAnd mkTop_ Mock.b))
-                                mkBottom_
+                                ( applyAliasToNoArgs
+                                    "C"
+                                    (mkAnd (mkTop Mock.testSort) Mock.b)
+                                )
+                                (mkBottom Mock.testSort)
                             )
                         )
                     )
@@ -123,13 +132,19 @@ test_antiLeft =
                             ( applyAliasToNoArgs
                                 "B"
                                 ( mkOr
-                                    (applyAliasToNoArgs "C" (mkAnd mkTop_ Mock.a))
-                                    mkBottom_
+                                    ( applyAliasToNoArgs
+                                        "C"
+                                        (mkAnd (mkTop Mock.testSort) Mock.a)
+                                    )
+                                    (mkBottom Mock.testSort)
                                 )
                             )
                             ( mkOr
-                                (applyAliasToNoArgs "D" (mkAnd mkTop_ Mock.b))
-                                mkBottom_
+                                ( applyAliasToNoArgs
+                                    "D"
+                                    (mkAnd (mkTop Mock.testSort) Mock.b)
+                                )
+                                (mkBottom Mock.testSort)
                             )
                         )
                     )
@@ -156,10 +171,13 @@ test_antiLeft =
                                 Mock.x
                                 ( applyAliasToNoArgs
                                     "B"
-                                    (mkAnd mkTop_ (Mock.f (mkElemVar Mock.x)))
+                                    ( mkAnd
+                                        (mkTop Mock.testSort)
+                                        (Mock.f (mkElemVar Mock.x))
+                                    )
                                 )
                             )
-                            mkBottom_
+                            (mkBottom Mock.testSort)
                         )
                     )
                 )
@@ -168,7 +186,9 @@ test_antiLeft =
     ]
 
 parseAndApply ::
-    AntiLeftTerm -> TermLike VariableName -> IO (Predicate VariableName)
+    AntiLeftTerm ->
+    TermLike VariableName ->
+    IO (Predicate VariableName)
 parseAndApply (AntiLeftTerm antiLeftTerm) configurationTerm = do
     antiLeft <- case parse antiLeftTerm of
         Nothing ->

--- a/kore/test/Test/Kore/Step/Axiom/Identifier.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Identifier.hs
@@ -23,11 +23,14 @@ test_matchAxiomIdentifier =
         (Application Mock.sortInjectionId)
     , matches
         "\\ceil(f(a))"
-        (TermLike.mkCeil_ (Mock.f Mock.a))
+        (TermLike.mkCeil Mock.topSort (Mock.f Mock.a))
         (Ceil (Application Mock.fId))
     , matches
         "\\ceil(\\ceil(f(a)))"
-        (TermLike.mkCeil_ (TermLike.mkCeil_ (Mock.f Mock.a)))
+        ( TermLike.mkCeil
+            Mock.topSort
+            (TermLike.mkCeil Mock.subSort (Mock.f Mock.a))
+        )
         (Ceil (Ceil (Application Mock.fId)))
     , notMatches
         "\\and(f(a), g(a))"
@@ -35,7 +38,11 @@ test_matchAxiomIdentifier =
     , matches "x" (TermLike.mkElemVar Mock.x) Variable
     , matches
         "\\equals(x, f(a))"
-        (TermLike.mkEquals_ (TermLike.mkElemVar Mock.x) (Mock.f Mock.a))
+        ( TermLike.mkEquals
+            Mock.topSort
+            (TermLike.mkElemVar Mock.x)
+            (Mock.f Mock.a)
+        )
         (Equals Variable (Application Mock.fId))
     , matches
         "\\exists(x, f(a))"
@@ -44,7 +51,10 @@ test_matchAxiomIdentifier =
     , matches
         "\\exists(x, \\equals(x, f(a)))"
         ( TermLike.mkExists Mock.x $
-            TermLike.mkEquals_ (TermLike.mkElemVar Mock.x) (Mock.f Mock.a)
+            TermLike.mkEquals
+                Mock.topSort
+                (TermLike.mkElemVar Mock.x)
+                (Mock.f Mock.a)
         )
         (Exists (Equals Variable (Application Mock.fId)))
     , testGroup
@@ -100,7 +110,7 @@ test_matchAxiomIdentifier =
             [ matches name termLike axiomIdentifier
             , matches
                 ceilName
-                (TermLike.mkCeil_ termLike)
+                (TermLike.mkCeil Mock.topSort termLike)
                 (Ceil axiomIdentifier)
             ]
       where

--- a/kore/test/Test/Kore/Step/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Matcher.hs
@@ -99,7 +99,10 @@ test_matcherEqualHeads =
         ]
     , testCase "Bottom" $ do
         let expect = Just (makeTruePredicate, Map.empty)
-        actual <- matchDefinition mkBottom_ mkBottom_
+        actual <-
+            matchDefinition
+                (mkBottom Mock.topSort)
+                (mkBottom Mock.topSort)
         assertEqual "" expect actual
     , testCase "Ceil" $ do
         let expect =
@@ -109,8 +112,8 @@ test_matcherEqualHeads =
                     )
         actual <-
             matchDefinition
-                (mkCeil_ (Mock.plain10 (mkElemVar Mock.xConfig)))
-                (mkCeil_ (Mock.plain10 Mock.a))
+                (mkCeil Mock.topSort (Mock.plain10 (mkElemVar Mock.xConfig)))
+                (mkCeil Mock.topSort (Mock.plain10 Mock.a))
         assertEqual "" expect actual
     , testCase "Equals" $ do
         let expect =
@@ -122,11 +125,13 @@ test_matcherEqualHeads =
                     )
         actual <-
             matchDefinition
-                ( mkEquals_
+                ( mkEquals
+                    Mock.topSort
                     (Mock.plain10 (mkElemVar Mock.xConfig))
                     (Mock.plain10 Mock.a)
                 )
-                ( mkEquals_
+                ( mkEquals
+                    Mock.topSort
                     (Mock.plain10 (mkElemVar Mock.yConfig))
                     (Mock.plain10 Mock.a)
                 )
@@ -172,8 +177,8 @@ test_matcherEqualHeads =
     , testCase "Top" $ do
         actual <-
             matchDefinition
-                mkTop_
-                mkTop_
+                (mkTop Mock.topSort)
+                (mkTop Mock.topSort)
         assertEqual "" topCondition actual
     , testCase "Iff vs Or" $ do
         let expect = Nothing

--- a/kore/test/Test/Kore/Step/Axiom/Registry.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Registry.hs
@@ -407,8 +407,8 @@ testDef =
                 , sentenceAxiomPattern =
                     externalize $
                         mkRewrites
-                            (mkAnd mkTop_ (mkApplySymbol fHead []))
-                            (mkAnd mkTop_ (mkApplySymbol tHead []))
+                            (mkAnd (mkTop sortS) (mkApplySymbol fHead []))
+                            (mkAnd (mkTop sortS) (mkApplySymbol tHead []))
                 }
         , SentenceAxiomSentence
             SentenceAxiom
@@ -422,7 +422,7 @@ testDef =
                                 ( mkEquals
                                     sortVarS
                                     (mkCeil sortVar1S (mkApplySymbol fHead []))
-                                    mkTop_
+                                    (mkTop sortVar1S)
                                 )
                                 (mkTop sortVarS)
                             )

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -1870,8 +1870,8 @@ ceilDummyRule =
 ceilDummySetRule :: Equation RewritingVariableName
 ceilDummySetRule =
     axiom_
-        (mkCeil _ $ Builtin.dummyInt $ mkSetVar xsConfigInt)
-        (mkEquals _ (Builtin.eqInt (mkSetVar xsConfigInt) (mkInt 0)) (mkBool False))
+        (mkCeil Builtin.kSort $ Builtin.dummyInt $ mkSetVar xsConfigInt)
+        (mkEquals Builtin.kSort (Builtin.eqInt (mkSetVar xsConfigInt) (mkInt 0)) (mkBool False))
 
 -- Simplification tests: check that one or more rules applies or not
 withSimplified ::

--- a/kore/test/Test/Kore/Step/Function/Integration.hs
+++ b/kore/test/Test/Kore/Step/Function/Integration.hs
@@ -134,7 +134,7 @@ test_functionIntegration =
                     )
                 )
                 (Mock.functional10 Mock.c)
-        assertEqual "" expect (OrPattern.toTermLike actual)
+        assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Simple evaluation (builtin branch)" $ do
         let expect = Mock.g Mock.c
         actual <-
@@ -148,7 +148,7 @@ test_functionIntegration =
                     )
                 )
                 (Mock.functional10 Mock.c)
-        assertEqual "" expect (OrPattern.toTermLike actual)
+        assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Simple evaluation (Axioms & Builtin branch, Builtin works)" $
         do
             let expect = Mock.g Mock.c
@@ -169,7 +169,7 @@ test_functionIntegration =
                         )
                     )
                     (Mock.functional10 Mock.c)
-            assertEqual "" expect (OrPattern.toTermLike actual)
+            assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Simple evaluation (Axioms & Builtin branch, Builtin fails)" $
         do
             let expect = Mock.g Mock.c
@@ -189,7 +189,7 @@ test_functionIntegration =
                         )
                     )
                     (Mock.functional10 Mock.c)
-            assertEqual "" expect (OrPattern.toTermLike actual)
+            assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Evaluates inside functions" $ do
         let expect = Mock.functional11 (Mock.functional11 Mock.c)
         actual <-
@@ -202,7 +202,7 @@ test_functionIntegration =
                     )
                 )
                 (Mock.functional10 (Mock.functional10 Mock.c))
-        assertEqual "" expect (OrPattern.toTermLike actual)
+        assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Evaluates 'or'" $ do
         let expect =
                 mkOr
@@ -223,7 +223,7 @@ test_functionIntegration =
                         (Mock.functional10 Mock.d)
                     )
                 )
-        assertEqual "" expect (OrPattern.toTermLike actual)
+        assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Evaluates on multiple branches" $ do
         let expect =
                 Mock.functional11
@@ -246,7 +246,7 @@ test_functionIntegration =
                         (Mock.functional10 Mock.c)
                     )
                 )
-        assertEqual "" expect (OrPattern.toTermLike actual)
+        assertEqual "" expect (OrPattern.toTermLike Mock.testSort actual)
     , testCase "Returns conditions" $ do
         let expect =
                 Conditional
@@ -452,7 +452,7 @@ test_functionIntegration =
                     [ "Expected:"
                     , Pretty.indent 4 (unparse expect)
                     , "but found:"
-                    , Pretty.indent 4 (unparse $ OrPattern.toTermLike actual)
+                    , Pretty.indent 4 (Pretty.pretty actual)
                     ]
         assertEqual message (MultiOr.singleton expect) actual
     , testCase "Evaluates only simplifications." $ do
@@ -1664,11 +1664,11 @@ test_updateList =
     , equals
         "negative index"
         (updateList singletonList (mkInt (-1)) (mkInt 1))
-        [mkBottom_]
+        [mkBottom listSort]
     , equals
         "positive index outside rage"
         (updateList singletonList (mkInt 1) (mkInt 1))
-        [mkBottom_]
+        [mkBottom listSort]
     , applies
         "same abstract key"
         [updateListSimplifier]
@@ -1850,7 +1850,7 @@ test_Ceil =
     [ simplifies
         "\\ceil(dummy(X)) => ... ~ \\ceil(dummy(Y))"
         ceilDummyRule
-        (mkCeil_ $ Builtin.dummyInt $ mkElemVar yConfigInt)
+        (mkCeil Builtin.kSort $ Builtin.dummyInt $ mkElemVar yConfigInt)
     , notSimplifies
         "\\ceil(dummy(X)) => \\not(\\equals(X, 0)) !~ dummy(Y)"
         ceilDummyRule
@@ -1858,20 +1858,20 @@ test_Ceil =
     , simplifies
         "\\ceil(dummy(@X)) => ... ~ \\ceil(dummy(Y))"
         ceilDummySetRule
-        (mkCeil_ $ Builtin.dummyInt $ mkElemVar yConfigInt)
+        (mkCeil Builtin.kSort $ Builtin.dummyInt $ mkElemVar yConfigInt)
     ]
 
 ceilDummyRule :: Equation RewritingVariableName
 ceilDummyRule =
     axiom_
-        (mkCeil_ $ Builtin.dummyInt $ mkElemVar xConfigInt)
-        (mkEquals_ (Builtin.eqInt (mkElemVar xConfigInt) (mkInt 0)) (mkBool False))
+        (mkCeil Builtin.kSort $ Builtin.dummyInt $ mkElemVar xConfigInt)
+        (mkEquals Builtin.kSort (Builtin.eqInt (mkElemVar xConfigInt) (mkInt 0)) (mkBool False))
 
 ceilDummySetRule :: Equation RewritingVariableName
 ceilDummySetRule =
     axiom_
-        (mkCeil_ $ Builtin.dummyInt $ mkSetVar xsConfigInt)
-        (mkEquals_ (Builtin.eqInt (mkSetVar xsConfigInt) (mkInt 0)) (mkBool False))
+        (mkCeil _ $ Builtin.dummyInt $ mkSetVar xsConfigInt)
+        (mkEquals _ (Builtin.eqInt (mkSetVar xsConfigInt) (mkInt 0)) (mkBool False))
 
 -- Simplification tests: check that one or more rules applies or not
 withSimplified ::

--- a/kore/test/Test/Kore/Step/Implication.hs
+++ b/kore/test/Test/Kore/Step/Implication.hs
@@ -93,7 +93,8 @@ test_substitute :: [TestTree]
 test_substitute =
     [ testCase "does not capture free variables from the substitution" $ do
         let dummy =
-                Pattern.fromCondition_
+                Pattern.fromCondition
+                    Mock.testSort
                     (fromPredicate Predicate.makeTruePredicate)
             right = OrPattern.fromTermLike (mkElemVar y)
             imp = mkImplication () dummy right [x]

--- a/kore/test/Test/Kore/Step/RewriteStep.hs
+++ b/kore/test/Test/Kore/Step/RewriteStep.hs
@@ -987,12 +987,12 @@ test_applyRewriteRule_ =
     axiomSigmaTopId =
         RewriteRule $
             rulePattern
-                (Mock.sigma (mkElemVar Mock.xRule) mkTop_)
+                (Mock.sigma (mkElemVar Mock.xRule) (mkTop Mock.testSort))
                 (mkElemVar Mock.xRule)
 
     claimSigmaTopId =
         claimPatternFromTerms
-            (Mock.sigma (mkElemVar Mock.xRule) mkTop_)
+            (Mock.sigma (mkElemVar Mock.xRule) (mkTop Mock.testSort))
             (mkElemVar Mock.xRule)
             []
 

--- a/kore/test/Test/Kore/Step/Rule.hs
+++ b/kore/test/Test/Kore/Step/Rule.hs
@@ -105,8 +105,8 @@ axiomPatternsUnitTests =
                     ( applyInj
                         sortKItem
                         ( mkRewrites
-                            (mkAnd mkTop_ varI1)
-                            (mkAnd mkTop_ varI2)
+                            (mkAnd (mkTop sortAInt) varI1)
+                            (mkAnd (mkTop sortAInt) varI2)
                         )
                     )
               moduleTest =
@@ -152,8 +152,8 @@ axiomPatternsUnitTests =
                                     symbolInj
                                     [sortAInt, sortKItem]
                                     [ mkRewrites
-                                        (mkAnd mkTop_ varI1)
-                                        (mkAnd mkTop_ varI2)
+                                        (mkAnd (mkTop sortAInt) varI1)
+                                        (mkAnd (mkTop sortAInt) varI2)
                                     ]
                                 )
                             )

--- a/kore/test/Test/Kore/Step/Rule/Combine.hs
+++ b/kore/test/Test/Kore/Step/Rule/Combine.hs
@@ -27,9 +27,9 @@ import Kore.Internal.TermLike (
     TermLike,
     mkAnd,
     mkApplyAlias,
-    mkBottom_,
+    mkBottom,
     mkElemVar,
-    mkEquals_,
+    mkEquals,
     mkOr,
  )
 import qualified Kore.Internal.TermLike as TermLike.DoNotUse
@@ -206,9 +206,12 @@ test_combineRulesPredicate =
                     ( mkOr
                         ( applyAlias
                             "B"
-                            (mkAnd (mkEquals_ Mock.cf Mock.cg) Mock.ch)
+                            ( mkAnd
+                                (mkEquals Mock.testSort Mock.cf Mock.cg)
+                                Mock.ch
+                            )
                         )
-                        mkBottom_
+                        (mkBottom Mock.testSort)
                     )
                 )
         let expected =

--- a/kore/test/Test/Kore/Step/Simplification/And.hs
+++ b/kore/test/Test/Kore/Step/Simplification/And.hs
@@ -46,15 +46,15 @@ test_andSimplification =
         assertEqual
             "false and true = false"
             OrPattern.bottom
-            =<< evaluate (makeAnd [] [Pattern.top])
+            =<< evaluate (makeAnd [] [Pattern.topOf Mock.testSort])
         assertEqual
             "true and false = false"
             OrPattern.bottom
-            =<< evaluate (makeAnd [Pattern.top] [])
+            =<< evaluate (makeAnd [Pattern.topOf Mock.testSort] [])
         assertEqual
             "true and true = true"
-            OrPattern.top
-            =<< evaluate (makeAnd [Pattern.top] [Pattern.top])
+            (OrPattern.top Mock.testSort)
+            =<< evaluate (makeAnd [Pattern.topOf Mock.testSort] [Pattern.topOf Mock.testSort])
     , testCase "And with booleans" $ do
         assertEqual
             "false and something = false"
@@ -67,11 +67,11 @@ test_andSimplification =
         assertEqual
             "true and something = something"
             (OrPattern.fromPatterns [fOfXExpanded])
-            =<< evaluate (makeAnd [Pattern.top] [fOfXExpanded])
+            =<< evaluate (makeAnd [Pattern.topOf Mock.testSort] [fOfXExpanded])
         assertEqual
             "something and true = something"
             (OrPattern.fromPatterns [fOfXExpanded])
-            =<< evaluate (makeAnd [fOfXExpanded] [Pattern.top])
+            =<< evaluate (makeAnd [fOfXExpanded] [Pattern.topOf Mock.testSort])
     , testCase "And with partial booleans" $ do
         assertEqual
             "false term and something = false"
@@ -110,7 +110,7 @@ test_andSimplification =
         , testCase "And predicates" $ do
             let expect =
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate =
                             makeAndPredicate
                                 (makeCeilPredicate fOfX)
@@ -120,12 +120,12 @@ test_andSimplification =
             actual <-
                 evaluatePatterns
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate fOfX
                         , substitution = mempty
                         }
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate gOfX
                         , substitution = mempty
                         }
@@ -133,7 +133,7 @@ test_andSimplification =
         , testCase "And substitutions - simple" $ do
             let expect =
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.unsafeWrap
@@ -144,7 +144,7 @@ test_andSimplification =
             actual <-
                 evaluatePatterns
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -152,7 +152,7 @@ test_andSimplification =
                                     [(inject Mock.yConfig, fOfX)]
                         }
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -183,7 +183,7 @@ test_andSimplification =
         , testCase "And substitutions - separate predicate" $ do
             let expect =
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeEqualsPredicate fOfX gOfX
                         , substitution =
                             Substitution.unsafeWrap [(inject Mock.yConfig, fOfX)]
@@ -191,7 +191,7 @@ test_andSimplification =
             actual <-
                 evaluatePatterns
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -199,7 +199,7 @@ test_andSimplification =
                                     [(inject Mock.yConfig, fOfX)]
                         }
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -211,7 +211,7 @@ test_andSimplification =
             actual <-
                 evaluatePatterns
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -224,7 +224,7 @@ test_andSimplification =
                                     ]
                         }
                     Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeTruePredicate
                         , substitution =
                             Substitution.wrap $
@@ -244,7 +244,7 @@ test_andSimplification =
             assertEqual
                 "Combines conditions with substitution merge condition"
                 Pattern
-                    { term = mkTop_
+                    { term = mkTop Mock.topSort
                     , predicate =
                         fst $ makeAndPredicate
                             (fst $ makeAndPredicate
@@ -259,12 +259,12 @@ test_andSimplification =
                     , (gSymbol, mock.functionAttributes)
                     ]
                     Pattern
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate fOfX
                         , substitution = [(y, fOfX)]
                         }
                     Pattern
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate gOfX
                         , substitution = [(y, gOfX)]
                         }
@@ -352,7 +352,7 @@ test_andSimplification =
                         , substitution = mempty
                         }
                     , Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate =
                             makeAndPredicate
                                 (makeCeilPredicate fOfX)
@@ -365,14 +365,14 @@ test_andSimplification =
                 ( makeAnd
                     [ fOfXExpanded
                     , Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate fOfX
                         , substitution = mempty
                         }
                     ]
                     [ gOfXExpanded
                     , Conditional
-                        { term = mkTop_
+                        { term = mkTop Mock.topSort
                         , predicate = makeCeilPredicate gOfX
                         , substitution = mempty
                         }
@@ -435,13 +435,13 @@ test_andSimplification =
             }
     bottomTerm =
         Conditional
-            { term = mkBottom_
+            { term = mkBottom Mock.topSort
             , predicate = makeTruePredicate
             , substitution = mempty
             }
     falsePredicate =
         Conditional
-            { term = mkTop_
+            { term = mkTop Mock.topSort
             , predicate = makeFalsePredicate
             , substitution = mempty
             }
@@ -466,7 +466,7 @@ evaluate ::
     IO (OrPattern RewritingVariableName)
 evaluate And{andFirst, andSecond} =
     MultiAnd.make [andFirst, andSecond]
-        & simplify Not.notSimplifier SideCondition.top
+        & simplify Mock.topSort Not.notSimplifier SideCondition.top
         & runSimplifier Mock.env
 
 evaluatePatterns ::
@@ -475,6 +475,6 @@ evaluatePatterns ::
     IO (OrPattern RewritingVariableName)
 evaluatePatterns first second =
     MultiAnd.make [first, second]
-        & makeEvaluate Not.notSimplifier SideCondition.top
+        & makeEvaluate Mock.topSort Not.notSimplifier SideCondition.top
         & runSimplifierBranch Mock.env
         & fmap OrPattern.fromPatterns

--- a/kore/test/Test/Kore/Step/Simplification/Bottom.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Bottom.hs
@@ -6,9 +6,7 @@ import Kore.Internal.OrPattern (
     OrPattern,
  )
 import qualified Kore.Internal.OrPattern as OrPattern
-import qualified Kore.Internal.Pattern as Pattern (
-    bottom,
- )
+import qualified Kore.Internal.Pattern as Pattern
 import Kore.Rewriting.RewritingVariable (
     RewritingVariableName,
  )
@@ -28,7 +26,7 @@ test_bottomSimplification =
         "Bottom evaluates to bottom"
         ( assertEqual
             ""
-            (OrPattern.fromPatterns [Pattern.bottom])
+            (OrPattern.fromPatterns [Pattern.bottomOf Mock.testSort])
             (evaluate Bottom{bottomSort = Mock.testSort})
         )
     ]

--- a/kore/test/Test/Kore/Step/Simplification/Floor.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Floor.hs
@@ -14,11 +14,7 @@ import Kore.Internal.Pattern (
     Conditional (..),
     Pattern,
  )
-import qualified Kore.Internal.Pattern as Pattern (
-    bottom,
-    fromCondition,
-    top,
- )
+import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate (
     makeAndPredicate,
     makeEqualsPredicate,
@@ -41,6 +37,7 @@ import Test.Kore (
     testId,
  )
 import Test.Kore.Step.MockSymbols (
+    subSort,
     testSort,
  )
 import Test.Kore.Step.Simplification
@@ -56,7 +53,7 @@ test_floorSimplification =
             ""
             ( OrPattern.fromPatterns
                 [ Conditional
-                    { term = mkTop_
+                    { term = mkTop testSort
                     , predicate = makeFloorPredicate (mkOr a b)
                     , substitution = mempty
                     }
@@ -75,11 +72,11 @@ test_floorSimplification =
             assertEqual
                 "floor(top)"
                 ( OrPattern.fromPatterns
-                    [Pattern.top]
+                    [Pattern.topOf testSort]
                 )
                 ( evaluate
                     ( makeFloor
-                        [Pattern.top]
+                        [Pattern.topOf subSort]
                     )
                 )
             -- floor(bottom) = bottom
@@ -99,7 +96,7 @@ test_floorSimplification =
         assertEqual
             "floor(top)"
             ( OrPattern.fromPatterns
-                [Pattern.top]
+                [Pattern.topOf testSort]
             )
             ( evaluate
                 ( makeFloor
@@ -113,19 +110,19 @@ test_floorSimplification =
             assertEqual
                 "floor(top)"
                 ( OrPattern.fromPatterns
-                    [Pattern.top]
+                    [Pattern.topOf testSort]
                 )
                 ( makeEvaluate
-                    (Pattern.top :: Pattern RewritingVariableName)
+                    testSort
+                    (Pattern.topOf subSort :: Pattern RewritingVariableName)
                 )
             -- floor(bottom) = bottom
             assertEqual
                 "floor(bottom)"
-                ( OrPattern.fromPatterns
-                    []
-                )
+                OrPattern.bottom
                 ( makeEvaluate
-                    (Pattern.bottom :: Pattern RewritingVariableName)
+                    testSort
+                    (Pattern.bottomOf subSort :: Pattern RewritingVariableName)
                 )
         )
     , testCase
@@ -136,7 +133,7 @@ test_floorSimplification =
             "floor(top)"
             ( OrPattern.fromPatterns
                 [ Conditional
-                    { term = mkTop_
+                    { term = mkTop testSort
                     , predicate =
                         makeAndPredicate
                             (makeFloorPredicate a)
@@ -149,6 +146,7 @@ test_floorSimplification =
                 ]
             )
             ( makeEvaluate
+                testSort
                 Conditional
                     { term = a
                     , predicate = makeEqualsPredicate fOfA gOfA
@@ -211,5 +209,8 @@ evaluate ::
     OrPattern RewritingVariableName
 evaluate = simplify . fmap simplifiedOrPattern
 
-makeEvaluate :: Pattern RewritingVariableName -> OrPattern RewritingVariableName
-makeEvaluate = makeEvaluateFloor . simplifiedPattern
+makeEvaluate ::
+    Sort ->
+    Pattern RewritingVariableName ->
+    OrPattern RewritingVariableName
+makeEvaluate sort = makeEvaluateFloor sort . simplifiedPattern

--- a/kore/test/Test/Kore/Step/Simplification/Forall.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Forall.hs
@@ -61,21 +61,17 @@ test_forallSimplification =
             -- forall(top) = top
             assertEqual
                 "forall(top)"
-                ( OrPattern.fromPatterns
-                    [Pattern.top]
-                )
+                (OrPattern.top Mock.topSort)
                 ( evaluate
                     ( makeForall
                         Mock.xConfig
-                        [Pattern.top]
+                        [Pattern.topOf Mock.topSort]
                     )
                 )
             -- forall(bottom) = bottom
             assertEqual
                 "forall(bottom)"
-                ( OrPattern.fromPatterns
-                    []
-                )
+                (OrPattern.bottom)
                 ( evaluate
                     ( makeForall
                         Mock.xConfig
@@ -89,18 +85,18 @@ test_forallSimplification =
             -- forall(top) = top
             assertEqual
                 "forall(top)"
-                Pattern.top
+                (Pattern.topOf Mock.topSort)
                 ( makeEvaluate
                     Mock.xConfig
-                    (Pattern.top :: Pattern RewritingVariableName)
+                    (Pattern.topOf Mock.topSort :: Pattern RewritingVariableName)
                 )
             -- forall(bottom) = bottom
             assertEqual
                 "forall(bottom)"
-                Pattern.bottom
+                (Pattern.bottomOf Mock.topSort)
                 ( makeEvaluate
                     Mock.xConfig
-                    (Pattern.bottom :: Pattern RewritingVariableName)
+                    (Pattern.bottomOf Mock.topSort :: Pattern RewritingVariableName)
                 )
         )
     , testCase
@@ -115,11 +111,13 @@ test_forallSimplification =
                         ( mkAnd
                             ( mkAnd
                                 (Mock.f $ mkElemVar Mock.xConfig)
-                                (mkCeil_ (Mock.h (mkElemVar Mock.xConfig)))
+                                ( (mkCeil Mock.testSort)
+                                    (Mock.h (mkElemVar Mock.xConfig))
+                                )
                             )
                             ( mkAnd
-                                (mkEquals_ (mkElemVar Mock.xConfig) gOfA)
-                                (mkEquals_ (mkElemVar Mock.yConfig) fOfA)
+                                (mkEquals Mock.testSort (mkElemVar Mock.xConfig) gOfA)
+                                (mkEquals Mock.testSort (mkElemVar Mock.yConfig) fOfA)
                             )
                         )
                 , predicate = makeTruePredicate
@@ -165,7 +163,7 @@ test_forallSimplification =
         ( assertEqual
             "forall on term"
             Conditional
-                { term = mkForall Mock.xConfig (mkAnd fOfX (mkCeil_ gOfA))
+                { term = mkForall Mock.xConfig (mkAnd fOfX (mkCeil Mock.testSort gOfA))
                 , predicate = makeTruePredicate
                 , substitution = mempty
                 }
@@ -210,9 +208,9 @@ test_forallSimplification =
                         ( mkAnd
                             ( mkAnd
                                 fOfA
-                                (mkCeil_ fOfX)
+                                (mkCeil Mock.testSort fOfX)
                             )
-                            (mkEquals_ (mkElemVar Mock.yConfig) fOfA)
+                            (mkEquals Mock.testSort (mkElemVar Mock.yConfig) fOfA)
                         )
                 , predicate = makeTruePredicate
                 , substitution = mempty
@@ -236,7 +234,7 @@ test_forallSimplification =
         ( assertEqual
             "forall on predicate"
             Conditional
-                { term = mkTop_
+                { term = mkTop Mock.topSort
                 , predicate =
                     makeForallPredicate
                         Mock.xConfig
@@ -249,7 +247,7 @@ test_forallSimplification =
             ( makeEvaluate
                 Mock.xConfig
                 Conditional
-                    { term = mkTop_
+                    { term = mkTop Mock.topSort
                     , predicate = makeCeilPredicate fOfX
                     , substitution =
                         Substitution.wrap $
@@ -268,8 +266,8 @@ test_forallSimplification =
                     mkForall
                         Mock.xConfig
                         ( mkAnd
-                            (mkAnd fOfX (mkEquals_ fOfX gOfA))
-                            (mkEquals_ (mkElemVar Mock.yConfig) hOfA)
+                            (mkAnd fOfX (mkEquals Mock.testSort fOfX gOfA))
+                            (mkEquals Mock.testSort (mkElemVar Mock.yConfig) hOfA)
                         )
                 , predicate = makeTruePredicate
                 , substitution = mempty

--- a/kore/test/Test/Kore/Step/Simplification/InternalList.hs
+++ b/kore/test/Test/Kore/Step/Simplification/InternalList.hs
@@ -67,7 +67,7 @@ test_simplify =
     ceilb =
         makeCeilPredicate (Mock.f Mock.b)
             & Condition.fromPredicate
-    bottom = OrPattern.fromPatterns [Pattern.bottom]
+    bottom = OrPattern.fromPatterns [Pattern.bottomOf Mock.listSort]
     becomes ::
         HasCallStack =>
         TestName ->
@@ -91,5 +91,7 @@ mkList children =
         , internalListChild = Seq.fromList children
         }
 
-evaluate :: InternalList (OrPattern RewritingVariableName) -> OrPattern RewritingVariableName
+evaluate ::
+    InternalList (OrPattern RewritingVariableName) ->
+    OrPattern RewritingVariableName
 evaluate = simplify

--- a/kore/test/Test/Kore/Step/Simplification/InternalMap.hs
+++ b/kore/test/Test/Kore/Step/Simplification/InternalMap.hs
@@ -99,7 +99,7 @@ test_simplify =
     ceilb =
         makeCeilPredicate (Mock.f Mock.b)
             & Condition.fromPredicate
-    bottom = OrPattern.fromPatterns [Pattern.bottom]
+    bottom = OrPattern.fromPatterns [Pattern.bottomOf Mock.topSort]
     becomes ::
         HasCallStack =>
         TestName ->
@@ -111,7 +111,7 @@ test_simplify =
             assertEqual
                 ""
                 (OrPattern.fromPatterns expect)
-                (evaluate origin)
+                (evaluate Mock.topSort origin)
 
 mkMap :: [(child, child)] -> [child] -> InternalMap Key child
 mkMap = mkMapAux []
@@ -140,6 +140,7 @@ mkMapAux concreteElements elements opaque =
         }
 
 evaluate ::
+    Sort ->
     InternalMap Key (OrPattern RewritingVariableName) ->
     OrPattern RewritingVariableName
 evaluate = simplify

--- a/kore/test/Test/Kore/Step/Simplification/InternalSet.hs
+++ b/kore/test/Test/Kore/Step/Simplification/InternalSet.hs
@@ -73,7 +73,7 @@ test_simplify =
     ceila =
         makeCeilPredicate (Mock.f Mock.a)
             & Condition.fromPredicate
-    bottom = OrPattern.fromPatterns [Pattern.bottom]
+    bottom = OrPattern.fromPatterns [Pattern.bottomOf Mock.topSort]
     becomes ::
         HasCallStack =>
         TestName ->
@@ -82,7 +82,7 @@ test_simplify =
         TestTree
     becomes name origin (OrPattern.fromPatterns -> expects) =
         testCase name $ do
-            let actuals = evaluate origin
+            let actuals = evaluate Mock.topSort origin
             assertEqual "" expects actuals
 
 mkSet :: [child] -> [child] -> InternalSet Key child
@@ -114,6 +114,7 @@ mkSetAux concreteElements elements opaque =
     mkSetValue = \x -> (x, SetValue)
 
 evaluate ::
+    Sort ->
     InternalSet Key (OrPattern RewritingVariableName) ->
     OrPattern RewritingVariableName
 evaluate = simplify

--- a/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
+++ b/kore/test/Test/Kore/Step/Simplification/OrPattern.hs
@@ -38,8 +38,8 @@ import Test.Tasty.HUnit.Ext
 test_orPatternSimplification :: [TestTree]
 test_orPatternSimplification =
     [ testCase "Identity for top" $ do
-        actual <- runSimplifyPredicates makeTruePredicate OrPattern.top
-        assertEqual "" OrPattern.top actual
+        actual <- runSimplifyPredicates makeTruePredicate (OrPattern.top Mock.topSort)
+        assertEqual "" (OrPattern.top Mock.topSort) actual
     , testCase "Identity for bottom" $ do
         actual <- runSimplifyPredicates makeTruePredicate OrPattern.bottom
         assertEqual "" OrPattern.bottom actual

--- a/kore/test/Test/Kore/Step/Simplification/Top.hs
+++ b/kore/test/Test/Kore/Step/Simplification/Top.hs
@@ -27,12 +27,13 @@ test_topSimplification =
         "Top evaluates to top"
         ( assertEqual
             ""
-            (OrPattern.fromPattern Pattern.top)
-            (evaluate Top{topSort = testSort})
+            (OrPattern.fromPattern (Pattern.topOf testSort))
+            (evaluate testSort Top{topSort = testSort})
         )
     ]
 
 evaluate ::
+    Sort ->
     Top Sort (OrPattern RewritingVariableName) ->
     OrPattern RewritingVariableName
 evaluate = simplify


### PR DESCRIPTION
Remove the predicate sort in favour of using known sorts at all call
sites. This mostly adds sort arguments to various functions that
previously implicitly used _PREDICATE sort. In turn this means removing
the various underbar methods previously in `Kore.Internal.TermLike`.

Fixes #2152

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
