### PR TITLE
Do not update files with Fourmolu

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -73,18 +73,6 @@ jobs:
     name: 'Style'
     runs-on: ubuntu-latest
     steps:
-      - id: config
-        run: |
-          ref=${{ github.ref }}
-          if [ "${{ github.event_name }}" == 'pull_request' ]; then
-            ref="${{ github.event.pull_request.head.sha }}"
-          fi
-          ref="${ref#refs/heads/}"
-          echo "::set-output name=ref::$ref"
-
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
@@ -104,31 +92,11 @@ jobs:
           name: kore
           signingKey: '${{ secrets.KORE_CACHIX_SIGNING_KEY }}'
 
-      - name: Format
-        run: ./nix/fourmolu.sh
-
-      - name: Update branch
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
+      - name: Check Haskell style
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-            if git status -s -b | grep -q '^##.*(no branch)$'; then
-              echo 2>&1 "Error: Git is in detached HEAD state"
-              exit 1
-            fi
-          fi
-
+          ./nix/fourmolu.sh
           if [ -n "$(git status --porcelain '*.hs')" ]; then
-            if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
-              echo 2>&1 "Error: found modified files"
-              git diff
-              exit 1
-            elif [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-              git add '*.hs'
-              git commit -m 'Format with fourmolu'
-              git push
-            else
-              echo 2>&1 "Error: event not supported: $GITHUB_EVENT_NAME"
-              exit 1
-            fi
+            echo 2>&1 "Error: found un-styled files"
+            git diff
+            exit 1
           fi


### PR DESCRIPTION
The test job for pull requests now checks that Haskell source files are styled
correctly with Fourmolu, but it does not automatically update them:

- Automatic updates fill the Git history with style-update commits, which is
  obnoxious to read and makes rebasing (and other operations on the history)
  difficult.
- Every member of the Kore team should have their editor configured to use
  Fourmolu automatically already.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
