### PR TITLE
SideCondition: Separate Predicate and TermLike replacements

### DIFF
--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -440,7 +440,7 @@ cannotReplaceTerm ::
 cannotReplaceTerm SideCondition{replacementsTermLike} term =
     HashMap.lookup term replacementsTermLike & isNothing
 
--- | Looks up the term in the table of replacements.
+-- | Looks up the predicate in the table of replacements.
 replacePredicate ::
     InternalVariable variable =>
     SideCondition variable ->

--- a/kore/src/Kore/Internal/SideCondition.hs
+++ b/kore/src/Kore/Internal/SideCondition.hs
@@ -449,7 +449,7 @@ replacePredicate ::
 replacePredicate SideCondition{replacementsPredicate} original =
     HashMap.lookup original replacementsPredicate
 
-{- | If the term isn't a key in the table of replacements
+{- | If the predicate isn't a key in the table of replacements
 then it cannot be replaced.
 -}
 cannotReplacePredicate ::

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -39,11 +39,7 @@ import qualified Kore.Internal.Predicate as Predicate
 import Kore.Internal.SideCondition (
     SideCondition,
  )
-import qualified Kore.Internal.SideCondition as SideCondition (
-    cannotReplaceTerm,
-    replaceTerm,
-    toRepresentation,
- )
+import qualified Kore.Internal.SideCondition as SideCondition
 import qualified Kore.Internal.SideCondition.SideCondition as SideCondition (
     Representation,
  )
@@ -224,12 +220,16 @@ simplify sideCondition = \termLike ->
         | otherwise =
             case Predicate.makePredicate termLike of
                 Left _ -> return . OrPattern.fromTermLike $ termLike
-                Right termPredicate -> do
+                Right predicate -> do
+                    let predicate' =
+                            predicate
+                                & SideCondition.replacePredicate sideCondition
+                                & fromMaybe predicate
                     condition <-
-                        ensureSimplifiedCondition
-                            sideConditionRepresentation
-                            termLike
-                            (Condition.fromPredicate termPredicate)
+                        Condition.fromPredicate predicate'
+                            & ensureSimplifiedCondition
+                                sideConditionRepresentation
+                                termLike
                     condition
                         & Pattern.fromCondition (termLikeSort termLike)
                         & OrPattern.fromPattern

--- a/kore/src/Kore/Step/Simplification/TermLike.hs
+++ b/kore/src/Kore/Step/Simplification/TermLike.hs
@@ -221,12 +221,8 @@ simplify sideCondition = \termLike ->
             case Predicate.makePredicate termLike of
                 Left _ -> return . OrPattern.fromTermLike $ termLike
                 Right predicate -> do
-                    let predicate' =
-                            predicate
-                                & SideCondition.replacePredicate sideCondition
-                                & fromMaybe predicate
                     condition <-
-                        Condition.fromPredicate predicate'
+                        Condition.fromPredicate predicate
                             & ensureSimplifiedCondition
                                 sideConditionRepresentation
                                 termLike


### PR DESCRIPTION
This pull request will store the `Predicate` and `TermLike` replacements separately in the `SideCondition`. To do so, the new `Predicate` simplifier is modified to apply the replacements itself, instead of delegating to the `TermLike` simplifier. This will be required by #2650 and #2653.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
