### PR TITLE
shell.fourmolu.nix: Set LOCALE_ARCHIVE on relevant platforms

### DIFF
--- a/nix/shell.fourmolu.nix
+++ b/nix/shell.fourmolu.nix
@@ -3,8 +3,13 @@ let
   fourmolu = import ./fourmolu.nix {};
   inherit (default) pkgs;
   inherit (pkgs) fd;
+  inherit (pkgs) lib mkShell stdenv glibcLocales;
 in
 
-pkgs.mkShell {
+mkShell {
+  LOCALE_ARCHIVE =
+    lib.optionalString
+      (stdenv.hostPlatform.libc == "glibc")
+      "${glibcLocales}/lib/locale/locale-archive";
   buildInputs = [ fourmolu fd ];
 }


### PR DESCRIPTION
We must set LOCALE_ARCHIVE so that the Haskell standard library can access the
current locale setting through glibc, otherwise we will see errors such as:

> hGetContents: invalid argument (invalid byte sequence)

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
