### PR TITLE
Investigate Set simplification #2700

### DIFF
--- a/georgy/debug.sh
+++ b/georgy/debug.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+K_FILE=test.k
+
+LOG_FILE=debug.log
+LOG_ENTRIES=DebugAttemptEquation,DebugApplyEquation
+# LOG_ENTRIES=DebugAppliedRewriteRules,DebugAttemptEquation,DebugApplyEquation
+export KORE_EXEC_OPTS="--log ${LOG_FILE} --log-entries ${LOG_ENTRIES}"
+# export KORE_EXEC_OPTS="--log ${LOG_FILE} --debug-equation \"LblSet'Coln'difference{}\""
+
+rm -r test-kompiled
+rm $LOG_FILE
+
+kompile --backend haskell $K_FILE --main-module TEST --syntax-module TEST
+kprove test.k --def-module TEST --spec-module TEST-SPEC

--- a/georgy/equation-lhs.1
+++ b/georgy/equation-lhs.1
@@ -1,0 +1,14 @@
+        /* Fn Spa */
+        LblSet'Coln'difference{}(
+            /* Fn Spa */
+            /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+                /* element: */ LblSetItem{}(
+                    /* Fl Fn D Sfa */ EquationVarX:SortKItem{}
+                ),
+                /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+            )
+        )

--- a/georgy/equation-lhs.2
+++ b/georgy/equation-lhs.2
@@ -1,0 +1,14 @@
+        /* Fn Spa */
+        LblSet'Coln'difference{}(
+            /* Fn Spa */
+            /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+                /* element: */ LblSetItem{}(
+                    /* Fl Fn D Sfa */ EquationVarX:SortKItem{}
+                ),
+                /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+            )
+        )

--- a/georgy/output
+++ b/georgy/output
@@ -1,0 +1,161 @@
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))
+TRACE::: Symbolic difference application pattern: 
+\and{SortSet{}}(
+        /* term: */
+        /* Fl Fn D Spa */
+        LblSet'Coln'difference{}(
+            /* Fl Fn D Sfa Cl */
+            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+            ),
+            /* Fl Fn D Spa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */
+                /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                    /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+                )
+            )
+        ),
+    \and{SortSet{}}(
+        /* predicate: */
+        /* D Sfa */ \top{SortSet{}}(),
+        /* substitution: */
+        \top{SortSet{}}()
+    ))

--- a/georgy/output-modified.debug
+++ b/georgy/output-modified.debug
@@ -1,0 +1,267 @@
+rm: cannot remove 'debug.log': No such file or directory
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ RuleVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ RuleVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ RuleVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ RuleVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ RuleVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ RuleVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ RuleVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ RuleVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ ConfigVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ ConfigVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ ConfigVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ ConfigVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ ConfigVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ ConfigVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Sfa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ ConfigVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ ConfigVarREST:SortSet{}
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa */ ConfigVarREST:SortSet{},
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa */ ConfigVarREST:SortSet{},
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa */ ConfigVarREST:SortSet{},
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(/* Fl Fn D Sfa */ EquationVarX:SortKItem{}),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ EquationVarY:SortKItem{}
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa */ ConfigVarREST:SortSet{},
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */ ConfigVarY:SortKItem{}
+    )
+)

--- a/georgy/output.debug
+++ b/georgy/output.debug
@@ -1,0 +1,236 @@
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(
+            /* Fl Fn D Spa */
+            /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                /* Fl Fn D Sfa */ EquationVarX:SortInt{}
+            )
+        ),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Spa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ EquationVarY:SortInt{}
+        )
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(
+            /* Fl Fn D Spa */
+            /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                /* Fl Fn D Sfa */ EquationVarX:SortInt{}
+            )
+        ),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Spa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ EquationVarY:SortInt{}
+        )
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ RuleVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(
+            /* Fl Fn D Spa */
+            /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                /* Fl Fn D Sfa */ EquationVarX:SortInt{}
+            )
+        ),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Spa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ EquationVarY:SortInt{}
+        )
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fn Spa */
+LblSet'Coln'difference{}(
+    /* Fn Spa */
+    /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+        /* element: */ LblSetItem{}(
+            /* Fl Fn D Spa */
+            /* Inj: */ inj{SortInt{}, SortKItem{}}(
+                /* Fl Fn D Sfa */ EquationVarX:SortInt{}
+            )
+        ),
+        /* opaque child: */ /* Fl Fn D Sfa */ EquationVarREST:SortSet{}
+    ),
+    /* Fl Fn D Spa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Spa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ EquationVarY:SortInt{}
+        )
+    )
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+        )
+    )
+)
+
+term1
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */ /* InternalSet: */ Lbl'Stop'Set{}(),
+    /* Fl Fn D Sfa */ EquationVar'Unds'0:SortSet{}
+)
+term2
+/* Fl Fn D Spa */
+LblSet'Coln'difference{}(
+    /* Fl Fn D Sfa Cl */
+    /* InternalSet: */ /* concrete element: */ LblSetItem{}(
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
+    ),
+    /* Fl Fn D Sfa */
+    /* InternalSet: */ /* element: */ LblSetItem{}(
+        /* Fl Fn D Sfa */
+        /* Inj: */ inj{SortInt{}, SortKItem{}}(
+            /* Fl Fn D Sfa */ ConfigVarX:SortInt{}
+        )
+    )
+)

--- a/georgy/term-lhs.1
+++ b/georgy/term-lhs.1
@@ -1,0 +1,14 @@
+        /* Fn Spa */
+        LblSet'Coln'difference{}(
+            /* Fn Sfa */
+            /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+                /* element: */ LblSetItem{}(
+                    /* Fl Fn D Sfa */ RuleVarX:SortKItem{}
+                ),
+                /* opaque child: */ /* Fl Fn D Sfa */ RuleVarZ:SortSet{}
+            ),
+            /* Fl Fn D Sfa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+            )
+        )

--- a/georgy/term-lhs.2
+++ b/georgy/term-lhs.2
@@ -1,0 +1,14 @@
+        /* Fn Spa */
+        LblSet'Coln'difference{}(
+            /* Fn Sfa */
+            /* InternalSet: */ Lbl'Unds'Set'Unds'{}(
+                /* element: */ LblSetItem{}(
+                    /* Fl Fn D Sfa */ RuleVarX:SortKItem{}
+                ),
+                /* opaque child: */ /* Fl Fn D Sfa */ RuleVarREST:SortSet{}
+            ),
+            /* Fl Fn D Sfa */
+            /* InternalSet: */ /* element: */ LblSetItem{}(
+                /* Fl Fn D Sfa */ RuleVarY:SortKItem{}
+            )
+        )

--- a/georgy/test-backup.k
+++ b/georgy/test-backup.k
@@ -1,0 +1,45 @@
+requires "domains.md"
+
+module TEST
+    imports INT
+    imports SET
+
+    configuration <k> $PGM:Step </k>
+
+    syntax Step ::= run ( Set ) | done ( Set )
+
+    rule [step]: <k> run(S) => done(S) ... </k>
+
+    syntax Bool ::= pred ( Int ) [function, no-evaluators]
+
+    rule [set.diff.empty]: .Set -Set _ => .Set [simplification]
+    // rule [set.diff.concat.item]: (SetItem(X) SetItem(Z)) -Set SetItem(Y) => 
+    //                         SetItem(X) (SetItem(Z) -Set SetItem(Y))
+    rule [set.diff.concat]: (SetItem(X) REST) -Set SetItem(Y) => 
+                            SetItem(X) (REST -Set SetItem(Y))
+                            [simplification]
+    //   requires notBool (X in REST)
+
+      // requires notBool pred(X) andBool pred(Y) 
+      // [simplification] // commenting this out makes the proof go through
+
+    // rule [pred.false]: pred(X) => false requires 1 <=Int X andBool X <=Int 9 [simplification]
+endmodule
+
+module TEST-SPEC
+    imports TEST
+
+    claim <k> run((SetItem(X) REST) -Set SetItem(Y)) => 
+              done(SetItem(X) (REST -Set SetItem(Y))) </k>
+
+    // // Works with set.diff.empty, does not withoug -- OK
+    // claim <k> run(.Set -Set SetItem(X)) => done(.Set) </k>
+
+    // // Works woth set.diff.concat.item
+    // claim <k> run((SetItem(X) SetItem(Z)) -Set SetItem(Y)) => 
+    //           done(SetItem(X) (SetItem(Z) -Set SetItem(Y))) </k>
+
+    //   requires notBool (X in Z)
+    // claim <k> run(SetItem(X) SetItem(Y)) => done(SetItem(Y) SetItem(X)) </k>
+    // claim <k> run(SetItem(Y) -Set SetItem(X)) => done(SetItem(X)) </k> requires X =/=Int Y
+endmodule

--- a/georgy/test-no-set.k
+++ b/georgy/test-no-set.k
@@ -1,0 +1,22 @@
+requires "domains.md"
+
+module TEST-NO-SET
+    imports INT
+
+    configuration <k> $PGM:Step </k>
+
+    syntax Step ::= run ( Int ) | done ( Int )
+    rule [step]: <k> run(S) => done(S) ... </k>
+
+    syntax Bool ::= pred ( Int ) [function, no-evaluators]
+    syntax Int ::= f (Int, Int) [function, no-evaluators]
+
+    rule [pred.false]: pred(X) => false requires 1 <=Int X andBool X <=Int 9 [simplification]
+    rule [f.rule]: f(X, Y) => 4 requires pred(X) andBool notBool pred(Y) [simplification]
+endmodule
+
+module TEST-SPEC
+    imports TEST-NO-SET
+
+    claim <k> run(f(X, 7)) => done(4) ... </k> requires pred(X)
+endmodule

--- a/georgy/test.k
+++ b/georgy/test.k
@@ -1,0 +1,45 @@
+requires "domains.md"
+
+module TEST
+    imports INT
+    imports SET
+
+    configuration <k> $PGM:Step </k>
+
+    syntax Step ::= run ( Set ) | done ( Set )
+
+    rule [step]: <k> run(S) => done(S) ... </k>
+
+    syntax Bool ::= pred ( Int ) [function, no-evaluators]
+
+    rule [set.diff.empty]: .Set -Set _ => .Set [simplification]
+    // rule [set.diff.concat.item]: (SetItem(X) SetItem(Z)) -Set SetItem(Y) => 
+    //                         SetItem(X) (SetItem(Z) -Set SetItem(Y))
+    rule [set.diff.concat]: (SetItem(X) REST) -Set SetItem(Y) => 
+                            SetItem(X) (REST -Set SetItem(Y))
+                            [simplification]
+    //   requires notBool (X in REST)
+
+      // requires notBool pred(X) andBool pred(Y) 
+      // [simplification] // commenting this out makes the proof go through
+
+    // rule [pred.false]: pred(X) => false requires 1 <=Int X andBool X <=Int 9 [simplification]
+endmodule
+
+module TEST-SPEC
+    imports TEST
+
+    claim <k> run((SetItem(X) REST) -Set SetItem(Y)) => 
+              done(SetItem(X) (REST -Set SetItem(Y))) </k>
+
+    // // Works with set.diff.empty, does not withoug -- OK
+    // claim <k> run(.Set -Set SetItem(X)) => done(.Set) </k>
+
+    // // Works woth set.diff.concat.item
+    // claim <k> run((SetItem(X) SetItem(Z)) -Set SetItem(Y)) => 
+    //           done(SetItem(X) (SetItem(Z) -Set SetItem(Y))) </k>
+
+    //   requires notBool (X in Z)
+    // claim <k> run(SetItem(X) SetItem(Y)) => done(SetItem(Y) SetItem(X)) </k>
+    // claim <k> run(SetItem(Y) -Set SetItem(X)) => done(SetItem(X)) </k> requires X =/=Int Y
+endmodule

--- a/georgy/test.k.1
+++ b/georgy/test.k.1
@@ -1,0 +1,31 @@
+requires "domains.md"
+
+module TEST
+    imports INT
+    imports SET
+
+    configuration <k> $PGM:Step </k>
+
+    // syntax Step ::= run ( Set ) | done ( Set )
+    syntax Step ::= run ( Int ) | done ( Int )
+
+    rule <k> run(S) => done(S) ... </k>
+
+    // rule .Set -Set _ => .Set [simplification]
+    // rule (SetItem(X) REST) -Set SetItem(Y) => SetItem(X) (REST -Set SetItem(Y)) 
+    //   [simplification]
+
+    rule <k> done(1) => done(2) ... </k> // success
+    // rule done(1) => done(2) [simplification]
+    // rule (SetItem(1)) => SetItem(2)
+endmodule
+
+module TEST-SPEC
+    imports TEST
+
+    // claim <k> run(SetItem(1) -Set SetItem(X)) => done(SetItem(1)) ... </k> 
+    //       // requires pred(X)
+    //       requires X =/=Int 1
+    claim <k> run(1) => done(2) ... </k> 
+
+endmodule

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -79,12 +79,13 @@ import Kore.Internal.Pattern (
 import qualified Kore.Internal.Pattern as Pattern
 import Kore.Internal.Predicate (
     makeCeilPredicate,
-    makeMultipleAndPredicate,
+    --    makeMultipleAndPredicate,
  )
 import Kore.Internal.SideCondition (
     SideCondition,
  )
-import qualified Kore.Internal.SideCondition as SideCondition
+
+-- import qualified Kore.Internal.SideCondition as SideCondition
 import Kore.Internal.TermLike (
     Key,
     TermLike,
@@ -117,7 +118,7 @@ import Kore.Unification.Unify (
 import qualified Kore.Unification.Unify as Monad.Unify
 import Prelude.Kore
 
-import qualified Pretty
+-- import qualified Pretty
 
 -- | Builtin name of the @Set@ sort.
 sort :: Text
@@ -353,10 +354,10 @@ evalDifference ::
     TermLike.Application TermLike.Symbol (TermLike variable) ->
     MaybeT simplifier (Pattern variable)
 evalDifference
-    sideCondition
+    _ -- sideCondition
     ( TermLike.Application
-            symbol@TermLike.Symbol{symbolSorts = ApplicationSorts _ resultSort}
-            args@[_set1, _set2]
+            TermLike.Symbol{symbolSorts = ApplicationSorts _ resultSort}
+            [_set1, _set2]
         ) =
         do
             let rightIdentity = do
@@ -368,74 +369,74 @@ evalDifference
                     _set1 <- expectConcreteBuiltinSet ctx _set1
                     _set2 <- expectConcreteBuiltinSet ctx _set2
                     returnConcreteSet resultSort (HashMap.difference _set1 _set2)
-                symbolic = do
-                    _set1 <- expectBuiltinSet ctx _set1
-                    _set2 <- expectBuiltinSet ctx _set2
-                    let definedArgs =
-                            filter (not . SideCondition.isDefined sideCondition) args
-                                & map makeCeilPredicate
-                                & makeMultipleAndPredicate
-                                & Conditional.fromPredicate
-                    let NormalizedAc
-                            { concreteElements = concrete1
-                            , elementsWithVariables = symbolic1'
-                            , opaque = opaque1'
-                            } =
-                                unwrapAc _set1
-                        symbolic1 =
-                            unwrapElement <$> symbolic1'
-                                & HashMap.fromList
-                        opaque1 = HashSet.fromList opaque1'
-                    let NormalizedAc
-                            { concreteElements = concrete2
-                            , elementsWithVariables = symbolic2'
-                            , opaque = opaque2'
-                            } =
-                                unwrapAc _set2
-                        symbolic2 =
-                            unwrapElement <$> symbolic2'
-                                & HashMap.fromList
-                        opaque2 = HashSet.fromList opaque2'
-                    let set1' =
-                            NormalizedAc
-                                { concreteElements =
-                                    HashMap.difference concrete1 concrete2
-                                , elementsWithVariables =
-                                    HashMap.difference symbolic1 symbolic2
-                                        & HashMap.toList
-                                        & map wrapElement
-                                , opaque =
-                                    HashSet.difference opaque1 opaque2 & HashSet.toList
-                                }
-                        set2' =
-                            NormalizedAc
-                                { concreteElements =
-                                    HashMap.difference concrete2 concrete1
-                                , elementsWithVariables =
-                                    HashMap.difference symbolic2 symbolic1
-                                        & HashMap.toList
-                                        & map wrapElement
-                                , opaque =
-                                    HashSet.difference opaque1 opaque1 & HashSet.toList
-                                }
-                    pat1 <- Ac.returnAc resultSort (NormalizedSet set1')
-                    pat2 <- Ac.returnAc resultSort (NormalizedSet set2')
-                    let pat
-                            | (not . nullAc) set1'
-                              , (not . nullAc) set2' =
-                                differenceSet <$> pat1 <*> pat2
-                            | otherwise = pat1
-                    traceM "TRACE::: Symbolic difference application pattern: "
-                    traceM
-                        ( show . Pretty.nest 4 . Pretty.pretty $
-                            pat
-                        )
-                    return (Pattern.andCondition pat definedArgs)
-
-            rightIdentity <|> bothConcrete <|> symbolic
+            -- symbolic = do
+            --     _set1 <- expectBuiltinSet ctx _set1
+            --     _set2 <- expectBuiltinSet ctx _set2
+            --     let definedArgs =
+            --             filter (not . SideCondition.isDefined sideCondition) args
+            --                 & map makeCeilPredicate
+            --                 & makeMultipleAndPredicate
+            --                 & Conditional.fromPredicate
+            --     let NormalizedAc
+            --             { concreteElements = concrete1
+            --             , elementsWithVariables = symbolic1'
+            --             , opaque = opaque1'
+            --             } =
+            --                 unwrapAc _set1
+            --         symbolic1 =
+            --             unwrapElement <$> symbolic1'
+            --                 & HashMap.fromList
+            --         opaque1 = HashSet.fromList opaque1'
+            --     let NormalizedAc
+            --             { concreteElements = concrete2
+            --             , elementsWithVariables = symbolic2'
+            --             , opaque = opaque2'
+            --             } =
+            --                 unwrapAc _set2
+            --         symbolic2 =
+            --             unwrapElement <$> symbolic2'
+            --                 & HashMap.fromList
+            --         opaque2 = HashSet.fromList opaque2'
+            --     let set1' =
+            --             NormalizedAc
+            --                 { concreteElements =
+            --                     HashMap.difference concrete1 concrete2
+            --                 , elementsWithVariables =
+            --                     HashMap.difference symbolic1 symbolic2
+            --                         & HashMap.toList
+            --                         & map wrapElement
+            --                 , opaque =
+            --                     HashSet.difference opaque1 opaque2 & HashSet.toList
+            --                 }
+            --         set2' =
+            --             NormalizedAc
+            --                 { concreteElements =
+            --                     HashMap.difference concrete2 concrete1
+            --                 , elementsWithVariables =
+            --                     HashMap.difference symbolic2 symbolic1
+            --                         & HashMap.toList
+            --                         & map wrapElement
+            --                 , opaque =
+            --                     HashSet.difference opaque1 opaque1 & HashSet.toList
+            --                 }
+            --     pat1 <- Ac.returnAc resultSort (NormalizedSet set1')
+            --     pat2 <- Ac.returnAc resultSort (NormalizedSet set2')
+            --     let pat
+            --             | (not . nullAc) set1'
+            --               , (not . nullAc) set2' =
+            --                 differenceSet <$> pat1 <*> pat2
+            --             | otherwise = pat1
+            -- traceM "TRACE::: Symbolic difference application pattern: "
+            -- traceM
+            --     ( show . Pretty.nest 4 . Pretty.pretty $
+            --         pat
+            --     )x
+            -- return (Pattern.andCondition pat definedArgs)
+            rightIdentity <|> bothConcrete -- <|> symbolic
+            -- rightIdentity <|> bothConcrete <|> symbolic
       where
         ctx = Set.differenceKey
-        differenceSet set1 set2 = TermLike.mkApplySymbol symbol [set1, set2]
+-- differenceSet set1 set2 = TermLike.mkApplySymbol symbol [set1, set2]
 evalDifference _ _ =
     Builtin.wrongArity Set.differenceKey
 

--- a/kore/src/Kore/Builtin/Set.hs
+++ b/kore/src/Kore/Builtin/Set.hs
@@ -117,6 +117,8 @@ import Kore.Unification.Unify (
 import qualified Kore.Unification.Unify as Monad.Unify
 import Prelude.Kore
 
+import qualified Pretty
+
 -- | Builtin name of the @Set@ sort.
 sort :: Text
 sort = "SET.Set"
@@ -423,6 +425,11 @@ evalDifference
                               , (not . nullAc) set2' =
                                 differenceSet <$> pat1 <*> pat2
                             | otherwise = pat1
+                    traceM "TRACE::: Symbolic difference application pattern: "
+                    traceM
+                        ( show . Pretty.nest 4 . Pretty.pretty $
+                            pat
+                        )
                     return (Pattern.andCondition pat definedArgs)
 
             rightIdentity <|> bothConcrete <|> symbolic

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -114,6 +114,7 @@ import Kore.Syntax.Variable
 import Kore.TopBottom
 import Kore.Unparser (
     Unparse (..),
+    unparseToString,
  )
 import Log (
     Entry (..),
@@ -172,8 +173,14 @@ attemptEquation sideCondition termLike equation =
     match term1 term2 =
         matchIncremental sideCondition term1 term2
             & MaybeT
-            & noteT matchError
-
+            & noteT
+                ( trace
+                    ( "\nterm1\n" <> unparseToString term1
+                        <> "\nterm2\n"
+                        <> unparseToString term2
+                    )
+                    matchError -- matchError
+                )
     matchAndApplyResults left' argument' antiLeft'
         | isNothing argument'
           , isNothing antiLeft' = do

--- a/kore/src/Kore/Equation/Application.hs
+++ b/kore/src/Kore/Equation/Application.hs
@@ -464,7 +464,9 @@ data MatchError variable = MatchError
     deriving anyclass (Debug, Diff)
 
 instance Pretty (MatchError RewritingVariableName) where
-    pretty _ = "equation did not match term"
+    pretty (MatchError _ equation) = pretty equation
+
+-- "equation did not match term"
 
 {- | Errors that can occur during 'applyMatchResult'.
 

--- a/kore/test/Test/Kore/Step/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Matcher.hs
@@ -43,7 +43,9 @@ import Kore.Rewriting.RewritingVariable (
 import Kore.Step.Axiom.Matcher (
     matchIncremental,
  )
+import Kore.Unparser
 import Prelude.Kore
+import Pretty
 import Test.Kore (
     testId,
  )
@@ -57,9 +59,6 @@ import qualified Test.Kore.Step.MockSymbols as Mock
 import Test.Kore.Step.Simplification
 import Test.Tasty
 import Test.Tasty.HUnit.Ext
-
-import Kore.Unparser
-import Pretty
 
 test_matcherEqualHeads :: [TestTree]
 test_matcherEqualHeads =

--- a/kore/test/Test/Kore/Step/Axiom/Matcher.hs
+++ b/kore/test/Test/Kore/Step/Axiom/Matcher.hs
@@ -58,6 +58,9 @@ import Test.Kore.Step.Simplification
 import Test.Tasty
 import Test.Tasty.HUnit.Ext
 
+import Kore.Unparser
+import Pretty
+
 test_matcherEqualHeads :: [TestTree]
 test_matcherEqualHeads =
     [ testGroup
@@ -883,6 +886,13 @@ test_matching_Set =
             , (sSet, mkSet [mkInt 0] [])
             ]
         ]
+    , matches
+        "testing"
+        (mkSet [mkElemVar Mock.xEquation] [mkElemVar Mock.yEquation])
+        (mkSet [mkElemVar Mock.uRule] [mkElemVar Mock.xRuleSet])
+        [ (inject Mock.xEquation, mkElemVar Mock.uRule)
+        , (inject Mock.yEquation, mkElemVar Mock.xRuleSet)
+        ]
     ]
 
 sSet :: SomeVariable RewritingVariableName
@@ -1180,6 +1190,25 @@ withMatch ::
 withMatch check comment term1 term2 =
     testCase comment $ do
         actual <- match term1 term2
+        case actual of
+            Nothing -> undefined
+            Just (predicate, termMap) ->
+                trace
+                    ( "\npredicate:\n" <> show (pretty predicate)
+                        <> "\nterm map:\n"
+                        <> Map.foldlWithKey
+                            ( \acc var term ->
+                                acc
+                                    <> "("
+                                    <> show var
+                                    <> "|-> "
+                                    <> unparseToString term
+                                    <> ")"
+                            )
+                            ""
+                            termMap
+                    )
+                    (pure ())
         check actual
 
 doesn'tMatch ::

--- a/kore/test/Test/Kore/Step/MockSymbols.hs
+++ b/kore/test/Test/Kore/Step/MockSymbols.hs
@@ -852,6 +852,10 @@ zRule :: MockRewritingElementVariable
 zRule = mkRuleElementVariable (testId "z") mempty testSort
 zConfig :: MockRewritingElementVariable
 zConfig = mkConfigElementVariable (testId "z") mempty testSort
+xEquation :: MockRewritingElementVariable
+xEquation = mkEquationElementVariable (testId "x") mempty testSort
+yEquation :: MockRewritingElementVariable
+yEquation = mkEquationElementVariable (testId "y") mempty setSort
 zEquation :: MockRewritingElementVariable
 zEquation = mkEquationElementVariable (testId "z") mempty testSort
 t :: MockElementVariable


### PR DESCRIPTION
* Trace execution of `Kore.Builtin.Set.evalDifference`

Debugging with the example from the description of issue #2700 produces 7 outputs that look like attempted applications of the builtin set difference:
```
\and{SortSet{}}(
        /* term: */
        /* Fl Fn D Spa */
        LblSet'Coln'difference{}(
            /* Fl Fn D Sfa Cl */
            /* InternalSet: */ /* concrete element: */ LblSetItem{}(
                /* Inj: */ inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("1"))
            ),
            /* Fl Fn D Spa */
            /* InternalSet: */ /* element: */ LblSetItem{}(
                /* Fl Fn D Sfa */
                /* Inj: */ inj{SortInt{}, SortKItem{}}(
                    /* Fl Fn D Sfa */ RuleVarX:SortInt{}
                )
            )
        ),
    \and{SortSet{}}(
        /* predicate: */
        /* D Sfa */ \top{SortSet{}}(),
        /* substitution: */
        \top{SortSet{}}()
    ))
```
I'm posting this here to facilitate our discussion with @ana-pantilie.