### PR TITLE
Overhaul Predicate simplifier: Equals, v2

### DIFF
--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -159,7 +159,7 @@ Equals(a and b, b and a) will not be evaluated to Top.
 simplify ::
     MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
-    Equals sort (OrPattern RewritingVariableName) ->
+    Equals Sort (OrPattern RewritingVariableName) ->
     simplifier (OrCondition RewritingVariableName)
 simplify sideCondition Equals{equalsFirst = first, equalsSecond = second} =
     simplifyEvaluated sideCondition first' second'

--- a/kore/src/Kore/Simplify/Equals.hs
+++ b/kore/src/Kore/Simplify/Equals.hs
@@ -159,7 +159,7 @@ Equals(a and b, b and a) will not be evaluated to Top.
 simplify ::
     MonadSimplify simplifier =>
     SideCondition RewritingVariableName ->
-    Equals Sort (OrPattern RewritingVariableName) ->
+    Equals sort (OrPattern RewritingVariableName) ->
     simplifier (OrCondition RewritingVariableName)
 simplify sideCondition Equals{equalsFirst = first, equalsSecond = second} =
     simplifyEvaluated sideCondition first' second'

--- a/kore/src/Kore/Simplify/Predicate.hs
+++ b/kore/src/Kore/Simplify/Predicate.hs
@@ -506,7 +506,7 @@ simplifyEquals ::
     simplifier NormalForm
 simplifyEquals sideCondition sort equals =
     Equals.simplify sideCondition equals'
-        >>= return . MultiOr.map (from @(Condition _))
+        <&> MultiOr.map (from @(Condition _))
   where
     equals' =
         equals

--- a/kore/src/Kore/Simplify/Predicate.hs
+++ b/kore/src/Kore/Simplify/Predicate.hs
@@ -535,4 +535,4 @@ simplifyEquals ::
     simplifier NormalForm
 simplifyEquals sideCondition =
     Equals.simplify sideCondition
-    >=> return . MultiOr.map (from @(Condition _))
+        >=> return . MultiOr.map (from @(Condition _))


### PR DESCRIPTION
Fixes #2570

Completes all cases of `Predicate.simplify`.

I didn't add any tests for `simplifyEquals` because it only calls `Equals.simplify`, which we will need to modify for https://github.com/kframework/kore/issues/2610.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
