### PR TITLE
debugUnifyBottomAndReturnBottom: remove duplicate call to TermLike.mapVariables

### DIFF
--- a/kore/src/Kore/Log/DebugUnifyBottom.hs
+++ b/kore/src/Kore/Log/DebugUnifyBottom.hs
@@ -93,6 +93,6 @@ debugUnifyBottomAndReturnBottom ::
 debugUnifyBottomAndReturnBottom info first second = do
     debugUnifyBottom
         info
-        (TermLike.mapVariables (pure $ from @_ @VariableName) first)
-        (TermLike.mapVariables (pure $ from @_ @VariableName) second)
+        first
+        second
     empty


### PR DESCRIPTION
…er called twice.

This code issue was discovered when investigating the performance regression for #2643, but it appears the gain is independent of that pull request, so this fix should be pushed to master independently, and #2643 should be investigated further.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
