### PR TITLE
Debugging: equation application, issue #2785

### DIFF
--- a/kore/src/Kore/Simplify/Condition.hs
+++ b/kore/src/Kore/Simplify/Condition.hs
@@ -10,8 +10,6 @@ module Kore.Simplify.Condition (
     simplifyPredicates,
 ) where
 
-import qualified Pretty
-
 import Changed
 import qualified Control.Lens as Lens
 import Control.Monad.State.Strict (
@@ -55,6 +53,7 @@ import Kore.Substitute
 import qualified Kore.TopBottom as TopBottom
 import Logic
 import Prelude.Kore
+import qualified Pretty
 
 -- | Create a 'ConditionSimplifier' using 'simplify'.
 create ::
@@ -90,14 +89,14 @@ simplify SubstitutionSimplifier{simplifySubstitution} sideCondition =
         simplified <- do
             res <-
                 trace ("\nInput predicate:\n" <> show (Pretty.pretty predicate')) $
-                simplifyPredicate predicate' >>= Logic.scatter
+                    simplifyPredicate predicate' >>= Logic.scatter
             trace ("\nIntermediate result:\n" <> show (Pretty.pretty res)) $
                 simplifyPredicates sideCondition res
-            -- trace ("\nInput predicate:\n" <> show (Pretty.pretty predicate')) $
-            -- simplifyPredicates sideCondition (from predicate')
-            -- simplifyPredicate predicate'
-            --     >>= Logic.scatter
-            --     >>= simplifyPredicates sideCondition
+        -- trace ("\nInput predicate:\n" <> show (Pretty.pretty predicate')) $
+        -- simplifyPredicates sideCondition (from predicate')
+        -- simplifyPredicate predicate'
+        --     >>= Logic.scatter
+        --     >>= simplifyPredicates sideCondition
         trace ("\nSimplified predicate:\n" <> show (Pretty.pretty simplified)) $ TopBottom.guardAgainstBottom simplified
         -- TopBottom.guardAgainstBottom simplified
         let merged = simplified <> Condition.fromSubstitution substitution


### PR DESCRIPTION
Draft PR which illustrates debugging method for https://github.com/kframework/kore/issues/2785

@emarzion found the commit where the proof from the issue started failing. This commit added the call to `simplifyPredicate` immediately before the one to `simplifyPredicates`, in the `Condition` simplifier. This resulted in this proof (and possibly others) to not pass, seemingly because we attempted some equations without all the necessary information in the side condition.

The method I used to debug this issue was the following:

1. Label the problematic equation, in this particular case, the second `#hashedLocation` one.
2. Keep two versions of the backend on hand: one where we call both `simplifyPredicate` and `simplifyPredicates` (this is the _failing_ version) and another where we only call `simplifyPredicates` (this is the _passing_ version).
3. Run the proof with `--debug-equation` for the labeled equation on both versions of the backend and compare logs.
4. Find the corresponding log entries in the two log files: one where the equation is applicable and applied, the other where it's not applied. This showed me that in the case where it's not applied, the `SideCondition` is `#Top`, so some necessary information is missing, and deeper inspection is needed. These log entries also show us the term to which we apply the equations.
5. Add traces to the problematic part of the code, in both backend versions. Search for the term found in the previous step, compare sequence of logs.
6. This is where I noticed that, on the failing version, after `simplifyPredicate` is called, the result is marked as fully simplified! That explains why, in the failing equation log, the side condition doesn't contain enough information: we don't actually get to apply `simplifyPredicates` because the predicate is marked simplified.

See comments on this PR for detailed information. Also, on a more technical note, I've had problems in the past with `traceM` (it would sometimes not evaluate), so the traces I added all use `trace`. 


---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
