### PR TITLE
build haskell backend on macos-11 for nix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     name: 'Nix / Build'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
@@ -36,7 +36,7 @@ jobs:
     name: 'Nix / Shell'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
@@ -67,7 +67,7 @@ jobs:
     needs: nix-build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code


### PR DESCRIPTION
The IELE semantics is still failing to build with Nix on MacOS 11 because it's using an old version of ld, to build Haskell code, but I noticed that the haskell backend repo isn't actually testing on MacOS 11, so I thought I would bump the version of the github runner to see if anything fails and thus might help us narrow down the bug further.

Shouldn't require any changes to the tests since it is not actually changing the functional behavior of the system at all.

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
