### PR TITLE
Search: use matching instead of unification

### DIFF
--- a/kore/src/Kore/Rewrite/Search.hs
+++ b/kore/src/Kore/Rewrite/Search.hs
@@ -128,7 +128,7 @@ matchWith ::
     Pattern RewritingVariableName ->
     MaybeT m (OrCondition RewritingVariableName)
 matchWith sideCondition e1 e2 = do
-    unifiers <- MaybeT $ matchIncremental sideCondition t1 t2
+    matchResults <- MaybeT $ matchIncremental sideCondition t1 t2
     let mergeAndEvaluate ::
             MatchResult RewritingVariableName ->
             m (OrCondition RewritingVariableName)
@@ -158,7 +158,7 @@ matchWith sideCondition e1 e2 = do
                     Conditional.substitution merged
                         & Condition.fromSubstitution
                         & return
-    results <- lift $ mergeAndEvaluate unifiers
+    results <- lift $ mergeAndEvaluate matchResults
     -- let orResults :: OrCondition RewritingVariableName
     --     orResults = MultiOr.mergeAll results
     guardAgainstBottom results

--- a/kore/src/Kore/Rewrite/Search.hs
+++ b/kore/src/Kore/Rewrite/Search.hs
@@ -19,6 +19,9 @@ import Data.Limit (
     Limit (..),
  )
 import qualified Data.Limit as Limit
+import qualified Data.Map.Strict as Map
+import Kore.Internal.Substitution
+    (Substitution)
 import qualified Kore.Internal.Condition as Condition (
     bottom,
     fromSubstitution,
@@ -146,7 +149,7 @@ matchWith sideCondition e1 e2 = do
                     , Conditional.predicate e1
                     , Conditional.predicate e2
                     ]
-                    [from substitution]
+                    [from @(Map.Map _ _) @(Substitution _) substitution]
             lift (SMT.evalConditional merged Nothing) >>= \case
                 Nothing ->
                     mergePredicatesAndSubstitutions

--- a/kore/src/Kore/Rewrite/Search.hs
+++ b/kore/src/Kore/Rewrite/Search.hs
@@ -159,8 +159,6 @@ matchWith sideCondition e1 e2 = do
                         & Condition.fromSubstitution
                         & return
     results <- lift $ mergeAndEvaluate matchResults
-    -- let orResults :: OrCondition RewritingVariableName
-    --     orResults = MultiOr.mergeAll results
     guardAgainstBottom results
     return results
   where


### PR DESCRIPTION
Fixes #2879 

### Scope: Use matching in Kore.Rewrite.Search.matchWith

### Estimate: December, 2

---

###### Review checklist

The author performs the actions on the checklist. The reviewer evaluates the work and checks the boxes as they are completed.

-   [ ] **Summary.** Write a summary of the changes. Explain what you did to fix the issue, and why you did it. Present the changes in a logical order. Instead of writing a summary in the pull request, you may push a clean Git history.
-   [ ] **Documentation.** Write documentation for new functions. Update documentation for functions that changed, or complete documentation where it is missing.
-   [ ] **Tests.** Write unit tests for every change. Write the unit tests that were missing before the changes. Include any examples from the reported issue as integration tests.
-   [ ] **Clean up.** The changes are already clean. Clean up anything near the changes that you noticed while working. This does not mean only spatially near the changes, but logically near: any code that interacts with the changes!
