### PR TITLE
booster: configurable HS-only symbols before LLVM simplify

### DIFF
--- a/booster/hs-backend-booster.cabal
+++ b/booster/hs-backend-booster.cabal
@@ -462,6 +462,7 @@ test-suite unit-tests
   main-is: Driver.hs
   other-modules:
       Test.Booster.Builtin
+      Test.Booster.CLOptions
       Test.Booster.Definition.Internalise
       Test.Booster.Fixture
       Test.Booster.JsonRpc.DiffTest
@@ -499,6 +500,7 @@ test-suite unit-tests
     , hs-backend-booster
     , kore-rpc-types
     , monad-logger
+    , optparse-applicative
     , process
     , tasty
     , tasty-golden
@@ -506,4 +508,5 @@ test-suite unit-tests
     , tasty-hunit
     , text
     , transformers
+    , unordered-containers
   default-language: Haskell2010

--- a/booster/library/Booster/CLOptions.hs
+++ b/booster/library/Booster/CLOptions.hs
@@ -17,8 +17,11 @@ module Booster.CLOptions (
 ) where
 
 import Control.Monad.Logger (LogLevel (..))
+import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS (pack)
 import Data.Char (isAscii, isPrint)
+import Data.HashSet (HashSet)
+import Data.HashSet qualified as HashSet
 import Data.List (intercalate, partition)
 import Data.List.Extra (splitOn, trim)
 import Data.Map (Map)
@@ -43,6 +46,7 @@ data CLOptions = CLOptions
     { definitionFile :: FilePath
     , mainModuleName :: Text
     , llvmLibraryFile :: Maybe FilePath
+    , hsOnlySymbols :: HashSet ByteString
     , port :: Int
     , logOptions :: LogOptions
     , smtOptions :: Maybe SMTOptions
@@ -109,6 +113,16 @@ clOptionsParser =
                     <> help "Path to the .so/.dylib shared LLVM backend library"
                 )
             )
+        <*> ( HashSet.fromList
+                <$> many
+                    ( option
+                        (eitherReader readHsOnlySymbol)
+                        ( metavar "LABEL"
+                            <> long "hs-only-symbol"
+                            <> help "User-readable label that must stay on the Haskell side before LLVM simplification"
+                        )
+                    )
+            )
         <*> option
             auto
             ( metavar "SERVER_PORT"
@@ -121,6 +135,11 @@ clOptionsParser =
         <*> parseSMTOptions
         <*> parseEquationOptions
         <*> parseRewriteOptions
+
+readHsOnlySymbol :: String -> Either String ByteString
+readHsOnlySymbol raw
+    | null raw = Left "empty label"
+    | otherwise = Right (BS.pack raw)
 
 parseLogOptions :: Parser LogOptions
 parseLogOptions =

--- a/booster/library/Booster/Definition/Ceil.hs
+++ b/booster/library/Booster/Definition/Ceil.hs
@@ -17,7 +17,7 @@ import Booster.LLVM as LLVM (API, simplifyBool)
 import Booster.Log
 import Booster.Pattern.Bool
 import Booster.Pattern.Pretty
-import Booster.Pattern.Util (isConcrete, sortOfTerm)
+import Booster.Pattern.Util (containsSymbolName, isConcrete, sortOfTerm)
 import Booster.SMT.Interface
 import Booster.Util (Flag (..))
 import Control.DeepSeq (NFData)
@@ -29,6 +29,7 @@ import Control.Monad.Trans.Writer (runWriterT, tell)
 import Data.ByteString.Char8 (isPrefixOf)
 import Data.Coerce (coerce)
 import Data.Foldable (toList)
+import Data.HashSet (HashSet)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Sequence qualified as Seq
@@ -79,13 +80,14 @@ instance FromModifiersT mods => Pretty (PrettyWithModifiers mods ComputeCeilSumm
 computeCeilsDefinition ::
     LoggerMIO io =>
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     KoreDefinition ->
     io (KoreDefinition, [ComputeCeilSummary])
-computeCeilsDefinition mllvm def@KoreDefinition{rewriteTheory} = do
+computeCeilsDefinition mllvm hsOnlySymbols def@KoreDefinition{rewriteTheory} = do
     (rewriteTheory', ceilSummaries) <-
         runWriterT $
             let ceilComputation r = do
-                    lift (computeCeilRule mllvm def r) >>= \case
+                    lift (computeCeilRule mllvm hsOnlySymbols def r) >>= \case
                         Nothing -> pure r
                         Just summary@ComputeCeilSummary{newRule} -> do
                             tell (Seq.singleton summary)
@@ -96,14 +98,15 @@ computeCeilsDefinition mllvm def@KoreDefinition{rewriteTheory} = do
 computeCeilRule ::
     LoggerMIO io =>
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     KoreDefinition ->
     RewriteRule.RewriteRule "Rewrite" ->
     io (Maybe ComputeCeilSummary)
-computeCeilRule mllvm def r@RewriteRule.RewriteRule{lhs, requires, rhs, attributes, computedAttributes}
+computeCeilRule mllvm hsOnlySymbols def r@RewriteRule.RewriteRule{lhs, requires, rhs, attributes, computedAttributes}
     | null computedAttributes.notPreservesDefinednessReasons = pure Nothing
     | otherwise = do
         ns <- noSolver
-        (res, _) <- runEquationT def mllvm ns mempty mempty $ do
+        (res, _) <- runEquationT def mllvm hsOnlySymbols ns mempty mempty $ do
             lhsCeils <- Set.fromList <$> computeCeil lhs
             requiresCeils <- Set.fromList <$> concatMapM (computeCeil . coerce) requires
             let subtractLHSAndRequiresCeils = (Set.\\ (lhsCeils `Set.union` requiresCeils)) . Set.fromList
@@ -140,12 +143,16 @@ computeCeilRule mllvm def r@RewriteRule.RewriteRule{lhs, requires, rhs, attribut
 
     simplifyCeil api p@(Left (Predicate t@(Term TermAttributes{canBeEvaluated} _)))
         | isConcrete t && canBeEvaluated = do
-            simplifyBool api t >>= \case
-                Left{} -> pure $ Just p
-                Right res ->
-                    if res
-                        then pure Nothing
-                        else error "ceil simplified to bottom"
+            hsOnly <- (.hsOnlySymbols) <$> getConfig
+            if containsSymbolName hsOnly t
+                then pure $ Just p
+                else
+                    simplifyBool api t >>= \case
+                        Left{} -> pure $ Just p
+                        Right res ->
+                            if res
+                                then pure Nothing
+                                else error "ceil simplified to bottom"
         | otherwise = pure $ Just p
     simplifyCeil _ other = pure $ Just other
 

--- a/booster/library/Booster/JsonRpc.hs
+++ b/booster/library/Booster/JsonRpc.hs
@@ -25,6 +25,7 @@ import Control.Monad.Trans.Except (catchE, except, runExcept, runExceptT, throwE
 import Crypto.Hash (SHA256 (..), hashWith)
 import Data.Bifunctor (first, second)
 import Data.Foldable
+import Data.HashSet (HashSet)
 import Data.List (singleton)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -45,7 +46,7 @@ import Booster.Definition.Base qualified as Definition (RewriteRule (..))
 import Booster.LLVM as LLVM (API, llvmReset)
 import Booster.Log
 import Booster.Pattern.ApplyEquations qualified as ApplyEquations
-import Booster.Pattern.Base (Pattern (..), Sort (SortApp))
+import Booster.Pattern.Base (Pattern (..), Sort (SortApp), SymbolName)
 import Booster.Pattern.Base qualified as Pattern
 import Booster.Pattern.Bool (isFalse)
 import Booster.Pattern.Bool qualified as Pattern
@@ -110,7 +111,7 @@ respond stateVar request =
                 | isJust req.stepTimeout -> pure $ Left $ RpcError.unsupportedOption ("step-timeout" :: String)
                 | isJust req.movingAverageStepTimeout ->
                     pure $ Left $ RpcError.unsupportedOption ("moving-average-step-timeout" :: String)
-            RpcTypes.Execute req -> withModule req._module $ \(def, mLlvmLibrary, mSMTOptions, rewriteOpts) -> Booster.Log.withContext CtxExecute $ do
+            RpcTypes.Execute req -> withModule req._module $ \(def, mLlvmLibrary, hsOnlySymbolsSet, mSMTOptions, rewriteOpts) -> Booster.Log.withContext CtxExecute $ do
                 -- internalise given constrained term
                 let internalised = runExcept $ internalisePattern DisallowAlias CheckSubsorts Nothing def req.state.term
 
@@ -161,6 +162,7 @@ respond stateVar request =
                                 RewriteConfig
                                     { definition = def
                                     , llvmApi = mLlvmLibrary
+                                    , hsOnlySymbols = hsOnlySymbolsSet
                                     , smtSolver = solver
                                     , varsToAvoid = substVars
                                     , doTracing
@@ -236,7 +238,7 @@ respond stateVar request =
                     Booster.Log.logMessage $
                         "Added a new module. Now in scope: " <> Text.intercalate ", " (Map.keys newDefinitions)
                     pure $ RpcTypes.AddModule $ RpcTypes.AddModuleResult moduleHash
-            RpcTypes.Simplify req -> withModule req._module $ \(def, mLlvmLibrary, mSMTOptions, _) -> Booster.Log.withContext CtxSimplify $ do
+            RpcTypes.Simplify req -> withModule req._module $ \(def, mLlvmLibrary, hsOnlySymbolsSet, mSMTOptions, _) -> Booster.Log.withContext CtxSimplify $ do
                 let internalised =
                         runExcept $ internaliseTermOrPredicate DisallowAlias CheckSubsorts Nothing def req.state.term
 
@@ -257,7 +259,7 @@ respond stateVar request =
                         unless (null unsupported) $ do
                             withKorePatternContext (KoreJson.KJAnd (externaliseSort $ sortOfPattern pat) unsupported) $ do
                                 logMessage ("ignoring unsupported predicate parts" :: Text)
-                        ApplyEquations.evaluatePattern def mLlvmLibrary solver mempty pat >>= \case
+                        ApplyEquations.evaluatePattern def mLlvmLibrary hsOnlySymbolsSet solver mempty pat >>= \case
                             (Right newPattern, _) ->
                                 if Pattern.isBottom newPattern
                                     then
@@ -293,6 +295,7 @@ respond stateVar request =
                                 ApplyEquations.simplifyConstraints
                                     def
                                     mLlvmLibrary
+                                    hsOnlySymbolsSet
                                     solver
                                     mempty
                                     (predicates <> Substitution.asEquations ps.substitution)
@@ -320,11 +323,11 @@ respond stateVar request =
                             RpcTypes.SimplifyResult{state, logs = Nothing}
                 pure $ second mkSimplifyResponse result
             RpcTypes.GetModel req -> withModule req._module $ \case
-                (_, _, Nothing, _) -> do
+                (_, _, _, Nothing, _) -> do
                     withContext CtxGetModel $
                         logMessage' ("get-model request, not supported without SMT solver" :: Text)
                     pure $ Left RpcError.notImplemented
-                (def, _, Just smtOptions, _) -> do
+                (def, _, _, Just smtOptions, _) -> do
                     let internalised =
                             runExcept $
                                 internaliseTermOrPredicate DisallowAlias CheckSubsorts Nothing def req.state.term
@@ -423,13 +426,13 @@ respond stateVar request =
                                             { satisfiable = RpcTypes.Unknown
                                             , substitution = Nothing
                                             }
-            RpcTypes.Implies req -> withModule req._module $ \(def, mLlvmLibrary, mSMTOptions, _) -> runImplies def mLlvmLibrary mSMTOptions req.antecedent req.consequent
+            RpcTypes.Implies req -> withModule req._module $ \(def, mLlvmLibrary, hsOnlySymbolsSet, mSMTOptions, _) -> runImplies def mLlvmLibrary hsOnlySymbolsSet mSMTOptions req.antecedent req.consequent
             -- this case is only reachable if the cancel appeared as part of a batch request
             RpcTypes.Cancel -> pure $ Left RpcError.cancelUnsupportedInBatchMode
   where
     withModule ::
         Maybe Text ->
-        ( (KoreDefinition, Maybe LLVM.API, Maybe SMT.SMTOptions, RewriteOptions) ->
+        ( (KoreDefinition, Maybe LLVM.API, HashSet SymbolName, Maybe SMT.SMTOptions, RewriteOptions) ->
           m (Either ErrorObj (RpcTypes.API 'RpcTypes.Res))
         ) ->
         m (Either ErrorObj (RpcTypes.API 'RpcTypes.Res))
@@ -440,7 +443,7 @@ respond stateVar request =
         case Map.lookup mainName state.definitions of
             Nothing -> pure $ Left $ RpcError.backendError $ RpcError.CouldNotFindModule mainName
             Just d ->
-                action (d, state.mLlvmLibrary, state.mSMTOptions, state.rewriteOptions) <* purgeLlvmLib
+                action (d, state.mLlvmLibrary, state.hsOnlySymbols, state.mSMTOptions, state.rewriteOptions) <* purgeLlvmLib
 
 handleSmtError :: JsonRpcHandler
 handleSmtError = JsonRpcHandler $ \case
@@ -458,6 +461,8 @@ data ServerState = ServerState
     -- ^ default main module (initially from command line, could be changed later)
     , mLlvmLibrary :: Maybe LLVM.API
     -- ^ Read-only: optional LLVM simplification library
+    , hsOnlySymbols :: HashSet SymbolName
+    -- ^ Read-only: symbols that must stay on the Haskell side before LLVM simplification
     , mSMTOptions :: Maybe SMT.SMTOptions
     -- ^ Read-only: (optional) SMT solver options
     , rewriteOptions :: RewriteOptions

--- a/booster/library/Booster/JsonRpc.hs
+++ b/booster/library/Booster/JsonRpc.hs
@@ -443,7 +443,8 @@ respond stateVar request =
         case Map.lookup mainName state.definitions of
             Nothing -> pure $ Left $ RpcError.backendError $ RpcError.CouldNotFindModule mainName
             Just d ->
-                action (d, state.mLlvmLibrary, state.hsOnlySymbols, state.mSMTOptions, state.rewriteOptions) <* purgeLlvmLib
+                action (d, state.mLlvmLibrary, state.hsOnlySymbols, state.mSMTOptions, state.rewriteOptions)
+                    <* purgeLlvmLib
 
 handleSmtError :: JsonRpcHandler
 handleSmtError = JsonRpcHandler $ \case

--- a/booster/library/Booster/Pattern/ApplyEquations.hs
+++ b/booster/library/Booster/Pattern/ApplyEquations.hs
@@ -40,6 +40,7 @@ import Data.ByteString.Char8 qualified as BS
 import Data.Coerce (coerce)
 import Data.Data (Data, Proxy)
 import Data.Foldable (toList, traverse_)
+import Data.HashSet (HashSet)
 import Data.List (foldl1', intersperse, partition)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
@@ -146,6 +147,7 @@ instance Pretty (PrettyWithModifiers mods EquationFailure) where
 data EquationConfig = EquationConfig
     { definition :: KoreDefinition
     , llvmApi :: Maybe LLVM.API
+    , hsOnlySymbols :: HashSet SymbolName
     , smtSolver :: SMT.SMTContext
     , maxRecursion :: Bound "Recursion"
     , maxIterations :: Bound "Iterations"
@@ -333,12 +335,13 @@ runEquationT ::
     LoggerMIO io =>
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     SimplifierCache ->
     Set Predicate ->
     EquationT io a ->
     io (Either EquationFailure a, SimplifierCache)
-runEquationT definition llvmApi smtSolver sCache known (EquationT m) = do
+runEquationT definition llvmApi hsOnlySymbols smtSolver sCache known (EquationT m) = do
     globalEquationOptions <- liftIO GlobalState.readGlobalEquationOptions
     logger <- getLogger
     prettyModifiers <- getPrettyModifiers
@@ -350,6 +353,7 @@ runEquationT definition llvmApi smtSolver sCache known (EquationT m) = do
                     EquationConfig
                         { definition
                         , llvmApi
+                        , hsOnlySymbols
                         , smtSolver
                         , maxIterations = globalEquationOptions.maxIterations
                         , maxRecursion = globalEquationOptions.maxRecursion
@@ -419,13 +423,17 @@ llvmSimplify term = do
     case config.llvmApi of
         Nothing -> pure term
         Just api -> do
-            let simp = cached LLVM $ evalLlvm config.definition api $ traverseTerm BottomUp simp pure
+            let simp =
+                    cached LLVM $
+                        evalLlvm config.definition config.hsOnlySymbols api $
+                            traverseTerm BottomUp simp pure
              in simp term
   where
-    evalLlvm definition api cb t@(Term attributes _)
+    evalLlvm definition hsOnlySymbols api cb t@(Term attributes _)
         | attributes.isEvaluated = pure t
         | isConcrete t
         , attributes.canBeEvaluated
+        , not (containsSymbolName hsOnlySymbols t)
         , isFunctionApp t = withContext CtxLlvm . withTermContext t $ do
             LLVM.simplifyTerm api definition t (sortOfTerm t)
                 >>= \case
@@ -460,13 +468,14 @@ evaluateTerm ::
     Direction ->
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     SimplifierCache ->
     Set Predicate ->
     Term ->
     io (Either EquationFailure Term, SimplifierCache)
-evaluateTerm direction def llvmApi smtSolver cache knownPredicates term =
-    runEquationT def llvmApi smtSolver cache knownPredicates $
+evaluateTerm direction def llvmApi hsOnlySymbols smtSolver cache knownPredicates term =
+    runEquationT def llvmApi hsOnlySymbols smtSolver cache knownPredicates $
         withTermContext term $
             evaluateTerm' direction term
 
@@ -488,14 +497,16 @@ evaluatePattern ::
     LoggerMIO io =>
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     SimplifierCache ->
     Pattern ->
     io (Either EquationFailure Pattern, SimplifierCache)
-evaluatePattern def mLlvmLibrary smtSolver cache pat =
+evaluatePattern def mLlvmLibrary hsOnlySymbols smtSolver cache pat =
     runEquationT
         def
         mLlvmLibrary
+        hsOnlySymbols
         smtSolver
         cache
         -- interpret substitution as additional known constraints
@@ -559,11 +570,12 @@ evaluateConstraints ::
     LoggerMIO io =>
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     Set Predicate ->
     io (Either EquationFailure (Set Predicate))
-evaluateConstraints def mLlvmLibrary smtSolver constraints =
-    fmap fst $ runEquationT def mLlvmLibrary smtSolver mempty constraints $ do
+evaluateConstraints def mLlvmLibrary hsOnlySymbols smtSolver constraints =
+    fmap fst $ runEquationT def mLlvmLibrary hsOnlySymbols smtSolver mempty constraints $ do
         -- evaluate all existing constraints, once
         traverse_ simplifyAssumedPredicate . predicates =<< getState
         -- this may yield additional new constraints, left unevaluated
@@ -1142,13 +1154,14 @@ simplifyConstraint ::
     LoggerMIO io =>
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     SimplifierCache ->
     Set Predicate ->
     Predicate ->
     io (Either EquationFailure Predicate, SimplifierCache)
-simplifyConstraint def mbApi smt cache knownPredicates =
-    runEquationT def mbApi smt cache knownPredicates
+simplifyConstraint def mbApi hsOnlySymbols smt cache knownPredicates =
+    runEquationT def mbApi hsOnlySymbols smt cache knownPredicates
         . (coerce <$>)
         . simplifyConstraint' True
         . coerce
@@ -1157,12 +1170,13 @@ simplifyConstraints ::
     LoggerMIO io =>
     KoreDefinition ->
     Maybe LLVM.API ->
+    HashSet SymbolName ->
     SMT.SMTContext ->
     SimplifierCache ->
     [Predicate] ->
     io (Either EquationFailure [Predicate], SimplifierCache)
-simplifyConstraints def mbApi mbSMT cache ps =
-    runEquationT def mbApi mbSMT cache mempty $
+simplifyConstraints def mbApi hsOnlySymbols mbSMT cache ps =
+    runEquationT def mbApi hsOnlySymbols mbSMT cache mempty $
         concatMap splitAndBools
             <$> mapM ((coerce <$>) . simplifyConstraint' True . coerce) ps
 
@@ -1176,8 +1190,10 @@ simplifyConstraint' recurseIntoEvalBool = \case
         | isEvaluated ->
             pure t
         | isConcrete t && canBeEvaluated -> do
-            mbApi <- (.llvmApi) <$> getConfig
+            config <- getConfig
+            let mbApi = config.llvmApi
             case mbApi of
+                _ | containsSymbolName config.hsOnlySymbols t -> evaluateTerm' BottomUp t
                 Just api ->
                     withContext CtxLlvm . withTermContext t $
                         LLVM.simplifyBool api t >>= \case

--- a/booster/library/Booster/Pattern/Implies.hs
+++ b/booster/library/Booster/Pattern/Implies.hs
@@ -9,6 +9,7 @@ import Control.Monad.Extra (void)
 import Control.Monad.Trans.Except (runExcept)
 import Data.Coerce (coerce)
 import Data.Data (Proxy)
+import Data.HashSet (HashSet)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text, pack)
@@ -20,7 +21,7 @@ import Booster.LLVM qualified
 import Booster.Log (getPrettyModifiers)
 import Booster.Log qualified
 import Booster.Pattern.ApplyEquations qualified as ApplyEquations
-import Booster.Pattern.Base (Pattern (..), Predicate (..))
+import Booster.Pattern.Base (Pattern (..), Predicate (..), SymbolName)
 import Booster.Pattern.Bool (pattern TrueBool)
 import Booster.Pattern.Match (FailReason (..), MatchResult (..), MatchType (Implies), matchTerms)
 import Booster.Pattern.Pretty (FromModifiersT, ModifiersRep (..), pretty')
@@ -53,11 +54,12 @@ runImplies ::
     Booster.Log.LoggerMIO m =>
     KoreDefinition ->
     Maybe Booster.LLVM.API ->
+    HashSet SymbolName ->
     Maybe SMT.SMTOptions ->
     Kore.Syntax.KoreJson ->
     Kore.Syntax.KoreJson ->
     m (Either ErrorObj (RpcTypes.API 'RpcTypes.Res))
-runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
+runImplies def mLlvmLibrary hsOnlySymbols mSMTOptions antecedent consequent =
     getPrettyModifiers >>= \case
         ModifiersRep (_ :: FromModifiersT mods => Proxy mods) -> Booster.Log.withContext Booster.Log.CtxImplies $ do
             solver <- maybe (SMT.noSolver) (SMT.initSolver def) mSMTOptions
@@ -122,7 +124,7 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                                 (externaliseExistTerm existsL patL.term)
                                 (externaliseExistTerm existsR patR.term)
                         MatchIndeterminate _remainder ->
-                            ApplyEquations.evaluatePattern def mLlvmLibrary solver mempty patL >>= \case
+                            ApplyEquations.evaluatePattern def mLlvmLibrary hsOnlySymbols solver mempty patL >>= \case
                                 (Right simplifedSubstPatL, _) ->
                                     if patL == simplifedSubstPatL
                                         then -- we are being conservative here for now and returning "not-implied".
@@ -150,7 +152,7 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                                         subst
                                 else -- FIXME This is incomplete because patL.constraints are not assumed in the check.
 
-                                    ApplyEquations.evaluateConstraints def mLlvmLibrary solver filteredConsequentPreds >>= \case
+                                    ApplyEquations.evaluateConstraints def mLlvmLibrary hsOnlySymbols solver filteredConsequentPreds >>= \case
                                         Right newPreds ->
                                             if all (== Predicate TrueBool) newPreds
                                                 then

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -33,6 +33,7 @@ import Data.Bifunctor (bimap)
 import Data.Coerce (coerce)
 import Data.Data (Proxy)
 import Data.Hashable qualified as Hashable
+import Data.HashSet (HashSet)
 import Data.List (intersperse, partition)
 import Data.List.NonEmpty (NonEmpty (..), toList)
 import Data.List.NonEmpty qualified as NE
@@ -99,6 +100,7 @@ data RewriteState = RewriteState
 data RewriteConfig = RewriteConfig
     { definition :: KoreDefinition
     , llvmApi :: Maybe LLVM.API
+    , hsOnlySymbols :: HashSet SymbolName
     , smtSolver :: SMT.SMTContext
     , varsToAvoid :: Set.Set Variable
     , doTracing :: Flag "CollectRewriteTraces"
@@ -554,12 +556,12 @@ applyRule pat@Pattern{ceilConditions} rule =
         Predicate ->
         RewriteRuleAppT (RewriteT io) (Maybe a)
     checkConstraint onUnclear onBottom extraPredicates p = do
-        RewriteConfig{definition, llvmApi, smtSolver} <- lift $ RewriteT ask
+        RewriteConfig{definition, llvmApi, hsOnlySymbols, smtSolver} <- lift $ RewriteT ask
         RewriteState{cache} <- lift . RewriteT . lift $ get
         let knownPredicates = knownPatternPredicates <> extraPredicates
         (simplified, newCache) <-
             withContext CtxConstraint $
-                simplifyConstraint definition llvmApi smtSolver cache knownPredicates p
+                simplifyConstraint definition llvmApi hsOnlySymbols smtSolver cache knownPredicates p
         -- Important: only retain new cache if no extraPredicates were supplied!
         when (Set.null extraPredicates) $
             lift (updateRewriterCache newCache)
@@ -1009,7 +1011,7 @@ performRewrite ::
 performRewrite rewriteConfig pat = do
     -- simplify all constraints (individually) before starting to rewrite
     simplifiedConstraints <-
-        withContext CtxSimplify $ evaluateConstraints definition llvmApi smtSolver pat.constraints
+        withContext CtxSimplify $ evaluateConstraints definition llvmApi hsOnlySymbols smtSolver pat.constraints
     (rr, RewriteStepsState{counter, traces}) <-
         case simplifiedConstraints of
             Right constraints ->
@@ -1037,6 +1039,7 @@ performRewrite rewriteConfig pat = do
     RewriteConfig
         { definition
         , llvmApi
+        , hsOnlySymbols
         , smtSolver
         , doTracing
         , mbMaxDepth
@@ -1067,7 +1070,7 @@ performRewrite rewriteConfig pat = do
     simplifyT :: Pattern -> StateT RewriteStepsState io (Maybe Pattern)
     simplifyT p = withContext CtxSimplify $ do
         cache <- simplifierCache <$> get
-        evaluateTerm BottomUp definition llvmApi smtSolver cache p.constraints p.term >>= \(res, newCache) -> do
+        evaluateTerm BottomUp definition llvmApi hsOnlySymbols smtSolver cache p.constraints p.term >>= \(res, newCache) -> do
             updateCache newCache
             case res of
                 Right newTerm -> do
@@ -1088,7 +1091,7 @@ performRewrite rewriteConfig pat = do
     simplifyP p = withContext CtxSimplify $ do
         st <- get
         let cache = st.simplifierCache
-        evaluatePattern definition llvmApi smtSolver cache p >>= \(res, newCache) -> do
+        evaluatePattern definition llvmApi hsOnlySymbols smtSolver cache p >>= \(res, newCache) -> do
             updateCache newCache
             case res of
                 Right newPattern -> do

--- a/booster/library/Booster/Pattern/Rewrite.hs
+++ b/booster/library/Booster/Pattern/Rewrite.hs
@@ -32,8 +32,8 @@ import Data.Aeson (object, (.=))
 import Data.Bifunctor (bimap)
 import Data.Coerce (coerce)
 import Data.Data (Proxy)
-import Data.Hashable qualified as Hashable
 import Data.HashSet (HashSet)
+import Data.Hashable qualified as Hashable
 import Data.List (intersperse, partition)
 import Data.List.NonEmpty (NonEmpty (..), toList)
 import Data.List.NonEmpty qualified as NE
@@ -1011,7 +1011,8 @@ performRewrite ::
 performRewrite rewriteConfig pat = do
     -- simplify all constraints (individually) before starting to rewrite
     simplifiedConstraints <-
-        withContext CtxSimplify $ evaluateConstraints definition llvmApi hsOnlySymbols smtSolver pat.constraints
+        withContext CtxSimplify $
+            evaluateConstraints definition llvmApi hsOnlySymbols smtSolver pat.constraints
     (rr, RewriteStepsState{counter, traces}) <-
         case simplifiedConstraints of
             Right constraints ->

--- a/booster/library/Booster/Pattern/Util.hs
+++ b/booster/library/Booster/Pattern/Util.hs
@@ -18,6 +18,7 @@ module Booster.Pattern.Util (
     checkSymbolIsAc,
     checkTermSymbols,
     isConcrete,
+    containsSymbolName,
     filterTermSymbols,
     sizeOfTerm,
     termVarStats,
@@ -41,6 +42,8 @@ import Data.ByteString qualified as BS
 import Data.Char (ord)
 import Data.Coerce (coerce)
 import Data.Functor.Foldable (Corecursive (embed), cata)
+import Data.HashSet (HashSet)
+import Data.HashSet qualified as HashSet
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
@@ -183,6 +186,53 @@ freeVariables (Term attributes _) = attributes.variables
 
 isConcrete :: Term -> Bool
 isConcrete = Set.null . freeVariables
+
+containsSymbolName :: HashSet SymbolName -> Term -> Bool
+containsSymbolName names
+    | HashSet.null names = const False
+    | otherwise = cata $ \case
+        SymbolApplicationF symbol _ children ->
+            any (`matchesSymbol` symbol.name) configuredLabels || or children
+        other -> or other
+  where
+    configuredLabels =
+        concatMap
+            (HashSet.toList . labelVariants)
+            (HashSet.toList names)
+
+    labelVariants :: SymbolName -> HashSet SymbolName
+    labelVariants label =
+        HashSet.fromList $
+            [ label
+            , stripLblPrefix label
+            ]
+                <> [ "Lbl" <> label | not ("Lbl" `BS.isPrefixOf` label) ]
+                <> [ "Lbl'Hash'" <> rest | Just rest <- [BS.stripPrefix "#" label] ]
+
+    matchesSymbol :: SymbolName -> SymbolName -> Bool
+    matchesSymbol label symbolName =
+        any (isLabelMatch label) symbolNameCandidates
+      where
+        symbolNameCandidates =
+            [ symbolName
+            , stripLblPrefix symbolName
+            ]
+
+    isLabelMatch :: SymbolName -> SymbolName -> Bool
+    isLabelMatch label candidate =
+        candidate == label
+            || case BS.stripPrefix label candidate of
+                Just rest -> isNameBoundary rest
+                Nothing -> False
+
+    stripLblPrefix :: SymbolName -> SymbolName
+    stripLblPrefix name =
+        fromMaybe name (BS.stripPrefix "Lbl" name)
+
+    isNameBoundary :: SymbolName -> Bool
+    isNameBoundary rest = case BS.uncons rest of
+        Nothing -> True
+        Just (c, _) -> c == 0x27 || c == 0x28 || c == 0x5f || c == 0x7b
 
 isConstructorSymbol :: Symbol -> Bool
 isConstructorSymbol symbol =

--- a/booster/library/Booster/Pattern/Util.hs
+++ b/booster/library/Booster/Pattern/Util.hs
@@ -206,8 +206,8 @@ containsSymbolName names
             [ label
             , stripLblPrefix label
             ]
-                <> [ "Lbl" <> label | not ("Lbl" `BS.isPrefixOf` label) ]
-                <> [ "Lbl'Hash'" <> rest | Just rest <- [BS.stripPrefix "#" label] ]
+                <> ["Lbl" <> label | not ("Lbl" `BS.isPrefixOf` label)]
+                <> ["Lbl'Hash'" <> rest | Just rest <- [BS.stripPrefix "#" label]]
 
     matchesSymbol :: SymbolName -> SymbolName -> Bool
     matchesSymbol label symbolName =

--- a/booster/package.yaml
+++ b/booster/package.yaml
@@ -184,6 +184,7 @@ tests:
     - hs-backend-booster
     - kore-rpc-types
     - monad-logger
+    - optparse-applicative
     - process
     - tasty
     - tasty-golden
@@ -191,6 +192,7 @@ tests:
     - tasty-hunit
     - text
     - transformers
+    - unordered-containers
     ghc-options:
     - -rtsopts
     - -threaded

--- a/booster/tools/booster/Server.hs
+++ b/booster/tools/booster/Server.hs
@@ -126,6 +126,7 @@ main = do
                     , mainModuleName
                     , port
                     , llvmLibraryFile
+                    , hsOnlySymbols
                     , logOptions =
                         LogOptions
                             { logLevels
@@ -237,7 +238,7 @@ main = do
                 definitionsWithCeilSummaries <-
                     liftIO $
                         loadDefinition rewriteOptions.indexCells definitionFile
-                            >>= mapM (mapM (runNoLoggingT . computeCeilsDefinition mLlvmLibrary))
+                            >>= mapM (mapM (runNoLoggingT . computeCeilsDefinition mLlvmLibrary hsOnlySymbols))
                             >>= evaluate . force . either (error . show) id
                 unless (isJust $ Map.lookup mainModuleName definitionsWithCeilSummaries) $ do
                     runBoosterLogger $
@@ -303,6 +304,7 @@ main = do
                                 { definitions = Map.map fst definitionsWithCeilSummaries
                                 , defaultMain = mainModuleName
                                 , mLlvmLibrary
+                                , hsOnlySymbols
                                 , mSMTOptions = if boosterSMT then smtOptions else Nothing
                                 , rewriteOptions
                                 , addedModules = mempty

--- a/booster/unit-tests/Test/Booster/CLOptions.hs
+++ b/booster/unit-tests/Test/Booster/CLOptions.hs
@@ -2,28 +2,54 @@ module Test.Booster.CLOptions (
     test_hsOnlySymbolParser,
 ) where
 
+import Data.ByteString.Char8 qualified as BS
+import Data.HashSet qualified as HashSet
+import Data.List (isInfixOf)
 import Options.Applicative
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Booster.CLOptions (clOptionsParser)
+import Booster.CLOptions (CLOptions (hsOnlySymbols), clOptionsParser)
 
 test_hsOnlySymbolParser :: TestTree
 test_hsOnlySymbolParser =
-    testCase "Parser accepts repeated --hs-only-symbol options" $ do
-        let parserInfo = info clOptionsParser mempty
-            args =
-                [ "definition.kore"
-                , "--module"
-                , "KMIR"
-                , "--hs-only-symbol"
-                , "lookupTy"
-                , "--hs-only-symbol"
-                , "#getBlocks"
-                ]
-        case execParserPure defaultPrefs parserInfo args of
-            Success _ -> pure ()
-            Failure failure ->
-                assertFailure $ fst $ renderFailure failure "kore-rpc-booster"
-            CompletionInvoked _ ->
-                assertFailure "Unexpected completion result"
+    testGroup
+        "hs-only symbol parser"
+        [ testCase "accepts repeated options and stores configured symbols" $ do
+            let parserInfo = info clOptionsParser mempty
+                args =
+                    [ "definition.kore"
+                    , "--module"
+                    , "KMIR"
+                    , "--hs-only-symbol"
+                    , "lookupTy"
+                    , "--hs-only-symbol"
+                    , "#getBlocks"
+                    , "--hs-only-symbol"
+                    , "lookupTy"
+                    ]
+            case execParserPure defaultPrefs parserInfo args of
+                Success options ->
+                    hsOnlySymbols options @?= HashSet.fromList [BS.pack "lookupTy", BS.pack "#getBlocks"]
+                Failure failure ->
+                    assertFailure $ fst $ renderFailure failure "kore-rpc-booster"
+                CompletionInvoked _ ->
+                    assertFailure "Unexpected completion result"
+        , testCase "rejects an empty symbol label" $ do
+            let parserInfo = info clOptionsParser mempty
+                args =
+                    [ "definition.kore"
+                    , "--module"
+                    , "KMIR"
+                    , "--hs-only-symbol"
+                    , ""
+                    ]
+            case execParserPure defaultPrefs parserInfo args of
+                Success _ ->
+                    assertFailure "Expected parser failure for empty hs-only symbol label"
+                Failure failure -> do
+                    let (msg, _) = renderFailure failure "kore-rpc-booster"
+                    assertBool "Expected an 'empty label' parse error" ("empty label" `isInfixOf` msg)
+                CompletionInvoked _ ->
+                    assertFailure "Unexpected completion result"
+        ]

--- a/booster/unit-tests/Test/Booster/CLOptions.hs
+++ b/booster/unit-tests/Test/Booster/CLOptions.hs
@@ -1,0 +1,29 @@
+module Test.Booster.CLOptions (
+    test_hsOnlySymbolParser,
+) where
+
+import Options.Applicative
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Booster.CLOptions (clOptionsParser)
+
+test_hsOnlySymbolParser :: TestTree
+test_hsOnlySymbolParser =
+    testCase "Parser accepts repeated --hs-only-symbol options" $ do
+        let parserInfo = info clOptionsParser mempty
+            args =
+                [ "definition.kore"
+                , "--module"
+                , "KMIR"
+                , "--hs-only-symbol"
+                , "lookupTy"
+                , "--hs-only-symbol"
+                , "#getBlocks"
+                ]
+        case execParserPure defaultPrefs parserInfo args of
+            Success _ -> pure ()
+            Failure failure ->
+                assertFailure $ fst $ renderFailure failure "kore-rpc-booster"
+            CompletionInvoked _ ->
+                assertFailure "Unexpected completion result"

--- a/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -12,11 +12,13 @@ module Test.Booster.Pattern.ApplyEquations (
     test_simplify,
     test_simplifyPattern,
     test_simplifyConstraint,
+    test_hsOnlySymbolGuard,
     test_errors,
 ) where
 
 import Control.Monad.Logger (runNoLoggingT)
 import Data.ByteString (ByteString)
+import Data.HashSet qualified as HashSet
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
@@ -29,10 +31,10 @@ import Booster.Pattern.ApplyEquations
 import Booster.Pattern.Base
 import Booster.Pattern.Bool
 import Booster.Pattern.Index (CellIndex (..), TermIndex (..))
-import Booster.Pattern.Util (sortOfTerm)
+import Booster.Pattern.Util (containsSymbolName, sortOfTerm)
 import Booster.SMT.Interface (noSolver)
 import Booster.Syntax.Json.Internalise (trm)
-import Booster.Util (Flag (..))
+import Booster.Util (Flag (..), decodeLabel')
 import Test.Booster.Fixture hiding (inj)
 import Test.Booster.Util ((@?>>=))
 
@@ -98,7 +100,7 @@ test_evaluateFunction =
   where
     eval direction t = do
         ns <- noSolver
-        runNoLoggingT $ fst <$> evaluateTerm direction funDef Nothing ns mempty mempty t
+        runNoLoggingT $ fst <$> evaluateTerm direction funDef Nothing mempty ns mempty mempty t
 
     isTooManyIterations (Left (TooManyIterations _n _ _)) = pure ()
     isTooManyIterations (Left err) = assertFailure $ "Unexpected error " <> show err
@@ -127,7 +129,7 @@ test_simplify =
   where
     simpl direction t = do
         ns <- noSolver
-        runNoLoggingT $ fst <$> evaluateTerm direction simplDef Nothing ns mempty mempty t
+        runNoLoggingT $ fst <$> evaluateTerm direction simplDef Nothing mempty ns mempty mempty t
     a = var "A" someSort
 
 test_simplifyPattern :: TestTree
@@ -155,7 +157,7 @@ test_simplifyPattern =
   where
     simpl t = do
         ns <- noSolver
-        runNoLoggingT $ fst <$> evaluatePattern simplDef Nothing ns mempty t
+        runNoLoggingT $ fst <$> evaluatePattern simplDef Nothing mempty ns mempty t
     a = var "A" someSort
 
 test_simplifyConstraint :: TestTree
@@ -224,7 +226,7 @@ test_simplifyConstraint =
     simpl t =
         do
             ns <- noSolver
-            runNoLoggingT $ fst <$> simplifyConstraint testDefinition Nothing ns mempty mempty t
+            runNoLoggingT $ fst <$> simplifyConstraint testDefinition Nothing mempty ns mempty mempty t
 
 test_errors :: TestTree
 test_errors =
@@ -240,13 +242,42 @@ test_errors =
             isLoop loopTerms
                 =<< ( runNoLoggingT $
                         fst
-                            <$> evaluateTerm TopDown loopDef Nothing ns mempty mempty subj
+                            <$> evaluateTerm TopDown loopDef Nothing mempty ns mempty mempty subj
                     )
         ]
   where
     isLoop ts (Left (EquationLoop ts')) = ts @?= ts'
     isLoop _ (Left err) = assertFailure $ "Unexpected error " <> show err
     isLoop _ (Right r) = assertFailure $ "Unexpected result " <> show r
+
+test_hsOnlySymbolGuard :: TestTree
+test_hsOnlySymbolGuard =
+    testGroup
+        "HS-only symbol guard helper"
+        [ testCase "Empty configuration does not match" $ do
+            let term = [trm| f1{}(con2{}(A:SomeSort{})) |]
+            containsSymbolName mempty term @?= False
+        , testCase "Configured symbol is detected in a candidate subtree" $ do
+            let term = [trm| f2{}(f1{}(con2{}(A:SomeSort{}))) |]
+            containsSymbolName (HashSet.singleton "f1") term @?= True
+        , testCase "Short label matches fully-qualified symbol names" $ do
+            let helperSym = f1{name = "#getBlocks(_)_KMIR-CONTROL-FLOW_List_Ty"}
+                term = app helperSym [var "A" someSort]
+            containsSymbolName (HashSet.singleton "#getBlocks") term @?= True
+        , testCase "Short label matches encoded Lbl symbol names" $ do
+            let encodedName = "Lbl'Hash'getBlocks'LParUndsRParUnds'KMIR-CONTROL-FLOW_List_Ty"
+                helperSym = f1{name = encodedName}
+                term = app helperSym [var "A" someSort]
+            decodeLabel' encodedName @?= "Lbl#getBlocks(_)_KMIR-CONTROL-FLOW_List_Ty"
+            containsSymbolName (HashSet.singleton "#getBlocks") term @?= True
+        , testCase "Guard clears after HS-side simplification removes inner helper" $ do
+            let term = [trm| f2{}(f1{}(con2{}(A:SomeSort{}))) |]
+                expected = [trm| f2{}(con2{}(A:SomeSort{})) |]
+            ns <- noSolver
+            simplified <- runNoLoggingT $ fst <$> evaluateTerm TopDown funDef Nothing mempty ns mempty mempty term
+            simplified @?= Right expected
+            containsSymbolName (HashSet.singleton "f1") expected @?= False
+        ]
 
 ----------------------------------------
 

--- a/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs
@@ -274,7 +274,8 @@ test_hsOnlySymbolGuard =
             let term = [trm| f2{}(f1{}(con2{}(A:SomeSort{}))) |]
                 expected = [trm| f2{}(con2{}(A:SomeSort{})) |]
             ns <- noSolver
-            simplified <- runNoLoggingT $ fst <$> evaluateTerm TopDown funDef Nothing mempty ns mempty mempty term
+            simplified <-
+                runNoLoggingT $ fst <$> evaluateTerm TopDown funDef Nothing mempty ns mempty mempty term
             simplified @?= Right expected
             containsSymbolName (HashSet.singleton "f1") expected @?= False
         ]

--- a/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
+++ b/booster/unit-tests/Test/Booster/Pattern/Rewrite.hs
@@ -160,6 +160,7 @@ testConf = do
         RewriteConfig
             { definition = def
             , llvmApi = Nothing
+            , hsOnlySymbols = mempty
             , smtSolver
             , varsToAvoid = mempty
             , doTracing = NoCollectRewriteTraces

--- a/dev-tools/booster-dev/Server.hs
+++ b/dev-tools/booster-dev/Server.hs
@@ -51,6 +51,7 @@ main = do
             { definitionFile
             , mainModuleName
             , llvmLibraryFile
+            , hsOnlySymbols
             , port
             , logOptions =
                 LogOptions
@@ -76,7 +77,7 @@ main = do
     withLlvmLib llvmLibraryFile $ \mLlvmLibrary -> do
         definitionMap <-
             loadDefinition rewriteOptions.indexCells definitionFile
-                >>= mapM (mapM ((fst <$>) . runNoLoggingT . computeCeilsDefinition mLlvmLibrary))
+                >>= mapM (mapM ((fst <$>) . runNoLoggingT . computeCeilsDefinition mLlvmLibrary hsOnlySymbols))
                 >>= evaluate . force . either (error . show) id
         -- ensure the (default) main module is present in the definition
         when (isNothing $ Map.lookup mainModuleName definitionMap) $
@@ -91,6 +92,7 @@ main = do
             definitionMap
             mainModuleName
             mLlvmLibrary
+            hsOnlySymbols
             rewriteOptions
             logFile
             smtOptions
@@ -118,22 +120,7 @@ parserInfoModifiers =
         <> header
             "Haskell Backend Booster - a JSON RPC server for quick symbolic execution of Kore definitions"
 
-runServer ::
-    Int ->
-    Map Text KoreDefinition ->
-    Text ->
-    Maybe LLVM.API ->
-    RewriteOptions ->
-    Maybe FilePath ->
-    Maybe SMT.SMTOptions ->
-    (LogLevel, [LogLevel]) ->
-    [Booster.Log.ContextFilter] ->
-    Bool ->
-    TimestampFormat ->
-    LogFormat ->
-    [ModifierT] ->
-    IO ()
-runServer port definitions defaultMain mLlvmLibrary rewriteOpts logFile mSMTOptions (_logLevel, customLevels) logContexts logTimeStamps timeStampsFormat logFormat prettyPrintOptions =
+runServer port definitions defaultMain mLlvmLibrary hsOnlySymbols rewriteOpts logFile mSMTOptions (_logLevel, customLevels) logContexts logTimeStamps timeStampsFormat logFormat prettyPrintOptions =
     do
         let timestampFlag = case timeStampsFormat of
                 Pretty -> PrettyTimestamps
@@ -157,6 +144,7 @@ runServer port definitions defaultMain mLlvmLibrary rewriteOpts logFile mSMTOpti
                         { definitions
                         , defaultMain
                         , mLlvmLibrary
+                        , hsOnlySymbols
                         , mSMTOptions
                         , rewriteOptions = rewriteOpts
                         , addedModules = mempty

--- a/dev-tools/booster-dev/Server.hs
+++ b/dev-tools/booster-dev/Server.hs
@@ -15,24 +15,20 @@ import Control.Monad.Logger qualified as Log
 import Control.Monad.Logger.CallStack (LogLevel)
 import Control.Monad.Trans.Reader (runReaderT)
 import Data.Conduit.Network (serverSettings)
-import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, isJust, isNothing)
-import Data.Text (Text, unpack)
+import Data.Text (unpack)
 import Data.Text.Encoding qualified as Text
 import Options.Applicative
 
 import Booster.CLOptions
-import Booster.Definition.Base (KoreDefinition (..))
 import Booster.Definition.Ceil (computeCeilsDefinition)
 import Booster.GlobalState
 import Booster.JsonRpc (ServerState (..), handleSmtError, respond)
-import Booster.LLVM as LLVM (API)
 import Booster.LLVM.Internal (mkAPI, withDLib)
 import Booster.Log qualified
 import Booster.Log.Context qualified as Booster.Log
 import Booster.Pattern.Pretty
-import Booster.SMT.Interface qualified as SMT
 import Booster.Syntax.ParsedKore (loadDefinition)
 import Booster.Util (
     newTimeCache,
@@ -87,15 +83,20 @@ main = do
         writeGlobalEquationOptions equationOptions
 
         putStrLn "Starting RPC server"
+        let initialServerState =
+                ServerState
+                    { definitions = definitionMap
+                    , defaultMain = mainModuleName
+                    , mLlvmLibrary
+                    , hsOnlySymbols
+                    , mSMTOptions = smtOptions
+                    , rewriteOptions
+                    , addedModules = mempty
+                    }
         runServer
             port
-            definitionMap
-            mainModuleName
-            mLlvmLibrary
-            hsOnlySymbols
-            rewriteOptions
+            initialServerState
             logFile
-            smtOptions
             (adjustLogLevels logLevels)
             logContexts
             logTimeStamps
@@ -120,7 +121,18 @@ parserInfoModifiers =
         <> header
             "Haskell Backend Booster - a JSON RPC server for quick symbolic execution of Kore definitions"
 
-runServer port definitions defaultMain mLlvmLibrary hsOnlySymbols rewriteOpts logFile mSMTOptions (_logLevel, customLevels) logContexts logTimeStamps timeStampsFormat logFormat prettyPrintOptions =
+runServer ::
+    Int ->
+    ServerState ->
+    Maybe FilePath ->
+    (LogLevel, [LogLevel]) ->
+    [Booster.Log.ContextFilter] ->
+    Bool ->
+    TimestampFormat ->
+    LogFormat ->
+    [ModifierT] ->
+    IO ()
+runServer port initialState logFile (_logLevel, customLevels) logContexts logTimeStamps timeStampsFormat logFormat prettyPrintOptions =
     do
         let timestampFlag = case timeStampsFormat of
                 Pretty -> PrettyTimestamps
@@ -140,18 +152,10 @@ runServer port definitions defaultMain mLlvmLibrary hsOnlySymbols rewriteOpts lo
                                         <> concatMap (\case Log.LevelOther o -> fromMaybe [] $ levelToContext Map.!? o; _ -> []) customLevels
             stateVar <-
                 newMVar
-                    ServerState
-                        { definitions
-                        , defaultMain
-                        , mLlvmLibrary
-                        , hsOnlySymbols
-                        , mSMTOptions
-                        , rewriteOptions = rewriteOpts
-                        , addedModules = mempty
-                        }
+                    initialState
             jsonRpcServer
                 (serverSettings port "*")
-                (isJust mLlvmLibrary) -- run in bound threads if LLVM library in use
+                (isJust initialState.mLlvmLibrary) -- run in bound threads if LLVM library in use
                 ( \rawReq req ->
                     flip runReaderT (filteredBoosterContextLogger, toModifiersRep prettyPrintOptions)
                         . Booster.Log.unLoggerT

--- a/dev-tools/parsetest/Parsetest.hs
+++ b/dev-tools/parsetest/Parsetest.hs
@@ -58,7 +58,7 @@ testParse verbose veryVerbose file = do
     report = runExceptT $ do
         parsedDef <- liftIO (Text.readFile file) >>= except . parseKoreDefinition file
         internalDef' <- except (first (renderDefault . pretty' @'[Decoded]) $ internalise Nothing parsedDef)
-        (internalDef, ceilSummary) <- runNoLoggingT $ computeCeilsDefinition Nothing internalDef'
+        (internalDef, ceilSummary) <- runNoLoggingT $ computeCeilsDefinition Nothing mempty internalDef'
         pure $ mkSummary file internalDef ceilSummary
 
 findByExtension ::


### PR DESCRIPTION
### Behavior Delta

| | Before | After |
|---|---|---|
| Trigger | LLVM simplification runs unconditionally on all candidate terms, regardless of whether they contain symbols that should only be handled by the Haskell backend. | Users pass `--hs-only-symbol LABEL` (repeatable) to `kore-rpc-booster`; any term containing a listed symbol skips LLVM simplification and stays on the Haskell path. |
| Observable effect | Terms with Haskell-only helper symbols could be sent to LLVM, producing incorrect results or crashes when the LLVM backend does not understand those symbols. | `llvmSimplify`, `simplifyConstraint'`, and `simplifyCeil` now check for HS-only symbols before dispatching to LLVM, falling back to the Haskell evaluator when a match is found. |
| Affected inputs | `kore-rpc-booster` CLI, `ServerState`, equation/rewrite/ceil evaluation paths, dev-tools (`booster-dev`, `parsetest`). | Same components, plus a new `--hs-only-symbol` flag, `containsSymbolName` helper, and unit tests covering CLI parsing and symbol matching. |

```mermaid
flowchart TD
  CLI["--hs-only-symbol LABEL (CLI)"] --> CLOptions["CLOptions.hsOnlySymbols :: HashSet ByteString"]
  CLOptions --> ServerState["ServerState / EquationConfig / RewriteConfig"]
  ServerState --> Guard{"Term contains HS-only symbol?"}
  Guard -- Yes --> Haskell["Haskell evaluator (no LLVM)"]
  Guard -- No --> LLVM["LLVM simplification (unchanged)"]
```

### Invariants / Non-goals

- **Must still hold**: When no `--hs-only-symbol` flags are passed, the empty set propagates everywhere and all existing behavior is unchanged (zero-cost guard).
- **Explicitly unchanged**: LLVM simplification logic itself is not modified; only the dispatch decision is guarded.
- **Out of scope**: Automatic detection of which symbols should be HS-only; this is left to the user via CLI configuration.

### Validation

| Risk point | Evidence | Link |
|---|---|---|
| CLI flag parsing (plain & K-encoded `Lbl'Hash'...` names) | `Test.Booster.CLOptions` unit tests | `booster/unit-tests/Test/Booster/CLOptions.hs` |
| `containsSymbolName` correctly scans nested terms | `Test.Booster.Pattern.ApplyEquations` unit tests | `booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs` |
| Dev-tools still compile with new `computeCeilsDefinition` arity | `cabal build booster-dev parsetest` | local build |
| LLVM integration not regressed | `cabal test llvm-integration` (10/10 pass) | local run |
| Predicate integration not regressed | `cabal test predicates-integration` (13/13 pass) | local run |
| CI fully green | GitHub Actions run `22986242999` | [CI run](https://github.com/runtimeverification/haskell-backend/actions) |

### Risk / Blast Radius / Rollback

- **Most likely failure**: A symbol label is passed in the wrong encoding (e.g., missing `Lbl` prefix), causing the guard to silently miss matches — terms still go to LLVM.
- **Blast radius**: Only affects `kore-rpc-booster` users who explicitly opt-in via `--hs-only-symbol`; default behavior (empty set) is unchanged.
- **How to detect**: Booster logs will show LLVM simplification still being called for terms that should have been kept on the Haskell path; unit tests cover both plain and encoded symbol names.
- **How to rollback**: Remove the `--hs-only-symbol` flag from the launch command; the empty `HashSet` causes all guards to pass through to LLVM as before.

### Review Focus

1. Verify that `containsSymbolName` in `Booster/Pattern/Util.hs` recursively scans all term constructors (especially `Injection`, `KMap`, `KList`, `KSet` internal structures).
2. Confirm that `hsOnlySymbols` is threaded correctly through `ServerState` → `EquationConfig` / `RewriteConfig` → `simplifyCeil` without any path dropping the set.
3. Check that `readHsOnlySymbol` in `CLOptions.hs` validates and encodes labels correctly (ASCII-printable check, `Lbl` prefix addition).

<details>
<summary><b>Architecture Trace</b></summary>

### Context (C4-L1)

No L1 change — this PR does not alter external system interactions. The `kore-rpc-booster` JSON-RPC interface is unchanged.

### Container (C4-L2)

Single-container change within `kore-rpc-booster`. The LLVM backend shared library and the Haskell Kore evaluator are both unchanged; only the dispatch logic in front of LLVM is modified.

### Component (C4-L3)

```mermaid
flowchart LR
  CLI["CLOptions parser"] --> Server["Server.hs (ServerState)"]
  Server --> AE["ApplyEquations (llvmSimplify, simplifyConstraint')"]
  Server --> Ceil["Definition.Ceil (simplifyCeil)"]
  AE --> Util["Pattern.Util (containsSymbolName)"]
  Ceil --> Util
```

### Code Trace (C4-L4)

- CLI flag definition → `Booster.CLOptions` → `booster/library/Booster/CLOptions.hs`
- Term scanning helper → `Booster.Pattern.Util.containsSymbolName` → `booster/library/Booster/Pattern/Util.hs`
- LLVM dispatch guard (equations) → `Booster.Pattern.ApplyEquations` → `booster/library/Booster/Pattern/ApplyEquations.hs`
- LLVM dispatch guard (ceil) → `Booster.Definition.Ceil` → `booster/library/Booster/Definition/Ceil.hs`
- Server state threading → `booster/tools/booster/Server.hs`, `Booster.JsonRpc`
- Dev-tools fixup → `dev-tools/booster-dev/Server.hs`, `dev-tools/parsetest/Parsetest.hs`
- Unit tests → `booster/unit-tests/Test/Booster/CLOptions.hs`, `booster/unit-tests/Test/Booster/Pattern/ApplyEquations.hs`

### Decision Record

- **Decision**: Add a CLI-configurable symbol set that guards LLVM simplification entry points, keeping flagged terms on the Haskell evaluation path.
- **Alternatives considered**: (1) Hard-code known HS-only symbols in the booster — rejected because the set varies per K definition. (2) Detect HS-only symbols automatically from the definition — deferred as it requires deeper definition analysis infrastructure.
- **Trade-offs**: Requires users to know and pass the correct symbol labels; in exchange, zero runtime cost when unused and no changes to existing semantics.
- **Why chosen**: Provides an immediate, low-risk mechanism to prevent incorrect LLVM evaluation of Haskell-only symbols without waiting for automatic detection infrastructure.

</details>