### PR TITLE
Add downstream performance workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - linux
+    - normal
+    - self-macos-latest
+
+config-variables: null

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -50,7 +50,7 @@ runs:
       id: suite
       shell: bash
       env:
-        DOWNSTREAM_PERF_MANIFEST: scripts/logs/downstream-perf-${{ inputs.suite }}.manifest
+        DOWNSTREAM_PERF_MANIFEST: ${{ github.workspace }}/scripts/logs/downstream-perf-${{ inputs.suite }}.manifest
         DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS: ${{ inputs.feature-budget-seconds }}
         FEATURE_BRANCH_NAME: ${{ inputs.feature-branch-name }}
       run: |

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -18,9 +18,9 @@ inputs:
     description: 'Trigger reason emitted by the select job'
     required: true
   feature-budget-seconds:
-    description: 'If the feature run takes longer than this, skip baseline comparison and fail the suite'
+    description: 'Per-command timeout budget used for feature and baseline classification runs'
     required: false
-    default: '5400'
+    default: '3600'
 
 runs:
   using: 'composite'

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -17,10 +17,14 @@ inputs:
   reason:
     description: 'Trigger reason emitted by the select job'
     required: true
-  feature-budget-seconds:
-    description: 'Per-command timeout budget used for feature and baseline classification runs'
+  timeout-seconds:
+    description: 'Per-command timeout in seconds used for feature and baseline runs'
     required: false
-    default: '3600'
+    default: '14400'
+  shard-label:
+    description: 'Optional shard label to isolate per-shard outputs'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -61,7 +65,7 @@ runs:
       shell: bash
       env:
         DOWNSTREAM_PERF_MANIFEST: ${{ github.workspace }}/scripts/logs/downstream-perf-${{ inputs.suite }}.manifest
-        DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS: ${{ inputs.feature-budget-seconds }}
+        DOWNSTREAM_PERF_TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
         FEATURE_BRANCH_NAME: ${{ inputs.feature-branch-name }}
       run: |
         set +e
@@ -76,6 +80,7 @@ runs:
       env:
         FEATURE_BRANCH_NAME: ${{ inputs.feature-branch-name }}
         REASON: ${{ inputs.reason }}
+        DOWNSTREAM_PERF_SHARD_LABEL: ${{ inputs.shard-label }}
       run: |
         bash scripts/collect-downstream-perf-results.sh "${{ inputs.suite }}" "scripts/logs/downstream-perf-${{ inputs.suite }}.manifest" "$REASON" "$FEATURE_BRANCH_NAME"
 

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -1,0 +1,84 @@
+name: 'Downstream Perf Suite'
+description: 'Run one downstream performance suite, preserve artifacts, and fail only after collection/upload.'
+
+inputs:
+  suite:
+    description: 'Suite id, for example kevm or kontrol'
+    required: true
+  script:
+    description: 'Path to the suite runner script'
+    required: true
+  artifact-name:
+    description: 'Artifact name to upload'
+    required: true
+  feature-branch-name:
+    description: 'Raw feature branch name from GitHub context'
+    required: true
+  reason:
+    description: 'Trigger reason emitted by the select job'
+    required: true
+  feature-budget-seconds:
+    description: 'If the feature run takes longer than this, skip baseline comparison and fail the suite'
+    required: false
+    default: '5400'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install Nix'
+      uses: cachix/install-nix-action@v26
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.30.1/install
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
+          substituters = http://cache.nixos.org https://cache.iog.io
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+    - name: 'Install Cachix'
+      uses: cachix/cachix-action@v14
+      with:
+        name: k-framework
+        skipPush: true
+
+    - name: 'Install uv'
+      shell: bash
+      run: |
+        python3 -m pip install --user uv
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: 'Run suite'
+      id: suite
+      shell: bash
+      env:
+        DOWNSTREAM_PERF_MANIFEST: scripts/logs/downstream-perf-${{ inputs.suite }}.manifest
+        DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS: ${{ inputs.feature-budget-seconds }}
+        FEATURE_BRANCH_NAME: ${{ inputs.feature-branch-name }}
+      run: |
+        set +e
+        bash "${{ inputs.script }}"
+        status=$?
+        echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+        exit 0
+
+    - name: 'Collect suite results'
+      if: ${{ always() }}
+      shell: bash
+      env:
+        FEATURE_BRANCH_NAME: ${{ inputs.feature-branch-name }}
+        REASON: ${{ inputs.reason }}
+      run: |
+        bash scripts/collect-downstream-perf-results.sh "${{ inputs.suite }}" "scripts/logs/downstream-perf-${{ inputs.suite }}.manifest" "$REASON" "$FEATURE_BRANCH_NAME"
+
+    - name: 'Upload suite results'
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: downstream-perf/${{ inputs.suite }}
+        if-no-files-found: error
+
+    - name: 'Fail if suite failed'
+      if: ${{ steps.suite.outputs.exit_code != '0' }}
+      shell: bash
+      run: |
+        exit "${{ steps.suite.outputs.exit_code }}"

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -43,7 +43,17 @@ runs:
     - name: 'Install uv and cmake3'
       shell: bash
       run: |
-        python3 -m pip install --user uv "cmake<4"
+        python3 -m pip install --user uv
+        mkdir -p "$HOME/.local/bin" "$HOME/.local"
+        CMAKE_VERSION=3.31.6
+        CMAKE_ROOT="$HOME/.local/cmake-${CMAKE_VERSION}-linux-x86_64"
+        if [ ! -x "$CMAKE_ROOT/bin/cmake" ]; then
+          curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz" \
+            | tar -xz -C "$HOME/.local"
+        fi
+        ln -sf "$CMAKE_ROOT/bin/cmake" "$HOME/.local/bin/cmake"
+        ln -sf "$CMAKE_ROOT/bin/ctest" "$HOME/.local/bin/ctest"
+        ln -sf "$CMAKE_ROOT/bin/cpack" "$HOME/.local/bin/cpack"
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: 'Run suite'

--- a/.github/actions/downstream-perf-suite/action.yml
+++ b/.github/actions/downstream-perf-suite/action.yml
@@ -40,10 +40,10 @@ runs:
         name: k-framework
         skipPush: true
 
-    - name: 'Install uv'
+    - name: 'Install uv and cmake3'
       shell: bash
       run: |
-        python3 -m pip install --user uv
+        python3 -m pip install --user uv "cmake<4"
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: 'Run suite'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -140,7 +140,7 @@ jobs:
     name: 'KEVM downstream performance'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
-    runs-on: [self-hosted, linux, normal]
+    runs-on: [self-hosted, linux]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'
@@ -218,9 +218,9 @@ jobs:
 
   kontrol:
     name: 'Kontrol downstream performance'
-    needs: select
-    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
-    runs-on: [self-hosted, linux, normal]
+    needs: [select, kevm]
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') }}
+    runs-on: [self-hosted, linux]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -65,6 +65,7 @@ jobs:
               - 'scripts/performance-tests-kevm.sh'
               - 'scripts/performance-tests-kontrol.sh'
               - 'scripts/compare.py'
+              - 'scripts/compare-downstream-perf-artifacts.sh'
               - 'scripts/collect-downstream-perf-results.sh'
               - 'scripts/downstream-perf-lib.sh'
               - '.github/actions/downstream-perf-suite/**'
@@ -139,26 +140,43 @@ jobs:
             echo "- Target PR: ${target_pr:-none}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  kevm:
-    name: 'KEVM downstream performance (${{ matrix.proof }})'
+  kevm_master:
+    name: 'KEVM master raw'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - proof: rules
-            target: test-prove-rules
-          - proof: functional
-            target: test-prove-functional
-          - proof: optimizations
-            target: test-prove-optimizations
-          - proof: dss
-            target: test-prove-dss
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
     steps:
-      - name: 'Check out code'
+      - name: 'Check out master'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/heads/master
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: 'Run KEVM master raw run'
+        uses: ./.github/actions/downstream-perf-suite
+        env:
+          BASELINE_COMMIT: HEAD
+          PYTEST_PARALLEL: 1
+        with:
+          suite: kevm
+          script: scripts/performance-tests-kevm.sh
+          artifact-name: kevm-master-raw-${{ github.run_id }}
+          feature-branch-name: master
+          reason: ${{ needs.select.outputs.reason }}
+          timeout-seconds: '14400'
+          shard-label: master
+
+  kevm_current:
+    name: 'KEVM current raw'
+    needs: select
+    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
+    runs-on: [self-hosted, linux, normal]
+    timeout-minutes: 240
+    steps:
+      - name: 'Check out current'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -166,28 +184,56 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: 'Run KEVM downstream suite'
+      - name: 'Run KEVM current raw run'
         uses: ./.github/actions/downstream-perf-suite
         env:
+          BASELINE_COMMIT: HEAD
           PYTEST_PARALLEL: 1
-          KEVM_TEST_TARGET: ${{ matrix.target }}
         with:
           suite: kevm
           script: scripts/performance-tests-kevm.sh
-          artifact-name: kevm-downstream-perf-${{ github.run_id }}-${{ matrix.proof }}
+          artifact-name: kevm-current-raw-${{ github.run_id }}
           feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
           reason: ${{ needs.select.outputs.reason }}
           timeout-seconds: '14400'
-          shard-label: ${{ matrix.proof }}
+          shard-label: current
 
-  kontrol:
-    name: 'Kontrol downstream performance'
+  kontrol_master:
+    name: 'Kontrol master raw'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
     steps:
-      - name: 'Check out code'
+      - name: 'Check out master'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/heads/master
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: 'Run Kontrol master raw run'
+        uses: ./.github/actions/downstream-perf-suite
+        env:
+          BASELINE_COMMIT: HEAD
+        with:
+          suite: kontrol
+          script: scripts/performance-tests-kontrol.sh
+          artifact-name: kontrol-master-raw-${{ github.run_id }}
+          feature-branch-name: master
+          reason: ${{ needs.select.outputs.reason }}
+          timeout-seconds: '14400'
+          shard-label: master
+
+  kontrol_current:
+    name: 'Kontrol current raw'
+    needs: select
+    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
+    runs-on: [self-hosted, linux, normal]
+    timeout-minutes: 240
+    steps:
+      - name: 'Check out current'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -195,81 +241,175 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: 'Run Kontrol downstream suite'
+      - name: 'Run Kontrol current raw run'
         uses: ./.github/actions/downstream-perf-suite
+        env:
+          BASELINE_COMMIT: HEAD
         with:
           suite: kontrol
           script: scripts/performance-tests-kontrol.sh
-          artifact-name: kontrol-downstream-perf-${{ github.run_id }}
+          artifact-name: kontrol-current-raw-${{ github.run_id }}
           feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
           reason: ${{ needs.select.outputs.reason }}
           timeout-seconds: '14400'
+          shard-label: current
 
-  report:
-    name: 'Publish downstream perf PR comment'
+  kevm_compare:
+    name: 'KEVM compare'
     needs:
       - select
-      - kevm
-      - kontrol
-    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') && (needs.select.outputs.run_kontrol != 'true' || needs.kontrol.result != 'cancelled') }}
+      - kevm_master
+      - kevm_current
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' && needs.kevm_master.result != 'cancelled' && needs.kevm_current.result != 'cancelled' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 'Download KEVM master raw results'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: kevm-master-raw-${{ github.run_id }}
+          path: downstream-perf/raw/kevm-master
+
+      - name: 'Download KEVM current raw results'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: kevm-current-raw-${{ github.run_id }}
+          path: downstream-perf/raw/kevm-current
+
+      - name: 'Compare KEVM raw results'
+        id: compare
+        run: |
+          set +e
+          bash scripts/compare-downstream-perf-artifacts.sh \
+            kevm \
+            downstream-perf/raw/kevm-master \
+            downstream-perf/raw/kevm-current \
+            downstream-perf/final/kevm
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: 'Publish KEVM compare summary'
+        if: ${{ always() }}
+        run: |
+          if [ -f downstream-perf/final/kevm/summary.md ]; then
+            cat downstream-perf/final/kevm/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: 'Upload KEVM final artifact'
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kevm-final-${{ github.run_id }}
+          path: downstream-perf/final/kevm
+          if-no-files-found: error
+
+      - name: 'Fail if KEVM compare failed'
+        if: ${{ steps.compare.outputs.exit_code != '0' }}
+        run: |
+          exit "${{ steps.compare.outputs.exit_code }}"
+
+  kontrol_compare:
+    name: 'Kontrol compare'
+    needs:
+      - select
+      - kontrol_master
+      - kontrol_current
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' && needs.kontrol_master.result != 'cancelled' && needs.kontrol_current.result != 'cancelled' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 'Download Kontrol master raw results'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: kontrol-master-raw-${{ github.run_id }}
+          path: downstream-perf/raw/kontrol-master
+
+      - name: 'Download Kontrol current raw results'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: kontrol-current-raw-${{ github.run_id }}
+          path: downstream-perf/raw/kontrol-current
+
+      - name: 'Compare Kontrol raw results'
+        id: compare
+        run: |
+          set +e
+          bash scripts/compare-downstream-perf-artifacts.sh \
+            kontrol \
+            downstream-perf/raw/kontrol-master \
+            downstream-perf/raw/kontrol-current \
+            downstream-perf/final/kontrol
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: 'Publish Kontrol compare summary'
+        if: ${{ always() }}
+        run: |
+          if [ -f downstream-perf/final/kontrol/summary.md ]; then
+            cat downstream-perf/final/kontrol/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: 'Upload Kontrol final artifact'
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kontrol-final-${{ github.run_id }}
+          path: downstream-perf/final/kontrol
+          if-no-files-found: error
+
+      - name: 'Fail if Kontrol compare failed'
+        if: ${{ steps.compare.outputs.exit_code != '0' }}
+        run: |
+          exit "${{ steps.compare.outputs.exit_code }}"
+
+  report:
+    name: 'Report downstream perf comment'
+    needs:
+      - select
+      - kevm_compare
+      - kontrol_compare
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' && (needs.select.outputs.run_kevm != 'true' || needs.kevm_compare.result != 'cancelled') && (needs.select.outputs.run_kontrol != 'true' || needs.kontrol_compare.result != 'cancelled') }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       issues: write
       pull-requests: write
     steps:
-      - name: 'Download KEVM results'
-        if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm.result != 'cancelled' && needs.kevm.result != 'skipped' }}
+      - name: 'Download KEVM final artifact'
+        if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm_compare.result != 'cancelled' && needs.kevm_compare.result != 'skipped' }}
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          pattern: kevm-downstream-perf-${{ github.run_id }}-*
-          path: downstream-perf/kevm
-          merge-multiple: true
+          name: kevm-final-${{ github.run_id }}
+          path: downstream-perf/final/kevm
 
-      - name: 'Download Kontrol results'
-        if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result != 'cancelled' && needs.kontrol.result != 'skipped' }}
+      - name: 'Download Kontrol final artifact'
+        if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol_compare.result != 'cancelled' && needs.kontrol_compare.result != 'skipped' }}
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: kontrol-downstream-perf-${{ github.run_id }}
-          path: downstream-perf/kontrol
+          name: kontrol-final-${{ github.run_id }}
+          path: downstream-perf/final/kontrol
 
-      - name: 'Package KEVM bundle'
-        if: ${{ needs.select.outputs.run_kevm == 'true' }}
-        run: |
-          set -euo pipefail
-          mkdir -p downstream-perf/report
-          if [ -d downstream-perf/kevm ]; then
-            (cd downstream-perf && zip -qr report/kevm-bundle.zip kevm)
-          fi
-
-      - name: 'Upload KEVM bundle'
-        if: ${{ needs.select.outputs.run_kevm == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: kevm-downstream-perf-bundle-${{ github.run_id }}
-          path: downstream-perf/report/kevm-bundle.zip
-          if-no-files-found: ignore
-
-      - name: 'Package Kontrol bundle'
-        if: ${{ needs.select.outputs.run_kontrol == 'true' }}
-        run: |
-          set -euo pipefail
-          mkdir -p downstream-perf/report
-          if [ -d downstream-perf/kontrol ]; then
-            (cd downstream-perf && zip -qr report/kontrol-bundle.zip kontrol)
-          fi
-
-      - name: 'Upload Kontrol bundle'
-        if: ${{ needs.select.outputs.run_kontrol == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: kontrol-downstream-perf-bundle-${{ github.run_id }}
-          path: downstream-perf/report/kontrol-bundle.zip
-          if-no-files-found: ignore
-
-      - name: 'Resolve artifact links'
+      - name: 'Resolve final artifact links'
         id: artifact_links
         uses: actions/github-script@v7
         env:
@@ -297,10 +437,10 @@ jobs:
             }
 
             const kevmLink = process.env.RUN_KEVM === 'true'
-              ? linkForPrefix(`kevm-downstream-perf-bundle-${runId}`)
+              ? linkForPrefix(`kevm-final-${runId}`)
               : '';
             const kontrolLink = process.env.RUN_KONTROL === 'true'
-              ? linkForPrefix(`kontrol-downstream-perf-bundle-${runId}`)
+              ? linkForPrefix(`kontrol-final-${runId}`)
               : '';
 
             core.setOutput('kevm_link', kevmLink);
@@ -321,32 +461,6 @@ jobs:
           mkdir -p downstream-perf/report
           comment_file="downstream-perf/report/comment.md"
 
-          emit_summary_row() {
-            local manifest_path=$1
-            local label=$2
-            # shellcheck disable=SC1090
-            . "$manifest_path"
-            printf '| %s | %s | %s | %s | %s | %s |\n' \
-              "$label" \
-              "${FEATURE_STATUS:-unknown}" \
-              "${FEATURE_DURATION_SECONDS:-n/a}" \
-              "${BASELINE_STATUS:-not-run}" \
-              "${BASELINE_DURATION_SECONDS:-n/a}" \
-              "${COMPARE_STATUS:-not-run}"
-          }
-
-          emit_summary_values() {
-            local manifest_path=$1
-            # shellcheck disable=SC1090
-            . "$manifest_path"
-            printf '| %s | %s | %s | %s | %s |\n' \
-              "${FEATURE_STATUS:-unknown}" \
-              "${FEATURE_DURATION_SECONDS:-n/a}" \
-              "${BASELINE_STATUS:-not-run}" \
-              "${BASELINE_DURATION_SECONDS:-n/a}" \
-              "${COMPARE_STATUS:-not-run}"
-          }
-
           {
             echo '<!-- downstream-perf-report -->'
             echo '## Downstream Performance'
@@ -361,15 +475,10 @@ jobs:
               echo
               echo "- Artifacts: ${KEVM_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
-              if compgen -G 'downstream-perf/kevm/*/manifest.env' > /dev/null; then
-                echo '| Proof | Current | Current Seconds | Master | Master Seconds | Compare |'
-                echo '| --- | --- | ---: | --- | ---: | --- |'
-                for manifest in $(find downstream-perf/kevm -mindepth 2 -maxdepth 2 -name manifest.env | sort); do
-                  proof_name="$(basename "$(dirname "$manifest")")"
-                  emit_summary_row "$manifest" "$proof_name"
-                done
+              if [ -f downstream-perf/final/kevm/summary.md ]; then
+                sed '1,/^$/d' downstream-perf/final/kevm/summary.md
               else
-                echo 'No KEVM summary artifact was produced.'
+                echo 'No KEVM final summary was produced.'
               fi
               echo
             fi
@@ -379,12 +488,10 @@ jobs:
               echo
               echo "- Artifacts: ${KONTROL_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
-              if [ -f downstream-perf/kontrol/manifest.env ]; then
-                echo '| Current | Current Seconds | Master | Master Seconds | Compare |'
-                echo '| --- | ---: | --- | ---: | --- |'
-                emit_summary_values downstream-perf/kontrol/manifest.env
+              if [ -f downstream-perf/final/kontrol/summary.md ]; then
+                sed '1,/^$/d' downstream-perf/final/kontrol/summary.md
               else
-                echo 'No Kontrol summary artifact was produced.'
+                echo 'No Kontrol final summary was produced.'
               fi
               echo
             fi

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -140,7 +140,7 @@ jobs:
     name: 'KEVM downstream performance'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, normal]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'
@@ -220,7 +220,7 @@ jobs:
     name: 'Kontrol downstream performance'
     needs: [select, kevm]
     if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') }}
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, normal]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -140,20 +140,20 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   kevm:
-    name: 'KEVM downstream performance (shard ${{ matrix.shard }})'
+    name: 'KEVM downstream performance (${{ matrix.proof }})'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard: 1
+          - proof: rules
             target: test-prove-rules
-          - shard: 2
+          - proof: functional
             target: test-prove-functional
-          - shard: 3
+          - proof: optimizations
             target: test-prove-optimizations
-          - shard: 4
+          - proof: dss
             target: test-prove-dss
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
@@ -174,11 +174,11 @@ jobs:
         with:
           suite: kevm
           script: scripts/performance-tests-kevm.sh
-          artifact-name: kevm-downstream-perf-${{ github.run_id }}-shard-${{ matrix.shard }}
+          artifact-name: kevm-downstream-perf-${{ github.run_id }}-${{ matrix.proof }}
           feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
           reason: ${{ needs.select.outputs.reason }}
           timeout-seconds: '14400'
-          shard-label: shard-${{ matrix.shard }}
+          shard-label: ${{ matrix.proof }}
 
   kontrol:
     name: 'Kontrol downstream performance'
@@ -223,7 +223,7 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          pattern: kevm-downstream-perf-${{ github.run_id }}-shard-*
+          pattern: kevm-downstream-perf-${{ github.run_id }}-*
           path: downstream-perf/kevm
           merge-multiple: true
 
@@ -362,11 +362,11 @@ jobs:
               echo "- Artifacts: ${KEVM_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
               if compgen -G 'downstream-perf/kevm/*/manifest.env' > /dev/null; then
-                echo '| Shard | Current | Current Seconds | Master | Master Seconds | Compare |'
+                echo '| Proof | Current | Current Seconds | Master | Master Seconds | Compare |'
                 echo '| --- | --- | ---: | --- | ---: | --- |'
                 for manifest in $(find downstream-perf/kevm -mindepth 2 -maxdepth 2 -name manifest.env | sort); do
-                  shard_name="$(basename "$(dirname "$manifest")")"
-                  emit_summary_row "$manifest" "$shard_name"
+                  proof_name="$(basename "$(dirname "$manifest")")"
+                  emit_summary_row "$manifest" "$proof_name"
                 done
               else
                 echo 'No KEVM summary artifact was produced.'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -292,7 +292,7 @@ jobs:
       - select
       - kevm
       - kontrol
-    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' }}
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') && (needs.select.outputs.run_kontrol != 'true' || needs.kontrol.result != 'cancelled') }}
     runs-on: ubuntu-22.04
     steps:
       - name: 'Download KEVM results'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -65,6 +65,10 @@ jobs:
               - 'scripts/performance-tests-kevm.sh'
               - 'scripts/performance-tests-kontrol.sh'
               - 'scripts/compare.py'
+              - 'scripts/collect-downstream-perf-results.sh'
+              - 'scripts/downstream-perf-lib.sh'
+              - '.github/actions/downstream-perf-suite/**'
+              - '.github/actionlint.yaml'
               - '.github/workflows/downstream-perf.yml'
 
       - name: 'Decide suites'
@@ -199,6 +203,7 @@ jobs:
       - name: 'Download KEVM results'
         if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm.result != 'cancelled' && needs.kevm.result != 'skipped' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: kevm-downstream-perf-${{ github.run_id }}
           path: downstream-perf/kevm
@@ -206,6 +211,7 @@ jobs:
       - name: 'Download Kontrol results'
         if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result != 'cancelled' && needs.kontrol.result != 'skipped' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: kontrol-downstream-perf-${{ github.run_id }}
           path: downstream-perf/kontrol

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -161,8 +161,8 @@ jobs:
 
   kontrol:
     name: 'Kontrol downstream performance'
-    needs: [select, kevm]
-    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') }}
+    needs: select
+    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 180
     steps:

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -140,7 +140,7 @@ jobs:
     name: 'KEVM downstream performance'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, normal]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'
@@ -220,7 +220,7 @@ jobs:
     name: 'Kontrol downstream performance'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, normal]
     timeout-minutes: 180
     steps:
       - name: 'Check out code'

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -1,0 +1,400 @@
+name: 'Downstream Performance'
+
+on:
+  workflow_dispatch:
+    inputs:
+      suites:
+        description: 'Downstream suites to run'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - kevm
+          - kontrol
+      pr_number:
+        description: 'PR number to comment on when running manually'
+        required: false
+        type: string
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  select:
+    name: 'Select downstream perf suites'
+    runs-on: ubuntu-22.04
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      run_kevm: ${{ steps.decide.outputs.run_kevm }}
+      run_kontrol: ${{ steps.decide.outputs.run_kontrol }}
+      reason: ${{ steps.decide.outputs.reason }}
+      target_pr: ${{ steps.decide.outputs.target_pr }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: 'Detect relevant changes'
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            downstream_perf:
+              - 'booster/**'
+              - 'kore/**'
+              - 'kore-rpc-types/**'
+              - 'flake.nix'
+              - 'deps/**'
+              - 'scripts/performance-tests-kevm.sh'
+              - 'scripts/performance-tests-kontrol.sh'
+              - 'scripts/compare.py'
+              - '.github/workflows/downstream-perf.yml'
+
+      - name: 'Decide suites'
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_SUITES: ${{ inputs.suites || 'all' }}
+          REQUESTED_PR: ${{ inputs.pr_number || '' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HAS_PERF_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perf') }}
+          RELEVANT_CHANGES: ${{ steps.changes.outputs.downstream_perf || 'false' }}
+        run: |
+          should_run=false
+          run_kevm=false
+          run_kontrol=false
+          reason='not-requested'
+          target_pr="$PULL_REQUEST_NUMBER"
+
+          if [ -z "$target_pr" ] && [ -n "$REQUESTED_PR" ]; then
+            target_pr="$REQUESTED_PR"
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            should_run=true
+            reason='manual-dispatch'
+          elif [ "$HAS_PERF_LABEL" = "true" ]; then
+            should_run=true
+            reason='perf-label'
+          elif [ "$RELEVANT_CHANGES" = "true" ]; then
+            should_run=true
+            reason='relevant-path-change'
+          fi
+
+          if [ "$should_run" = "true" ]; then
+            case "$REQUESTED_SUITES" in
+              all)
+                run_kevm=true
+                run_kontrol=true
+                ;;
+              kevm)
+                run_kevm=true
+                ;;
+              kontrol)
+                run_kontrol=true
+                ;;
+              *)
+                echo "Unknown suites selection: $REQUESTED_SUITES" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          {
+            echo "should_run=$should_run"
+            echo "run_kevm=$run_kevm"
+            echo "run_kontrol=$run_kontrol"
+            echo "reason=$reason"
+            echo "target_pr=$target_pr"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Downstream perf selection"
+            echo
+            echo "- Event: $EVENT_NAME"
+            echo "- Reason: $reason"
+            echo "- KEVM: $run_kevm"
+            echo "- Kontrol: $run_kontrol"
+            echo "- Target PR: ${target_pr:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  kevm:
+    name: 'KEVM downstream performance'
+    needs: select
+    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 180
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v26
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v14
+        with:
+          name: k-framework
+          skipPush: true
+
+      - name: 'Run KEVM performance test'
+        env:
+          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          scripts/performance-tests-kevm.sh
+
+      - name: 'Collect KEVM results'
+        env:
+          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          REASON: ${{ needs.select.outputs.reason }}
+        run: |
+          set -euo pipefail
+
+          branch_slug="${FEATURE_BRANCH_NAME//\//-}"
+          mkdir -p downstream-perf/kevm
+
+          compare_file="$(find scripts/logs -maxdepth 1 -type f -name "kevm-*-$branch_slug-compare" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          feature_log="$(find scripts/logs -maxdepth 1 -type f -name "kevm-*-$branch_slug.log" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          master_log="$(find scripts/logs -maxdepth 1 -type f -name 'kevm-*-master-*.log' -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          summary_file="downstream-perf/kevm/summary.md"
+
+          cp "$compare_file" downstream-perf/kevm/
+          cp "$feature_log" downstream-perf/kevm/
+          cp "$master_log" downstream-perf/kevm/
+
+          {
+            echo "## KEVM downstream performance"
+            echo
+            echo "- Trigger: $REASON"
+            echo "- Feature branch: $FEATURE_BRANCH_NAME"
+            echo "- Compare file: $(basename "$compare_file")"
+            echo
+            if [ -s "$compare_file" ]; then
+              cat "$compare_file"
+            else
+              echo "No significant performance deltas above the current compare thresholds."
+            fi
+          } | tee "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 'Upload KEVM results'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kevm-downstream-perf-${{ github.run_id }}
+          path: downstream-perf/kevm
+          if-no-files-found: error
+
+  kontrol:
+    name: 'Kontrol downstream performance'
+    needs: select
+    if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 180
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v26
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v14
+        with:
+          name: k-framework
+          skipPush: true
+
+      - name: 'Run Kontrol performance test'
+        env:
+          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          scripts/performance-tests-kontrol.sh
+
+      - name: 'Collect Kontrol results'
+        env:
+          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          REASON: ${{ needs.select.outputs.reason }}
+        run: |
+          set -euo pipefail
+
+          branch_slug="${FEATURE_BRANCH_NAME//\//-}"
+          mkdir -p downstream-perf/kontrol
+
+          compare_file="$(find scripts/logs -maxdepth 1 -type f -name "kontrol-*-$branch_slug-compare" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          feature_log="$(find scripts/logs -maxdepth 1 -type f -name "kontrol-*-$branch_slug.log" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          master_log="$(find scripts/logs -maxdepth 1 -type f -name 'kontrol-*-master-*.log' -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
+          summary_file="downstream-perf/kontrol/summary.md"
+
+          cp "$compare_file" downstream-perf/kontrol/
+          cp "$feature_log" downstream-perf/kontrol/
+          cp "$master_log" downstream-perf/kontrol/
+
+          {
+            echo "## Kontrol downstream performance"
+            echo
+            echo "- Trigger: $REASON"
+            echo "- Feature branch: $FEATURE_BRANCH_NAME"
+            echo "- Compare file: $(basename "$compare_file")"
+            echo
+            if [ -s "$compare_file" ]; then
+              cat "$compare_file"
+            else
+              echo "No significant performance deltas above the current compare thresholds."
+            fi
+          } | tee "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 'Upload Kontrol results'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kontrol-downstream-perf-${{ github.run_id }}
+          path: downstream-perf/kontrol
+          if-no-files-found: error
+
+  report:
+    name: 'Publish downstream perf PR comment'
+    needs:
+      - select
+      - kevm
+      - kontrol
+    if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Download KEVM results'
+        if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: kevm-downstream-perf-${{ github.run_id }}
+          path: downstream-perf/kevm
+
+      - name: 'Download Kontrol results'
+        if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: kontrol-downstream-perf-${{ github.run_id }}
+          path: downstream-perf/kontrol
+
+      - name: 'Build PR comment body'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_KEVM: ${{ needs.select.outputs.run_kevm }}
+          RUN_KONTROL: ${{ needs.select.outputs.run_kontrol }}
+          KEVM_RESULT: ${{ needs.kevm.result }}
+          KONTROL_RESULT: ${{ needs.kontrol.result }}
+          TRIGGER_REASON: ${{ needs.select.outputs.reason }}
+          TARGET_PR: ${{ needs.select.outputs.target_pr }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p downstream-perf/report
+          comment_file="downstream-perf/report/comment.md"
+
+          {
+            echo '<!-- downstream-perf-report -->'
+            echo '## Downstream Performance'
+            echo
+            echo "- Trigger: $TRIGGER_REASON"
+            echo "- Target PR: #$TARGET_PR"
+            echo "- Workflow run: $RUN_URL"
+            echo
+
+            if [ "$RUN_KEVM" = "true" ]; then
+              echo "### KEVM"
+              echo
+              echo "- Job result: $KEVM_RESULT"
+              echo
+              if [ -f downstream-perf/kevm/summary.md ]; then
+                sed '1,/^$/d' downstream-perf/kevm/summary.md
+              else
+                echo 'No KEVM summary artifact was produced.'
+              fi
+              echo
+            fi
+
+            if [ "$RUN_KONTROL" = "true" ]; then
+              echo "### Kontrol"
+              echo
+              echo "- Job result: $KONTROL_RESULT"
+              echo
+              if [ -f downstream-perf/kontrol/summary.md ]; then
+                sed '1,/^$/d' downstream-perf/kontrol/summary.md
+              else
+                echo 'No Kontrol summary artifact was produced.'
+              fi
+              echo
+            fi
+          } > "$comment_file"
+
+      - name: 'Upsert PR comment'
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: downstream-perf/report/comment.md
+          TARGET_PR: ${{ needs.select.outputs.target_pr }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- downstream-perf-report -->';
+            const body = fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            const issue_number = Number(process.env.TARGET_PR);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -140,11 +140,23 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   kevm:
-    name: 'KEVM downstream performance'
+    name: 'KEVM downstream performance (shard ${{ matrix.shard }})'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kevm == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            k_expr: 'test_prove_rules and benchmarks'
+          - shard: 2
+            k_expr: 'test_prove_rules and erc20'
+          - shard: 3
+            k_expr: 'test_prove_rules and (examples or kontrol)'
+          - shard: 4
+            k_expr: 'test_prove_rules and mcd'
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v5
@@ -156,19 +168,24 @@ jobs:
 
       - name: 'Run KEVM downstream suite'
         uses: ./.github/actions/downstream-perf-suite
+        env:
+          PYTEST_PARALLEL: 1
+          KEVM_RULES_K_EXPR: ${{ matrix.k_expr }}
         with:
           suite: kevm
           script: scripts/performance-tests-kevm.sh
-          artifact-name: kevm-downstream-perf-${{ github.run_id }}
+          artifact-name: kevm-downstream-perf-${{ github.run_id }}-shard-${{ matrix.shard }}
           feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
           reason: ${{ needs.select.outputs.reason }}
+          timeout-seconds: '14400'
+          shard-label: shard-${{ matrix.shard }}
 
   kontrol:
     name: 'Kontrol downstream performance'
     needs: select
     if: ${{ needs.select.outputs.should_run == 'true' && needs.select.outputs.run_kontrol == 'true' }}
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v5
@@ -186,6 +203,7 @@ jobs:
           artifact-name: kontrol-downstream-perf-${{ github.run_id }}
           feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
           reason: ${{ needs.select.outputs.reason }}
+          timeout-seconds: '14400'
 
   report:
     name: 'Publish downstream perf PR comment'
@@ -205,8 +223,9 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: kevm-downstream-perf-${{ github.run_id }}
+          pattern: kevm-downstream-perf-${{ github.run_id }}-shard-*
           path: downstream-perf/kevm
+          merge-multiple: true
 
       - name: 'Download Kontrol results'
         if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result != 'cancelled' && needs.kontrol.result != 'skipped' }}
@@ -216,13 +235,84 @@ jobs:
           name: kontrol-downstream-perf-${{ github.run_id }}
           path: downstream-perf/kontrol
 
+      - name: 'Package KEVM bundle'
+        if: ${{ needs.select.outputs.run_kevm == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p downstream-perf/report
+          if [ -d downstream-perf/kevm ]; then
+            (cd downstream-perf && zip -qr report/kevm-bundle.zip kevm)
+          fi
+
+      - name: 'Upload KEVM bundle'
+        if: ${{ needs.select.outputs.run_kevm == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kevm-downstream-perf-bundle-${{ github.run_id }}
+          path: downstream-perf/report/kevm-bundle.zip
+          if-no-files-found: ignore
+
+      - name: 'Package Kontrol bundle'
+        if: ${{ needs.select.outputs.run_kontrol == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p downstream-perf/report
+          if [ -d downstream-perf/kontrol ]; then
+            (cd downstream-perf && zip -qr report/kontrol-bundle.zip kontrol)
+          fi
+
+      - name: 'Upload Kontrol bundle'
+        if: ${{ needs.select.outputs.run_kontrol == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kontrol-downstream-perf-bundle-${{ github.run_id }}
+          path: downstream-perf/report/kontrol-bundle.zip
+          if-no-files-found: ignore
+
+      - name: 'Resolve artifact links'
+        id: artifact_links
+        uses: actions/github-script@v7
+        env:
+          RUN_KEVM: ${{ needs.select.outputs.run_kevm }}
+          RUN_KONTROL: ${{ needs.select.outputs.run_kontrol }}
+        with:
+          script: |
+            const runId = Number(context.runId);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const artifactsPage = `${server}/${owner}/${repo}/actions/runs/${runId}#artifacts`;
+            const result = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: runId,
+              per_page: 100,
+            });
+            const artifacts = result.data.artifacts || [];
+
+            function linkForPrefix(prefix) {
+              const artifact = artifacts.find((item) => item.name.startsWith(prefix));
+              if (!artifact) return artifactsPage;
+              return `${server}/${owner}/${repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
+            }
+
+            const kevmLink = process.env.RUN_KEVM === 'true'
+              ? linkForPrefix(`kevm-downstream-perf-bundle-${runId}`)
+              : '';
+            const kontrolLink = process.env.RUN_KONTROL === 'true'
+              ? linkForPrefix(`kontrol-downstream-perf-bundle-${runId}`)
+              : '';
+
+            core.setOutput('kevm_link', kevmLink);
+            core.setOutput('kontrol_link', kontrolLink);
+
       - name: 'Build PR comment body'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_KEVM: ${{ needs.select.outputs.run_kevm }}
           RUN_KONTROL: ${{ needs.select.outputs.run_kontrol }}
-          KEVM_RESULT: ${{ needs.kevm.result }}
-          KONTROL_RESULT: ${{ needs.kontrol.result }}
+          KEVM_ARTIFACT_LINK: ${{ steps.artifact_links.outputs.kevm_link }}
+          KONTROL_ARTIFACT_LINK: ${{ steps.artifact_links.outputs.kontrol_link }}
           TRIGGER_REASON: ${{ needs.select.outputs.reason }}
           TARGET_PR: ${{ needs.select.outputs.target_pr }}
         run: |
@@ -230,6 +320,32 @@ jobs:
 
           mkdir -p downstream-perf/report
           comment_file="downstream-perf/report/comment.md"
+
+          emit_summary_row() {
+            local manifest_path=$1
+            local label=$2
+            # shellcheck disable=SC1090
+            . "$manifest_path"
+            printf '| %s | %s | %s | %s | %s | %s |\n' \
+              "$label" \
+              "${FEATURE_STATUS:-unknown}" \
+              "${FEATURE_DURATION_SECONDS:-n/a}" \
+              "${BASELINE_STATUS:-not-run}" \
+              "${BASELINE_DURATION_SECONDS:-n/a}" \
+              "${COMPARE_STATUS:-not-run}"
+          }
+
+          emit_summary_values() {
+            local manifest_path=$1
+            # shellcheck disable=SC1090
+            . "$manifest_path"
+            printf '| %s | %s | %s | %s | %s |\n' \
+              "${FEATURE_STATUS:-unknown}" \
+              "${FEATURE_DURATION_SECONDS:-n/a}" \
+              "${BASELINE_STATUS:-not-run}" \
+              "${BASELINE_DURATION_SECONDS:-n/a}" \
+              "${COMPARE_STATUS:-not-run}"
+          }
 
           {
             echo '<!-- downstream-perf-report -->'
@@ -243,10 +359,15 @@ jobs:
             if [ "$RUN_KEVM" = "true" ]; then
               echo "### KEVM"
               echo
-              echo "- Job result: $KEVM_RESULT"
+              echo "- Artifacts: ${KEVM_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
-              if [ -f downstream-perf/kevm/summary.md ]; then
-                sed '1,/^$/d' downstream-perf/kevm/summary.md
+              if compgen -G 'downstream-perf/kevm/*/manifest.env' > /dev/null; then
+                echo '| Shard | Feature | Feature Seconds | Baseline | Baseline Seconds | Compare |'
+                echo '| --- | --- | ---: | --- | ---: | --- |'
+                for manifest in $(find downstream-perf/kevm -mindepth 2 -maxdepth 2 -name manifest.env | sort); do
+                  shard_name="$(basename "$(dirname "$manifest")")"
+                  emit_summary_row "$manifest" "$shard_name"
+                done
               else
                 echo 'No KEVM summary artifact was produced.'
               fi
@@ -256,10 +377,12 @@ jobs:
             if [ "$RUN_KONTROL" = "true" ]; then
               echo "### Kontrol"
               echo
-              echo "- Job result: $KONTROL_RESULT"
+              echo "- Artifacts: ${KONTROL_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
-              if [ -f downstream-perf/kontrol/summary.md ]; then
-                sed '1,/^$/d' downstream-perf/kontrol/summary.md
+              if [ -f downstream-perf/kontrol/manifest.env ]; then
+                echo '| Feature | Feature Seconds | Baseline | Baseline Seconds | Compare |'
+                echo '| --- | ---: | --- | ---: | --- |'
+                emit_summary_values downstream-perf/kontrol/manifest.env
               else
                 echo 'No Kontrol summary artifact was produced.'
               fi

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -165,6 +165,11 @@ jobs:
           name: k-framework
           skipPush: true
 
+      - name: 'Install uv'
+        run: |
+          python3 -m pip install --user uv
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: 'Run KEVM performance test'
         env:
           FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -239,6 +244,11 @@ jobs:
         with:
           name: k-framework
           skipPush: true
+
+      - name: 'Install uv'
+        run: |
+          python3 -m pip install --user uv
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: 'Run Kontrol performance test'
         env:

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -147,13 +147,27 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
     steps:
-      - name: 'Check out master'
+      - name: 'Check out workflow code'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 'Check out master source tree'
         uses: actions/checkout@v5
         with:
           ref: refs/heads/master
+          path: haskell-backend-master
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
+
+      - name: 'Sync downstream perf scripts into master tree'
+        run: |
+          install -m 755 scripts/performance-tests-kevm.sh haskell-backend-master/scripts/performance-tests-kevm.sh
+          install -m 644 scripts/downstream-perf-lib.sh haskell-backend-master/scripts/downstream-perf-lib.sh
+          install -m 644 scripts/compare.py haskell-backend-master/scripts/compare.py
 
       - name: 'Run KEVM master raw run'
         uses: ./.github/actions/downstream-perf-suite
@@ -162,7 +176,7 @@ jobs:
           PYTEST_PARALLEL: 1
         with:
           suite: kevm
-          script: scripts/performance-tests-kevm.sh
+          script: haskell-backend-master/scripts/performance-tests-kevm.sh
           artifact-name: kevm-master-raw-${{ github.run_id }}
           feature-branch-name: master
           reason: ${{ needs.select.outputs.reason }}
@@ -205,13 +219,27 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
     steps:
-      - name: 'Check out master'
+      - name: 'Check out workflow code'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 'Check out master source tree'
         uses: actions/checkout@v5
         with:
           ref: refs/heads/master
+          path: haskell-backend-master
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
+
+      - name: 'Sync downstream perf scripts into master tree'
+        run: |
+          install -m 755 scripts/performance-tests-kontrol.sh haskell-backend-master/scripts/performance-tests-kontrol.sh
+          install -m 644 scripts/downstream-perf-lib.sh haskell-backend-master/scripts/downstream-perf-lib.sh
+          install -m 644 scripts/compare.py haskell-backend-master/scripts/compare.py
 
       - name: 'Run Kontrol master raw run'
         uses: ./.github/actions/downstream-perf-suite
@@ -219,7 +247,7 @@ jobs:
           BASELINE_COMMIT: HEAD
         with:
           suite: kontrol
-          script: scripts/performance-tests-kontrol.sh
+          script: haskell-backend-master/scripts/performance-tests-kontrol.sh
           artifact-name: kontrol-master-raw-${{ github.run_id }}
           feature-branch-name: master
           reason: ${{ needs.select.outputs.reason }}

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -148,13 +148,13 @@ jobs:
       matrix:
         include:
           - shard: 1
-            k_expr: 'test_prove_rules and benchmarks'
+            target: test-prove-rules
           - shard: 2
-            k_expr: 'test_prove_rules and erc20'
+            target: test-prove-functional
           - shard: 3
-            k_expr: 'test_prove_rules and (examples or kontrol)'
+            target: test-prove-optimizations
           - shard: 4
-            k_expr: 'test_prove_rules and mcd'
+            target: test-prove-dss
     runs-on: [self-hosted, linux, normal]
     timeout-minutes: 240
     steps:
@@ -170,7 +170,7 @@ jobs:
         uses: ./.github/actions/downstream-perf-suite
         env:
           PYTEST_PARALLEL: 1
-          KEVM_RULES_K_EXPR: ${{ matrix.k_expr }}
+          KEVM_TEST_TARGET: ${{ matrix.target }}
         with:
           suite: kevm
           script: scripts/performance-tests-kevm.sh
@@ -362,7 +362,7 @@ jobs:
               echo "- Artifacts: ${KEVM_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
               if compgen -G 'downstream-perf/kevm/*/manifest.env' > /dev/null; then
-                echo '| Shard | Feature | Feature Seconds | Baseline | Baseline Seconds | Compare |'
+                echo '| Shard | Current | Current Seconds | Master | Master Seconds | Compare |'
                 echo '| --- | --- | ---: | --- | ---: | --- |'
                 for manifest in $(find downstream-perf/kevm -mindepth 2 -maxdepth 2 -name manifest.env | sort); do
                   shard_name="$(basename "$(dirname "$manifest")")"
@@ -380,7 +380,7 @@ jobs:
               echo "- Artifacts: ${KONTROL_ARTIFACT_LINK:-$RUN_URL#artifacts}"
               echo
               if [ -f downstream-perf/kontrol/manifest.env ]; then
-                echo '| Feature | Feature Seconds | Baseline | Baseline Seconds | Compare |'
+                echo '| Current | Current Seconds | Master | Master Seconds | Compare |'
                 echo '| --- | ---: | --- | ---: | --- |'
                 emit_summary_values downstream-perf/kontrol/manifest.env
               else

--- a/.github/workflows/downstream-perf.yml
+++ b/.github/workflows/downstream-perf.yml
@@ -27,8 +27,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
@@ -46,10 +44,11 @@ jobs:
       target_pr: ${{ steps.decide.outputs.target_pr }}
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Detect relevant changes'
         if: ${{ github.event_name == 'pull_request' }}
@@ -144,77 +143,21 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
-      - name: 'Install Nix'
-        uses: cachix/install-nix-action@v26
+      - name: 'Run KEVM downstream suite'
+        uses: ./.github/actions/downstream-perf-suite
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            substituters = http://cache.nixos.org https://cache.iog.io
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-
-      - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
-        with:
-          name: k-framework
-          skipPush: true
-
-      - name: 'Install uv'
-        run: |
-          python3 -m pip install --user uv
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: 'Run KEVM performance test'
-        env:
-          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
-        run: |
-          scripts/performance-tests-kevm.sh
-
-      - name: 'Collect KEVM results'
-        env:
-          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          REASON: ${{ needs.select.outputs.reason }}
-        run: |
-          set -euo pipefail
-
-          branch_slug="${FEATURE_BRANCH_NAME//\//-}"
-          mkdir -p downstream-perf/kevm
-
-          compare_file="$(find scripts/logs -maxdepth 1 -type f -name "kevm-*-$branch_slug-compare" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          feature_log="$(find scripts/logs -maxdepth 1 -type f -name "kevm-*-$branch_slug.log" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          master_log="$(find scripts/logs -maxdepth 1 -type f -name 'kevm-*-master-*.log' -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          summary_file="downstream-perf/kevm/summary.md"
-
-          cp "$compare_file" downstream-perf/kevm/
-          cp "$feature_log" downstream-perf/kevm/
-          cp "$master_log" downstream-perf/kevm/
-
-          {
-            echo "## KEVM downstream performance"
-            echo
-            echo "- Trigger: $REASON"
-            echo "- Feature branch: $FEATURE_BRANCH_NAME"
-            echo "- Compare file: $(basename "$compare_file")"
-            echo
-            if [ -s "$compare_file" ]; then
-              cat "$compare_file"
-            else
-              echo "No significant performance deltas above the current compare thresholds."
-            fi
-          } | tee "$summary_file" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: 'Upload KEVM results'
-        uses: actions/upload-artifact@v4
-        with:
-          name: kevm-downstream-perf-${{ github.run_id }}
-          path: downstream-perf/kevm
-          if-no-files-found: error
+          suite: kevm
+          script: scripts/performance-tests-kevm.sh
+          artifact-name: kevm-downstream-perf-${{ github.run_id }}
+          feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          reason: ${{ needs.select.outputs.reason }}
 
   kontrol:
     name: 'Kontrol downstream performance'
@@ -224,77 +167,21 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
-      - name: 'Install Nix'
-        uses: cachix/install-nix-action@v26
+      - name: 'Run Kontrol downstream suite'
+        uses: ./.github/actions/downstream-perf-suite
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            substituters = http://cache.nixos.org https://cache.iog.io
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-
-      - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
-        with:
-          name: k-framework
-          skipPush: true
-
-      - name: 'Install uv'
-        run: |
-          python3 -m pip install --user uv
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: 'Run Kontrol performance test'
-        env:
-          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
-        run: |
-          scripts/performance-tests-kontrol.sh
-
-      - name: 'Collect Kontrol results'
-        env:
-          FEATURE_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          REASON: ${{ needs.select.outputs.reason }}
-        run: |
-          set -euo pipefail
-
-          branch_slug="${FEATURE_BRANCH_NAME//\//-}"
-          mkdir -p downstream-perf/kontrol
-
-          compare_file="$(find scripts/logs -maxdepth 1 -type f -name "kontrol-*-$branch_slug-compare" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          feature_log="$(find scripts/logs -maxdepth 1 -type f -name "kontrol-*-$branch_slug.log" -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          master_log="$(find scripts/logs -maxdepth 1 -type f -name 'kontrol-*-master-*.log' -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)"
-          summary_file="downstream-perf/kontrol/summary.md"
-
-          cp "$compare_file" downstream-perf/kontrol/
-          cp "$feature_log" downstream-perf/kontrol/
-          cp "$master_log" downstream-perf/kontrol/
-
-          {
-            echo "## Kontrol downstream performance"
-            echo
-            echo "- Trigger: $REASON"
-            echo "- Feature branch: $FEATURE_BRANCH_NAME"
-            echo "- Compare file: $(basename "$compare_file")"
-            echo
-            if [ -s "$compare_file" ]; then
-              cat "$compare_file"
-            else
-              echo "No significant performance deltas above the current compare thresholds."
-            fi
-          } | tee "$summary_file" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: 'Upload Kontrol results'
-        uses: actions/upload-artifact@v4
-        with:
-          name: kontrol-downstream-perf-${{ github.run_id }}
-          path: downstream-perf/kontrol
-          if-no-files-found: error
+          suite: kontrol
+          script: scripts/performance-tests-kontrol.sh
+          artifact-name: kontrol-downstream-perf-${{ github.run_id }}
+          feature-branch-name: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          reason: ${{ needs.select.outputs.reason }}
 
   report:
     name: 'Publish downstream perf PR comment'
@@ -304,16 +191,20 @@ jobs:
       - kontrol
     if: ${{ always() && needs.select.outputs.should_run == 'true' && needs.select.outputs.target_pr != '' && (needs.select.outputs.run_kevm != 'true' || needs.kevm.result != 'cancelled') && (needs.select.outputs.run_kontrol != 'true' || needs.kontrol.result != 'cancelled') }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: 'Download KEVM results'
-        if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm.result == 'success' }}
+        if: ${{ needs.select.outputs.run_kevm == 'true' && needs.kevm.result != 'cancelled' && needs.kevm.result != 'skipped' }}
         uses: actions/download-artifact@v4
         with:
           name: kevm-downstream-perf-${{ github.run_id }}
           path: downstream-perf/kevm
 
       - name: 'Download Kontrol results'
-        if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result == 'success' }}
+        if: ${{ needs.select.outputs.run_kontrol == 'true' && needs.kontrol.result != 'cancelled' && needs.kontrol.result != 'skipped' }}
         uses: actions/download-artifact@v4
         with:
           name: kontrol-downstream-perf-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: 'Test downstream perf shell helpers'
+        run: bash scripts/test-downstream-perf-lib.sh
+
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v25
         with:

--- a/scripts/collect-downstream-perf-results.sh
+++ b/scripts/collect-downstream-perf-results.sh
@@ -8,6 +8,7 @@ SUITE=$1
 MANIFEST_PATH=$2
 REASON=$3
 RAW_FEATURE_BRANCH=$4
+SHARD_LABEL=${DOWNSTREAM_PERF_SHARD_LABEL:-}
 
 if [[ -f $MANIFEST_PATH ]]; then
     # shellcheck disable=SC1090
@@ -16,6 +17,9 @@ fi
 
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(downstream_perf_normalize_feature_branch "$RAW_FEATURE_BRANCH")"}
 OUTPUT_DIR="downstream-perf/$SUITE"
+if [[ -n $SHARD_LABEL ]]; then
+    OUTPUT_DIR="$OUTPUT_DIR/$SHARD_LABEL"
+fi
 SUMMARY_FILE="$OUTPUT_DIR/summary.md"
 TITLE="KEVM downstream performance"
 if [[ $SUITE == "kontrol" ]]; then
@@ -60,8 +64,8 @@ copy_if_present "${COMPARE_FILE:-}"
     if [[ -n ${BASELINE_DURATION_SECONDS:-} ]]; then
         echo "- Baseline duration (seconds): $BASELINE_DURATION_SECONDS"
     fi
-    if [[ -n ${SKIP_REASON:-} ]]; then
-        echo "- Skip reason: $SKIP_REASON"
+    if [[ -n ${TIMEOUT_SECONDS:-} ]]; then
+        echo "- Timeout (seconds): $TIMEOUT_SECONDS"
     fi
     echo
 
@@ -73,10 +77,10 @@ copy_if_present "${COMPARE_FILE:-}"
         else
             echo "No significant performance deltas above the current compare thresholds."
         fi
-    elif [[ ${FEATURE_STATUS:-unknown} == "budget-exceeded" && ${BASELINE_STATUS:-not-run} == "budget-exceeded" ]]; then
-        echo "Feature and baseline runs both exceeded the configured budget, so compare output is unavailable."
-    elif [[ ${FEATURE_STATUS:-unknown} == "budget-exceeded" ]]; then
-        echo "Feature run exceeded the configured budget, so baseline comparison was skipped."
+    elif [[ ${FEATURE_STATUS:-unknown} == "timeout" && ${BASELINE_STATUS:-not-run} == "timeout" ]]; then
+        echo "Feature and baseline runs both timed out, so compare output is unavailable."
+    elif [[ ${FEATURE_STATUS:-unknown} == "timeout" ]]; then
+        echo "Feature run timed out, so baseline comparison was skipped."
     elif [[ ${FEATURE_STATUS:-unknown} != "success" ]]; then
         echo "Feature run failed before a compare artifact could be produced."
     elif [[ ${BASELINE_STATUS:-not-run} != "success" ]]; then

--- a/scripts/collect-downstream-perf-results.sh
+++ b/scripts/collect-downstream-perf-results.sh
@@ -73,6 +73,8 @@ copy_if_present "${COMPARE_FILE:-}"
         else
             echo "No significant performance deltas above the current compare thresholds."
         fi
+    elif [[ ${FEATURE_STATUS:-unknown} == "budget-exceeded" && ${BASELINE_STATUS:-not-run} == "budget-exceeded" ]]; then
+        echo "Feature and baseline runs both exceeded the configured budget, so compare output is unavailable."
     elif [[ ${FEATURE_STATUS:-unknown} == "budget-exceeded" ]]; then
         echo "Feature run exceeded the configured budget, so baseline comparison was skipped."
     elif [[ ${FEATURE_STATUS:-unknown} != "success" ]]; then

--- a/scripts/collect-downstream-perf-results.sh
+++ b/scripts/collect-downstream-perf-results.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/downstream-perf-lib.sh"
+
+SUITE=$1
+MANIFEST_PATH=$2
+REASON=$3
+RAW_FEATURE_BRANCH=$4
+
+if [[ -f $MANIFEST_PATH ]]; then
+    # shellcheck disable=SC1090
+    . "$MANIFEST_PATH"
+fi
+
+FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(downstream_perf_normalize_feature_branch "$RAW_FEATURE_BRANCH")"}
+OUTPUT_DIR="downstream-perf/$SUITE"
+SUMMARY_FILE="$OUTPUT_DIR/summary.md"
+TITLE="KEVM downstream performance"
+if [[ $SUITE == "kontrol" ]]; then
+    TITLE="Kontrol downstream performance"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+if [[ -f $MANIFEST_PATH ]]; then
+    cp "$MANIFEST_PATH" "$OUTPUT_DIR/manifest.env"
+fi
+
+copy_if_present() {
+    local maybe_path=$1
+    if [[ -n $maybe_path && -f $maybe_path ]]; then
+        cp "$maybe_path" "$OUTPUT_DIR/"
+    fi
+}
+
+copy_if_present "${FEATURE_LOG:-}"
+copy_if_present "${BASELINE_LOG:-}"
+copy_if_present "${COMPARE_FILE:-}"
+
+{
+    echo "## $TITLE"
+    echo
+    echo "- Trigger: $REASON"
+    echo "- Feature branch: $FEATURE_BRANCH_NAME"
+    if [[ -n ${HEAD_COMMIT:-} ]]; then
+        echo "- Head commit: $HEAD_COMMIT"
+    fi
+    if [[ -n ${BASELINE_COMMIT_SHORT:-} ]]; then
+        echo "- Baseline commit: $BASELINE_COMMIT_SHORT"
+    fi
+    echo "- Feature status: ${FEATURE_STATUS:-unknown}"
+    if [[ -n ${FEATURE_DURATION_SECONDS:-} ]]; then
+        echo "- Feature duration (seconds): $FEATURE_DURATION_SECONDS"
+    fi
+    if [[ ${BASELINE_STATUS:-not-run} != "not-run" ]]; then
+        echo "- Baseline status: $BASELINE_STATUS"
+    fi
+    if [[ -n ${BASELINE_DURATION_SECONDS:-} ]]; then
+        echo "- Baseline duration (seconds): $BASELINE_DURATION_SECONDS"
+    fi
+    if [[ -n ${SKIP_REASON:-} ]]; then
+        echo "- Skip reason: $SKIP_REASON"
+    fi
+    echo
+
+    if [[ -f ${COMPARE_FILE:-} ]]; then
+        echo "- Compare file: $(basename "$COMPARE_FILE")"
+        echo
+        if [[ -s $COMPARE_FILE ]]; then
+            cat "$COMPARE_FILE"
+        else
+            echo "No significant performance deltas above the current compare thresholds."
+        fi
+    elif [[ ${FEATURE_STATUS:-unknown} == "budget-exceeded" ]]; then
+        echo "Feature run exceeded the configured budget, so baseline comparison was skipped."
+    elif [[ ${FEATURE_STATUS:-unknown} != "success" ]]; then
+        echo "Feature run failed before a compare artifact could be produced."
+    elif [[ ${BASELINE_STATUS:-not-run} != "success" ]]; then
+        echo "Baseline run did not complete, so compare output is unavailable."
+    else
+        echo "No compare artifact was produced."
+    fi
+} | tee "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/collect-downstream-perf-results.sh
+++ b/scripts/collect-downstream-perf-results.sh
@@ -47,22 +47,22 @@ copy_if_present "${COMPARE_FILE:-}"
     echo "## $TITLE"
     echo
     echo "- Trigger: $REASON"
-    echo "- Feature branch: $FEATURE_BRANCH_NAME"
+    echo "- Current branch: $FEATURE_BRANCH_NAME"
     if [[ -n ${HEAD_COMMIT:-} ]]; then
         echo "- Head commit: $HEAD_COMMIT"
     fi
     if [[ -n ${BASELINE_COMMIT_SHORT:-} ]]; then
         echo "- Baseline commit: $BASELINE_COMMIT_SHORT"
     fi
-    echo "- Feature status: ${FEATURE_STATUS:-unknown}"
+    echo "- Current status: ${FEATURE_STATUS:-unknown}"
     if [[ -n ${FEATURE_DURATION_SECONDS:-} ]]; then
-        echo "- Feature duration (seconds): $FEATURE_DURATION_SECONDS"
+        echo "- Current duration (seconds): $FEATURE_DURATION_SECONDS"
     fi
     if [[ ${BASELINE_STATUS:-not-run} != "not-run" ]]; then
-        echo "- Baseline status: $BASELINE_STATUS"
+        echo "- Master status: $BASELINE_STATUS"
     fi
     if [[ -n ${BASELINE_DURATION_SECONDS:-} ]]; then
-        echo "- Baseline duration (seconds): $BASELINE_DURATION_SECONDS"
+        echo "- Master duration (seconds): $BASELINE_DURATION_SECONDS"
     fi
     if [[ -n ${TIMEOUT_SECONDS:-} ]]; then
         echo "- Timeout (seconds): $TIMEOUT_SECONDS"
@@ -78,13 +78,13 @@ copy_if_present "${COMPARE_FILE:-}"
             echo "No significant performance deltas above the current compare thresholds."
         fi
     elif [[ ${FEATURE_STATUS:-unknown} == "timeout" && ${BASELINE_STATUS:-not-run} == "timeout" ]]; then
-        echo "Feature and baseline runs both timed out, so compare output is unavailable."
+        echo "Current and master runs both timed out, so compare output is unavailable."
     elif [[ ${FEATURE_STATUS:-unknown} == "timeout" ]]; then
-        echo "Feature run timed out, so baseline comparison was skipped."
+        echo "Current run timed out, so master comparison was skipped."
     elif [[ ${FEATURE_STATUS:-unknown} != "success" ]]; then
-        echo "Feature run failed before a compare artifact could be produced."
+        echo "Current run failed before a compare artifact could be produced."
     elif [[ ${BASELINE_STATUS:-not-run} != "success" ]]; then
-        echo "Baseline run did not complete, so compare output is unavailable."
+        echo "Master run did not complete, so compare output is unavailable."
     else
         echo "No compare artifact was produced."
     fi

--- a/scripts/compare-downstream-perf-artifacts.sh
+++ b/scripts/compare-downstream-perf-artifacts.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 <suite> <master-raw-root> <current-raw-root> <output-dir>" >&2
+    exit 2
+fi
+
+SUITE=$1
+MASTER_RAW_ROOT=$2
+CURRENT_RAW_ROOT=$3
+OUTPUT_DIR=$4
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+mkdir -p "$OUTPUT_DIR"
+
+find_manifest() {
+    local root=$1
+    find "$root" -type f -name manifest.env | head -n 1
+}
+
+MASTER_MANIFEST=$(find_manifest "$MASTER_RAW_ROOT")
+CURRENT_MANIFEST=$(find_manifest "$CURRENT_RAW_ROOT")
+
+if [[ -z $MASTER_MANIFEST || -z $CURRENT_MANIFEST ]]; then
+    {
+        echo "## ${SUITE^^} compare"
+        echo
+        echo "- Error: missing raw manifest(s)"
+        echo "- Master manifest: ${MASTER_MANIFEST:-missing}"
+        echo "- Current manifest: ${CURRENT_MANIFEST:-missing}"
+    } > "$OUTPUT_DIR/summary.md"
+    {
+        echo "SUITE=$SUITE"
+        echo "MASTER_STATUS=missing"
+        echo "CURRENT_STATUS=missing"
+        echo "COMPARE_STATUS=missing-input"
+    } > "$OUTPUT_DIR/summary.env"
+    exit 1
+fi
+
+MASTER_DIR=$(dirname "$MASTER_MANIFEST")
+CURRENT_DIR=$(dirname "$CURRENT_MANIFEST")
+
+# shellcheck disable=SC1090
+. "$MASTER_MANIFEST"
+MASTER_STATUS=${FEATURE_STATUS:-unknown}
+MASTER_DURATION_SECONDS=${FEATURE_DURATION_SECONDS:-}
+MASTER_HEAD_COMMIT=${HEAD_COMMIT:-}
+
+# shellcheck disable=SC1090
+. "$CURRENT_MANIFEST"
+CURRENT_STATUS=${FEATURE_STATUS:-unknown}
+CURRENT_DURATION_SECONDS=${FEATURE_DURATION_SECONDS:-}
+CURRENT_HEAD_COMMIT=${HEAD_COMMIT:-}
+
+MASTER_LOG=$(find "$MASTER_DIR" -maxdepth 1 -type f -name '*.log' | head -n 1)
+CURRENT_LOG=$(find "$CURRENT_DIR" -maxdepth 1 -type f -name '*.log' | head -n 1)
+
+COMPARE_STATUS=skipped
+COMPARE_REASON='compare-skipped'
+COMPARE_FILE="$OUTPUT_DIR/compare.txt"
+
+if [[ $MASTER_STATUS == success && $CURRENT_STATUS == success ]]; then
+    if [[ -n $MASTER_LOG && -n $CURRENT_LOG ]]; then
+        python3 "$SCRIPT_DIR/compare.py" "$CURRENT_LOG" "$MASTER_LOG" > "$COMPARE_FILE"
+        COMPARE_STATUS=success
+        COMPARE_REASON='ok'
+    else
+        COMPARE_STATUS=error
+        COMPARE_REASON='missing-log-input'
+    fi
+elif [[ $MASTER_STATUS != success && $CURRENT_STATUS != success ]]; then
+    COMPARE_REASON='both-non-success'
+else
+    COMPARE_REASON='one-side-non-success'
+fi
+
+cp -R "$MASTER_DIR" "$OUTPUT_DIR/master"
+cp -R "$CURRENT_DIR" "$OUTPUT_DIR/current"
+
+{
+    echo "## ${SUITE^^} compare"
+    echo
+    echo "| Side | Status | Duration (s) | Head commit |"
+    echo "| --- | --- | ---: | --- |"
+    echo "| master | ${MASTER_STATUS:-unknown} | ${MASTER_DURATION_SECONDS:-n/a} | ${MASTER_HEAD_COMMIT:-n/a} |"
+    echo "| current | ${CURRENT_STATUS:-unknown} | ${CURRENT_DURATION_SECONDS:-n/a} | ${CURRENT_HEAD_COMMIT:-n/a} |"
+    echo
+    if [[ -f $COMPARE_FILE ]]; then
+        echo "- Compare file: $(basename "$COMPARE_FILE")"
+    else
+        echo "- Compare file: not generated"
+    fi
+} > "$OUTPUT_DIR/summary.md"
+
+{
+    echo "SUITE=$SUITE"
+    echo "MASTER_STATUS=$MASTER_STATUS"
+    echo "MASTER_DURATION_SECONDS=${MASTER_DURATION_SECONDS:-}"
+    echo "MASTER_HEAD_COMMIT=${MASTER_HEAD_COMMIT:-}"
+    echo "CURRENT_STATUS=$CURRENT_STATUS"
+    echo "CURRENT_DURATION_SECONDS=${CURRENT_DURATION_SECONDS:-}"
+    echo "CURRENT_HEAD_COMMIT=${CURRENT_HEAD_COMMIT:-}"
+    echo "COMPARE_STATUS=$COMPARE_STATUS"
+    echo "COMPARE_REASON=$COMPARE_REASON"
+} > "$OUTPUT_DIR/summary.env"
+
+if [[ $MASTER_STATUS != success || $CURRENT_STATUS != success ]]; then
+    exit 1
+fi
+
+if [[ $COMPARE_STATUS != success ]]; then
+    exit 1
+fi

--- a/scripts/downstream-perf-lib.sh
+++ b/scripts/downstream-perf-lib.sh
@@ -44,7 +44,7 @@ downstream_perf_write_manifest_snapshot() {
 
 downstream_perf_baseline_commit() {
     local baseline_ref=$1
-    git merge-base "$baseline_ref" HEAD
+    git rev-parse "$baseline_ref"
 }
 
 downstream_perf_run_and_log() {
@@ -55,7 +55,9 @@ downstream_perf_run_and_log() {
     start_time=$(date +%s)
 
     set +e
-    "$@" | tee "$logfile"
+    # Keep stdout reserved for machine-readable "status duration" output.
+    # Stream command output to the console via stderr while preserving a full log file.
+    "$@" 2>&1 | tee "$logfile" >&2
     status=${PIPESTATUS[0]}
     set -e
 

--- a/scripts/downstream-perf-lib.sh
+++ b/scripts/downstream-perf-lib.sh
@@ -37,7 +37,7 @@ downstream_perf_write_manifest_snapshot() {
     downstream_perf_write_kv "$manifest" "BASELINE_STATUS" "${BASELINE_STATUS-not-run}"
     downstream_perf_write_kv "$manifest" "FEATURE_DURATION_SECONDS" "${FEATURE_DURATION_SECONDS-}"
     downstream_perf_write_kv "$manifest" "BASELINE_DURATION_SECONDS" "${BASELINE_DURATION_SECONDS-}"
-    downstream_perf_write_kv "$manifest" "FEATURE_BUDGET_SECONDS" "${FEATURE_BUDGET_SECONDS-}"
+    downstream_perf_write_kv "$manifest" "TIMEOUT_SECONDS" "${TIMEOUT_SECONDS-}"
     downstream_perf_write_kv "$manifest" "COMPARE_STATUS" "${COMPARE_STATUS-not-run}"
     downstream_perf_write_kv "$manifest" "SKIP_REASON" "${SKIP_REASON-}"
 }

--- a/scripts/downstream-perf-lib.sh
+++ b/scripts/downstream-perf-lib.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+downstream_perf_normalize_feature_branch() {
+    local raw_branch=$1
+    raw_branch=${raw_branch//\//-}
+    if [[ $raw_branch == "master" ]]; then
+        raw_branch="feature"
+    fi
+    printf '%s\n' "$raw_branch"
+}
+
+downstream_perf_write_kv() {
+    local manifest=$1
+    local key=$2
+    local value=$3
+    printf '%s=%q\n' "$key" "$value" >> "$manifest"
+}
+
+downstream_perf_write_manifest_snapshot() {
+    local manifest=${1:-}
+    if [[ -z $manifest ]]; then
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$manifest")"
+    : > "$manifest"
+
+    downstream_perf_write_kv "$manifest" "SUITE" "${DOWNSTREAM_PERF_SUITE-}"
+    downstream_perf_write_kv "$manifest" "FEATURE_BRANCH_NAME" "${FEATURE_BRANCH_NAME-}"
+    downstream_perf_write_kv "$manifest" "HEAD_COMMIT" "${HEAD_COMMIT-}"
+    downstream_perf_write_kv "$manifest" "BASELINE_COMMIT" "${BASELINE_COMMIT-}"
+    downstream_perf_write_kv "$manifest" "BASELINE_COMMIT_SHORT" "${BASELINE_COMMIT_SHORT-}"
+    downstream_perf_write_kv "$manifest" "FEATURE_LOG" "${FEATURE_LOG-}"
+    downstream_perf_write_kv "$manifest" "BASELINE_LOG" "${BASELINE_LOG-}"
+    downstream_perf_write_kv "$manifest" "COMPARE_FILE" "${COMPARE_FILE-}"
+    downstream_perf_write_kv "$manifest" "FEATURE_STATUS" "${FEATURE_STATUS-unknown}"
+    downstream_perf_write_kv "$manifest" "BASELINE_STATUS" "${BASELINE_STATUS-not-run}"
+    downstream_perf_write_kv "$manifest" "FEATURE_DURATION_SECONDS" "${FEATURE_DURATION_SECONDS-}"
+    downstream_perf_write_kv "$manifest" "BASELINE_DURATION_SECONDS" "${BASELINE_DURATION_SECONDS-}"
+    downstream_perf_write_kv "$manifest" "FEATURE_BUDGET_SECONDS" "${FEATURE_BUDGET_SECONDS-}"
+    downstream_perf_write_kv "$manifest" "COMPARE_STATUS" "${COMPARE_STATUS-not-run}"
+    downstream_perf_write_kv "$manifest" "SKIP_REASON" "${SKIP_REASON-}"
+}
+
+downstream_perf_baseline_commit() {
+    local baseline_ref=$1
+    git merge-base "$baseline_ref" HEAD
+}
+
+downstream_perf_run_and_log() {
+    local logfile=$1
+    shift
+
+    local start_time end_time status
+    start_time=$(date +%s)
+
+    set +e
+    "$@" | tee "$logfile"
+    status=${PIPESTATUS[0]}
+    set -e
+
+    end_time=$(date +%s)
+    printf '%s %s\n' "$status" "$((end_time - start_time))"
+}

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -162,12 +162,17 @@ read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
         feature_shell \
-        "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv $BUG_REPORT --kompiled-targets-dir $PREKOMPILED_DIR'"
+        "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv $BUG_REPORT --kompiled-targets-dir $PREKOMPILED_DIR'"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "No zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
+    if [[ $feature_exit -eq 124 ]]; then
+        FEATURE_STATUS=budget-exceeded
+        SKIP_REASON='feature-run-exceeded-budget'
+        exit 1
+    fi
     FEATURE_STATUS=failure
     if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
         BASELINE_STATUS=skipped
@@ -180,7 +185,7 @@ if [[ $feature_exit -ne 0 ]]; then
         downstream_perf_run_and_log \
             "$BASELINE_LOG" \
             master_shell \
-            "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+            "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
     )
     BASELINE_DURATION_SECONDS=$baseline_duration
     killall kore-rpc-booster || echo "No zombie processes found"
@@ -221,7 +226,7 @@ if [ -z "$BUG_REPORT" ]; then
             downstream_perf_run_and_log \
                 "$BASELINE_LOG" \
                 master_shell \
-                "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+                "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
         )
         BASELINE_DURATION_SECONDS=$baseline_duration
         killall kore-rpc-booster || echo "No zombie processes found"

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -18,8 +18,9 @@ BASELINE_COMMIT_SHORT="$(git rev-parse --short "$BASELINE_COMMIT")"
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
 FEATURE_BRANCH_NAME="$(downstream_perf_normalize_feature_branch "$FEATURE_BRANCH_NAME")"
 
-PYTEST_PARALLEL=${PYTEST_PARALLEL:-3}
-FEATURE_BUDGET_SECONDS=${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-5400}
+PYTEST_PARALLEL=${PYTEST_PARALLEL:-1}
+TIMEOUT_SECONDS=${DOWNSTREAM_PERF_TIMEOUT_SECONDS:-${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-14400}}
+KEVM_RULES_K_EXPR=${KEVM_RULES_K_EXPR:-'test_prove_rules'}
 DOWNSTREAM_PERF_SUITE=kevm
 FEATURE_STATUS=running
 BASELINE_STATUS=not-run
@@ -75,6 +76,16 @@ first_existing_file() {
     fi
   done
   return 1
+}
+
+build_prove_rules_command() {
+  local bug_report_arg=$1
+  printf 'timeout %ss make -C kevm-pyk/ test-integration PYTEST_PARALLEL=%s PYTEST_ARGS='\''--maxfail=0 -vv %s --kompiled-targets-dir %s -k "%s"'\''' \
+    "$TIMEOUT_SECONDS" \
+    "$PYTEST_PARALLEL" \
+    "$bug_report_arg" \
+    "$PREKOMPILED_DIR" \
+    "$KEVM_RULES_K_EXPR"
 }
 
 cd $TEMPD
@@ -162,18 +173,18 @@ read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
         feature_shell \
-        "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv $BUG_REPORT --kompiled-targets-dir $PREKOMPILED_DIR'"
+        "$(build_prove_rules_command "$BUG_REPORT")"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "No zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
     if [[ $feature_exit -eq 124 ]]; then
-        FEATURE_STATUS=budget-exceeded
+        FEATURE_STATUS=timeout
         if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
             BASELINE_STATUS=skipped
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-run-exceeded-budget-baseline-same-as-head'
+            SKIP_REASON='feature-run-timeout-baseline-same-as-head'
             exit 1
         fi
 
@@ -181,28 +192,28 @@ if [[ $feature_exit -ne 0 ]]; then
             downstream_perf_run_and_log \
                 "$BASELINE_LOG" \
                 master_shell \
-                "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+                "$(build_prove_rules_command "")"
         )
         BASELINE_DURATION_SECONDS=$baseline_duration
         killall kore-rpc-booster || echo "No zombie processes found"
 
         if [[ $baseline_exit -eq 124 ]]; then
-            BASELINE_STATUS=budget-exceeded
+            BASELINE_STATUS=timeout
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-and-baseline-run-exceeded-budget'
+            SKIP_REASON='feature-and-baseline-run-timeout'
             exit 0
         fi
 
         if [[ $baseline_exit -ne 0 ]]; then
             BASELINE_STATUS=failure
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-budget-exceeded-baseline-failed'
+            SKIP_REASON='feature-timeout-baseline-failed'
             exit 0
         fi
 
         BASELINE_STATUS=success
         COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-exceeded-budget-baseline-succeeded'
+        SKIP_REASON='feature-run-timeout-baseline-succeeded'
         exit 1
     fi
     FEATURE_STATUS=failure
@@ -217,7 +228,7 @@ if [[ $feature_exit -ne 0 ]]; then
         downstream_perf_run_and_log \
             "$BASELINE_LOG" \
             master_shell \
-            "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+            "$(build_prove_rules_command "")"
     )
     BASELINE_DURATION_SECONDS=$baseline_duration
     killall kore-rpc-booster || echo "No zombie processes found"
@@ -233,12 +244,6 @@ if [[ $feature_exit -ne 0 ]]; then
     COMPARE_STATUS=skipped
     SKIP_REASON='feature-run-failed-baseline-succeeded'
     exit "$feature_exit"
-fi
-
-if [[ $FEATURE_DURATION_SECONDS -gt $FEATURE_BUDGET_SECONDS ]]; then
-    FEATURE_STATUS=budget-exceeded
-    SKIP_REASON='feature-run-exceeded-budget'
-    exit 1
 fi
 
 FEATURE_STATUS=success
@@ -258,7 +263,7 @@ if [ -z "$BUG_REPORT" ]; then
             downstream_perf_run_and_log \
                 "$BASELINE_LOG" \
                 master_shell \
-                "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+                "$(build_prove_rules_command "")"
         )
         BASELINE_DURATION_SECONDS=$baseline_duration
         killall kore-rpc-booster || echo "No zombie processes found"

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -119,7 +119,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # Keep nix develop as the primary environment, and add missing tool binaries
 # needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
 K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat deps/k_release)#k")/bin"
-CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths github:NixOS/nixpkgs/nixos-24.05#clang_14)/bin"
 OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
 OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
 GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -66,11 +66,30 @@ master_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --ignore-environment --command bash -c "$1"
 }
 
+first_existing_file() {
+  local candidate=''
+  for candidate in "$@"; do
+    if [ -e "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Keep nix develop as the primary environment, and add missing tool binaries
 # needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
 K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
 CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
+OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
+GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"
+GMP_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.dev)"
+OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$OPENSSL_OUT_DIR/lib/libcrypto.so.3" "$OPENSSL_OUT_DIR/lib/libcrypto.dylib" "$OPENSSL_OUT_DIR/lib/libcrypto.a")"
+OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
+GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
 
 cd $TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
@@ -114,7 +133,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
+    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export OPENSSL_ROOT_DIR=\"$OPENSSL_OUT_DIR\"; export OPENSSL_INCLUDE_DIR=\"$OPENSSL_DEV_DIR/include\"; export OPENSSL_CRYPTO_LIBRARY=\"$OPENSSL_CRYPTO_LIB\"; export OPENSSL_SSL_LIBRARY=\"$OPENSSL_SSL_LIB\"; export GMP_INCLUDE_DIR=\"$GMP_DEV_DIR/include\"; export GMP_LIBRARY=\"$GMP_LIB\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -90,6 +90,7 @@ OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSS
 GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
 PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
+PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
 
 cd $TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
@@ -133,7 +134,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export OPENSSL_ROOT_DIR=\"$OPENSSL_OUT_DIR\"; export OPENSSL_INCLUDE_DIR=\"$OPENSSL_DEV_DIR/include\"; export OPENSSL_CRYPTO_LIBRARY=\"$OPENSSL_CRYPTO_LIB\"; export OPENSSL_SSL_LIBRARY=\"$OPENSSL_SSL_LIB\"; export GMP_INCLUDE_DIR=\"$GMP_DEV_DIR/include\"; export GMP_LIBRARY=\"$GMP_LIB\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
+    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -66,6 +66,12 @@ master_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --ignore-environment --command bash -c "$1"
 }
 
+# Keep nix develop as the primary environment, and add missing tool binaries
+# needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
+K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
+CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+
 cd $TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     git clone --depth 1 --branch $KEVM_VERSION https://github.com/runtimeverification/evm-semantics.git
@@ -108,7 +114,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang nixpkgs#openssl nixpkgs#gmp nixpkgs#pkg-config --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
+    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -107,7 +107,8 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
-    feature_shell "make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
+    # Ensure plugin build prerequisites are available on self-hosted runners.
+    feature_shell "nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#cmake nixpkgs#clang --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -108,7 +108,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
+    feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang nixpkgs#openssl nixpkgs#gmp nixpkgs#pkg-config --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -169,7 +169,32 @@ killall kore-rpc-booster || echo "No zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
     FEATURE_STATUS=failure
-    SKIP_REASON='feature-run-failed'
+    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+        BASELINE_STATUS=skipped
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-run-failed-baseline-same-as-head'
+        exit "$feature_exit"
+    fi
+
+    read -r baseline_exit baseline_duration < <(
+        downstream_perf_run_and_log \
+            "$BASELINE_LOG" \
+            master_shell \
+            "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+    )
+    BASELINE_DURATION_SECONDS=$baseline_duration
+    killall kore-rpc-booster || echo "No zombie processes found"
+
+    if [[ $baseline_exit -ne 0 ]]; then
+        BASELINE_STATUS=failure
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-and-baseline-run-failed'
+        exit 0
+    fi
+
+    BASELINE_STATUS=success
+    COMPARE_STATUS=skipped
+    SKIP_REASON='feature-run-failed-baseline-succeeded'
     exit "$feature_exit"
 fi
 

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -108,7 +108,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#cmake nixpkgs#clang --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
+    feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang --command bash -c 'make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4'"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -8,18 +8,28 @@ export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 KEVM_VERSION=${KEVM_VERSION:-'master'}
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/downstream-perf-lib.sh"
 
-MASTER_COMMIT="$(git rev-parse origin/master)"
-MASTER_COMMIT_SHORT="$(git rev-parse --short origin/master)"
+BASELINE_REF=${BASELINE_REF:-origin/master}
+HEAD_COMMIT="$(git rev-parse HEAD)"
+BASELINE_COMMIT=${BASELINE_COMMIT:-"$(downstream_perf_baseline_commit "$BASELINE_REF")"}
+BASELINE_COMMIT_SHORT="$(git rev-parse --short "$BASELINE_COMMIT")"
 
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
-FEATURE_BRANCH_NAME="${FEATURE_BRANCH_NAME//\//-}"
+FEATURE_BRANCH_NAME="$(downstream_perf_normalize_feature_branch "$FEATURE_BRANCH_NAME")"
 
 PYTEST_PARALLEL=${PYTEST_PARALLEL:-3}
-
-if [[ $FEATURE_BRANCH_NAME == "master" ]]; then
-  FEATURE_BRANCH_NAME="feature"
-fi
+FEATURE_BUDGET_SECONDS=${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-5400}
+DOWNSTREAM_PERF_SUITE=kevm
+FEATURE_STATUS=running
+BASELINE_STATUS=not-run
+COMPARE_STATUS=not-run
+SKIP_REASON=''
+FEATURE_DURATION_SECONDS=''
+BASELINE_DURATION_SECONDS=''
+FEATURE_LOG=''
+BASELINE_LOG=''
+COMPARE_FILE=''
 
 # Create a temporary directory (or use the one provided) and store its name in a variable.
 KEEP_TEMPD=${KEEP_TEMPD:-''}
@@ -37,6 +47,7 @@ if [ ! -e "$TEMPD" ]; then
 fi
 
 clean_up () {
+    downstream_perf_write_manifest_snapshot "${DOWNSTREAM_PERF_MANIFEST:-}"
     if [ -z "$KEEP_TEMPD" ]; then
         rm -rf "$TEMPD"
     fi
@@ -52,7 +63,7 @@ feature_shell() {
 }
 
 master_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$MASTER_COMMIT --ignore-environment --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --ignore-environment --command bash -c "$1"
 }
 
 cd $TEMPD
@@ -105,6 +116,9 @@ mkdir -p $PREKOMPILED_DIR
 feature_shell "uv --directory kevm-pyk run -- pytest src/tests/integration/test_prove.py::test_kompile_targets -vv --maxfail=0 --kompiled-targets-dir $PREKOMPILED_DIR"
 
 mkdir -p $SCRIPT_DIR/logs
+FEATURE_LOG="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
+BASELINE_LOG="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-baseline-$BASELINE_COMMIT_SHORT.log"
+COMPARE_FILE="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-baseline-$BASELINE_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare"
 
 # use special options if given, but restore KORE_RPC_OPTS afterwards
 FEATURE_SERVER_OPTS=${FEATURE_SERVER_OPTS:-''}
@@ -116,9 +130,28 @@ if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     export KORE_RPC_OPTS=${FEATURE_SERVER_OPTS}
 fi
 
-feature_shell "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv $BUG_REPORT --kompiled-targets-dir $PREKOMPILED_DIR' | tee $SCRIPT_DIR/logs/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
+read -r feature_exit feature_duration < <(
+    downstream_perf_run_and_log \
+        "$FEATURE_LOG" \
+        feature_shell \
+        "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv $BUG_REPORT --kompiled-targets-dir $PREKOMPILED_DIR'"
+)
+FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "No zombie processes found"
 
+if [[ $feature_exit -ne 0 ]]; then
+    FEATURE_STATUS=failure
+    SKIP_REASON='feature-run-failed'
+    exit "$feature_exit"
+fi
+
+if [[ $FEATURE_DURATION_SECONDS -gt $FEATURE_BUDGET_SECONDS ]]; then
+    FEATURE_STATUS=budget-exceeded
+    SKIP_REASON='feature-run-exceeded-budget'
+    exit 1
+fi
+
+FEATURE_STATUS=success
 
 if [ -z "$BUG_REPORT" ]; then
     if [ ! -z "${PRIOR_OPTS:-}" ]; then
@@ -126,11 +159,31 @@ if [ -z "$BUG_REPORT" ]; then
     else
         unset KORE_RPC_OPTS
     fi
-    if [ ! -e "$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
-        master_shell "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR' | tee $SCRIPT_DIR/logs/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log"
+    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+        BASELINE_STATUS=skipped
+        COMPARE_STATUS=skipped
+        SKIP_REASON='baseline-same-as-head'
+    else
+        read -r baseline_exit baseline_duration < <(
+            downstream_perf_run_and_log \
+                "$BASELINE_LOG" \
+                master_shell \
+                "make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+        )
+        BASELINE_DURATION_SECONDS=$baseline_duration
         killall kore-rpc-booster || echo "No zombie processes found"
-    fi
 
-    cd $SCRIPT_DIR
-    python3 compare.py logs/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log logs/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT.log > logs/kevm-$KEVM_VERSION-master-$MASTER_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare
+        if [[ $baseline_exit -ne 0 ]]; then
+            BASELINE_STATUS=failure
+            COMPARE_STATUS=skipped
+            SKIP_REASON='baseline-run-failed'
+            exit "$baseline_exit"
+        fi
+
+        BASELINE_STATUS=success
+
+        cd "$SCRIPT_DIR"
+        python3 compare.py "$FEATURE_LOG" "$BASELINE_LOG" > "$COMPARE_FILE"
+        COMPARE_STATUS=success
+    fi
 fi

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -170,7 +170,39 @@ killall kore-rpc-booster || echo "No zombie processes found"
 if [[ $feature_exit -ne 0 ]]; then
     if [[ $feature_exit -eq 124 ]]; then
         FEATURE_STATUS=budget-exceeded
-        SKIP_REASON='feature-run-exceeded-budget'
+        if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+            BASELINE_STATUS=skipped
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-run-exceeded-budget-baseline-same-as-head'
+            exit 1
+        fi
+
+        read -r baseline_exit baseline_duration < <(
+            downstream_perf_run_and_log \
+                "$BASELINE_LOG" \
+                master_shell \
+                "timeout ${FEATURE_BUDGET_SECONDS}s make test-prove-rules PYTEST_PARALLEL=$PYTEST_PARALLEL PYTEST_ARGS='--maxfail=0 -vv --kompiled-targets-dir $PREKOMPILED_DIR'"
+        )
+        BASELINE_DURATION_SECONDS=$baseline_duration
+        killall kore-rpc-booster || echo "No zombie processes found"
+
+        if [[ $baseline_exit -eq 124 ]]; then
+            BASELINE_STATUS=budget-exceeded
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-and-baseline-run-exceeded-budget'
+            exit 0
+        fi
+
+        if [[ $baseline_exit -ne 0 ]]; then
+            BASELINE_STATUS=failure
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-budget-exceeded-baseline-failed'
+            exit 0
+        fi
+
+        BASELINE_STATUS=success
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-run-exceeded-budget-baseline-succeeded'
         exit 1
     fi
     FEATURE_STATUS=failure

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -20,7 +20,7 @@ FEATURE_BRANCH_NAME="$(downstream_perf_normalize_feature_branch "$FEATURE_BRANCH
 
 PYTEST_PARALLEL=${PYTEST_PARALLEL:-1}
 TIMEOUT_SECONDS=${DOWNSTREAM_PERF_TIMEOUT_SECONDS:-${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-14400}}
-KEVM_RULES_K_EXPR=${KEVM_RULES_K_EXPR:-'test_prove_rules'}
+KEVM_TEST_TARGET=${KEVM_TEST_TARGET:-test-prove-rules}
 DOWNSTREAM_PERF_SUITE=kevm
 FEATURE_STATUS=running
 BASELINE_STATUS=not-run
@@ -78,14 +78,14 @@ first_existing_file() {
   return 1
 }
 
-build_prove_rules_command() {
+build_kevm_command() {
   local bug_report_arg=$1
-  printf 'timeout %ss make -C kevm-pyk/ test-integration PYTEST_PARALLEL=%s PYTEST_ARGS='\''--maxfail=0 -vv %s --kompiled-targets-dir %s -k "%s"'\''' \
+  printf 'timeout %ss make %s PYTEST_PARALLEL=%s PYTEST_ARGS='\''--maxfail=0 -vv %s --kompiled-targets-dir %s'\''' \
     "$TIMEOUT_SECONDS" \
+    "$KEVM_TEST_TARGET" \
     "$PYTEST_PARALLEL" \
     "$bug_report_arg" \
-    "$PREKOMPILED_DIR" \
-    "$KEVM_RULES_K_EXPR"
+    "$PREKOMPILED_DIR"
 }
 
 cd $TEMPD
@@ -159,7 +159,35 @@ FEATURE_LOG="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-$FEATURE_BRANCH_NAME.log"
 BASELINE_LOG="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-baseline-$BASELINE_COMMIT_SHORT.log"
 COMPARE_FILE="$SCRIPT_DIR/logs/kevm-$KEVM_VERSION-baseline-$BASELINE_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare"
 
-# use special options if given, but restore KORE_RPC_OPTS afterwards
+status_from_exit() {
+    local exit_code=$1
+    if [[ $exit_code -eq 0 ]]; then
+        printf 'success\n'
+    elif [[ $exit_code -eq 124 ]]; then
+        printf 'timeout\n'
+    else
+        printf 'failure\n'
+    fi
+}
+
+baseline_exit=0
+if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+    BASELINE_STATUS=skipped
+    COMPARE_STATUS=skipped
+    SKIP_REASON='baseline-same-as-head'
+else
+    read -r baseline_exit baseline_duration < <(
+        downstream_perf_run_and_log \
+            "$BASELINE_LOG" \
+            master_shell \
+            "$(build_kevm_command "")"
+    )
+    BASELINE_DURATION_SECONDS=$baseline_duration
+    BASELINE_STATUS="$(status_from_exit "$baseline_exit")"
+    killall kore-rpc-booster || echo "No zombie processes found"
+fi
+
+# use special options if given for the current-branch run only, then restore.
 FEATURE_SERVER_OPTS=${FEATURE_SERVER_OPTS:-''}
 if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     echo "Using special options '${FEATURE_SERVER_OPTS}' via KORE_RPC_OPTS"
@@ -173,112 +201,48 @@ read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
         feature_shell \
-        "$(build_prove_rules_command "$BUG_REPORT")"
+        "$(build_kevm_command "$BUG_REPORT")"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
+FEATURE_STATUS="$(status_from_exit "$feature_exit")"
 killall kore-rpc-booster || echo "No zombie processes found"
 
-if [[ $feature_exit -ne 0 ]]; then
-    if [[ $feature_exit -eq 124 ]]; then
-        FEATURE_STATUS=timeout
-        if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-            BASELINE_STATUS=skipped
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-run-timeout-baseline-same-as-head'
-            exit 1
-        fi
-
-        read -r baseline_exit baseline_duration < <(
-            downstream_perf_run_and_log \
-                "$BASELINE_LOG" \
-                master_shell \
-                "$(build_prove_rules_command "")"
-        )
-        BASELINE_DURATION_SECONDS=$baseline_duration
-        killall kore-rpc-booster || echo "No zombie processes found"
-
-        if [[ $baseline_exit -eq 124 ]]; then
-            BASELINE_STATUS=timeout
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-and-baseline-run-timeout'
-            exit 0
-        fi
-
-        if [[ $baseline_exit -ne 0 ]]; then
-            BASELINE_STATUS=failure
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-timeout-baseline-failed'
-            exit 0
-        fi
-
-        BASELINE_STATUS=success
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-timeout-baseline-succeeded'
-        exit 1
-    fi
-    FEATURE_STATUS=failure
-    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-        BASELINE_STATUS=skipped
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-failed-baseline-same-as-head'
-        exit "$feature_exit"
-    fi
-
-    read -r baseline_exit baseline_duration < <(
-        downstream_perf_run_and_log \
-            "$BASELINE_LOG" \
-            master_shell \
-            "$(build_prove_rules_command "")"
-    )
-    BASELINE_DURATION_SECONDS=$baseline_duration
-    killall kore-rpc-booster || echo "No zombie processes found"
-
-    if [[ $baseline_exit -ne 0 ]]; then
-        BASELINE_STATUS=failure
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-and-baseline-run-failed'
-        exit 0
-    fi
-
-    BASELINE_STATUS=success
-    COMPARE_STATUS=skipped
-    SKIP_REASON='feature-run-failed-baseline-succeeded'
-    exit "$feature_exit"
-fi
-
-FEATURE_STATUS=success
-
-if [ -z "$BUG_REPORT" ]; then
+if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     if [ ! -z "${PRIOR_OPTS:-}" ]; then
         export KORE_RPC_OPTS=${PRIOR_OPTS}
     else
         unset KORE_RPC_OPTS
     fi
-    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-        BASELINE_STATUS=skipped
-        COMPARE_STATUS=skipped
-        SKIP_REASON='baseline-same-as-head'
+fi
+
+if [[ $FEATURE_STATUS != success ]]; then
+    COMPARE_STATUS=skipped
+    if [[ $BASELINE_STATUS == success ]]; then
+        SKIP_REASON="feature-run-${FEATURE_STATUS}-baseline-succeeded"
+    elif [[ $BASELINE_STATUS == skipped ]]; then
+        SKIP_REASON="feature-run-${FEATURE_STATUS}-baseline-skipped"
     else
-        read -r baseline_exit baseline_duration < <(
-            downstream_perf_run_and_log \
-                "$BASELINE_LOG" \
-                master_shell \
-                "$(build_prove_rules_command "")"
-        )
-        BASELINE_DURATION_SECONDS=$baseline_duration
-        killall kore-rpc-booster || echo "No zombie processes found"
-
-        if [[ $baseline_exit -ne 0 ]]; then
-            BASELINE_STATUS=failure
-            COMPARE_STATUS=skipped
-            SKIP_REASON='baseline-run-failed'
-            exit "$baseline_exit"
-        fi
-
-        BASELINE_STATUS=success
-
-        cd "$SCRIPT_DIR"
-        python3 compare.py "$FEATURE_LOG" "$BASELINE_LOG" > "$COMPARE_FILE"
-        COMPARE_STATUS=success
+        SKIP_REASON="feature-and-baseline-run-${FEATURE_STATUS}-${BASELINE_STATUS}"
     fi
+    exit 1
+fi
+
+if [[ -n $BUG_REPORT ]]; then
+    COMPARE_STATUS=skipped
+    SKIP_REASON='bug-report-mode'
+    exit 0
+fi
+
+if [[ $BASELINE_STATUS == success ]]; then
+    cd "$SCRIPT_DIR"
+    python3 compare.py "$FEATURE_LOG" "$BASELINE_LOG" > "$COMPARE_FILE"
+    COMPARE_STATUS=success
+    exit 0
+fi
+
+COMPARE_STATUS=skipped
+if [[ $BASELINE_STATUS == skipped ]]; then
+    SKIP_REASON='baseline-same-as-head'
+else
+    SKIP_REASON="baseline-run-${BASELINE_STATUS}"
 fi

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -77,22 +77,6 @@ first_existing_file() {
   return 1
 }
 
-# Keep nix develop as the primary environment, and add missing tool binaries
-# needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
-K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
-CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
-OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
-OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
-GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"
-GMP_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.dev)"
-OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$OPENSSL_OUT_DIR/lib/libcrypto.so.3" "$OPENSSL_OUT_DIR/lib/libcrypto.dylib" "$OPENSSL_OUT_DIR/lib/libcrypto.a")"
-OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
-GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
-PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
-DOWNSTREAM_PERF_RUNTIME_PATH="$PLUGIN_TOOLCHAIN_PATH"
-PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
-PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
-
 cd $TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     git clone --depth 1 --branch $KEVM_VERSION https://github.com/runtimeverification/evm-semantics.git
@@ -131,6 +115,22 @@ while [[ $# -gt 0 ]]; do
 done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
+# Keep nix develop as the primary environment, and add missing tool binaries
+# needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
+K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat deps/k_release)#k")/bin"
+CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
+OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
+GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"
+GMP_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.dev)"
+OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$OPENSSL_OUT_DIR/lib/libcrypto.so.3" "$OPENSSL_OUT_DIR/lib/libcrypto.dylib" "$OPENSSL_OUT_DIR/lib/libcrypto.a")"
+OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
+GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
+PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+DOWNSTREAM_PERF_RUNTIME_PATH="$PLUGIN_TOOLCHAIN_PATH"
+PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
+PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
 
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then

--- a/scripts/performance-tests-kevm.sh
+++ b/scripts/performance-tests-kevm.sh
@@ -59,11 +59,11 @@ trap "exit 1"  HUP INT PIPE QUIT TERM
 trap clean_up  EXIT
 
 feature_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend $SCRIPT_DIR/../ --ignore-environment --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend $SCRIPT_DIR/../ --ignore-environment --command bash -c "export PATH=\"$DOWNSTREAM_PERF_RUNTIME_PATH:\$PATH\"; $1"
 }
 
 master_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --ignore-environment --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --ignore-environment --command bash -c "export PATH=\"$DOWNSTREAM_PERF_RUNTIME_PATH:\$PATH\"; $1"
 }
 
 first_existing_file() {
@@ -89,6 +89,7 @@ OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$
 OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
 GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+DOWNSTREAM_PERF_RUNTIME_PATH="$PLUGIN_TOOLCHAIN_PATH"
 PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
 PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
 
@@ -134,7 +135,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 # kompile evm-semantics or skip kompilation if using an existing TEMPD
 if [[ $FRESH_TEMPD -gt 0 ]]; then
     # Ensure plugin build prerequisites are available on self-hosted runners.
-    feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
+    feature_shell "export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; make kevm-pyk && uv --project kevm-pyk run -- kdist --verbose build evm-semantics.plugin evm-semantics.haskell --jobs 4"
 fi
 
 # kompile all verification K definitions and specs

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -8,18 +8,28 @@ export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 KONTROL_VERSION=${KONTROL_VERSION:-'master'}
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/downstream-perf-lib.sh"
 
-MASTER_COMMIT="$(git rev-parse origin/master)"
-MASTER_COMMIT_SHORT="$(git rev-parse --short origin/master)"
+BASELINE_REF=${BASELINE_REF:-origin/master}
+HEAD_COMMIT="$(git rev-parse HEAD)"
+BASELINE_COMMIT=${BASELINE_COMMIT:-"$(downstream_perf_baseline_commit "$BASELINE_REF")"}
+BASELINE_COMMIT_SHORT="$(git rev-parse --short "$BASELINE_COMMIT")"
 
 FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
-FEATURE_BRANCH_NAME="${FEATURE_BRANCH_NAME//\//-}"
+FEATURE_BRANCH_NAME="$(downstream_perf_normalize_feature_branch "$FEATURE_BRANCH_NAME")"
 
 PYTEST_PARALLEL=${PYTEST_PARALLEL:-2}
-
-if [[ $FEATURE_BRANCH_NAME == "master" ]]; then
-  FEATURE_BRANCH_NAME="feature"
-fi
+FEATURE_BUDGET_SECONDS=${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-5400}
+DOWNSTREAM_PERF_SUITE=kontrol
+FEATURE_STATUS=running
+BASELINE_STATUS=not-run
+COMPARE_STATUS=not-run
+SKIP_REASON=''
+FEATURE_DURATION_SECONDS=''
+BASELINE_DURATION_SECONDS=''
+FEATURE_LOG=''
+BASELINE_LOG=''
+COMPARE_FILE=''
 
 # Create a temporary directory and store its name in a variable.
 TEMPD=$(mktemp -d)
@@ -32,6 +42,7 @@ if [ ! -e "$TEMPD" ]; then
 fi
 
 clean_up () {
+    downstream_perf_write_manifest_snapshot "${DOWNSTREAM_PERF_MANIFEST:-}"
     if [ -z "$KEEP_TEMPD" ]; then
         rm -rf "$TEMPD"
     fi
@@ -100,7 +111,7 @@ feature_shell() {
 }
 
 master_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$MASTER_COMMIT --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --command bash -c "$1"
 }
 
 # kompile Kontrol's K dependencies
@@ -115,6 +126,9 @@ feature_shell "make test-integration TEST_ARGS='--basetemp=$PYTEST_TEMP_DIR -n0 
 cp -r $PYTEST_TEMP_DIR/foundry/* $FOUNDRY_DIR
 
 mkdir -p $SCRIPT_DIR/logs
+FEATURE_LOG="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
+BASELINE_LOG="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-baseline-$BASELINE_COMMIT_SHORT.log"
+COMPARE_FILE="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-baseline-$BASELINE_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare"
 
 # use special options if given, but restore KORE_RPC_OPTS afterwards
 FEATURE_SERVER_OPTS=${FEATURE_SERVER_OPTS:-''}
@@ -130,8 +144,28 @@ fi
 QUOTE='"'
 TEST_ARGS="--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k 'not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)'"
 
-feature_shell "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
+read -r feature_exit feature_duration < <(
+    downstream_perf_run_and_log \
+        "$FEATURE_LOG" \
+        feature_shell \
+        "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+)
+FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "no zombie processes found"
+
+if [[ $feature_exit -ne 0 ]]; then
+    FEATURE_STATUS=failure
+    SKIP_REASON='feature-run-failed'
+    exit "$feature_exit"
+fi
+
+if [[ $FEATURE_DURATION_SECONDS -gt $FEATURE_BUDGET_SECONDS ]]; then
+    FEATURE_STATUS=budget-exceeded
+    SKIP_REASON='feature-run-exceeded-budget'
+    exit 1
+fi
+
+FEATURE_STATUS=success
 
 if [ -z "$BUG_REPORT" ]; then
     if [ ! -z "${PRIOR_OPTS:-}" ]; then
@@ -139,13 +173,34 @@ if [ -z "$BUG_REPORT" ]; then
     else
         unset KORE_RPC_OPTS
     fi
-    if [ ! -e "$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log" ]; then
-      # remove proofs so that they are not reused by the master shell call
+    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+      BASELINE_STATUS=skipped
+      COMPARE_STATUS=skipped
+      SKIP_REASON='baseline-same-as-head'
+    else
       rm -rf $FOUNDRY_DIR/out/proofs
-      master_shell "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE | tee $SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log"
+      read -r baseline_exit baseline_duration < <(
+          downstream_perf_run_and_log \
+              "$BASELINE_LOG" \
+              master_shell \
+              "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+      )
+      BASELINE_DURATION_SECONDS=$baseline_duration
       killall kore-rpc-booster || echo "no zombie processes found"
+
+      if [[ $baseline_exit -ne 0 ]]; then
+        BASELINE_STATUS=failure
+        COMPARE_STATUS=skipped
+        SKIP_REASON='baseline-run-failed'
+        exit "$baseline_exit"
+      fi
+
+      BASELINE_STATUS=success
     fi
 fi
 
 cd $SCRIPT_DIR
-python3 compare.py logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT.log > logs/kontrol-$KONTROL_VERSION-master-$MASTER_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare
+if [[ $BASELINE_STATUS == success ]]; then
+    python3 compare.py "$FEATURE_LOG" "$BASELINE_LOG" > "$COMPARE_FILE"
+    COMPARE_STATUS=success
+fi

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -19,7 +19,7 @@ FEATURE_BRANCH_NAME=${FEATURE_BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
 FEATURE_BRANCH_NAME="$(downstream_perf_normalize_feature_branch "$FEATURE_BRANCH_NAME")"
 
 PYTEST_PARALLEL=${PYTEST_PARALLEL:-2}
-FEATURE_BUDGET_SECONDS=${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-5400}
+TIMEOUT_SECONDS=${DOWNSTREAM_PERF_TIMEOUT_SECONDS:-${DOWNSTREAM_PERF_FEATURE_BUDGET_SECONDS:-14400}}
 DOWNSTREAM_PERF_SUITE=kontrol
 FEATURE_STATUS=running
 BASELINE_STATUS=not-run
@@ -176,18 +176,18 @@ read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
         feature_shell \
-        "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+        "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "no zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
     if [[ $feature_exit -eq 124 ]]; then
-        FEATURE_STATUS=budget-exceeded
+        FEATURE_STATUS=timeout
         if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
             BASELINE_STATUS=skipped
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-run-exceeded-budget-baseline-same-as-head'
+            SKIP_REASON='feature-run-timeout-baseline-same-as-head'
             exit 1
         fi
 
@@ -196,28 +196,28 @@ if [[ $feature_exit -ne 0 ]]; then
             downstream_perf_run_and_log \
                 "$BASELINE_LOG" \
                 master_shell \
-                "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+                "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
         )
         BASELINE_DURATION_SECONDS=$baseline_duration
         killall kore-rpc-booster || echo "no zombie processes found"
 
         if [[ $baseline_exit -eq 124 ]]; then
-            BASELINE_STATUS=budget-exceeded
+            BASELINE_STATUS=timeout
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-and-baseline-run-exceeded-budget'
+            SKIP_REASON='feature-and-baseline-run-timeout'
             exit 0
         fi
 
         if [[ $baseline_exit -ne 0 ]]; then
             BASELINE_STATUS=failure
             COMPARE_STATUS=skipped
-            SKIP_REASON='feature-budget-exceeded-baseline-failed'
+            SKIP_REASON='feature-timeout-baseline-failed'
             exit 0
         fi
 
         BASELINE_STATUS=success
         COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-exceeded-budget-baseline-succeeded'
+        SKIP_REASON='feature-run-timeout-baseline-succeeded'
         exit 1
     fi
     FEATURE_STATUS=failure
@@ -233,7 +233,7 @@ if [[ $feature_exit -ne 0 ]]; then
         downstream_perf_run_and_log \
             "$BASELINE_LOG" \
             master_shell \
-            "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+            "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
     )
     BASELINE_DURATION_SECONDS=$baseline_duration
     killall kore-rpc-booster || echo "no zombie processes found"
@@ -249,12 +249,6 @@ if [[ $feature_exit -ne 0 ]]; then
     COMPARE_STATUS=skipped
     SKIP_REASON='feature-run-failed-baseline-succeeded'
     exit "$feature_exit"
-fi
-
-if [[ $FEATURE_DURATION_SECONDS -gt $FEATURE_BUDGET_SECONDS ]]; then
-    FEATURE_STATUS=budget-exceeded
-    SKIP_REASON='feature-run-exceeded-budget'
-    exit 1
 fi
 
 FEATURE_STATUS=success
@@ -275,7 +269,7 @@ if [ -z "$BUG_REPORT" ]; then
           downstream_perf_run_and_log \
               "$BASELINE_LOG" \
               master_shell \
-              "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+              "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
       )
       BASELINE_DURATION_SECONDS=$baseline_duration
       killall kore-rpc-booster || echo "no zombie processes found"

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -128,7 +128,7 @@ first_existing_file() {
 # Keep nix develop as the primary environment, and add missing tool binaries
 # needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
 K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat deps/k_release)#k")/bin"
-CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths github:NixOS/nixpkgs/nixos-24.05#clang_14)/bin"
 OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
 OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
 GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -114,9 +114,15 @@ master_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --command bash -c "$1"
 }
 
+# Keep nix develop as the primary environment, and add missing tool binaries
+# needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
+K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
+CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang nixpkgs#openssl nixpkgs#gmp nixpkgs#pkg-config --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
+feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -107,11 +107,11 @@ sed -i'' -e "s|'forge', 'build'|'forge', 'build', '--no-auto-detect'|g" src/test
 uv lock
 
 feature_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend $SCRIPT_DIR/../  --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend $SCRIPT_DIR/../  --command bash -c "export PATH=\"$DOWNSTREAM_PERF_RUNTIME_PATH:\$PATH\"; $1"
 }
 
 master_shell() {
-  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --command bash -c "$1"
+  GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --command bash -c "export PATH=\"$DOWNSTREAM_PERF_RUNTIME_PATH:\$PATH\"; $1"
 }
 
 first_existing_file() {
@@ -137,12 +137,13 @@ OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$
 OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
 GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+DOWNSTREAM_PERF_RUNTIME_PATH="$PLUGIN_TOOLCHAIN_PATH"
 PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
 PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
 
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
+feature_shell "export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -138,10 +138,11 @@ OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSS
 GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
 PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
+PLUGIN_LIBFF_FLAGS="-DOPENSSL_ROOT_DIR=$OPENSSL_OUT_DIR -DOPENSSL_INCLUDE_DIR=$OPENSSL_DEV_DIR/include -DOPENSSL_CRYPTO_LIBRARY=$OPENSSL_CRYPTO_LIB -DOPENSSL_SSL_LIBRARY=$OPENSSL_SSL_LIB -DGMP_INCLUDE_DIR=$GMP_DEV_DIR/include -DGMP_LIBRARY=$GMP_LIB"
 
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export OPENSSL_ROOT_DIR=\"$OPENSSL_OUT_DIR\"; export OPENSSL_INCLUDE_DIR=\"$OPENSSL_DEV_DIR/include\"; export OPENSSL_CRYPTO_LIBRARY=\"$OPENSSL_CRYPTO_LIB\"; export OPENSSL_SSL_LIBRARY=\"$OPENSSL_SSL_LIB\"; export GMP_INCLUDE_DIR=\"$GMP_DEV_DIR/include\"; export GMP_LIBRARY=\"$GMP_LIB\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
+feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export LIBFF_CMAKE_FLAGS=\"$PLUGIN_LIBFF_FLAGS\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -116,7 +116,7 @@ master_shell() {
 
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#cmake nixpkgs#clang --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
+feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -115,7 +115,8 @@ master_shell() {
 }
 
 # kompile Kontrol's K dependencies
-feature_shell "uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
+# Ensure plugin build prerequisites are available on self-hosted runners.
+feature_shell "nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#cmake nixpkgs#clang --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -114,15 +114,34 @@ master_shell() {
   GC_DONT_GC=1 nix develop . --extra-experimental-features 'nix-command flakes' --override-input kevm/k-framework/haskell-backend github:runtimeverification/haskell-backend/$BASELINE_COMMIT --command bash -c "$1"
 }
 
+first_existing_file() {
+  local candidate=''
+  for candidate in "$@"; do
+    if [ -e "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Keep nix develop as the primary environment, and add missing tool binaries
 # needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
 K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
 CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
+OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
+OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"
+GMP_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.out)"
+GMP_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#gmp.dev)"
+OPENSSL_CRYPTO_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libcrypto.so" "$OPENSSL_OUT_DIR/lib/libcrypto.so.3" "$OPENSSL_OUT_DIR/lib/libcrypto.dylib" "$OPENSSL_OUT_DIR/lib/libcrypto.a")"
+OPENSSL_SSL_LIB="$(first_existing_file "$OPENSSL_OUT_DIR/lib/libssl.so" "$OPENSSL_OUT_DIR/lib/libssl.so.3" "$OPENSSL_OUT_DIR/lib/libssl.dylib" "$OPENSSL_OUT_DIR/lib/libssl.a")"
+GMP_LIB="$(first_existing_file "$GMP_OUT_DIR/lib/libgmp.so" "$GMP_OUT_DIR/lib/libgmp.so.10" "$GMP_OUT_DIR/lib/libgmp.dylib" "$GMP_OUT_DIR/lib/libgmp.a")"
 PLUGIN_TOOLCHAIN_PATH="$HOME/.local/bin:$K_BIN_DIR:$CLANG_BIN_DIR"
+PLUGIN_CMAKE_PREFIX_PATH="$OPENSSL_OUT_DIR:$OPENSSL_DEV_DIR:$GMP_OUT_DIR:$GMP_DEV_DIR"
 
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
+feature_shell "export PATH=\"$PLUGIN_TOOLCHAIN_PATH:\$PATH\"; export CMAKE_PREFIX_PATH=\"$PLUGIN_CMAKE_PREFIX_PATH\"; export OPENSSL_ROOT_DIR=\"$OPENSSL_OUT_DIR\"; export OPENSSL_INCLUDE_DIR=\"$OPENSSL_DEV_DIR/include\"; export OPENSSL_CRYPTO_LIBRARY=\"$OPENSSL_CRYPTO_LIB\"; export OPENSSL_SSL_LIBRARY=\"$OPENSSL_SSL_LIB\"; export GMP_INCLUDE_DIR=\"$GMP_DEV_DIR/include\"; export GMP_LIBRARY=\"$GMP_LIB\"; uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -158,7 +158,40 @@ FEATURE_LOG="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-$FEATURE_BRANCH_NAME.log"
 BASELINE_LOG="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-baseline-$BASELINE_COMMIT_SHORT.log"
 COMPARE_FILE="$SCRIPT_DIR/logs/kontrol-$KONTROL_VERSION-baseline-$BASELINE_COMMIT_SHORT-$FEATURE_BRANCH_NAME-compare"
 
-# use special options if given, but restore KORE_RPC_OPTS afterwards
+# set test arguments and select which tests to run
+QUOTE='"'
+TEST_ARGS="--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k 'not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)'"
+
+status_from_exit() {
+    local exit_code=$1
+    if [[ $exit_code -eq 0 ]]; then
+        printf 'success\n'
+    elif [[ $exit_code -eq 124 ]]; then
+        printf 'timeout\n'
+    else
+        printf 'failure\n'
+    fi
+}
+
+baseline_exit=0
+if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+    BASELINE_STATUS=skipped
+    COMPARE_STATUS=skipped
+    SKIP_REASON='baseline-same-as-head'
+else
+    rm -rf $FOUNDRY_DIR/out/proofs
+    read -r baseline_exit baseline_duration < <(
+        downstream_perf_run_and_log \
+            "$BASELINE_LOG" \
+            master_shell \
+            "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+    )
+    BASELINE_DURATION_SECONDS=$baseline_duration
+    BASELINE_STATUS="$(status_from_exit "$baseline_exit")"
+    killall kore-rpc-booster || echo "no zombie processes found"
+fi
+
+# use special options if given for the current-branch run only, then restore.
 FEATURE_SERVER_OPTS=${FEATURE_SERVER_OPTS:-''}
 if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     echo "Using special options '${FEATURE_SERVER_OPTS}' via KORE_RPC_OPTS"
@@ -168,10 +201,6 @@ if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     export KORE_RPC_OPTS=${FEATURE_SERVER_OPTS}
 fi
 
-# set test arguments and select which tests to run
-QUOTE='"'
-TEST_ARGS="--foundry-root $FOUNDRY_DIR --maxfail=0 --numprocesses=$PYTEST_PARALLEL -vv $BUG_REPORT -k 'not (test_kontrol_cse or test_foundry_minimize_proof or test_kontrol_end_to_end)'"
-
 read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
@@ -179,114 +208,45 @@ read -r feature_exit feature_duration < <(
         "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
+FEATURE_STATUS="$(status_from_exit "$feature_exit")"
 killall kore-rpc-booster || echo "no zombie processes found"
 
-if [[ $feature_exit -ne 0 ]]; then
-    if [[ $feature_exit -eq 124 ]]; then
-        FEATURE_STATUS=timeout
-        if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-            BASELINE_STATUS=skipped
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-run-timeout-baseline-same-as-head'
-            exit 1
-        fi
-
-        rm -rf $FOUNDRY_DIR/out/proofs
-        read -r baseline_exit baseline_duration < <(
-            downstream_perf_run_and_log \
-                "$BASELINE_LOG" \
-                master_shell \
-                "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
-        )
-        BASELINE_DURATION_SECONDS=$baseline_duration
-        killall kore-rpc-booster || echo "no zombie processes found"
-
-        if [[ $baseline_exit -eq 124 ]]; then
-            BASELINE_STATUS=timeout
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-and-baseline-run-timeout'
-            exit 0
-        fi
-
-        if [[ $baseline_exit -ne 0 ]]; then
-            BASELINE_STATUS=failure
-            COMPARE_STATUS=skipped
-            SKIP_REASON='feature-timeout-baseline-failed'
-            exit 0
-        fi
-
-        BASELINE_STATUS=success
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-timeout-baseline-succeeded'
-        exit 1
-    fi
-    FEATURE_STATUS=failure
-    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-        BASELINE_STATUS=skipped
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-run-failed-baseline-same-as-head'
-        exit "$feature_exit"
-    fi
-
-    rm -rf $FOUNDRY_DIR/out/proofs
-    read -r baseline_exit baseline_duration < <(
-        downstream_perf_run_and_log \
-            "$BASELINE_LOG" \
-            master_shell \
-            "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
-    )
-    BASELINE_DURATION_SECONDS=$baseline_duration
-    killall kore-rpc-booster || echo "no zombie processes found"
-
-    if [[ $baseline_exit -ne 0 ]]; then
-        BASELINE_STATUS=failure
-        COMPARE_STATUS=skipped
-        SKIP_REASON='feature-and-baseline-run-failed'
-        exit 0
-    fi
-
-    BASELINE_STATUS=success
-    COMPARE_STATUS=skipped
-    SKIP_REASON='feature-run-failed-baseline-succeeded'
-    exit "$feature_exit"
-fi
-
-FEATURE_STATUS=success
-
-if [ -z "$BUG_REPORT" ]; then
+if [ ! -z "${FEATURE_SERVER_OPTS}" ]; then
     if [ ! -z "${PRIOR_OPTS:-}" ]; then
         export KORE_RPC_OPTS=${PRIOR_OPTS}
     else
         unset KORE_RPC_OPTS
     fi
-    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
-      BASELINE_STATUS=skipped
-      COMPARE_STATUS=skipped
-      SKIP_REASON='baseline-same-as-head'
+fi
+
+if [[ $FEATURE_STATUS != success ]]; then
+    COMPARE_STATUS=skipped
+    if [[ $BASELINE_STATUS == success ]]; then
+        SKIP_REASON="feature-run-${FEATURE_STATUS}-baseline-succeeded"
+    elif [[ $BASELINE_STATUS == skipped ]]; then
+        SKIP_REASON="feature-run-${FEATURE_STATUS}-baseline-skipped"
     else
-      rm -rf $FOUNDRY_DIR/out/proofs
-      read -r baseline_exit baseline_duration < <(
-          downstream_perf_run_and_log \
-              "$BASELINE_LOG" \
-              master_shell \
-              "timeout ${TIMEOUT_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
-      )
-      BASELINE_DURATION_SECONDS=$baseline_duration
-      killall kore-rpc-booster || echo "no zombie processes found"
-
-      if [[ $baseline_exit -ne 0 ]]; then
-        BASELINE_STATUS=failure
-        COMPARE_STATUS=skipped
-        SKIP_REASON='baseline-run-failed'
-        exit "$baseline_exit"
-      fi
-
-      BASELINE_STATUS=success
+        SKIP_REASON="feature-and-baseline-run-${FEATURE_STATUS}-${BASELINE_STATUS}"
     fi
+    exit 1
+fi
+
+if [[ -n $BUG_REPORT ]]; then
+    COMPARE_STATUS=skipped
+    SKIP_REASON='bug-report-mode'
+    exit 0
 fi
 
 cd $SCRIPT_DIR
 if [[ $BASELINE_STATUS == success ]]; then
     python3 compare.py "$FEATURE_LOG" "$BASELINE_LOG" > "$COMPARE_FILE"
     COMPARE_STATUS=success
+    exit 0
+fi
+
+COMPARE_STATUS=skipped
+if [[ $BASELINE_STATUS == skipped ]]; then
+    SKIP_REASON='baseline-same-as-head'
+else
+    SKIP_REASON="baseline-run-${BASELINE_STATUS}"
 fi

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -184,7 +184,40 @@ killall kore-rpc-booster || echo "no zombie processes found"
 if [[ $feature_exit -ne 0 ]]; then
     if [[ $feature_exit -eq 124 ]]; then
         FEATURE_STATUS=budget-exceeded
-        SKIP_REASON='feature-run-exceeded-budget'
+        if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+            BASELINE_STATUS=skipped
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-run-exceeded-budget-baseline-same-as-head'
+            exit 1
+        fi
+
+        rm -rf $FOUNDRY_DIR/out/proofs
+        read -r baseline_exit baseline_duration < <(
+            downstream_perf_run_and_log \
+                "$BASELINE_LOG" \
+                master_shell \
+                "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+        )
+        BASELINE_DURATION_SECONDS=$baseline_duration
+        killall kore-rpc-booster || echo "no zombie processes found"
+
+        if [[ $baseline_exit -eq 124 ]]; then
+            BASELINE_STATUS=budget-exceeded
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-and-baseline-run-exceeded-budget'
+            exit 0
+        fi
+
+        if [[ $baseline_exit -ne 0 ]]; then
+            BASELINE_STATUS=failure
+            COMPARE_STATUS=skipped
+            SKIP_REASON='feature-budget-exceeded-baseline-failed'
+            exit 0
+        fi
+
+        BASELINE_STATUS=success
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-run-exceeded-budget-baseline-succeeded'
         exit 1
     fi
     FEATURE_STATUS=failure

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -127,7 +127,7 @@ first_existing_file() {
 
 # Keep nix develop as the primary environment, and add missing tool binaries
 # needed by blockchain-k-plugin (k tools + clang + cmake from ~/.local/bin).
-K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k")/bin"
+K_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths "github:runtimeverification/k/v$(cat deps/k_release)#k")/bin"
 CLANG_BIN_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#clang)/bin"
 OPENSSL_OUT_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.out)"
 OPENSSL_DEV_DIR="$(nix --extra-experimental-features 'nix-command flakes' build --no-link --print-out-paths nixpkgs#openssl.dev)"

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -183,7 +183,33 @@ killall kore-rpc-booster || echo "no zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
     FEATURE_STATUS=failure
-    SKIP_REASON='feature-run-failed'
+    if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
+        BASELINE_STATUS=skipped
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-run-failed-baseline-same-as-head'
+        exit "$feature_exit"
+    fi
+
+    rm -rf $FOUNDRY_DIR/out/proofs
+    read -r baseline_exit baseline_duration < <(
+        downstream_perf_run_and_log \
+            "$BASELINE_LOG" \
+            master_shell \
+            "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+    )
+    BASELINE_DURATION_SECONDS=$baseline_duration
+    killall kore-rpc-booster || echo "no zombie processes found"
+
+    if [[ $baseline_exit -ne 0 ]]; then
+        BASELINE_STATUS=failure
+        COMPARE_STATUS=skipped
+        SKIP_REASON='feature-and-baseline-run-failed'
+        exit 0
+    fi
+
+    BASELINE_STATUS=success
+    COMPARE_STATUS=skipped
+    SKIP_REASON='feature-run-failed-baseline-succeeded'
     exit "$feature_exit"
 fi
 

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -176,12 +176,17 @@ read -r feature_exit feature_duration < <(
     downstream_perf_run_and_log \
         "$FEATURE_LOG" \
         feature_shell \
-        "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+        "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
 )
 FEATURE_DURATION_SECONDS=$feature_duration
 killall kore-rpc-booster || echo "no zombie processes found"
 
 if [[ $feature_exit -ne 0 ]]; then
+    if [[ $feature_exit -eq 124 ]]; then
+        FEATURE_STATUS=budget-exceeded
+        SKIP_REASON='feature-run-exceeded-budget'
+        exit 1
+    fi
     FEATURE_STATUS=failure
     if [[ $BASELINE_COMMIT == $HEAD_COMMIT ]]; then
         BASELINE_STATUS=skipped
@@ -195,7 +200,7 @@ if [[ $feature_exit -ne 0 ]]; then
         downstream_perf_run_and_log \
             "$BASELINE_LOG" \
             master_shell \
-            "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+            "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
     )
     BASELINE_DURATION_SECONDS=$baseline_duration
     killall kore-rpc-booster || echo "no zombie processes found"
@@ -237,7 +242,7 @@ if [ -z "$BUG_REPORT" ]; then
           downstream_perf_run_and_log \
               "$BASELINE_LOG" \
               master_shell \
-              "make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
+              "timeout ${FEATURE_BUDGET_SECONDS}s make test-integration TEST_ARGS=$QUOTE$TEST_ARGS$QUOTE"
       )
       BASELINE_DURATION_SECONDS=$baseline_duration
       killall kore-rpc-booster || echo "no zombie processes found"

--- a/scripts/performance-tests-kontrol.sh
+++ b/scripts/performance-tests-kontrol.sh
@@ -116,7 +116,7 @@ master_shell() {
 
 # kompile Kontrol's K dependencies
 # Ensure plugin build prerequisites are available on self-hosted runners.
-feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
+feature_shell "export PATH=\"\$HOME/.local/bin:\$PATH\"; nix shell github:runtimeverification/k/v$(cat "$SCRIPT_DIR/../deps/k_release")#k nixpkgs#clang nixpkgs#openssl nixpkgs#gmp nixpkgs#pkg-config --command bash -c 'uv run kdist --verbose build evm-semantics.plugin evm-semantics.haskell kontrol.* --jobs 4'"
 
 # kompile the test contracts, to be reused in feature_shell and master_shell. Copy the result from pytest's temp directory
 PYTEST_TEMP_DIR=$TEMPD/pytest-temp-dir

--- a/scripts/test-downstream-perf-lib.sh
+++ b/scripts/test-downstream-perf-lib.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+. "$SCRIPT_DIR/downstream-perf-lib.sh"
+
+TEMPD=$(mktemp -d)
+trap 'rm -rf "$TEMPD"' EXIT
+
+LOGFILE="$TEMPD/helper.log"
+
+read -r status duration < <(
+    downstream_perf_run_and_log \
+        "$LOGFILE" \
+        bash -c "echo 'feature output line 1'; echo 'feature output line 2'; echo 'feature warning' >&2; exit 7"
+)
+
+if [[ $status != "7" ]]; then
+    echo "Expected status 7, got '$status'" >&2
+    exit 1
+fi
+
+if [[ ! $duration =~ ^[0-9]+$ ]]; then
+    echo "Expected numeric duration, got '$duration'" >&2
+    exit 1
+fi
+
+if [[ ! -s $LOGFILE ]]; then
+    echo "Expected non-empty logfile at '$LOGFILE'" >&2
+    exit 1
+fi
+
+grep -q "feature output line 1" "$LOGFILE"
+grep -q "feature output line 2" "$LOGFILE"
+grep -q "feature warning" "$LOGFILE"


### PR DESCRIPTION
## Summary
- add a standalone `downstream-perf` workflow for KEVM and Kontrol downstream checks
- run `master` and `current` for each suite as separate jobs, then compare them before publishing results
- publish one upserted PR comment driven by suite-level compare outputs

## Goal
- automate a workflow that was previously manual
- make the execution model explicit: raw runs first, suite compare second, PR reporting last
- keep expensive downstream jobs off most PRs while still self-testing workflow changes
- preserve diagnostics and downloadable artifacts even when one side fails or times out

## Security and Reliability
- workflow-level permissions stay at `contents: read`
- PR-comment write permissions are scoped to the final `report` job only
- checkout in non-report jobs uses `persist-credentials: false`
- suite collection and artifact upload run with `always()` so failure diagnostics are still preserved

## Triggering
- `workflow_dispatch` always enables the selected suites
- for `pull_request`, downstream jobs run only when at least one is true:
  - the PR has the `perf` label
  - the PR changes a configured downstream-perf path:
    - `booster/**`
    - `kore/**`
    - `kore-rpc-types/**`
    - `flake.nix`
    - `deps/**`
    - `scripts/performance-tests-kevm.sh`
    - `scripts/performance-tests-kontrol.sh`
    - `scripts/compare.py`
    - `scripts/collect-downstream-perf-results.sh`
    - `scripts/downstream-perf-lib.sh`
    - `.github/actions/downstream-perf-suite/**`
    - `.github/actionlint.yaml`
    - `.github/workflows/downstream-perf.yml`

## Confirmed Design
The intended workflow structure is:

1. Run four raw downstream jobs in parallel:
   - `KEVM master`
   - `KEVM current`
   - `Kontrol master`
   - `Kontrol current`
2. Run two suite compare jobs:
   - `KEVM compare`, which waits for `KEVM master` and `KEVM current`
   - `Kontrol compare`, which waits for `Kontrol master` and `Kontrol current`
3. Run one final reporting job:
   - `Report PR comment`, which waits for both compare jobs

The compare jobs are responsible for:
- consuming the raw results from `master` and `current`
- producing the suite-level comparison output
- producing the final suite artifact bundle that users download

The report job is responsible for:
- reading suite compare outputs
- writing a single PR comment
- linking to the final suite artifacts

## Workflow
```mermaid
flowchart TD
    T[Trigger] --> S[Select]

    S --> KM[KEVM master]
    S --> KC[KEVM current]
    S --> QM[Kontrol master]
    S --> QC[Kontrol current]

    KM --> KX[KEVM compare]
    KC --> KX

    QM --> QX[Kontrol compare]
    QC --> QX

    KX --> R[Report PR comment]
    QX --> R
```

## Artifact Model
- raw run jobs produce suite-and-branch specific intermediate results
- compare jobs consume those raw results and emit the final downloadable suite artifact
- the final PR comment is derived from compare outputs, not from ad hoc status reconstruction

In other words, the intended data flow is:

`master/current raw results -> suite compare -> final suite artifact + PR comment`

## Reporting Expectations
- checks should be named by suite and branch role, not by internal shard numbering
- suite comparison should be presented as `current` versus `master`
- the PR comment should contain the suite-level summary plus direct links to the final suite artifacts
- detailed logs, charts, top deltas, and raw summaries should live inside the final suite artifacts

## Current Policy Direction
- baseline target is current `origin/master`
- `master` and `current` runs use the same timeout setting within a suite
- compare happens only after both sides finish
- if one side fails or times out, the compare/report path should still surface that state with preserved diagnostics

## Testing
- local shell syntax checks passed for downstream scripts (`bash -n`)
- local helper regression test passed (`bash scripts/test-downstream-perf-lib.sh`)
- live GitHub Actions runs on this PR are being used to validate the workflow shape and reporting behavior
