### PR TITLE
Add builtin support to Booster

### DIFF
--- a/booster/hs-backend-booster.cabal
+++ b/booster/hs-backend-booster.cabal
@@ -228,6 +228,7 @@ library
       Booster.Builtin
       Booster.Builtin.Base
       Booster.Builtin.BOOL
+      Booster.Builtin.BYTES
       Booster.Builtin.INT
       Booster.Builtin.KEQUAL
       Booster.Builtin.LIST

--- a/booster/library/Booster/Builtin.hs
+++ b/booster/library/Booster/Builtin.hs
@@ -21,6 +21,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 
 import Booster.Builtin.BOOL
+import Booster.Builtin.BYTES
 import Booster.Builtin.Base
 import Booster.Builtin.INT
 import Booster.Builtin.KEQUAL
@@ -31,6 +32,7 @@ hooks :: Map ByteString BuiltinFunction
 hooks =
     Map.unions
         [ builtinsBOOL
+        , builtinsBYTES
         , builtinsINT
         , builtinsMAP
         , builtinsLIST

--- a/booster/library/Booster/Builtin/BYTES.hs
+++ b/booster/library/Booster/Builtin/BYTES.hs
@@ -83,7 +83,7 @@ bytesUpdate args
     , Just i <- readIntTerm iArg
     , Just byte <- readFillByte byteArg
     , i >= 0
-    , fromIntegral i < BS.length bs =
+    , i < toInteger (BS.length bs) =
         let idx = fromIntegral i
          in pure . Just . bytesTerm $
                 BS.take idx bs <> BS.singleton byte <> BS.drop (idx + 1) bs
@@ -97,7 +97,7 @@ bytesGet args
     , Just bs <- readBytesTerm bsArg
     , Just i <- readIntTerm iArg
     , i >= 0
-    , fromIntegral i < BS.length bs =
+    , i < toInteger (BS.length bs) =
         pure . Just . intTerm . toInteger $ BS.index bs (fromIntegral i)
     | otherwise = pure Nothing
 
@@ -111,15 +111,15 @@ bytesSubstr args
     , Just end <- readIntTerm endArg
     , start >= 0
     , end >= start
-    , fromIntegral end <= BS.length bs =
+    , end <= toInteger (BS.length bs) =
         pure . Just . bytesTerm $
             BS.take (fromIntegral (end - start)) (BS.drop (fromIntegral start) bs)
     | otherwise = pure Nothing
 
 {- | replaceAt(dest, i, src): overwrite dest starting at offset i with src bytes.
-Returns Nothing if i is out of bounds or src would not fit cleanly. Matches
-Kore semantics: result length is len(dest) - len(src) + len(src), i.e. the
-replaced slice is exactly len(src) bytes long.
+Per K's BYTES.replaceAt (domains.md), the result is `#False` if `i + length(src)`
+is not a valid end index, i.e. unless `0 <= i && i + length(src) <= length(dest)`.
+The result length therefore always equals length(dest).
 -}
 bytesReplaceAt :: BuiltinFunction
 bytesReplaceAt args
@@ -127,18 +127,13 @@ bytesReplaceAt args
     | [bsArg, iArg, srcArg] <- args
     , Just dest <- readBytesTerm bsArg
     , Just i <- readIntTerm iArg
-    , Just src <- readBytesTerm srcArg =
+    , Just src <- readBytesTerm srcArg
+    , i >= 0
+    , i + toInteger (BS.length src) <= toInteger (BS.length dest) =
         let delta = BS.length src
-            destLen = BS.length dest
             idx = fromIntegral i
-         in if delta == 0
-                then pure . Just $ bytesTerm dest
-                else
-                    if idx < 0 || idx >= destLen || destLen == 0
-                        then pure Nothing
-                        else
-                            pure . Just . bytesTerm $
-                                BS.take idx dest <> src <> BS.drop (idx + delta) dest
+         in pure . Just . bytesTerm $
+                BS.take idx dest <> src <> BS.drop (idx + delta) dest
     | otherwise = pure Nothing
 
 -- | padLeftBytes(BS, N, fill): left-pad BS with fill bytes to reach length N
@@ -148,10 +143,11 @@ bytesPadLeft args
     | [bsArg, nArg, fillArg] <- args
     , Just bs <- readBytesTerm bsArg
     , Just n <- readIntTerm nArg
-    , Just fill <- readFillByte fillArg =
-        let len = BS.length bs
-            padLen = max 0 (fromIntegral n - len)
-         in pure . Just . bytesTerm $ BS.replicate padLen fill <> bs
+    , Just fill <- readFillByte fillArg
+    , n >= 0 =
+        let len = toInteger (BS.length bs)
+            padLen = max 0 (n - len)
+         in pure . Just . bytesTerm $ BS.replicate (fromIntegral padLen) fill <> bs
     | otherwise = pure Nothing
 
 -- | padRightBytes(BS, N, fill): right-pad BS with fill bytes to reach length N
@@ -161,14 +157,18 @@ bytesPadRight args
     | [bsArg, nArg, fillArg] <- args
     , Just bs <- readBytesTerm bsArg
     , Just n <- readIntTerm nArg
-    , Just fill <- readFillByte fillArg =
-        let len = BS.length bs
-            padLen = max 0 (fromIntegral n - len)
-         in pure . Just . bytesTerm $ bs <> BS.replicate padLen fill
+    , Just fill <- readFillByte fillArg
+    , n >= 0 =
+        let len = toInteger (BS.length bs)
+            padLen = max 0 (n - len)
+         in pure . Just . bytesTerm $ bs <> BS.replicate (fromIntegral padLen) fill
     | otherwise = pure Nothing
 
 {- | int2bytes(len, val, endianness): encode val as len bytes in the given byte order.
-Positive values are zero-padded; negative values use 0xFF padding (two's complement).
+Per K's Int2Bytes (domains.md), when `len` is smaller than the magnitude of `val`,
+the most-significant bits of `val` are silently truncated; when larger, positive
+values are zero-padded and negative values use 0xFF padding (two's complement).
+A negative `len` returns Nothing rather than silently producing an empty result.
 -}
 bytesInt2Bytes :: BuiltinFunction
 bytesInt2Bytes args
@@ -176,7 +176,8 @@ bytesInt2Bytes args
     | [lenArg, valArg, endArg] <- args
     , Just len <- readIntTerm lenArg
     , Just val <- readIntTerm valArg
-    , Just end <- readEndianness endArg =
+    , Just end <- readEndianness endArg
+    , len >= 0 =
         let pad = if val < 0 then 0xFF else 0x00
             (littleEndian, _) = BS.unfoldrN (fromIntegral len) go val
             go v
@@ -228,16 +229,18 @@ readFillByte t = do
 
 data Endianness = BigEndian | LittleEndian
 
+-- K compiles `syntax Endianness ::= "BE" [symbol(bigEndianBytes)]` (etc.) into a
+-- kore constructor whose name is `LblbigEndianBytes`. We match the kore name.
 readEndianness :: Term -> Maybe Endianness
 readEndianness (SymbolApplication sym [] [])
-    | sym.name == "bigEndianBytes" = Just BigEndian
-    | sym.name == "littleEndianBytes" = Just LittleEndian
+    | sym.name == "LblbigEndianBytes" = Just BigEndian
+    | sym.name == "LbllittleEndianBytes" = Just LittleEndian
 readEndianness _ = Nothing
 
 data Signedness = Signed | Unsigned
 
 readSignedness :: Term -> Maybe Signedness
 readSignedness (SymbolApplication sym [] [])
-    | sym.name == "signedBytes" = Just Signed
-    | sym.name == "unsignedBytes" = Just Unsigned
+    | sym.name == "LblsignedBytes" = Just Signed
+    | sym.name == "LblunsignedBytes" = Just Unsigned
 readSignedness _ = Nothing

--- a/booster/library/Booster/Builtin/BYTES.hs
+++ b/booster/library/Booster/Builtin/BYTES.hs
@@ -1,0 +1,97 @@
+{- |
+Copyright   : (c) Runtime Verification, 2023
+License     : BSD-3-Clause
+
+Built-in functions (hooks) in the BYTES namespace, as described in
+[docs/hooks.md](https://github.com/runtimeverification/haskell-backend/blob/master/docs/hooks.md).
+-}
+module Booster.Builtin.BYTES (
+    builtinsBYTES,
+    readBytesTerm,
+    bytesTerm,
+) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Word (Word8)
+
+import Booster.Builtin.Base
+import Booster.Builtin.INT (readIntTerm)
+import Booster.Pattern.Base
+
+builtinsBYTES :: Map ByteString BuiltinFunction
+builtinsBYTES =
+    Map.mapKeys ("BYTES." <>) $
+        Map.fromList
+            [ "empty" ~~> bytesEmpty
+            , "padLeft" ~~> bytesPadLeft
+            , "padRight" ~~> bytesPadRight
+            , "concat" ~~> bytesConcat
+            , "length" ~~> bytesLength
+            ]
+
+-- | .Bytes constant: empty byte string
+bytesEmpty :: BuiltinFunction
+bytesEmpty args
+    | null args = pure . Just $ bytesTerm ""
+    | otherwise = arityError "BYTES.empty" 0 args
+
+-- | padLeftBytes(BS, N, fill): left-pad BS with fill bytes to reach length N
+bytesPadLeft :: BuiltinFunction
+bytesPadLeft args
+    | length args /= 3 = arityError "BYTES.padLeft" 3 args
+    | [bsArg, nArg, fillArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just n <- readIntTerm nArg
+    , Just fill <- readFillByte fillArg =
+        let len = BS.length bs
+            padLen = max 0 (fromIntegral n - len)
+         in pure . Just . bytesTerm $ BS.replicate padLen fill <> bs
+    | otherwise = pure Nothing
+
+-- | padRightBytes(BS, N, fill): right-pad BS with fill bytes to reach length N
+bytesPadRight :: BuiltinFunction
+bytesPadRight args
+    | length args /= 3 = arityError "BYTES.padRight" 3 args
+    | [bsArg, nArg, fillArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just n <- readIntTerm nArg
+    , Just fill <- readFillByte fillArg =
+        let len = BS.length bs
+            padLen = max 0 (fromIntegral n - len)
+         in pure . Just . bytesTerm $ bs <> BS.replicate padLen fill
+    | otherwise = pure Nothing
+
+-- | +Bytes: concatenate two byte strings
+bytesConcat :: BuiltinFunction
+bytesConcat args
+    | length args /= 2 = arityError "BYTES.concat" 2 args
+    | [arg1, arg2] <- args
+    , Just bs1 <- readBytesTerm arg1
+    , Just bs2 <- readBytesTerm arg2 =
+        pure . Just . bytesTerm $ bs1 <> bs2
+    | otherwise = pure Nothing
+
+-- | lengthBytes(BS): length of byte string as an integer
+bytesLength :: BuiltinFunction
+bytesLength args
+    | length args /= 1 = arityError "BYTES.length" 1 args
+    | [arg] <- args
+    , Just bs <- readBytesTerm arg =
+        pure . Just . DomainValue SortInt . BS8.pack . show $ BS.length bs
+    | otherwise = pure Nothing
+
+bytesTerm :: ByteString -> Term
+bytesTerm = DomainValue SortBytes
+
+readBytesTerm :: Term -> Maybe ByteString
+readBytesTerm (DomainValue SortBytes val) = Just val
+readBytesTerm _other = Nothing
+
+readFillByte :: Term -> Maybe Word8
+readFillByte t = do
+    i <- readIntTerm t
+    if i >= 0 && i <= 255 then Just (fromIntegral i) else Nothing

--- a/booster/library/Booster/Builtin/BYTES.hs
+++ b/booster/library/Booster/Builtin/BYTES.hs
@@ -19,7 +19,7 @@ import Data.Map qualified as Map
 import Data.Word (Word8)
 
 import Booster.Builtin.Base
-import Booster.Builtin.INT (readIntTerm)
+import Booster.Builtin.INT (intTerm, readIntTerm)
 import Booster.Pattern.Base
 
 builtinsBYTES :: Map ByteString BuiltinFunction
@@ -27,10 +27,17 @@ builtinsBYTES =
     Map.mapKeys ("BYTES." <>) $
         Map.fromList
             [ "empty" ~~> bytesEmpty
-            , "padLeft" ~~> bytesPadLeft
-            , "padRight" ~~> bytesPadRight
             , "concat" ~~> bytesConcat
             , "length" ~~> bytesLength
+            , "reverse" ~~> bytesReverse
+            , "update" ~~> bytesUpdate
+            , "get" ~~> bytesGet
+            , "substr" ~~> bytesSubstr
+            , "replaceAt" ~~> bytesReplaceAt
+            , "padLeft" ~~> bytesPadLeft
+            , "padRight" ~~> bytesPadRight
+            , "int2bytes" ~~> bytesInt2Bytes
+            , "bytes2int" ~~> bytesBytes2Int
             ]
 
 -- | .Bytes constant: empty byte string
@@ -38,6 +45,101 @@ bytesEmpty :: BuiltinFunction
 bytesEmpty args
     | null args = pure . Just $ bytesTerm ""
     | otherwise = arityError "BYTES.empty" 0 args
+
+-- | +Bytes: concatenate two byte strings
+bytesConcat :: BuiltinFunction
+bytesConcat args
+    | length args /= 2 = arityError "BYTES.concat" 2 args
+    | [arg1, arg2] <- args
+    , Just bs1 <- readBytesTerm arg1
+    , Just bs2 <- readBytesTerm arg2 =
+        pure . Just . bytesTerm $ bs1 <> bs2
+    | otherwise = pure Nothing
+
+-- | lengthBytes(BS): length of byte string as an integer
+bytesLength :: BuiltinFunction
+bytesLength args
+    | length args /= 1 = arityError "BYTES.length" 1 args
+    | [arg] <- args
+    , Just bs <- readBytesTerm arg =
+        pure . Just . DomainValue SortInt . BS8.pack . show $ BS.length bs
+    | otherwise = pure Nothing
+
+-- | reverseBytes(BS): reverse the byte sequence
+bytesReverse :: BuiltinFunction
+bytesReverse args
+    | length args /= 1 = arityError "BYTES.reverse" 1 args
+    | [arg] <- args
+    , Just bs <- readBytesTerm arg =
+        pure . Just . bytesTerm $ BS.reverse bs
+    | otherwise = pure Nothing
+
+-- | update(BS, i, byte): set byte at index i (0-based); returns Nothing if out of range
+bytesUpdate :: BuiltinFunction
+bytesUpdate args
+    | length args /= 3 = arityError "BYTES.update" 3 args
+    | [bsArg, iArg, byteArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just i <- readIntTerm iArg
+    , Just byte <- readFillByte byteArg
+    , i >= 0
+    , fromIntegral i < BS.length bs =
+        let idx = fromIntegral i
+         in pure . Just . bytesTerm $
+                BS.take idx bs <> BS.singleton byte <> BS.drop (idx + 1) bs
+    | otherwise = pure Nothing
+
+-- | get(BS, i): byte at index i as an integer (0-based); returns Nothing if out of range
+bytesGet :: BuiltinFunction
+bytesGet args
+    | length args /= 2 = arityError "BYTES.get" 2 args
+    | [bsArg, iArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just i <- readIntTerm iArg
+    , i >= 0
+    , fromIntegral i < BS.length bs =
+        pure . Just . intTerm . toInteger $ BS.index bs (fromIntegral i)
+    | otherwise = pure Nothing
+
+-- | substr(BS, start, end): bytes in [start, end); returns Nothing if indices out of range
+bytesSubstr :: BuiltinFunction
+bytesSubstr args
+    | length args /= 3 = arityError "BYTES.substr" 3 args
+    | [bsArg, startArg, endArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just start <- readIntTerm startArg
+    , Just end <- readIntTerm endArg
+    , start >= 0
+    , end >= start
+    , fromIntegral end <= BS.length bs =
+        pure . Just . bytesTerm $
+            BS.take (fromIntegral (end - start)) (BS.drop (fromIntegral start) bs)
+    | otherwise = pure Nothing
+
+{- | replaceAt(dest, i, src): overwrite dest starting at offset i with src bytes.
+Returns Nothing if i is out of bounds or src would not fit cleanly. Matches
+Kore semantics: result length is len(dest) - len(src) + len(src), i.e. the
+replaced slice is exactly len(src) bytes long.
+-}
+bytesReplaceAt :: BuiltinFunction
+bytesReplaceAt args
+    | length args /= 3 = arityError "BYTES.replaceAt" 3 args
+    | [bsArg, iArg, srcArg] <- args
+    , Just dest <- readBytesTerm bsArg
+    , Just i <- readIntTerm iArg
+    , Just src <- readBytesTerm srcArg =
+        let delta = BS.length src
+            destLen = BS.length dest
+            idx = fromIntegral i
+         in if delta == 0
+                then pure . Just $ bytesTerm dest
+                else
+                    if idx < 0 || idx >= destLen || destLen == 0
+                        then pure Nothing
+                        else
+                            pure . Just . bytesTerm $
+                                BS.take idx dest <> src <> BS.drop (idx + delta) dest
+    | otherwise = pure Nothing
 
 -- | padLeftBytes(BS, N, fill): left-pad BS with fill bytes to reach length N
 bytesPadLeft :: BuiltinFunction
@@ -65,23 +167,51 @@ bytesPadRight args
          in pure . Just . bytesTerm $ bs <> BS.replicate padLen fill
     | otherwise = pure Nothing
 
--- | +Bytes: concatenate two byte strings
-bytesConcat :: BuiltinFunction
-bytesConcat args
-    | length args /= 2 = arityError "BYTES.concat" 2 args
-    | [arg1, arg2] <- args
-    , Just bs1 <- readBytesTerm arg1
-    , Just bs2 <- readBytesTerm arg2 =
-        pure . Just . bytesTerm $ bs1 <> bs2
+{- | int2bytes(len, val, endianness): encode val as len bytes in the given byte order.
+Positive values are zero-padded; negative values use 0xFF padding (two's complement).
+-}
+bytesInt2Bytes :: BuiltinFunction
+bytesInt2Bytes args
+    | length args /= 3 = arityError "BYTES.int2bytes" 3 args
+    | [lenArg, valArg, endArg] <- args
+    , Just len <- readIntTerm lenArg
+    , Just val <- readIntTerm valArg
+    , Just end <- readEndianness endArg =
+        let pad = if val < 0 then 0xFF else 0x00
+            (littleEndian, _) = BS.unfoldrN (fromIntegral len) go val
+            go v
+                | v == 0 = Just (pad, 0)
+                | otherwise = let (d, m) = divMod v 0x100 in Just (fromIntegral m, d)
+            result = case end of
+                BigEndian -> BS.reverse littleEndian
+                LittleEndian -> littleEndian
+         in pure . Just $ bytesTerm result
     | otherwise = pure Nothing
 
--- | lengthBytes(BS): length of byte string as an integer
-bytesLength :: BuiltinFunction
-bytesLength args
-    | length args /= 1 = arityError "BYTES.length" 1 args
-    | [arg] <- args
-    , Just bs <- readBytesTerm arg =
-        pure . Just . DomainValue SortInt . BS8.pack . show $ BS.length bs
+{- | bytes2int(BS, endianness, signedness): decode BS as an integer.
+BigEndian means most-significant byte first. Signed uses two's complement.
+-}
+bytesBytes2Int :: BuiltinFunction
+bytesBytes2Int args
+    | length args /= 3 = arityError "BYTES.bytes2int" 3 args
+    | [bsArg, endArg, signArg] <- args
+    , Just bs <- readBytesTerm bsArg
+    , Just end <- readEndianness endArg
+    , Just sign <- readSignedness signArg =
+        let littleEndian = case end of
+                LittleEndian -> bs
+                BigEndian -> BS.reverse bs
+            (modulus, unsigned) =
+                BS.foldl'
+                    (\(!place, !acc) byte -> (place * 0x100, acc + place * fromIntegral byte))
+                    (1, 0)
+                    littleEndian
+            result = case sign of
+                Unsigned -> unsigned
+                Signed
+                    | 2 * unsigned >= modulus -> unsigned - modulus
+                    | otherwise -> unsigned
+         in pure . Just $ intTerm result
     | otherwise = pure Nothing
 
 bytesTerm :: ByteString -> Term
@@ -95,3 +225,19 @@ readFillByte :: Term -> Maybe Word8
 readFillByte t = do
     i <- readIntTerm t
     if i >= 0 && i <= 255 then Just (fromIntegral i) else Nothing
+
+data Endianness = BigEndian | LittleEndian
+
+readEndianness :: Term -> Maybe Endianness
+readEndianness (SymbolApplication sym [] [])
+    | sym.name == "bigEndianBytes" = Just BigEndian
+    | sym.name == "littleEndianBytes" = Just LittleEndian
+readEndianness _ = Nothing
+
+data Signedness = Signed | Unsigned
+
+readSignedness :: Term -> Maybe Signedness
+readSignedness (SymbolApplication sym [] [])
+    | sym.name == "signedBytes" = Just Signed
+    | sym.name == "unsignedBytes" = Just Unsigned
+readSignedness _ = Nothing

--- a/booster/library/Booster/Builtin/INT.hs
+++ b/booster/library/Booster/Builtin/INT.hs
@@ -37,11 +37,14 @@ builtinsINT =
             , "sub" ~~> intOperator (-)
             , "mul" ~~> intOperator (*)
             , "abs" ~~> intModifier abs
-            -- tdiv, tmod (truncating toward zero), ediv, emod (euclidian)
-            -- bitwise operations
-            -- and, or, xor, not, shl, shr
-            -- exponentiation
-            -- pow, powmod, log2 (truncating)
+            , -- tdiv, tmod (truncating toward zero), ediv, emod (euclidian)
+              "tdiv" ~~> intTDiv
+            , "tmod" ~~> intTMod
+            , -- bitwise operations
+              -- and, or, xor, not, shl, shr
+              -- exponentiation
+              "pow" ~~> intPow
+              -- powmod, log2 (truncating)
             ]
 
 compareInt :: (Integer -> Integer -> Bool) -> BuiltinFunction
@@ -68,6 +71,39 @@ intModifier f args
     | [arg] <- args
     , Just i <- readIntTerm arg =
         pure . Just . intTerm $ f i
+    | otherwise = pure Nothing
+
+-- | Integer exponentiation (non-negative exponents only; negative exponent returns Nothing)
+intPow :: BuiltinFunction
+intPow args
+    | length args /= 2 = arityError "INT.pow" 2 args
+    | [base, exp_] <- args
+    , Just b <- readIntTerm base
+    , Just e <- readIntTerm exp_
+    , e >= 0 =
+        pure . Just . intTerm $ b ^ e
+    | otherwise = pure Nothing
+
+-- | Truncating integer division (toward zero); division by zero returns Nothing
+intTDiv :: BuiltinFunction
+intTDiv args
+    | length args /= 2 = arityError "INT.tdiv" 2 args
+    | [arg1, arg2] <- args
+    , Just i1 <- readIntTerm arg1
+    , Just i2 <- readIntTerm arg2
+    , i2 /= 0 =
+        pure . Just . intTerm $ quot i1 i2
+    | otherwise = pure Nothing
+
+-- | Truncating integer modulo (toward zero); modulo by zero returns Nothing
+intTMod :: BuiltinFunction
+intTMod args
+    | length args /= 2 = arityError "INT.tmod" 2 args
+    | [arg1, arg2] <- args
+    , Just i1 <- readIntTerm arg1
+    , Just i2 <- readIntTerm arg2
+    , i2 /= 0 =
+        pure . Just . intTerm $ rem i1 i2
     | otherwise = pure Nothing
 
 intTerm :: Integer -> Term

--- a/booster/library/Booster/Builtin/INT.hs
+++ b/booster/library/Booster/Builtin/INT.hs
@@ -13,6 +13,7 @@ module Booster.Builtin.INT (
     intTerm,
 ) where
 
+import Data.Bits (complement, shiftL, shiftR, xor, (.&.), (.|.))
 import Data.ByteString.Char8 (ByteString, pack, unpack)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -37,14 +38,23 @@ builtinsINT =
             , "sub" ~~> intOperator (-)
             , "mul" ~~> intOperator (*)
             , "abs" ~~> intModifier abs
-            , -- tdiv, tmod (truncating toward zero), ediv, emod (euclidian)
+            , -- tdiv, tmod (truncating toward zero), ediv, emod (euclidean)
               "tdiv" ~~> intTDiv
             , "tmod" ~~> intTMod
+            , "ediv" ~~> intEDiv
+            , "emod" ~~> intEMod
             , -- bitwise operations
-              -- and, or, xor, not, shl, shr
-              -- exponentiation
+              "and" ~~> intOperator (.&.)
+            , "or" ~~> intOperator (.|.)
+            , "xor" ~~> intOperator xor
+            , "not" ~~> intModifier complement
+            , "shl" ~~> intShl
+            , "shr" ~~> intShr
+            , -- exponentiation
               "pow" ~~> intPow
-              -- powmod, log2 (truncating)
+            , "powmod" ~~> intPowMod
+            , -- logarithm
+              "log2" ~~> intLog2
             ]
 
 compareInt :: (Integer -> Integer -> Bool) -> BuiltinFunction
@@ -84,6 +94,37 @@ intPow args
         pure . Just . intTerm $ b ^ e
     | otherwise = pure Nothing
 
+-- | Modular exponentiation b^e mod m (e >= 0, m /= 0); returns Nothing otherwise
+intPowMod :: BuiltinFunction
+intPowMod args
+    | length args /= 3 = arityError "INT.powmod" 3 args
+    | [baseArg, expArg, modArg] <- args
+    , Just b <- readIntTerm baseArg
+    , Just e <- readIntTerm expArg
+    , Just m <- readIntTerm modArg
+    , e >= 0
+    , m /= 0 =
+        pure . Just . intTerm $ powMod b e m
+    | otherwise = pure Nothing
+  where
+    powMod _ 0 m = 1 `mod` m
+    powMod b e m
+        | even e = let half = powMod b (e `div` 2) m in (half * half) `mod` m
+        | otherwise = (b * powMod b (e - 1) m) `mod` m
+
+-- | Truncating log base 2 (positive integers only); returns Nothing for n <= 0
+intLog2 :: BuiltinFunction
+intLog2 args
+    | length args /= 1 = arityError "INT.log2" 1 args
+    | [arg] <- args
+    , Just n <- readIntTerm arg
+    , n > 0 =
+        pure . Just . intTerm $ go 0 n
+    | otherwise = pure Nothing
+  where
+    go acc 1 = acc
+    go acc n = go (acc + 1) (n `shiftR` 1)
+
 -- | Truncating integer division (toward zero); division by zero returns Nothing
 intTDiv :: BuiltinFunction
 intTDiv args
@@ -104,6 +145,59 @@ intTMod args
     , Just i2 <- readIntTerm arg2
     , i2 /= 0 =
         pure . Just . intTerm $ rem i1 i2
+    | otherwise = pure Nothing
+
+{- | Euclidean division: emod is always non-negative; ediv satisfies a = ediv*b + emod.
+Division by zero returns Nothing.
+-}
+intEDiv :: BuiltinFunction
+intEDiv args
+    | length args /= 2 = arityError "INT.ediv" 2 args
+    | [arg1, arg2] <- args
+    , Just i1 <- readIntTerm arg1
+    , Just i2 <- readIntTerm arg2
+    , i2 /= 0 =
+        pure . Just . intTerm $ euclidDiv i1 i2
+    | otherwise = pure Nothing
+
+-- | Euclidean modulo: result is always non-negative. Modulo by zero returns Nothing.
+intEMod :: BuiltinFunction
+intEMod args
+    | length args /= 2 = arityError "INT.emod" 2 args
+    | [arg1, arg2] <- args
+    , Just i1 <- readIntTerm arg1
+    , Just i2 <- readIntTerm arg2
+    , i2 /= 0 =
+        pure . Just . intTerm $ euclidMod i1 i2
+    | otherwise = pure Nothing
+
+-- emod is always >= 0: adjust rem result if negative
+euclidMod :: Integer -> Integer -> Integer
+euclidMod a b = let r = a `rem` b in if r < 0 then r + abs b else r
+
+euclidDiv :: Integer -> Integer -> Integer
+euclidDiv a b = (a - euclidMod a b) `div` b
+
+-- | Left shift (non-negative shift amount only); negative shift returns Nothing
+intShl :: BuiltinFunction
+intShl args
+    | length args /= 2 = arityError "INT.shl" 2 args
+    | [arg1, arg2] <- args
+    , Just i <- readIntTerm arg1
+    , Just n <- readIntTerm arg2
+    , n >= 0 =
+        pure . Just . intTerm $ shiftL i (fromIntegral n)
+    | otherwise = pure Nothing
+
+-- | Right shift (non-negative shift amount only); negative shift returns Nothing
+intShr :: BuiltinFunction
+intShr args
+    | length args /= 2 = arityError "INT.shr" 2 args
+    | [arg1, arg2] <- args
+    , Just i <- readIntTerm arg1
+    , Just n <- readIntTerm arg2
+    , n >= 0 =
+        pure . Just . intTerm $ shiftR i (fromIntegral n)
     | otherwise = pure Nothing
 
 intTerm :: Integer -> Term

--- a/booster/unit-tests/Test/Booster/Builtin.hs
+++ b/booster/unit-tests/Test/Booster/Builtin.hs
@@ -10,6 +10,7 @@ module Test.Booster.Builtin (
 
 import Control.Monad.Trans.Except
 import Data.Bifunctor (second)
+import Data.Bits (complement, shiftL, shiftR, xor, (.&.), (.|.))
 import Data.ByteString.Char8 qualified as BS
 import Data.Either (isLeft)
 import Data.Function (on)
@@ -64,8 +65,20 @@ testIntHooks =
         , -- truncating division and modulo
           testIntTdivHook
         , testIntTmodHook
-        , -- exponentiation
+        , -- euclidean division and modulo
+          testIntEdivHook
+        , testIntEmodHook
+        , -- bitwise operations
+          testIntHook2 "INT.and" (.&.) Builtin.intTerm
+        , testIntHook2 "INT.or" (.|.) Builtin.intTerm
+        , testIntHook2 "INT.xor" xor Builtin.intTerm
+        , testIntNotHook
+        , testIntShlHook
+        , testIntShrHook
+        , -- exponentiation and logarithm
           testIntPowHook
+        , testIntPowModHook
+        , testIntLog2Hook
         ]
   where
     testIntHook2 name op result =
@@ -207,16 +220,194 @@ testIntHooks =
                 assertException $
                     runHook "INT.pow" [Builtin.intTerm 2, Builtin.intTerm 3, Builtin.intTerm 4]
             ]
+    testIntEdivHook =
+        testGroup
+            "INT.ediv"
+            [ testProperty "quotient satisfies a = ediv*b + emod" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.ediv" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Just (Builtin.intTerm $ euclidDiv a b) === run [Builtin.intTerm a, Builtin.intTerm b]
+            , testCase "(-7) `ediv` 2 = -4 (floor, unlike tdiv which gives -3)" $ do
+                result <- evalHook "INT.ediv" [Builtin.intTerm (-7), Builtin.intTerm 2]
+                Just (Builtin.intTerm (-4)) @=? result
+            , testCase "division by zero returns Nothing" $ do
+                result <- evalHook "INT.ediv" [Builtin.intTerm 42, Builtin.intTerm 0]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.ediv" []
+                assertException $ runHook "INT.ediv" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.ediv" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntEmodHook =
+        testGroup
+            "INT.emod"
+            [ testProperty "remainder is always non-negative" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.emod" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                let r = euclidMod a b
+                assert (r >= 0)
+                Just (Builtin.intTerm r) === run [Builtin.intTerm a, Builtin.intTerm b]
+            , testCase "(-7) `emod` 2 = 1 (non-negative, unlike tmod which gives -1)" $ do
+                result <- evalHook "INT.emod" [Builtin.intTerm (-7), Builtin.intTerm 2]
+                Just (Builtin.intTerm 1) @=? result
+            , testCase "modulo by zero returns Nothing" $ do
+                result <- evalHook "INT.emod" [Builtin.intTerm 42, Builtin.intTerm 0]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.emod" []
+                assertException $ runHook "INT.emod" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.emod" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntNotHook =
+        testProperty "Hook \"INT.not\"" . property $ do
+            let f = runHook "INT.not"
+                run args = either (error . Text.unpack) id . runExcept $ f args
+            a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+            let dv_a = Builtin.intTerm a
+            Just (Builtin.intTerm $ complement a) === run [dv_a]
+            let fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+            Nothing === run [app fct [dv_a]]
+            let assertException = assert . isLeft . runExcept
+            assertException $ f []
+            assertException $ f [dv_a, dv_a]
+    testIntShlHook =
+        testGroup
+            "INT.shl"
+            [ testProperty "shifts left by non-negative amount" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.shl" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                n <- forAll $ Gen.int (Range.linear 0 63)
+                Just (Builtin.intTerm $ shiftL a n) === run [Builtin.intTerm a, Builtin.intTerm (fromIntegral n)]
+            , testCase "negative shift amount returns Nothing" $ do
+                result <- evalHook "INT.shl" [Builtin.intTerm 1, Builtin.intTerm (-1)]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.shl" []
+                assertException $ runHook "INT.shl" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.shl" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntShrHook =
+        testGroup
+            "INT.shr"
+            [ testProperty "shifts right by non-negative amount" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.shr" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                n <- forAll $ Gen.int (Range.linear 0 63)
+                Just (Builtin.intTerm $ shiftR a n) === run [Builtin.intTerm a, Builtin.intTerm (fromIntegral n)]
+            , testCase "negative shift amount returns Nothing" $ do
+                result <- evalHook "INT.shr" [Builtin.intTerm 8, Builtin.intTerm (-1)]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.shr" []
+                assertException $ runHook "INT.shr" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.shr" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntPowModHook =
+        testGroup
+            "INT.powmod"
+            [ testProperty "b^e mod m for small values" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.powmod" args
+                b <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear (-10) 10)
+                e <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear 0 10)
+                m <- fmap fromIntegral $ forAll $ Gen.filter (/= 0) $ Gen.int64 (Range.linear 1 100)
+                let expected = powMod b e m
+                Just (Builtin.intTerm expected) === run [Builtin.intTerm b, Builtin.intTerm e, Builtin.intTerm m]
+            , testCase "any base to power 0 mod m is 1 mod m" $ do
+                result <- evalHook "INT.powmod" [Builtin.intTerm 42, Builtin.intTerm 0, Builtin.intTerm 7]
+                Just (Builtin.intTerm 1) @=? result
+            , testCase "negative exponent returns Nothing" $ do
+                result <- evalHook "INT.powmod" [Builtin.intTerm 2, Builtin.intTerm (-1), Builtin.intTerm 5]
+                Nothing @=? result
+            , testCase "zero modulus returns Nothing" $ do
+                result <- evalHook "INT.powmod" [Builtin.intTerm 2, Builtin.intTerm 3, Builtin.intTerm 0]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.powmod" []
+                assertException $ runHook "INT.powmod" [Builtin.intTerm 2]
+                assertException $
+                    runHook "INT.powmod" [Builtin.intTerm 2, Builtin.intTerm 3]
+                assertException $
+                    runHook
+                        "INT.powmod"
+                        [Builtin.intTerm 2, Builtin.intTerm 3, Builtin.intTerm 4, Builtin.intTerm 5]
+            ]
+    testIntLog2Hook =
+        testGroup
+            "INT.log2"
+            [ testProperty "floor of log base 2 for positive integers" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.log2" args
+                n <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear 1 maxBound)
+                let expected = floor (logBase 2 (fromIntegral n) :: Double)
+                Just (Builtin.intTerm expected) === run [Builtin.intTerm n]
+            , testCase "log2(1) = 0" $ do
+                result <- evalHook "INT.log2" [Builtin.intTerm 1]
+                Just (Builtin.intTerm 0) @=? result
+            , testCase "log2(2) = 1" $ do
+                result <- evalHook "INT.log2" [Builtin.intTerm 2]
+                Just (Builtin.intTerm 1) @=? result
+            , testCase "log2(1024) = 10" $ do
+                result <- evalHook "INT.log2" [Builtin.intTerm 1024]
+                Just (Builtin.intTerm 10) @=? result
+            , testCase "zero returns Nothing" $ do
+                result <- evalHook "INT.log2" [Builtin.intTerm 0]
+                Nothing @=? result
+            , testCase "negative returns Nothing" $ do
+                result <- evalHook "INT.log2" [Builtin.intTerm (-1)]
+                Nothing @=? result
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.log2" []
+                assertException $ runHook "INT.log2" [Builtin.intTerm 1, Builtin.intTerm 2]
+            ]
+    -- Euclidean helpers (mirror the implementation for property checking)
+    euclidMod a b = let r = a `rem` b in if r < 0 then r + abs b else r
+    euclidDiv a b = (a - euclidMod a b) `div` b
+    powMod _ 0 m = 1 `mod` m
+    powMod b e m
+        | even e = let half = powMod b (e `div` 2) m in (half * half) `mod` m
+        | otherwise = (b * powMod b (e - 1) m) `mod` m
 
 testBytesHooks :: TestTree
 testBytesHooks =
     testGroup
         "BYTES hooks"
         [ testBytesEmptyHook
-        , testBytesPadLeftHook
-        , testBytesPadRightHook
         , testBytesConcatHook
         , testBytesLengthHook
+        , testBytesReverseHook
+        , testBytesUpdateHook
+        , testBytesGetHook
+        , testBytesSubstrHook
+        , testBytesReplaceAtHook
+        , testBytesPadLeftHook
+        , testBytesPadRightHook
+        , testBytesInt2BytesHook
+        , testBytesBytes2IntHook
         ]
 
 testBytesEmptyHook :: TestTree
@@ -376,6 +567,329 @@ testBytesLengthHook =
             assertException $
                 runHook "BYTES.length" [Builtin.bytesTerm "x", Builtin.bytesTerm "y"]
         ]
+
+testBytesReverseHook :: TestTree
+testBytesReverseHook =
+    testGroup
+        "BYTES.reverse"
+        [ testProperty "reverses a byte string" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 20) Gen.latin1
+            result <- evalHook "BYTES.reverse" [Builtin.bytesTerm bs]
+            Just (Builtin.bytesTerm $ BS.reverse bs) === result
+        , testCase "reverse of empty is empty" $ do
+            result <- evalHook "BYTES.reverse" [Builtin.bytesTerm ""]
+            Just (Builtin.bytesTerm "") @=? result
+        , testCase "unevaluated argument returns Nothing" $ do
+            result <- evalHook "BYTES.reverse" [[trm| X:SortBytes{} |]]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.reverse" []
+            assertException $
+                runHook "BYTES.reverse" [Builtin.bytesTerm "x", Builtin.bytesTerm "y"]
+        ]
+
+testBytesUpdateHook :: TestTree
+testBytesUpdateHook =
+    testGroup
+        "BYTES.update"
+        [ testProperty "replaces byte at valid index" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            i <- forAll $ between0And (BS.length bs - 1)
+            let iTerm = Builtin.intTerm $ fromIntegral i
+            result <- evalHook "BYTES.update" [Builtin.bytesTerm bs, iTerm, Builtin.intTerm 0x42]
+            let expected =
+                    BS.take i bs <> BS.singleton '\x42' <> BS.drop (i + 1) bs
+            Just (Builtin.bytesTerm expected) === result
+        , testCase "index out of range returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.update"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 5, Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "negative index returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.update"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm (-1), Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.update"
+                    [[trm| X:SortBytes{} |], Builtin.intTerm 0, Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.update" []
+            assertException $ runHook "BYTES.update" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook "BYTES.update" [Builtin.bytesTerm "x", Builtin.intTerm 0]
+            assertException $
+                runHook
+                    "BYTES.update"
+                    [ Builtin.bytesTerm "x"
+                    , Builtin.intTerm 0
+                    , Builtin.intTerm 0
+                    , Builtin.intTerm 0
+                    ]
+        ]
+
+testBytesGetHook :: TestTree
+testBytesGetHook =
+    testGroup
+        "BYTES.get"
+        [ testProperty "returns byte at valid index as integer" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            i <- forAll $ between0And (BS.length bs - 1)
+            result <- evalHook "BYTES.get" [Builtin.bytesTerm bs, Builtin.intTerm $ fromIntegral i]
+            Just (Builtin.intTerm . fromIntegral . fromEnum $ BS.index bs i) === result
+        , testCase "index out of range returns Nothing" $ do
+            result <- evalHook "BYTES.get" [Builtin.bytesTerm "abc", Builtin.intTerm 5]
+            Nothing @=? result
+        , testCase "negative index returns Nothing" $ do
+            result <- evalHook "BYTES.get" [Builtin.bytesTerm "abc", Builtin.intTerm (-1)]
+            Nothing @=? result
+        , testCase "unevaluated argument returns Nothing" $ do
+            result <- evalHook "BYTES.get" [[trm| X:SortBytes{} |], Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.get" []
+            assertException $ runHook "BYTES.get" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook
+                    "BYTES.get"
+                    [Builtin.bytesTerm "x", Builtin.intTerm 0, Builtin.intTerm 0]
+        ]
+
+testBytesSubstrHook :: TestTree
+testBytesSubstrHook =
+    testGroup
+        "BYTES.substr"
+        [ testProperty "extracts [start, end) slice" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            start <- forAll $ between0And (BS.length bs)
+            end <- forAll $ Gen.int (Range.linear start (BS.length bs))
+            let result' = BS.take (end - start) (BS.drop start bs)
+            result <-
+                evalHook
+                    "BYTES.substr"
+                    [ Builtin.bytesTerm bs
+                    , Builtin.intTerm $ fromIntegral start
+                    , Builtin.intTerm $ fromIntegral end
+                    ]
+            Just (Builtin.bytesTerm result') === result
+        , testCase "end > length returns Nothing" $ do
+            result <-
+                evalHook "BYTES.substr" [Builtin.bytesTerm "abc", Builtin.intTerm 0, Builtin.intTerm 5]
+            Nothing @=? result
+        , testCase "end < start returns Nothing" $ do
+            result <-
+                evalHook "BYTES.substr" [Builtin.bytesTerm "abc", Builtin.intTerm 2, Builtin.intTerm 1]
+            Nothing @=? result
+        , testCase "negative start returns Nothing" $ do
+            result <-
+                evalHook "BYTES.substr" [Builtin.bytesTerm "abc", Builtin.intTerm (-1), Builtin.intTerm 2]
+            Nothing @=? result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook "BYTES.substr" [[trm| X:SortBytes{} |], Builtin.intTerm 0, Builtin.intTerm 2]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.substr" []
+            assertException $ runHook "BYTES.substr" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook "BYTES.substr" [Builtin.bytesTerm "x", Builtin.intTerm 0]
+            assertException $
+                runHook
+                    "BYTES.substr"
+                    [ Builtin.bytesTerm "x"
+                    , Builtin.intTerm 0
+                    , Builtin.intTerm 1
+                    , Builtin.intTerm 2
+                    ]
+        ]
+
+testBytesReplaceAtHook :: TestTree
+testBytesReplaceAtHook =
+    testGroup
+        "BYTES.replaceAt"
+        [ testProperty "replaces slice of dest starting at index" . property $ do
+            dest <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            src <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 (BS.length dest)) Gen.latin1
+            i <- forAll $ between0And (BS.length dest - BS.length src)
+            let delta = BS.length src
+                expected =
+                    BS.take i dest <> src <> BS.drop (i + delta) dest
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [ Builtin.bytesTerm dest
+                    , Builtin.intTerm $ fromIntegral i
+                    , Builtin.bytesTerm src
+                    ]
+            Just (Builtin.bytesTerm expected) === result
+        , testCase "empty replacement returns dest unchanged" $ do
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [Builtin.bytesTerm "hello", Builtin.intTerm 2, Builtin.bytesTerm ""]
+            Just (Builtin.bytesTerm "hello") @=? result
+        , testCase "index out of range returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 5, Builtin.bytesTerm "x"]
+            Nothing @=? result
+        , testCase "negative index returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm (-1), Builtin.bytesTerm "x"]
+            Nothing @=? result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [[trm| X:SortBytes{} |], Builtin.intTerm 0, Builtin.bytesTerm "x"]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.replaceAt" []
+            assertException $ runHook "BYTES.replaceAt" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook "BYTES.replaceAt" [Builtin.bytesTerm "x", Builtin.intTerm 0]
+            assertException $
+                runHook
+                    "BYTES.replaceAt"
+                    [ Builtin.bytesTerm "x"
+                    , Builtin.intTerm 0
+                    , Builtin.bytesTerm "y"
+                    , Builtin.bytesTerm "z"
+                    ]
+        ]
+
+-- big-endian encoding: [0x00, 0x01] means 1; [0xFF] means 255 unsigned or -1 signed (1 byte)
+testBytesInt2BytesHook :: TestTree
+testBytesInt2BytesHook =
+    testGroup
+        "BYTES.int2bytes"
+        [ testCase "encodes 0 as requested number of zero bytes (big-endian)" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 4, Builtin.intTerm 0, bigEndian]
+            Just (Builtin.bytesTerm $ BS.replicate 4 '\NUL') @=? result
+        , testCase "encodes 1 as big-endian 4-byte value" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 4, Builtin.intTerm 1, bigEndian]
+            Just (Builtin.bytesTerm "\x00\x00\x00\x01") @=? result
+        , testCase "encodes 1 as little-endian 4-byte value" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 4, Builtin.intTerm 1, littleEndian]
+            Just (Builtin.bytesTerm "\x01\x00\x00\x00") @=? result
+        , testCase "encodes 256 = 0x0100 as big-endian 2-byte value" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 2, Builtin.intTerm 256, bigEndian]
+            Just (Builtin.bytesTerm "\x01\x00") @=? result
+        , testCase "negative value uses 0xFF padding (big-endian)" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 2, Builtin.intTerm (-1), bigEndian]
+            Just (Builtin.bytesTerm "\xFF\xFF") @=? result
+        , testCase "unevaluated endianness returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 4, Builtin.intTerm 0, [trm| X:SortEndianness{} |]]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.int2bytes" []
+            assertException $ runHook "BYTES.int2bytes" [Builtin.intTerm 4]
+            assertException $ runHook "BYTES.int2bytes" [Builtin.intTerm 4, Builtin.intTerm 0]
+            assertException $
+                runHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 4, Builtin.intTerm 0, bigEndian, bigEndian]
+        ]
+
+testBytesBytes2IntHook :: TestTree
+testBytesBytes2IntHook =
+    testGroup
+        "BYTES.bytes2int"
+        [ testCase "big-endian unsigned: 0x0001 = 1" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x00\x01", bigEndian, unsigned]
+            Just (Builtin.intTerm 1) @=? result
+        , testCase "little-endian unsigned: 0x0100 = 1" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x01\x00", littleEndian, unsigned]
+            Just (Builtin.intTerm 1) @=? result
+        , testCase "big-endian signed: 0xFF = -1 (1-byte two's complement)" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\xFF", bigEndian, signed]
+            Just (Builtin.intTerm (-1)) @=? result
+        , testCase "big-endian signed: 0x7F = 127 (positive)" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x7F", bigEndian, signed]
+            Just (Builtin.intTerm 127) @=? result
+        , testCase "big-endian unsigned: 0xFF = 255 (not -1)" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\xFF", bigEndian, unsigned]
+            Just (Builtin.intTerm 255) @=? result
+        , testProperty "int2bytes and bytes2int are inverses (unsigned, big-endian)" . property $ do
+            n <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear 0 maxBound)
+            let encoded = Builtin.bytesTerm $ int2bytesBE 8 n
+            result <- evalHook "BYTES.bytes2int" [encoded, bigEndian, unsigned]
+            Just (Builtin.intTerm n) === result
+        , testCase "unevaluated endianness returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x01", [trm| X:SortEndianness{} |], unsigned]
+            Nothing @=? result
+        , testCase "unevaluated signedness returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x01", bigEndian, [trm| X:SortSignedness{} |]]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.bytes2int" []
+            assertException $ runHook "BYTES.bytes2int" [Builtin.bytesTerm "\x01"]
+            assertException $
+                runHook "BYTES.bytes2int" [Builtin.bytesTerm "\x01", bigEndian]
+            assertException $
+                runHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\x01", bigEndian, unsigned, unsigned]
+        ]
+  where
+    -- helper to compute expected int2bytes result for round-trip test
+    int2bytesBE len n =
+        BS.reverse . fst $
+            BS.unfoldrN len (\v -> Just (toEnum . fromIntegral $ v `mod` 0x100, v `div` 0x100)) n
 
 testListHooks :: TestTree
 testListHooks =
@@ -1279,6 +1793,16 @@ testMapInclusionHook =
 
 ------------------------------------------------------------
 -- helpers
+
+-- endianness and signedness constructor terms for BYTES.int2bytes / BYTES.bytes2int
+bigEndian, littleEndian :: Term
+bigEndian = app [symb| symbol bigEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
+littleEndian = app [symb| symbol littleEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
+
+signed, unsigned :: Term
+signed = app [symb| symbol signedBytes{}() : SortSignedness{} [constructor{}()] |] []
+unsigned = app [symb| symbol unsignedBytes{}() : SortSignedness{} [constructor{}()] |] []
+
 runHook :: BS.ByteString -> Builtin.BuiltinFunction
 runHook name =
     fromMaybe (error $ show name <> " hook not found") $

--- a/booster/unit-tests/Test/Booster/Builtin.hs
+++ b/booster/unit-tests/Test/Booster/Builtin.hs
@@ -28,6 +28,7 @@ import Test.Tasty.Hedgehog
 
 import Booster.Builtin qualified as Builtin (hooks)
 import Booster.Builtin.BOOL qualified as Builtin
+import Booster.Builtin.BYTES qualified as Builtin
 import Booster.Builtin.Base qualified as Builtin (BuiltinFunction)
 import Booster.Builtin.INT qualified as Builtin
 import Booster.Builtin.LIST qualified as Builtin (kItemListDef)
@@ -39,6 +40,7 @@ import Test.Booster.Fixture as Fixture
 test_builtins :: [TestTree]
 test_builtins =
     [ testIntHooks
+    , testBytesHooks
     , testListHooks
     , testMapHooks
     ]
@@ -57,9 +59,15 @@ testIntHooks =
         , testIntHook2 "INT.le" (<=) Builtin.boolTerm
         , testIntHook2 "INT.eq" (==) Builtin.boolTerm
         , testIntHook2 "INT.ne" (/=) Builtin.boolTerm
+        , -- unary
+          testIntAbsHook
+        , -- truncating division and modulo
+          testIntTdivHook
+        , testIntTmodHook
+        , -- exponentiation
+          testIntPowHook
         ]
   where
-    -- testIntHook2 :: ByteString -> (Int -> Int -> a) -> (a -> Term) -> TestTree
     testIntHook2 name op result =
         testProperty ("Hook " <> show name) . property $ do
             let f = runHook name
@@ -80,6 +88,294 @@ testIntHooks =
             assertException $ f []
             assertException $ f [dv_a]
             assertException $ f [dv_a, dv_a, dv_a]
+    testIntAbsHook =
+        testProperty "Hook \"INT.abs\"" . property $ do
+            let f = runHook "INT.abs"
+                run args = either (error . Text.unpack) id . runExcept $ f args
+            a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+            let dv_a = Builtin.intTerm a
+            Just (Builtin.intTerm $ abs a) === run [dv_a]
+            let fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+            Nothing === run [app fct [dv_a]]
+            let assertException = assert . isLeft . runExcept
+            assertException $ f []
+            assertException $ f [dv_a, dv_a]
+    testIntTdivHook =
+        testGroup
+            "INT.tdiv"
+            [ testProperty "truncates toward zero (not floor)" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.tdiv" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Just (Builtin.intTerm $ quot a b) === run [Builtin.intTerm a, Builtin.intTerm b]
+            , testCase "(-7) `tdiv` 2 = -3, not -4 as floor division gives" $ do
+                result <- evalHook "INT.tdiv" [Builtin.intTerm (-7), Builtin.intTerm 2]
+                Just (Builtin.intTerm (-3)) @=? result
+            , testCase "division by zero returns Nothing" $ do
+                result <- evalHook "INT.tdiv" [Builtin.intTerm 42, Builtin.intTerm 0]
+                Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.tdiv" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm b]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm b]]
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.tdiv" []
+                assertException $ runHook "INT.tdiv" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.tdiv" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntTmodHook =
+        testGroup
+            "INT.tmod"
+            [ testProperty "remainder has sign of dividend" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.tmod" args
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Just (Builtin.intTerm $ rem a b) === run [Builtin.intTerm a, Builtin.intTerm b]
+            , testCase "(-7) `tmod` 2 = -1, not 1 as Euclidean division gives" $ do
+                result <- evalHook "INT.tmod" [Builtin.intTerm (-7), Builtin.intTerm 2]
+                Just (Builtin.intTerm (-1)) @=? result
+            , testCase "modulo by zero returns Nothing" $ do
+                result <- evalHook "INT.tmod" [Builtin.intTerm 42, Builtin.intTerm 0]
+                Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.tmod" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm b]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm b]]
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.tmod" []
+                assertException $ runHook "INT.tmod" [Builtin.intTerm 1]
+                assertException $
+                    runHook "INT.tmod" [Builtin.intTerm 1, Builtin.intTerm 2, Builtin.intTerm 3]
+            ]
+    testIntPowHook =
+        testGroup
+            "INT.pow"
+            [ testProperty "non-negative exponents compute correctly" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.pow" args
+                -- use small exponents to keep computation fast
+                base <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear (-10) 10)
+                exp_ <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear 0 10)
+                Just (Builtin.intTerm $ base ^ exp_)
+                    === run [Builtin.intTerm base, Builtin.intTerm exp_]
+            , testCase "any base to power 0 is 1" $ do
+                result <- evalHook "INT.pow" [Builtin.intTerm 42, Builtin.intTerm 0]
+                Just (Builtin.intTerm 1) @=? result
+            , testCase "negative exponent returns Nothing" $ do
+                result <- evalHook "INT.pow" [Builtin.intTerm 2, Builtin.intTerm (-1)]
+                Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.pow" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                base <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear (-10) 10)
+                Nothing === run [app fct [Builtin.intTerm base], Builtin.intTerm 2]
+                Nothing === run [Builtin.intTerm base, app fct [Builtin.intTerm 2]]
+            , testCase "arity error on wrong argument count" $ do
+                let assertException = assertBool "Unexpected success" . isLeft . runExcept
+                assertException $ runHook "INT.pow" []
+                assertException $ runHook "INT.pow" [Builtin.intTerm 2]
+                assertException $
+                    runHook "INT.pow" [Builtin.intTerm 2, Builtin.intTerm 3, Builtin.intTerm 4]
+            ]
+
+testBytesHooks :: TestTree
+testBytesHooks =
+    testGroup
+        "BYTES hooks"
+        [ testBytesEmptyHook
+        , testBytesPadLeftHook
+        , testBytesPadRightHook
+        , testBytesConcatHook
+        , testBytesLengthHook
+        ]
+
+testBytesEmptyHook :: TestTree
+testBytesEmptyHook =
+    testGroup
+        "BYTES.empty"
+        [ testCase "zero arguments returns empty byte string" $ do
+            result <- evalHook "BYTES.empty" []
+            Just (Builtin.bytesTerm "") @=? result
+        , testCase "arity error on non-empty argument list" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.empty" [Builtin.bytesTerm "x"]
+        ]
+
+testBytesPadLeftHook :: TestTree
+testBytesPadLeftHook =
+    testGroup
+        "BYTES.padLeft"
+        [ testProperty "pads shorter input on the left with fill byte" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 10) Gen.latin1
+            extra <- forAll $ between1And 20
+            let n = BS.length bs + extra
+                nTerm = Builtin.intTerm $ fromIntegral n
+                fillTerm = Builtin.intTerm 0
+            result <- evalHook "BYTES.padLeft" [Builtin.bytesTerm bs, nTerm, fillTerm]
+            Just (Builtin.bytesTerm $ BS.replicate extra '\NUL' <> bs) === result
+        , testProperty "no padding when input is at or beyond target length" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            shortN <- forAll $ between0And (BS.length bs)
+            let nTerm = Builtin.intTerm $ fromIntegral shortN
+                fillTerm = Builtin.intTerm 0
+            result <- evalHook "BYTES.padLeft" [Builtin.bytesTerm bs, nTerm, fillTerm]
+            Just (Builtin.bytesTerm bs) === result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.padLeft"
+                    [[trm| X:SortBytes{} |], Builtin.intTerm 10, Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "fill byte > 255 returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.padLeft"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 10, Builtin.intTerm 256]
+            Nothing @=? result
+        , testCase "negative fill byte returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.padLeft"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 10, Builtin.intTerm (-1)]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.padLeft" []
+            assertException $ runHook "BYTES.padLeft" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook "BYTES.padLeft" [Builtin.bytesTerm "x", Builtin.intTerm 5]
+            assertException $
+                runHook
+                    "BYTES.padLeft"
+                    [ Builtin.bytesTerm "x"
+                    , Builtin.intTerm 5
+                    , Builtin.intTerm 0
+                    , Builtin.intTerm 0
+                    ]
+        ]
+
+testBytesPadRightHook :: TestTree
+testBytesPadRightHook =
+    testGroup
+        "BYTES.padRight"
+        [ testProperty "pads shorter input on the right with fill byte" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 10) Gen.latin1
+            extra <- forAll $ between1And 20
+            let n = BS.length bs + extra
+                nTerm = Builtin.intTerm $ fromIntegral n
+                fillTerm = Builtin.intTerm 0
+            result <- evalHook "BYTES.padRight" [Builtin.bytesTerm bs, nTerm, fillTerm]
+            Just (Builtin.bytesTerm $ bs <> BS.replicate extra '\NUL') === result
+        , testProperty "no padding when input is at or beyond target length" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 1 20) Gen.latin1
+            shortN <- forAll $ between0And (BS.length bs)
+            let nTerm = Builtin.intTerm $ fromIntegral shortN
+                fillTerm = Builtin.intTerm 0
+            result <- evalHook "BYTES.padRight" [Builtin.bytesTerm bs, nTerm, fillTerm]
+            Just (Builtin.bytesTerm bs) === result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.padRight"
+                    [[trm| X:SortBytes{} |], Builtin.intTerm 10, Builtin.intTerm 0]
+            Nothing @=? result
+        , testCase "fill byte > 255 returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.padRight"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 10, Builtin.intTerm 256]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.padRight" []
+            assertException $ runHook "BYTES.padRight" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook "BYTES.padRight" [Builtin.bytesTerm "x", Builtin.intTerm 5]
+            assertException $
+                runHook
+                    "BYTES.padRight"
+                    [ Builtin.bytesTerm "x"
+                    , Builtin.intTerm 5
+                    , Builtin.intTerm 0
+                    , Builtin.intTerm 0
+                    ]
+        ]
+
+testBytesConcatHook :: TestTree
+testBytesConcatHook =
+    testGroup
+        "BYTES.concat"
+        [ testProperty "concatenates two concrete byte strings" . property $ do
+            bs1 <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 10) Gen.latin1
+            bs2 <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 10) Gen.latin1
+            result <-
+                evalHook "BYTES.concat" [Builtin.bytesTerm bs1, Builtin.bytesTerm bs2]
+            Just (Builtin.bytesTerm $ bs1 <> bs2) === result
+        , testCase "unevaluated first argument returns Nothing" $ do
+            result <-
+                evalHook "BYTES.concat" [[trm| X:SortBytes{} |], Builtin.bytesTerm "abc"]
+            Nothing @=? result
+        , testCase "unevaluated second argument returns Nothing" $ do
+            result <-
+                evalHook "BYTES.concat" [Builtin.bytesTerm "abc", [trm| X:SortBytes{} |]]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.concat" []
+            assertException $ runHook "BYTES.concat" [Builtin.bytesTerm "x"]
+            assertException $
+                runHook
+                    "BYTES.concat"
+                    [Builtin.bytesTerm "x", Builtin.bytesTerm "y", Builtin.bytesTerm "z"]
+        ]
+
+testBytesLengthHook :: TestTree
+testBytesLengthHook =
+    testGroup
+        "BYTES.length"
+        [ testProperty "returns byte count as integer" . property $ do
+            bs <- forAll $ fmap BS.pack $ Gen.string (Range.linear 0 32) Gen.latin1
+            result <- evalHook "BYTES.length" [Builtin.bytesTerm bs]
+            Just (Builtin.intTerm $ fromIntegral $ BS.length bs) === result
+        , testCase "unevaluated argument returns Nothing" $ do
+            result <- evalHook "BYTES.length" [[trm| X:SortBytes{} |]]
+            Nothing @=? result
+        , testCase "arity error on wrong argument count" $ do
+            let assertException = assertBool "Unexpected success" . isLeft . runExcept
+            assertException $ runHook "BYTES.length" []
+            assertException $
+                runHook "BYTES.length" [Builtin.bytesTerm "x", Builtin.bytesTerm "y"]
+        ]
 
 testListHooks :: TestTree
 testListHooks =

--- a/booster/unit-tests/Test/Booster/Builtin.hs
+++ b/booster/unit-tests/Test/Booster/Builtin.hs
@@ -239,6 +239,18 @@ testIntHooks =
             , testCase "division by zero returns Nothing" $ do
                 result <- evalHook "INT.ediv" [Builtin.intTerm 42, Builtin.intTerm 0]
                 Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.ediv" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm b]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm b]]
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
                 assertException $ runHook "INT.ediv" []
@@ -267,6 +279,18 @@ testIntHooks =
             , testCase "modulo by zero returns Nothing" $ do
                 result <- evalHook "INT.emod" [Builtin.intTerm 42, Builtin.intTerm 0]
                 Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.emod" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                b <-
+                    fmap fromIntegral $
+                        forAll $
+                            Gen.filter (/= 0) $
+                                Gen.int64 Range.linearBounded
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm b]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm b]]
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
                 assertException $ runHook "INT.emod" []
@@ -298,6 +322,14 @@ testIntHooks =
             , testCase "negative shift amount returns Nothing" $ do
                 result <- evalHook "INT.shl" [Builtin.intTerm 1, Builtin.intTerm (-1)]
                 Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.shl" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                n <- forAll $ Gen.int (Range.linear 0 63)
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm (fromIntegral n)]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm (fromIntegral n)]]
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
                 assertException $ runHook "INT.shl" []
@@ -317,6 +349,14 @@ testIntHooks =
             , testCase "negative shift amount returns Nothing" $ do
                 result <- evalHook "INT.shr" [Builtin.intTerm 8, Builtin.intTerm (-1)]
                 Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.shr" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                a <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+                n <- forAll $ Gen.int (Range.linear 0 63)
+                Nothing === run [app fct [Builtin.intTerm a], Builtin.intTerm (fromIntegral n)]
+                Nothing === run [Builtin.intTerm a, app fct [Builtin.intTerm (fromIntegral n)]]
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
                 assertException $ runHook "INT.shr" []
@@ -344,6 +384,19 @@ testIntHooks =
             , testCase "zero modulus returns Nothing" $ do
                 result <- evalHook "INT.powmod" [Builtin.intTerm 2, Builtin.intTerm 3, Builtin.intTerm 0]
                 Nothing @=? result
+            , testProperty "unevaluated argument returns Nothing" . property $ do
+                let run args =
+                        either (error . Text.unpack) id . runExcept $ runHook "INT.powmod" args
+                    fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                b <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear (-10) 10)
+                e <- fmap fromIntegral $ forAll $ Gen.int64 (Range.linear 0 10)
+                m <- fmap fromIntegral $ forAll $ Gen.filter (/= 0) $ Gen.int64 (Range.linear 1 100)
+                Nothing
+                    === run [app fct [Builtin.intTerm b], Builtin.intTerm e, Builtin.intTerm m]
+                Nothing
+                    === run [Builtin.intTerm b, app fct [Builtin.intTerm e], Builtin.intTerm m]
+                Nothing
+                    === run [Builtin.intTerm b, Builtin.intTerm e, app fct [Builtin.intTerm m]]
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
                 assertException $ runHook "INT.powmod" []
@@ -378,6 +431,10 @@ testIntHooks =
                 Nothing @=? result
             , testCase "negative returns Nothing" $ do
                 result <- evalHook "INT.log2" [Builtin.intTerm (-1)]
+                Nothing @=? result
+            , testCase "unevaluated argument returns Nothing" $ do
+                let fct = [symb| symbol f{}(SortInt) : SortInt [function{}()] |]
+                result <- evalHook "INT.log2" [app fct [Builtin.intTerm 4]]
                 Nothing @=? result
             , testCase "arity error on wrong argument count" $ do
                 let assertException = assertBool "Unexpected success" . isLeft . runExcept
@@ -459,6 +516,13 @@ testBytesPadLeftHook =
                     "BYTES.padLeft"
                     [Builtin.bytesTerm "abc", Builtin.intTerm 10, Builtin.intTerm (-1)]
             Nothing @=? result
+        , testCase "negative target length returns Nothing" $ do
+            -- per domains.md: padLeft is #False when length is negative
+            result <-
+                evalHook
+                    "BYTES.padLeft"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm (-1), Builtin.intTerm 0]
+            Nothing @=? result
         , testCase "arity error on wrong argument count" $ do
             let assertException = assertBool "Unexpected success" . isLeft . runExcept
             assertException $ runHook "BYTES.padLeft" []
@@ -505,6 +569,13 @@ testBytesPadRightHook =
                 evalHook
                     "BYTES.padRight"
                     [Builtin.bytesTerm "abc", Builtin.intTerm 10, Builtin.intTerm 256]
+            Nothing @=? result
+        , testCase "negative target length returns Nothing" $ do
+            -- per domains.md: padRight is #False when length is negative
+            result <-
+                evalHook
+                    "BYTES.padRight"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm (-1), Builtin.intTerm 0]
             Nothing @=? result
         , testCase "arity error on wrong argument count" $ do
             let assertException = assertBool "Unexpected success" . isLeft . runExcept
@@ -737,6 +808,19 @@ testBytesReplaceAtHook =
                     "BYTES.replaceAt"
                     [Builtin.bytesTerm "hello", Builtin.intTerm 2, Builtin.bytesTerm ""]
             Just (Builtin.bytesTerm "hello") @=? result
+        , testCase "src extending past dest end returns Nothing" $ do
+            -- regression: replaceAt("abc", 2, "xy") must not return "abxy"
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 2, Builtin.bytesTerm "xy"]
+            Nothing @=? result
+        , testCase "src exactly fitting the end of dest succeeds" $ do
+            result <-
+                evalHook
+                    "BYTES.replaceAt"
+                    [Builtin.bytesTerm "abc", Builtin.intTerm 1, Builtin.bytesTerm "xy"]
+            Just (Builtin.bytesTerm "axy") @=? result
         , testCase "index out of range returns Nothing" $ do
             result <-
                 evalHook
@@ -806,6 +890,20 @@ testBytesInt2BytesHook =
                     "BYTES.int2bytes"
                     [Builtin.intTerm 2, Builtin.intTerm (-1), bigEndian]
             Just (Builtin.bytesTerm "\xFF\xFF") @=? result
+        , testCase "value wider than len is silently truncated (per K spec)" $ do
+            -- domains.md: "If the length is less than the highest bit set in the
+            -- magnitude of the integer, the most-significant bits ... will be truncated."
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm 1, Builtin.intTerm 256, bigEndian]
+            Just (Builtin.bytesTerm "\x00") @=? result
+        , testCase "negative len returns Nothing" $ do
+            result <-
+                evalHook
+                    "BYTES.int2bytes"
+                    [Builtin.intTerm (-1), Builtin.intTerm 0, bigEndian]
+            Nothing @=? result
         , testCase "unevaluated endianness returns Nothing" $ do
             result <-
                 evalHook
@@ -862,6 +960,23 @@ testBytesBytes2IntHook =
             let encoded = Builtin.bytesTerm $ int2bytesBE 8 n
             result <- evalHook "BYTES.bytes2int" [encoded, bigEndian, unsigned]
             Just (Builtin.intTerm n) === result
+        , testProperty "int2bytes/bytes2int round-trip for signed 8-byte values" . property $ do
+            -- exercises both endiannesses and signed two's complement
+            n <- fmap fromIntegral $ forAll $ Gen.int64 Range.linearBounded
+            endian <- forAll $ Gen.element [bigEndian, littleEndian]
+            encoded <-
+                evalHook "BYTES.int2bytes" [Builtin.intTerm 8, Builtin.intTerm n, endian]
+            case encoded of
+                Just encodedTerm -> do
+                    result <- evalHook "BYTES.bytes2int" [encodedTerm, endian, signed]
+                    Just (Builtin.intTerm n) === result
+                Nothing -> failure
+        , testCase "little-endian signed: 0xFF = -1 (1-byte two's complement)" $ do
+            result <-
+                evalHook
+                    "BYTES.bytes2int"
+                    [Builtin.bytesTerm "\xFF", littleEndian, signed]
+            Just (Builtin.intTerm (-1)) @=? result
         , testCase "unevaluated endianness returns Nothing" $ do
             result <-
                 evalHook
@@ -1794,14 +1909,17 @@ testMapInclusionHook =
 ------------------------------------------------------------
 -- helpers
 
--- endianness and signedness constructor terms for BYTES.int2bytes / BYTES.bytes2int
+-- endianness and signedness constructor terms for BYTES.int2bytes / BYTES.bytes2int.
+-- K's `[symbol(bigEndianBytes)]` compiles to a kore symbol named `LblbigEndianBytes`,
+-- which is what readEndianness/readSignedness in BYTES.hs match against. The test
+-- fixtures must use the same `Lbl`-prefixed names or they bypass the real code path.
 bigEndian, littleEndian :: Term
-bigEndian = app [symb| symbol bigEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
-littleEndian = app [symb| symbol littleEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
+bigEndian = app [symb| symbol LblbigEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
+littleEndian = app [symb| symbol LbllittleEndianBytes{}() : SortEndianness{} [constructor{}()] |] []
 
 signed, unsigned :: Term
-signed = app [symb| symbol signedBytes{}() : SortSignedness{} [constructor{}()] |] []
-unsigned = app [symb| symbol unsignedBytes{}() : SortSignedness{} [constructor{}()] |] []
+signed = app [symb| symbol LblsignedBytes{}() : SortSignedness{} [constructor{}()] |] []
+unsigned = app [symb| symbol LblunsignedBytes{}() : SortSignedness{} [constructor{}()] |] []
 
 runHook :: BS.ByteString -> Builtin.BuiltinFunction
 runHook name =


### PR DESCRIPTION
While working on getting some KEVM proofs to pass without using the Kore fallback, I ran into some issues where bug report tarballs were not running properly on the booster because the LLVM backend library didn't link properly (it was generated with Nix, not directly with the glibc on my system).

Claude went ahead and implmented a bunch of builtins for us so that booster could still make progress on those bug reports. This is the result.

I did have it cross-reference the results it got with what the documented behavior in domains.md is, and to write tests for all cases it could.