### PR TITLE
Discharge implies-check consequent obligations under the antecedent via SMT

### DIFF
--- a/booster/library/Booster/Pattern/Implies.hs
+++ b/booster/library/Booster/Pattern/Implies.hs
@@ -137,32 +137,68 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                                 (Left err, _) ->
                                     pure . Left . RpcError.backendError $ RpcError.Aborted (Text.pack . constructorName $ err)
                         MatchSuccess subst -> do
-                            let filteredConsequentPreds =
-                                    (patR.constraints <> (Set.fromList $ asEquations patR.substitution))
-                                        `Set.difference` (patL.constraints <> (Set.fromList $ asEquations patL.substitution))
-
+                            let sort = sortOfPattern patL
+                                lhs = externaliseExistTerm existsL patL.term
+                                rhs = externaliseExistTerm existsR patR.term
+                                antecedentPreds =
+                                    patL.constraints <> Set.fromList (asEquations patL.substitution)
+                                filteredConsequentPreds =
+                                    (patR.constraints <> Set.fromList (asEquations patR.substitution))
+                                        `Set.difference` antecedentPreds
                             if null filteredConsequentPreds
-                                then
-                                    implies
-                                        (sortOfPattern patL)
-                                        (externaliseExistTerm existsL patL.term)
-                                        (externaliseExistTerm existsR patR.term)
-                                        subst
-                                else -- FIXME This is incomplete because patL.constraints are not assumed in the check.
-
-                                    ApplyEquations.evaluateConstraints def mLlvmLibrary solver filteredConsequentPreds >>= \case
-                                        Right newPreds ->
-                                            if all (== Predicate TrueBool) newPreds
-                                                then
-                                                    implies
-                                                        (sortOfPattern patL)
-                                                        (externaliseExistTerm existsL patL.term)
-                                                        (externaliseExistTerm existsR patR.term)
-                                                        subst
-                                                else -- here we conservatively abort (incomplete)
-                                                    pure . Left . RpcError.backendError $ RpcError.Aborted "unknown constraints"
-                                        Left other ->
-                                            pure . Left . RpcError.backendError $ RpcError.Aborted (Text.pack . constructorName $ other)
+                                then implies sort lhs rhs subst
+                                else do
+                                    -- Discharge the leftover consequent obligations under
+                                    -- the antecedent. Two stages:
+                                    --   1. Simplify each obligation with the antecedent in
+                                    --      'knownPredicates' so function-symbol unfolds
+                                    --      (e.g. '#rangeAddress') and boolean structure
+                                    --      collapse can fire.
+                                    --   2. SMT-close any non-'TrueBool' residue against
+                                    --      'antecedentPreds' / 'patL.substitution' — the
+                                    --      same pattern the rewrite path uses to discharge
+                                    --      rule requires-clauses
+                                    --      ('Booster.Pattern.Rewrite.checkRequires').
+                                    simplified <-
+                                        mapM
+                                            ( fmap fst
+                                                . ApplyEquations.simplifyConstraint
+                                                    def
+                                                    mLlvmLibrary
+                                                    solver
+                                                    mempty
+                                                    antecedentPreds
+                                            )
+                                            (Set.toList filteredConsequentPreds)
+                                    let impliesResult = implies sort lhs rhs subst
+                                        unsure = doesNotImplyIndeterminate sort lhs rhs
+                                        disjoint = doesNotImply sort lhs rhs
+                                    case sequence simplified of
+                                        Left _ ->
+                                            -- Equation engine error: route to Unsure
+                                            -- rather than the old hard 'Aborted', so the
+                                            -- client can escalate via kore fallback.
+                                            unsure
+                                        Right reduced
+                                            | all (== Predicate TrueBool) reduced ->
+                                                impliesResult
+                                            | otherwise -> do
+                                                let residue =
+                                                        Set.fromList $
+                                                            filter (/= Predicate TrueBool) reduced
+                                                SMT.checkPredicates
+                                                    solver
+                                                    antecedentPreds
+                                                    patL.substitution
+                                                    residue
+                                                    >>= \case
+                                                        SMT.IsValid -> impliesResult
+                                                        SMT.IsInvalid -> disjoint
+                                                        -- Vacuous antecedent: any consequent
+                                                        -- is implied.
+                                                        SMT.IsUnknown SMT.InconsistentGroundTruth ->
+                                                            impliesResult
+                                                        SMT.IsUnknown _ -> unsure
 
             case (internalised antecedent.term, internalised consequent.term) of
                 (Left patternError, _) -> do
@@ -217,6 +253,24 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                         }
 
     doesNotImply s' = let s = externaliseSort s' in doesNotImply' s Nothing
+
+    -- Variant of 'doesNotImply' that flags the result as indeterminate.
+    -- Use at non-decisive 'valid = False' outcomes — the 'MatchIndeterminate'
+    -- retry-ladder no-progress fall-through and the 'MatchSuccess'
+    -- SMT-discharge 'IsUnknown _' branch — so a recover-mode client
+    -- escalates to kore rather than trusting @valid: false@.
+    doesNotImplyIndeterminate s' l r =
+        let s = externaliseSort s'
+         in pure $
+                Right $
+                    RpcTypes.Implies
+                        RpcTypes.ImpliesResult
+                            { implication = addHeader $ Kore.Syntax.KJImplies s l r
+                            , valid = False
+                            , condition = Nothing
+                            , logs = Nothing
+                            , indeterminate = Just True
+                            }
 
     implies' predicate s l r subst =
         pure $

--- a/booster/library/Booster/Pattern/Implies.hs
+++ b/booster/library/Booster/Pattern/Implies.hs
@@ -213,9 +213,11 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                         , valid = False
                         , condition
                         , logs = Nothing
+                        , indeterminate = Nothing
                         }
 
     doesNotImply s' = let s = externaliseSort s' in doesNotImply' s Nothing
+
     implies' predicate s l r subst =
         pure $
             Right $
@@ -239,5 +241,6 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                                             $ subst
                                     }
                         , logs = Nothing
+                        , indeterminate = Nothing
                         }
     implies s' = let s = externaliseSort s' in implies' (Kore.Syntax.KJTop s) s

--- a/booster/library/Booster/Pattern/Implies.hs
+++ b/booster/library/Booster/Pattern/Implies.hs
@@ -240,17 +240,20 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
                         antecedent.term
                         consequent.term
   where
-    doesNotImply' s condition l r =
-        pure $
-            Right $
-                RpcTypes.Implies
-                    RpcTypes.ImpliesResult
-                        { implication = addHeader $ Kore.Syntax.KJImplies s l r
-                        , valid = False
-                        , condition
-                        , logs = Nothing
-                        , indeterminate = Nothing
-                        }
+    -- Single construction point for every implies / does-not-imply result.
+    -- The call sites differ only in 'valid', 'condition', and 'indeterminate';
+    -- centralising the record keeps a future field addition a one-line change.
+    mkResult s l r valid condition indeterminate =
+        pure . Right . RpcTypes.Implies $
+            RpcTypes.ImpliesResult
+                { implication = addHeader $ Kore.Syntax.KJImplies s l r
+                , valid
+                , condition
+                , logs = Nothing
+                , indeterminate
+                }
+
+    doesNotImply' s condition l r = mkResult s l r False condition Nothing
 
     doesNotImply s' = let s = externaliseSort s' in doesNotImply' s Nothing
 
@@ -260,41 +263,23 @@ runImplies def mLlvmLibrary mSMTOptions antecedent consequent =
     -- SMT-discharge 'IsUnknown _' branch — so a recover-mode client
     -- escalates to kore rather than trusting @valid: false@.
     doesNotImplyIndeterminate s' l r =
-        let s = externaliseSort s'
-         in pure $
-                Right $
-                    RpcTypes.Implies
-                        RpcTypes.ImpliesResult
-                            { implication = addHeader $ Kore.Syntax.KJImplies s l r
-                            , valid = False
-                            , condition = Nothing
-                            , logs = Nothing
-                            , indeterminate = Just True
-                            }
+        let s = externaliseSort s' in mkResult s l r False Nothing (Just True)
 
     implies' predicate s l r subst =
-        pure $
-            Right $
-                RpcTypes.Implies
-                    RpcTypes.ImpliesResult
-                        { implication = addHeader $ Kore.Syntax.KJImplies s l r
-                        , valid = True
-                        , condition =
-                            Just
-                                RpcTypes.Condition
-                                    { predicate = addHeader predicate
-                                    , substitution =
-                                        addHeader
-                                            $ ( \case
-                                                    [] -> Kore.Syntax.KJTop s
-                                                    [x] -> x
-                                                    xs -> Kore.Syntax.KJAnd s xs
-                                              )
-                                                . map (uncurry $ externaliseSubstitution s)
-                                                . Map.toList
-                                            $ subst
-                                    }
-                        , logs = Nothing
-                        , indeterminate = Nothing
-                        }
+        mkResult s l r True (Just condition) Nothing
+      where
+        condition =
+            RpcTypes.Condition
+                { predicate = addHeader predicate
+                , substitution =
+                    addHeader
+                        $ ( \case
+                                [] -> Kore.Syntax.KJTop s
+                                [x] -> x
+                                xs -> Kore.Syntax.KJAnd s xs
+                          )
+                            . map (uncurry $ externaliseSubstitution s)
+                            . Map.toList
+                        $ subst
+                }
     implies s' = let s = externaliseSort s' in implies' (Kore.Syntax.KJTop s) s

--- a/booster/test/rpc-integration/resources/implies-smt.k
+++ b/booster/test/rpc-integration/resources/implies-smt.k
@@ -1,0 +1,22 @@
+// Minimal definition for exercising booster's `implies` check against
+// integer / boolean obligations that need SMT discharge.
+//
+// The test claims send raw KORE `implies` requests whose antecedent and
+// consequent share identical configurations (so the matcher returns
+// MatchSuccess) but differ in their attached path-condition predicates.
+// The interesting cases are the ones where the leftover consequent
+// predicate is *implied* by the antecedent under linear-integer reasoning
+// (e.g. `X <Int 1000` from `X <Int 100`), so an SMT-aware discharge
+// step would close them as `valid : true`.
+//
+// The configuration is a single `<k>` cell containing an `Int` — enough
+// to give us a kompiled definition with `_<Int_`, `andBool`, `true`, and
+// the standard cell wrappers without any extra ceremony.
+
+module IMPLIES-SMT
+  imports INT
+  imports BOOL
+
+  configuration <k> $PGM:Int </k>
+
+endmodule

--- a/booster/test/rpc-integration/resources/implies-smt.kompile
+++ b/booster/test/rpc-integration/resources/implies-smt.kompile
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+name=$(basename "$0" .kompile)
+kompile --backend haskell "$name.k" --syntax-module IMPLIES-SMT
+cp "$name-kompiled/definition.kore" "./$name.kore"
+rm -r "$name-kompiled"

--- a/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.booster-dev
@@ -1,9 +1,63 @@
 {
     "jsonrpc": "2.0",
     "id": "implies-smt-001",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "VarX",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "EVar",
+                    "name": "VarX",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
     }
 }

--- a/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.booster-dev
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-001",
+    "error": {
+        "code": 6,
+        "data": "unknown constraints",
+        "message": "Aborted"
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.json
+++ b/booster/test/rpc-integration/test-implies-smt/response-001-bound-weakening.json
@@ -1,0 +1,177 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-001",
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "100"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "1000"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.booster-dev
@@ -1,9 +1,38 @@
 {
     "jsonrpc": "2.0",
     "id": "implies-smt-002",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "VarX",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "EVar",
+                    "name": "VarX",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        },
+        "indeterminate": true
     }
 }

--- a/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.booster-dev
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-002",
+    "error": {
+        "code": 6,
+        "data": "unknown constraints",
+        "message": "Aborted"
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.json
+++ b/booster/test/rpc-integration/test-implies-smt/response-002-does-not-imply.json
@@ -1,0 +1,177 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-002",
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "100"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "10"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-003-vacuous-antecedent.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-003-vacuous-antecedent.booster-dev
@@ -1,0 +1,209 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-003",
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds'andBool'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarX",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "10"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "20"
+                                            },
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarX",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "1000"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Bottom",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-003-vacuous-antecedent.json
+++ b/booster/test/rpc-integration/test-implies-smt/response-003-vacuous-antecedent.json
@@ -1,0 +1,234 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-003",
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "And",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "patterns": [
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    },
+                                    "second": {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "20"
+                                            },
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarX",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    },
+                                    "second": {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarX",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "10"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarX",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarX",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "1000"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Bottom",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.booster-dev
@@ -1,9 +1,63 @@
 {
     "jsonrpc": "2.0",
     "id": "implies-smt-004",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "EVar",
+                    "name": "VarACCT'Unds'ID",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                },
+                "second": {
+                    "tag": "EVar",
+                    "name": "VarACCT'Unds'ID",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
     }
 }

--- a/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.booster-dev
+++ b/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.booster-dev
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-004",
+    "error": {
+        "code": 6,
+        "data": "unknown constraints",
+        "message": "Aborted"
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.json
+++ b/booster/test/rpc-integration/test-implies-smt/response-004-address-bound.json
@@ -1,0 +1,234 @@
+{
+    "jsonrpc": "2.0",
+    "id": "implies-smt-004",
+    "result": {
+        "valid": true,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortInt",
+                    "args": []
+                },
+                "first": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarACCT'Unds'ID",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "And",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "patterns": [
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    },
+                                    "second": {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarACCT'Unds'ID",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            },
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "1461501637330902918203684832716283019655932542976"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "tag": "Equals",
+                                    "argSort": {
+                                        "tag": "SortApp",
+                                        "name": "SortBool",
+                                        "args": []
+                                    },
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "first": {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortBool",
+                                            "args": []
+                                        },
+                                        "value": "true"
+                                    },
+                                    "second": {
+                                        "tag": "App",
+                                        "name": "Lbl'Unds-LT-Eqls'Int'Unds'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "DV",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                },
+                                                "value": "0"
+                                            },
+                                            {
+                                                "tag": "EVar",
+                                                "name": "VarACCT'Unds'ID",
+                                                "sort": {
+                                                    "tag": "SortApp",
+                                                    "name": "SortInt",
+                                                    "args": []
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "And",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "patterns": [
+                        {
+                            "tag": "EVar",
+                            "name": "VarACCT'Unds'ID",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            }
+                        },
+                        {
+                            "tag": "Equals",
+                            "argSort": {
+                                "tag": "SortApp",
+                                "name": "SortBool",
+                                "args": []
+                            },
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "first": {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortBool",
+                                    "args": []
+                                },
+                                "value": "true"
+                            },
+                            "second": {
+                                "tag": "App",
+                                "name": "Lbl'Unds-LT-'Int'Unds'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarACCT'Unds'ID",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        }
+                                    },
+                                    {
+                                        "tag": "DV",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortInt",
+                                            "args": []
+                                        },
+                                        "value": "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "condition": {
+            "substitution": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            },
+            "predicate": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "Top",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    }
+                }
+            }
+        }
+    }
+}

--- a/booster/test/rpc-integration/test-implies-smt/state-001-bound-weakening.send
+++ b/booster/test/rpc-integration/test-implies-smt/state-001-bound-weakening.send
@@ -1,0 +1,59 @@
+{
+  "jsonrpc": "2.0",
+  "id": "implies-smt-001",
+  "method": "implies",
+  "params": {
+    "antecedent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "100"}
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "consequent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "1000"}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/booster/test/rpc-integration/test-implies-smt/state-002-does-not-imply.send
+++ b/booster/test/rpc-integration/test-implies-smt/state-002-does-not-imply.send
@@ -1,0 +1,59 @@
+{
+  "jsonrpc": "2.0",
+  "id": "implies-smt-002",
+  "method": "implies",
+  "params": {
+    "antecedent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "100"}
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "consequent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "10"}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/booster/test/rpc-integration/test-implies-smt/state-003-vacuous-antecedent.send
+++ b/booster/test/rpc-integration/test-implies-smt/state-003-vacuous-antecedent.send
@@ -1,0 +1,75 @@
+{
+  "jsonrpc": "2.0",
+  "id": "implies-smt-003",
+  "method": "implies",
+  "params": {
+    "antecedent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds'andBool'Unds'",
+              "sorts": [],
+              "args": [
+                {
+                  "tag": "App",
+                  "name": "Lbl'Unds-LT-'Int'Unds'",
+                  "sorts": [],
+                  "args": [
+                    {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                    {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "10"}
+                  ]
+                },
+                {
+                  "tag": "App",
+                  "name": "Lbl'Unds-LT-'Int'Unds'",
+                  "sorts": [],
+                  "args": [
+                    {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "20"},
+                    {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}}
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "consequent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarX", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "1000"}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/booster/test/rpc-integration/test-implies-smt/state-004-address-bound.send
+++ b/booster/test/rpc-integration/test-implies-smt/state-004-address-bound.send
@@ -1,0 +1,75 @@
+{
+  "jsonrpc": "2.0",
+  "id": "implies-smt-004",
+  "method": "implies",
+  "params": {
+    "antecedent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarACCT'Unds'ID", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds'andBool'Unds'",
+              "sorts": [],
+              "args": [
+                {
+                  "tag": "App",
+                  "name": "Lbl'Unds-LT-Eqls'Int'Unds'",
+                  "sorts": [],
+                  "args": [
+                    {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "0"},
+                    {"tag": "EVar", "name": "VarACCT'Unds'ID", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}}
+                  ]
+                },
+                {
+                  "tag": "App",
+                  "name": "Lbl'Unds-LT-'Int'Unds'",
+                  "sorts": [],
+                  "args": [
+                    {"tag": "EVar", "name": "VarACCT'Unds'ID", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                    {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "1461501637330902918203684832716283019655932542976"}
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "consequent": {
+      "format": "KORE",
+      "version": 1,
+      "term": {
+        "tag": "And",
+        "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+        "patterns": [
+          {"tag": "EVar", "name": "VarACCT'Unds'ID", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+          {
+            "tag": "Equals",
+            "argSort": {"tag": "SortApp", "name": "SortBool", "args": []},
+            "sort": {"tag": "SortApp", "name": "SortInt", "args": []},
+            "first": {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortBool", "args": []}, "value": "true"},
+            "second": {
+              "tag": "App",
+              "name": "Lbl'Unds-LT-'Int'Unds'",
+              "sorts": [],
+              "args": [
+                {"tag": "EVar", "name": "VarACCT'Unds'ID", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}},
+                {"tag": "DV", "sort": {"tag": "SortApp", "name": "SortInt", "args": []}, "value": "115792089237316195423570985008687907853269984665640564039457584007913129639936"}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/booster/test/rpc-integration/test-implies2/response-consequent-constraint.booster-dev
+++ b/booster/test/rpc-integration/test-implies2/response-consequent-constraint.booster-dev
@@ -1,9 +1,358 @@
 {
     "jsonrpc": "2.0",
     "id": "4567908768-001",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "first": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'T'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortPgm",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "Lblint'UndsSClnUnds'",
+                                                            "sorts": [],
+                                                            "args": [
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsCommUnds'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'UndsCommUnds'",
+                                                                            "sorts": [],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortId",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "$s"
+                                                                                },
+                                                                                {
+                                                                                    "tag": "App",
+                                                                                    "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                                    "sorts": [],
+                                                                                    "args": []
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "inj",
+                                                                            "sorts": [
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortInt",
+                                                                                    "args": []
+                                                                                },
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortAExp",
+                                                                                    "args": []
+                                                                                }
+                                                                            ],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "3"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'state'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'Stop'Map",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "EVar",
+                            "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedCounterCell",
+                                "args": []
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "Exists",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "var": "VarX",
+                    "varSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "arg": {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedTop'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'T'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'-LT-'k'-GT-'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "kseq",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "inj",
+                                                        "sorts": [
+                                                            {
+                                                                "tag": "SortApp",
+                                                                "name": "SortPgm",
+                                                                "args": []
+                                                            },
+                                                            {
+                                                                "tag": "SortApp",
+                                                                "name": "SortKItem",
+                                                                "args": []
+                                                            }
+                                                        ],
+                                                        "args": [
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "Lblint'UndsSClnUnds'",
+                                                                "sorts": [],
+                                                                "args": [
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'UndsCommUnds'",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "DV",
+                                                                                "sort": {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortId",
+                                                                                    "args": []
+                                                                                },
+                                                                                "value": "$n"
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "Lbl'UndsCommUnds'",
+                                                                                "sorts": [],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortId",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "$s"
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "App",
+                                                                                        "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                                        "sorts": [],
+                                                                                        "args": []
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "DV",
+                                                                                "sort": {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortId",
+                                                                                    "args": []
+                                                                                },
+                                                                                "value": "$n"
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "inj",
+                                                                                "sorts": [
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortAExp",
+                                                                                        "args": []
+                                                                                    }
+                                                                                ],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "EVar",
+                                                                                        "name": "VarX",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortInt",
+                                                                                            "args": []
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "dotk",
+                                                        "sorts": [],
+                                                        "args": []
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'-LT-'state'-GT-'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'Stop'Map",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "EVar",
+                                "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortGeneratedCounterCell",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "indeterminate": true
     }
 }

--- a/booster/test/rpc-integration/test-implies2/response-refutation-1.booster-dev
+++ b/booster/test/rpc-integration/test-implies2/response-refutation-1.booster-dev
@@ -1,9 +1,326 @@
 {
     "jsonrpc": "2.0",
     "id": "4428832288-001",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "first": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'T'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortPgm",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "Lblint'UndsSClnUnds'",
+                                                            "sorts": [],
+                                                            "args": [
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsCommUnds'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                            "sorts": [],
+                                                                            "args": []
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "inj",
+                                                                            "sorts": [
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortInt",
+                                                                                    "args": []
+                                                                                },
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortAExp",
+                                                                                    "args": []
+                                                                                }
+                                                                            ],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "0"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'state'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'Stop'Map",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "EVar",
+                            "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedCounterCell",
+                                "args": []
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "Exists",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "var": "VarX",
+                    "varSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "arg": {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedTop'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'T'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'-LT-'k'-GT-'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "kseq",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "inj",
+                                                        "sorts": [
+                                                            {
+                                                                "tag": "SortApp",
+                                                                "name": "SortPgm",
+                                                                "args": []
+                                                            },
+                                                            {
+                                                                "tag": "SortApp",
+                                                                "name": "SortKItem",
+                                                                "args": []
+                                                            }
+                                                        ],
+                                                        "args": [
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "Lblint'UndsSClnUnds'",
+                                                                "sorts": [],
+                                                                "args": [
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'UndsCommUnds'",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "DV",
+                                                                                "sort": {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortId",
+                                                                                    "args": []
+                                                                                },
+                                                                                "value": "$n"
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                                "sorts": [],
+                                                                                "args": []
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "DV",
+                                                                                "sort": {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortId",
+                                                                                    "args": []
+                                                                                },
+                                                                                "value": "$n"
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "inj",
+                                                                                "sorts": [
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortAExp",
+                                                                                        "args": []
+                                                                                    }
+                                                                                ],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortInt",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "0"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "dotk",
+                                                        "sorts": [],
+                                                        "args": []
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'-LT-'state'-GT-'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'Stop'Map",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "EVar",
+                                "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortGeneratedCounterCell",
+                                    "args": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "indeterminate": true
     }
 }

--- a/booster/test/rpc-integration/test-implies2/response-refutation-3.booster-dev
+++ b/booster/test/rpc-integration/test-implies2/response-refutation-3.booster-dev
@@ -1,9 +1,340 @@
 {
     "jsonrpc": "2.0",
     "id": "4573738480-001",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "first": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'T'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortPgm",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "Lblint'UndsSClnUnds'",
+                                                            "sorts": [],
+                                                            "args": [
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsCommUnds'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                            "sorts": [],
+                                                                            "args": []
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "inj",
+                                                                            "sorts": [
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortInt",
+                                                                                    "args": []
+                                                                                },
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortAExp",
+                                                                                    "args": []
+                                                                                }
+                                                                            ],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "0"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'state'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'Stop'Map",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "EVar",
+                            "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedCounterCell",
+                                "args": []
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "Exists",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "var": "VarY",
+                    "varSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "arg": {
+                        "tag": "Exists",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "var": "VarX",
+                        "varSort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
+                        },
+                        "arg": {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedTop'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'T'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'-LT-'k'-GT-'",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "kseq",
+                                                    "sorts": [],
+                                                    "args": [
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "inj",
+                                                            "sorts": [
+                                                                {
+                                                                    "tag": "SortApp",
+                                                                    "name": "SortPgm",
+                                                                    "args": []
+                                                                },
+                                                                {
+                                                                    "tag": "SortApp",
+                                                                    "name": "SortKItem",
+                                                                    "args": []
+                                                                }
+                                                            ],
+                                                            "args": [
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lblint'UndsSClnUnds'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'UndsCommUnds'",
+                                                                            "sorts": [],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortId",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "$n"
+                                                                                },
+                                                                                {
+                                                                                    "tag": "App",
+                                                                                    "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                                    "sorts": [],
+                                                                                    "args": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                            "sorts": [],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortId",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "$n"
+                                                                                },
+                                                                                {
+                                                                                    "tag": "App",
+                                                                                    "name": "inj",
+                                                                                    "sorts": [
+                                                                                        {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortInt",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortAExp",
+                                                                                            "args": []
+                                                                                        }
+                                                                                    ],
+                                                                                    "args": [
+                                                                                        {
+                                                                                            "tag": "DV",
+                                                                                            "sort": {
+                                                                                                "tag": "SortApp",
+                                                                                                "name": "SortInt",
+                                                                                                "args": []
+                                                                                            },
+                                                                                            "value": "0"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "dotk",
+                                                            "sorts": [],
+                                                            "args": []
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'-LT-'state'-GT-'",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "Lbl'Stop'Map",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "EVar",
+                                    "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortGeneratedCounterCell",
+                                        "args": []
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "indeterminate": true
     }
 }

--- a/booster/test/rpc-integration/test-implies2/response-refutation-4.booster-dev
+++ b/booster/test/rpc-integration/test-implies2/response-refutation-4.booster-dev
@@ -1,9 +1,353 @@
 {
     "jsonrpc": "2.0",
     "id": "4567922016-001",
-    "error": {
-        "code": 6,
-        "data": "unknown constraints",
-        "message": "Aborted"
+    "result": {
+        "valid": false,
+        "implication": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "Implies",
+                "sort": {
+                    "tag": "SortApp",
+                    "name": "SortGeneratedTopCell",
+                    "args": []
+                },
+                "first": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'T'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "kseq",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortPgm",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "App",
+                                                            "name": "Lblint'UndsSClnUnds'",
+                                                            "sorts": [],
+                                                            "args": [
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsCommUnds'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                            "sorts": [],
+                                                                            "args": []
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "tag": "App",
+                                                                    "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                    "sorts": [],
+                                                                    "args": [
+                                                                        {
+                                                                            "tag": "DV",
+                                                                            "sort": {
+                                                                                "tag": "SortApp",
+                                                                                "name": "SortId",
+                                                                                "args": []
+                                                                            },
+                                                                            "value": "$n"
+                                                                        },
+                                                                        {
+                                                                            "tag": "App",
+                                                                            "name": "inj",
+                                                                            "sorts": [
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortInt",
+                                                                                    "args": []
+                                                                                },
+                                                                                {
+                                                                                    "tag": "SortApp",
+                                                                                    "name": "SortAExp",
+                                                                                    "args": []
+                                                                                }
+                                                                            ],
+                                                                            "args": [
+                                                                                {
+                                                                                    "tag": "DV",
+                                                                                    "sort": {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    "value": "0"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "dotk",
+                                                    "sorts": [],
+                                                    "args": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'state'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'Stop'Map",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "EVar",
+                            "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedCounterCell",
+                                "args": []
+                            }
+                        }
+                    ]
+                },
+                "second": {
+                    "tag": "Exists",
+                    "sort": {
+                        "tag": "SortApp",
+                        "name": "SortGeneratedTopCell",
+                        "args": []
+                    },
+                    "var": "VarZ",
+                    "varSort": {
+                        "tag": "SortApp",
+                        "name": "SortInt",
+                        "args": []
+                    },
+                    "arg": {
+                        "tag": "Exists",
+                        "sort": {
+                            "tag": "SortApp",
+                            "name": "SortGeneratedTopCell",
+                            "args": []
+                        },
+                        "var": "VarY",
+                        "varSort": {
+                            "tag": "SortApp",
+                            "name": "SortInt",
+                            "args": []
+                        },
+                        "arg": {
+                            "tag": "Exists",
+                            "sort": {
+                                "tag": "SortApp",
+                                "name": "SortGeneratedTopCell",
+                                "args": []
+                            },
+                            "var": "VarX",
+                            "varSort": {
+                                "tag": "SortApp",
+                                "name": "SortInt",
+                                "args": []
+                            },
+                            "arg": {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'generatedTop'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'-LT-'T'-GT-'",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'-LT-'k'-GT-'",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "kseq",
+                                                        "sorts": [],
+                                                        "args": [
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "inj",
+                                                                "sorts": [
+                                                                    {
+                                                                        "tag": "SortApp",
+                                                                        "name": "SortPgm",
+                                                                        "args": []
+                                                                    },
+                                                                    {
+                                                                        "tag": "SortApp",
+                                                                        "name": "SortKItem",
+                                                                        "args": []
+                                                                    }
+                                                                ],
+                                                                "args": [
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lblint'UndsSClnUnds'",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "Lbl'UndsCommUnds'",
+                                                                                "sorts": [],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortId",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "$n"
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "App",
+                                                                                        "name": "Lbl'Stop'List'LBraQuotUndsCommUndsQuotRBra'",
+                                                                                        "sorts": [],
+                                                                                        "args": []
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "Lbl'UndsEqlsUndsSCln'",
+                                                                                "sorts": [],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortId",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "$n"
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "App",
+                                                                                        "name": "inj",
+                                                                                        "sorts": [
+                                                                                            {
+                                                                                                "tag": "SortApp",
+                                                                                                "name": "SortInt",
+                                                                                                "args": []
+                                                                                            },
+                                                                                            {
+                                                                                                "tag": "SortApp",
+                                                                                                "name": "SortAExp",
+                                                                                                "args": []
+                                                                                            }
+                                                                                        ],
+                                                                                        "args": [
+                                                                                            {
+                                                                                                "tag": "DV",
+                                                                                                "sort": {
+                                                                                                    "tag": "SortApp",
+                                                                                                    "name": "SortInt",
+                                                                                                    "args": []
+                                                                                                },
+                                                                                                "value": "0"
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "dotk",
+                                                                "sorts": [],
+                                                                "args": []
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "tag": "App",
+                                                "name": "Lbl'-LT-'state'-GT-'",
+                                                "sorts": [],
+                                                "args": [
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "Lbl'Stop'Map",
+                                                        "sorts": [],
+                                                        "args": []
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "tag": "EVar",
+                                        "name": "VarGENERATED'Unds'COUNTER'Unds'CELL",
+                                        "sort": {
+                                            "tag": "SortApp",
+                                            "name": "SortGeneratedCounterCell",
+                                            "args": []
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/kore-rpc-types/src/Kore/JsonRpc/Types.hs
+++ b/kore-rpc-types/src/Kore/JsonRpc/Types.hs
@@ -162,6 +162,18 @@ data ImpliesResult = ImpliesResult
     , valid :: Bool
     , condition :: Maybe Condition
     , logs :: Maybe [LogEntry]
+    , indeterminate :: Maybe Bool
+    -- ^ Booster-only signal: 'Just True' on a 'valid = False' result
+    -- where booster's match check was indeterminate (e.g. an
+    -- unevaluated function blocking unification) and the
+    -- simplify-LHS / simplify-RHS retry ladder did not make
+    -- progress.  Absent ('Nothing') on every decisive outcome
+    -- ('valid = True', or 'valid = False' from a 'MatchFailed{}' /
+    -- bottom-consequent path), all error paths, and every kore-side
+    -- result.  Clients that want to distinguish "couldn't tell" from
+    -- "definitely not implied" should escalate on
+    -- @indeterminate = Just True@ and trust @valid = False@ in every
+    -- other case.
     }
     deriving stock (Generic, Show, Eq)
     deriving

--- a/kore/src/Kore/JsonRpc.hs
+++ b/kore/src/Kore/JsonRpc.hs
@@ -463,16 +463,16 @@ respond reqId serverState moduleName runSMT =
                  in Right . Implies $
                         case r of
                             Claim.Implied Nothing ->
-                                ImpliesResult jsonTerm True (Just . renderCond sort $ Condition.bottom) logs
+                                ImpliesResult jsonTerm True (Just . renderCond sort $ Condition.bottom) logs Nothing
                             Claim.Implied (Just cond) ->
-                                ImpliesResult jsonTerm True (Just . renderCond sort $ cond) logs
+                                ImpliesResult jsonTerm True (Just . renderCond sort $ cond) logs Nothing
                             Claim.NotImplied _ ->
-                                ImpliesResult jsonTerm False Nothing logs
+                                ImpliesResult jsonTerm False Nothing logs Nothing
                             Claim.NotImpliedStuck (Just cond) ->
                                 let jsonCond = renderCond sort cond
-                                 in ImpliesResult jsonTerm False (Just jsonCond) logs
+                                 in ImpliesResult jsonTerm False (Just jsonCond) logs Nothing
                             Claim.NotImpliedStuck Nothing ->
-                                ImpliesResult jsonTerm False (Just . renderCond sort $ Condition.bottom) logs
+                                ImpliesResult jsonTerm False (Just . renderCond sort $ Condition.bottom) logs Nothing
         Simplify SimplifyRequest{state, _module} -> withMainModule (coerce _module) $ \serializedModule lemmas -> do
             case verifyIn serializedModule state of
                 Left Error{errorError, errorContext} ->

--- a/scripts/booster-integration-tests.sh
+++ b/scripts/booster-integration-tests.sh
@@ -37,7 +37,7 @@ for dir in $(ls -d test-*); do
             SERVER=$KORE_RPC_DEV ./runDirectoryTest.sh test-$name $@
             SERVER=$KORE_RPC_BOOSTER ./runDirectoryTest.sh test-$name $@
             ;;
-        "get-model" | "collectiontest" | "implies" | "implies2" | "implies-issue-3941" | "remainder-predicates" | "use-path-condition-in-equations" | "issue3764-vacuous-branch" | "3934-smt")
+        "get-model" | "collectiontest" | "implies" | "implies2" | "implies-issue-3941" | "implies-smt" | "remainder-predicates" | "use-path-condition-in-equations" | "issue3764-vacuous-branch" | "3934-smt")
             SERVER=$BOOSTER_DEV ./runDirectoryTest.sh test-$name $@
             SERVER=$KORE_RPC_BOOSTER ./runDirectoryTest.sh test-$name $@
             ;;


### PR DESCRIPTION
When booster's `implies` check matches the consequent against the antecedent and finds leftover consequent obligations, it previously passed them to `evaluateConstraints` with no path-condition context — effectively asking SMT whether each obligation holds "under the assumption of itself". Anything depending on the antecedent's constraints couldn't be closed, and unresolved obligations aborted the RPC with `Aborted "unknown constraints"` (the source of 57 `kore-implies` handoffs observed in KEVM recover-mode). This change discharges those obligations under the antecedent, mirroring the rewrite path's two-stage approach (`Booster.Pattern.Rewrite.checkRequires`): each obligation is first simplified with the antecedent in `knownPredicates` (so K-level vocabulary like `#rangeAddress` unfolds), then any non-`TrueBool` residue is SMT-closed against the antecedent's predicates and substitution. Unresolvable obligations now return an indeterminate `valid: false` verdict instead of an RPC error, so a recover-mode client escalates to kore rather than failing.
    
**Changes:**
- `Booster.Pattern.Implies`: replace the `MatchSuccess` FIXME path with simplify-under-antecedent + `SMT.checkPredicates`; map `IsValid`→implies, `IsInvalid`→does-not-imply, `IsUnknown InconsistentGroundTruth`→implies (vacuous antecedent), `IsUnknown _`→indeterminate.
- `kore-rpc-types`: add an optional `indeterminate :: Maybe Bool` field to `ImpliesResult` (omitted when absent) so clients can distinguish a decisive `valid: false` from an indeterminate one.
- `kore/JsonRpc`: set the new field to `Nothing` on kore-side results (always decisive).
- Add `test-implies-smt` RPC integration tests (bound-weakening, does-not-imply, vacuous-antecedent, address-bound) and update `test-implies2` goldens for the cases that previously aborted.
- Some refactors to clean up the Implies check file a bit: `mkResult` helps build implication results in a standard way, and we pre-compute several terms that are used on several branches of the implication check.

**Validation:**
- Builds clean under `-Wall -Werror` (stack, GHC 9.6.5); fourmolu-clean.
- Booster unit tests pass (721 tests).
- Tested on KEVM:
  - Does not cause any notable overall performance regressions.
  - Does not change any passing tests, and does not cause any tests to be passable with booster-dev that were not before.
  - Does clear some `Implies` checks directly in booster that were not cleared before and relied on Kore (collecting data on that now).
