### PR TITLE
Remove warning about deprecated Node

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,12 +22,12 @@ jobs:
           sudo apt install --yes z3 libsecp256k1-dev
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Cache Stack root
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.stack
           key: stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
@@ -35,7 +35,7 @@ jobs:
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
-      - uses: haskell-actions/setup@v2.7
+      - uses: haskell-actions/setup@v2.11.0
         id: setup-haskell-stack
         with:
           ghc-version: ${{ env.ghc_version }}
@@ -56,7 +56,7 @@ jobs:
     needs: [cache-stack]
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           # fetch-depth 0 means deep clone the repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       version: ${{ steps.make-release.outputs.version }}
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Make release'
         id: 'make-release'
         env:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -52,14 +52,14 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= 
 
       - name: Install Cachix
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: k-framework
           extraPullNames: k-framework-binary
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
       - name: 'Build and Cache'
-        uses: workflow/nix-shell-action@v3
+        uses: workflow/nix-shell-action@v4.0.0
         env:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_PUBLIC_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -85,7 +85,7 @@ jobs:
           sudo apt install --yes debhelper z3 libsecp256k1-dev
 
       - name: Cache Stack root
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.stack
           key: stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
@@ -93,7 +93,7 @@ jobs:
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
-      - uses: haskell-actions/setup@v2.7
+      - uses: haskell-actions/setup@v2.11.0
         id: setup-haskell-stack
         with:
           ghc-version: ${{ env.ghc_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= 
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
@@ -124,7 +124,7 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
@@ -140,12 +140,12 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= 
 
       - name: Install Cachix
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: k-framework
           skipPush: true
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -193,14 +193,14 @@ jobs:
         run: |
           sudo apt install --yes debhelper z3 libsecp256k1-dev
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Cache Stack root
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.stack
           key: stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
@@ -208,7 +208,7 @@ jobs:
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}-${{ hashFiles('stack.yaml') }}
             stack-${{ runner.os }}-ghc-${{ env.ghc_version }}
 
-      - uses: haskell-actions/setup@v2.7
+      - uses: haskell-actions/setup@v2.11.0
         id: setup-haskell-stack
         with:
           ghc-version: ${{ env.ghc_version }}
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -255,7 +255,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= 
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -30,7 +30,7 @@ jobs:
           install_url: https://releases.nixos.org/nix/nix-2.30.1/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v17
         with:
           name: k-framework
           authToken: ${{ secrets.CACHIX_PUBLIC_TOKEN }}


### PR DESCRIPTION
We're getting warnings on CI:

```
Formatting and Style
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, cachix/cachix-action@v14.
Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.
Please check if updated versions of these actions are available that support Node.js 24.
To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```


This should fix it by bumping all the action versions.